### PR TITLE
Enable Control Flow Guard for Windows Build

### DIFF
--- a/Yubico.NativeShims/CMakeLists.txt
+++ b/Yubico.NativeShims/CMakeLists.txt
@@ -25,8 +25,11 @@ elseif(NOT MSVC)
     string(CONCAT CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
         " -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.gnu")
 else()
+#enable control flow guard for windows
     string(CONCAT CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
-        " /def:\"${CMAKE_CURRENT_SOURCE_DIR}/exports.msvc\"")
+        " /guard:cf /def:\"${CMAKE_CURRENT_SOURCE_DIR}/exports.msvc\"")
+    string(CONCAT CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS}
+        " /guard:cf /def:\"${CMAKE_EXE_LINKER_FLAGS}/exports.msvc\"")
 endif()
 
 

--- a/Yubico.NativeShims/CMakeLists.txt
+++ b/Yubico.NativeShims/CMakeLists.txt
@@ -28,8 +28,6 @@ else()
 #enable control flow guard for windows
     string(CONCAT CMAKE_SHARED_LINKER_FLAGS ${CMAKE_SHARED_LINKER_FLAGS}
         " /guard:cf /def:\"${CMAKE_CURRENT_SOURCE_DIR}/exports.msvc\"")
-    string(CONCAT CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS}
-        " /guard:cf /def:\"${CMAKE_EXE_LINKER_FLAGS}/exports.msvc\"")
 endif()
 
 


### PR DESCRIPTION
### CHANGES:
   Added /cf parameter to Windows build (change in CMakelists.txt) to enable Control Flow Guard in Yubico.Nativeshims project.

   There is no known vulnerability in the Yubico SDK that drives this change; it is simply a best practice for code that interacts with unsafe functions to adopt all available platform security measures for native code. This change may enable high security environments to proactively protect against unknown future vulnerabilities found in code that interacts with memory unsafe functions.
 
### Control Flow Guard Information: 
Control Flow Guard (CFG) is a robust security feature designed to counter memory corruption vulnerabilities by imposing strict limitations on code execution within an application. It significantly reduces the risk of exploits, particularly those exploiting vulnerabilities like buffer overflows. CFG builds upon previous mitigation technologies such as /GS, DEP, and ASLR, enhancing overall platform security. Its key features include preventing memory corruption and ransomware attacks, limiting server capabilities to reduce attack surface, and increasing the difficulty of exploiting arbitrary code vulnerabilities like buffer overflows.

### More info: 
https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard