### PR TITLE
Update MSBuild DLL import conditions

### DIFF
--- a/Yubico.NativeShims/msbuild/Yubico.NativeShims.targets
+++ b/Yubico.NativeShims/msbuild/Yubico.NativeShims.targets
@@ -3,14 +3,14 @@
     <!-- .NET Framework versions don't seem to include the native runtime files that
         are needed for this package. This makes sure they are included in downlevel projects.
         Since .NET Framework is Windows only, we only need to worry about that platform. -->
-    <ItemGroup Condition="'$(Platform)' == 'x86' OR '$(Platform)' == 'AnyCPU'">
+    <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' OR '$(Platform)' == 'x86'">
         <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\Yubico.NativeShims.dll">
             <Link>Yubico.NativeShims.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>
         </Content>
     </ItemGroup>
-    <ItemGroup Condition="'$(Platform)' == 'x64'">
+    <ItemGroup Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' OR '$(Platform)' == 'x64'">
         <Content Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\Yubico.NativeShims.dll">
             <Link>Yubico.NativeShims.dll</Link>
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>


### PR DESCRIPTION
This fixes an issue that causes the wrong Yubio.NativeShims.dll to be used. If a user uses the 'AnyCPU' platform target, this issue could potentially result in users mixing 32-bit and 64-bit dlls and leave users with errors such as 'BadImageFormatException' whenever code that utilizes the Yubico SDK was called.

AnyCPU shouldn't default to x86 unless the architecture of the host machine performing a build is also x86.
AnyCPU can also utilize x64 architecture, and is supposed to only fallback to x86 if x64 isn't possible.
Defaulting to either option can potentially result in bitness mismatches

https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-options/output#platformtarget