### PR TITLE
Default back to old SCardConnect behavior

### DIFF
--- a/Yubico.Core/src/Yubico/Core/CoreCompatSwitches.cs
+++ b/Yubico.Core/src/Yubico/Core/CoreCompatSwitches.cs
@@ -1,4 +1,4 @@
-// Copyright 2023 Yubico AB
+// Copyright 2024 Yubico AB
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.

--- a/Yubico.Core/src/Yubico/Core/CoreCompatSwitches.cs
+++ b/Yubico.Core/src/Yubico/Core/CoreCompatSwitches.cs
@@ -1,0 +1,29 @@
+// Copyright 2023 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.Core
+{
+    /// <summary>
+    /// Compatibility switch names that can be used with `AppContext.SetSwitch` to control breaking behavioral changes
+    /// within the `Yubico.Core` layer.
+    /// </summary>
+    public static class CoreCompatSwitches
+    {
+        /// <summary>
+        /// If set to true, Yubico.Core will attempt to open smart card handles exclusively. False will open shared.
+        /// Default is false / shared.
+        /// </summary>
+        public const string OpenSmartCardHandlesExclusively = nameof(OpenSmartCardHandlesExclusively);
+    }
+}

--- a/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDevice.cs
@@ -131,10 +131,18 @@ namespace Yubico.Core.Devices.SmartCard
 
             try
             {
+                SCARD_SHARE shareMode = SCARD_SHARE.SHARED;
+
+                if (AppContext.TryGetSwitch(CoreCompatSwitches.OpenSmartCardHandlesExclusively, out bool enabled) &&
+                    enabled)
+                {
+                    shareMode = SCARD_SHARE.EXCLUSIVE;
+                }
+
                 result = SCardConnect(
                     context,
                     _readerName,
-                    SCARD_SHARE.EXCLUSIVE,
+                    shareMode,
                     SCARD_PROTOCOL.Tx,
                     out cardHandle,
                     out SCARD_PROTOCOL activeProtocol);


### PR DESCRIPTION
# Description

Reverts the change in behavior to open smart card handles exclusively. Instead now defaults back to shared like it was before, but allows for applications to toggle between the new and old behavior through the use of `AppContext.SetSwitch`.

Fixes #72 and probably #81 as well.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Wrote some test code using the TestApp and verified:
- No compat flag present = SHARED
- Flag present & false = SHARED
- Flag present & true = EXCLUSIVE

**Test configuration**:
* Firmware version: 5.4.3
* Yubikey model: ANFC

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
