### PR TITLE
Make YubiKeyDeviceListener resettable

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Devices/DeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/DeviceEventArgs.cs
@@ -13,30 +13,60 @@
 // limitations under the License.
 
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace Yubico.Core.Devices
 {
     /// <summary>
-    /// Event arguments given whenever a device is added or removed from the system.
+    /// Defines the contract for device-related event arguments in a generic context.
+    /// This interface allows for type-safe access to device information in event handling
+    /// scenarios, supporting device types that implement the <see cref="IDevice"/> interface.
+    /// It enables specific device type information to be preserved and accessed in event handlers.
     /// </summary>
-    public class DeviceEventArgs : EventArgs
+    /// <remarks>
+    /// While this interface does not inherit from <see cref="System.EventArgs"/>, it retains the "Args" suffix
+    /// in its name. This naming convention is deliberately chosen to maintain consistency with standard
+    /// event argument naming patterns in C#, particularly for improved readability when used in delegate
+    /// and event handler signatures. The familiar "Args" suffix clearly indicates the interface's role
+    /// in event-related contexts, despite not directly extending <see cref="System.EventArgs"/>.
+    /// </remarks>
+    /// <typeparam name="TDevice">The specific type of <see cref="IDevice"/> this event argument represents.
+    /// This type parameter is covariant, allowing for more specific device types to be used
+    /// where a more general device type is expected.</typeparam>
+    #pragma warning disable CA1711 // Identifiers should not have incorrect suffix
+    public interface IDeviceEventArgs<out TDevice> where TDevice : IDevice
+    #pragma warning restore CA1711 // Identifiers should not have incorrect suffix
     {
         /// <summary>
-        /// The device that originated the event.
+        /// Gets the specific type of <see cref="IDevice"/> that originated the event.
+        /// This property will always be populated, regardless of whether this is an arrival event or a removal event.
+        /// If the device was removed, not all members will be available on the object. An exception will be thrown if
+        /// you try to use the device in a way that requires it to be present.
         /// </summary>
-        public IDevice? BaseDevice { get; set; }
+        /// <remarks>
+        /// This property provides access to the specific <c>TDevice</c> instance associated with the current event.
+        /// </remarks>
+        /// <value>
+        /// An instance of <c>TDevice</c> that triggered this event.
+        /// </value>
+        TDevice Device { get; }
+    }
+
+    /// <summary>
+    /// Event arguments given whenever a device is added or removed from the system, providing strongly-typed access to the device that triggered the event.
+    /// </summary>
+    /// <typeparam name="TDevice">The type of device associated with this event, which must implement <see cref="IDevice"/>.</typeparam>
+    public abstract class DeviceEventArgs<TDevice> : EventArgs, IDeviceEventArgs<TDevice>
+        where TDevice : IDevice
+    {
+        /// <inheritdoc />
+        public TDevice Device { get; }
 
         /// <summary>
-        /// Constructs a new instance of the <see cref="DeviceEventArgs"/> class.
+        /// Constructs a new instance of the <see cref="DeviceEventArgs{TDevice}"/> class.
         /// </summary>
-        /// <param name="device">
-        /// The device that is originating this event.
-        /// </param>
-        public DeviceEventArgs(IDevice? device)
+        protected DeviceEventArgs(TDevice device)
         {
-            BaseDevice = device;
+            Device = device;
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/DeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/DeviceEventArgs.cs
@@ -1,0 +1,42 @@
+﻿// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Yubico.Core.Devices
+{
+    /// <summary>
+    /// Event arguments given whenever a device is added or removed from the system.
+    /// </summary>
+    public class DeviceEventArgs : EventArgs
+    {
+        /// <summary>
+        /// The device that originated the event.
+        /// </summary>
+        public IDevice? BaseDevice { get; set; }
+
+        /// <summary>
+        /// Constructs a new instance of the <see cref="DeviceEventArgs"/> class.
+        /// </summary>
+        /// <param name="device">
+        /// The device that is originating this event.
+        /// </param>
+        public DeviceEventArgs(IDevice? device)
+        {
+            BaseDevice = device;
+        }
+    }
+}

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceEventArgs.cs
@@ -17,17 +17,8 @@ namespace Yubico.Core.Devices.Hid
     /// <summary>
     /// Event arguments given whenever a HID device is added or removed from the system.
     /// </summary>
-    public class HidDeviceEventArgs : DeviceEventArgs
+    public class HidDeviceEventArgs : DeviceEventArgs<IHidDevice>
     {
-        /// <summary>
-        /// The HID device that originated the event.
-        /// </summary>
-        /// <remarks>
-        /// This property will always be populated, regardless of whether this is an arrival event or a removal event.
-        /// If the device was removed, not all members will be available on the object. An exception will be thrown if
-        /// you try to use the device in a way that requires it to be present.
-        /// </remarks>
-        public IHidDevice? Device { get; set; }
 
         /// <summary>
         /// Constructs a new instance of the <see cref="HidDeviceEventArgs"/> class.
@@ -35,9 +26,8 @@ namespace Yubico.Core.Devices.Hid
         /// <param name="device">
         /// The HID device that is originating this event.
         /// </param>
-        public HidDeviceEventArgs(IHidDevice? device) : base(device)
+        public HidDeviceEventArgs(IHidDevice device) : base(device)
         {
-            Device = device;
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceEventArgs.cs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Yubico.Core.Devices.Hid
 {
     /// <summary>
     /// Event arguments given whenever a HID device is added or removed from the system.
     /// </summary>
-    public class HidDeviceEventArgs : EventArgs
+    public class HidDeviceEventArgs : DeviceEventArgs
     {
         /// <summary>
         /// The HID device that originated the event.
@@ -37,7 +35,7 @@ namespace Yubico.Core.Devices.Hid
         /// <param name="device">
         /// The HID device that is originating this event.
         /// </param>
-        public HidDeviceEventArgs(IHidDevice? device)
+        public HidDeviceEventArgs(IHidDevice? device) : base(device)
         {
             Device = device;
         }

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceListener.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceListener.cs
@@ -86,7 +86,7 @@ namespace Yubico.Core.Devices.Hid
         /// <param name="device">
         /// The device instance that originates this event.
         /// </param>
-        protected void OnRemoved(IHidDevice? device)
+        protected void OnRemoved(IHidDevice device)
         {
             _log.LogInformation("HID {Device} removed.", device);
             Removed?.Invoke(this, new HidDeviceEventArgs(device));

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDeviceListener.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDeviceListener.cs
@@ -139,6 +139,6 @@ namespace Yubico.Core.Devices.Hid
             OnArrived(new MacOSHidDevice(MacOSHidDevice.GetEntryId(device)));
 
         private void RemovedCallback(IntPtr context, int result, IntPtr sender, IntPtr device) =>
-            OnRemoved(null);
+            OnRemoved(NullDevice.Instance);
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/NullDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/NullDevice.cs
@@ -1,0 +1,38 @@
+﻿// Copyright 2024 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Yubico.Core.Devices.Hid
+{
+    public class NullDevice : IHidDevice
+    {
+        public string Path => string.Empty;
+        public string? ParentDeviceId => default;
+        public DateTime LastAccessed => default;
+        public short VendorId => default;
+        public short ProductId => default;
+        public short Usage => default;
+        public HidUsagePage UsagePage => default;
+        public IHidConnection ConnectToFeatureReports() => throw new NotImplementedException();
+        public IHidConnection ConnectToIOReports() => throw new NotImplementedException();
+
+        /// <summary>
+        /// Creates a default <see cref="IHidDevice"/> with all it's properties set to its default values, indicating a null device.
+        /// This might be used in cases where the <see cref="IHidDevice"/> otherwise would be null.
+        /// </summary>
+        internal static IHidDevice Instance => new NullDevice();
+        private NullDevice() { }
+    }
+}

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs
@@ -128,7 +128,7 @@ namespace Yubico.Core.Devices.Hid
             }
             else if (action == CM_NOTIFY_ACTION.DEVICEINTERFACEREMOVAL)
             {
-                thisObj?.OnRemoved(null);
+                thisObj?.OnRemoved(NullDevice.Instance);
             }
 
             return 0;

--- a/Yubico.Core/src/Yubico/Core/Devices/SmartCard/SmartCardDeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/SmartCard/SmartCardDeviceEventArgs.cs
@@ -17,18 +17,8 @@ namespace Yubico.Core.Devices.SmartCard
     /// <summary>
     /// Event arguments given whenever a smart card device is added or removed from the system.
     /// </summary>
-    public class SmartCardDeviceEventArgs : DeviceEventArgs
+    public class SmartCardDeviceEventArgs : DeviceEventArgs<ISmartCardDevice>
     {
-        /// <summary>
-        /// The smart card device that originated the event.
-        /// </summary>
-        /// <remarks>
-        /// This property will always be populated, regardless of whether this is an arrival event or a removal event.
-        /// If the device was removed, not all members will be available on the object. An exception will be thrown if
-        /// you try to use the device in a way that requires it to be present.
-        /// </remarks>
-        public ISmartCardDevice Device { get; set; }
-
         /// <summary>
         /// Constructs a new instance of the <see cref="SmartCardDeviceEventArgs"/> class.
         /// </summary>
@@ -37,7 +27,6 @@ namespace Yubico.Core.Devices.SmartCard
         /// </param>
         public SmartCardDeviceEventArgs(ISmartCardDevice device) : base(device)
         {
-            Device = device;
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/SmartCard/SmartCardDeviceEventArgs.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/SmartCard/SmartCardDeviceEventArgs.cs
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
-
 namespace Yubico.Core.Devices.SmartCard
 {
     /// <summary>
     /// Event arguments given whenever a smart card device is added or removed from the system.
     /// </summary>
-    public class SmartCardDeviceEventArgs : EventArgs
+    public class SmartCardDeviceEventArgs : DeviceEventArgs
     {
         /// <summary>
         /// The smart card device that originated the event.
@@ -37,7 +35,7 @@ namespace Yubico.Core.Devices.SmartCard
         /// <param name="device">
         /// The smart card device that is originating this event.
         /// </param>
-        public SmartCardDeviceEventArgs(ISmartCardDevice device)
+        public SmartCardDeviceEventArgs(ISmartCardDevice device) : base(device)
         {
             Device = device;
         }

--- a/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
@@ -146,7 +146,10 @@ namespace Yubico.Core.Devices.Hid.UnitTests
 #if Windows
 #pragma warning disable CA1825
         [Theory]
+#pragma warning disable CA1825 // Avoid zero-length array allocations
+        // The compiler mistakenly thinks that this somehow involves a zero-length array.
         [MemberData(nameof(GetTestData))]
+#pragma warning restore CA1825 // Avoid zero-length array allocations
         public void GetChar_GivenHidCode_ReturnsCorrectChar(KeyboardLayout layout, (char, byte)[] testData)
         {
             var hid = HidCodeTranslator.GetInstance(layout);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
@@ -54,6 +54,11 @@ namespace Yubico.YubiKey
         /// <see cref="IYubiKeyDevice"/> using their serial number. If they cannot be matched,
         /// each connection will be returned as a separate <see cref="IYubiKeyDevice"/>.
         /// </para>
+        /// <para>
+        /// If your application no longer needs to watch for insertion or removal notifications,
+        /// you can call <see cref="YubiKeyDeviceListener.StopListening"/> to release resources
+        /// and avoid the logging and other actions from the listeners.
+        /// </para>
         /// </remarks>
         /// <param name="transport">
         /// Argument controls which devices are searched for. Values <see cref="Transport.None"/>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceListener.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceListener.cs
@@ -16,8 +16,8 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Yubico.Core.Devices;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Devices.SmartCard;
@@ -111,30 +111,14 @@ namespace Yubico.YubiKey
 
         internal List<IYubiKeyDevice> GetAll() => _internalCache.Keys.ToList();
 
-        private void ArriveHandler(object? sender, EventArgs e) => ListenerHandler("Arrival", e);
+        private void ArriveHandler(object? sender, DeviceEventArgs e) => ListenerHandler("Arrival", e);
 
-        private void RemoveHandler(object? sender, EventArgs e) => ListenerHandler("Removal", e);
+        private void RemoveHandler(object? sender, DeviceEventArgs e) => ListenerHandler("Removal", e);
 
-        private void ListenerHandler(string eventType, EventArgs e)
+        private void ListenerHandler(string eventType, DeviceEventArgs e)
         {
-            object? device;
-            string deviceType;
-            if (e is SmartCardDeviceEventArgs se)
-            {
-                deviceType = "smart card";
-                device = se.Device;
-            }
-            else if (e is HidDeviceEventArgs he)
-            {
-                deviceType = "HID";
-                device = he.Device;
-            }
-            else
-            {
-                // Given this is a private method, this case isn't likely.
-                deviceType = "unknown";
-                device = "undefined";
-            }
+            IDevice? device = e.BaseDevice;
+            string deviceType = e is HidDeviceEventArgs ? "HID" : "smart card";
 
             _log.LogInformation(
                 "{EventType} of {DeviceType} {Device} is triggering update.",

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiKeyTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiKeyTests.cs
@@ -221,5 +221,29 @@ namespace Yubico.YubiKey
                 _testOutputHelper.WriteLine($"\t({keys.Count}) -{sw.ElapsedMilliseconds,5}ms");
             }
         }
+
+        [Fact]
+        public void TestResettingDeviceListener()
+        {
+            // Get devices (if any) and ensure the listeners are running.
+            List<IYubiKeyDevice> beforeDevices = YubiKeyDevice.FindAll().ToList();
+            _testOutputHelper.WriteLine($"Found {beforeDevices.Count} YubiKey devices before reset");
+
+            // Test that the listeners are running.
+            Assert.True(YubiKeyDeviceListener.IsListenerRunning, $"{nameof(YubiKeyDeviceListener.Instance)} is not active");
+
+            // Stop the listeners.
+            YubiKeyDeviceListener.StopListening();
+
+            // Test that we really stopped it.
+            Assert.False(YubiKeyDeviceListener.IsListenerRunning, $"{nameof(YubiKeyDeviceListener.Instance)} is still active");
+
+            // Make sure we can still enumerate devices.
+            List<IYubiKeyDevice> afterDevices = YubiKeyDevice.FindAll().ToList();
+            _testOutputHelper.WriteLine($"Found {afterDevices.Count} YubiKey devices after reset");
+
+            // Check that we have the same devices as the first check.
+            Assert.True(afterDevices.SequenceEqual(beforeDevices), "Before and after aren't the same.");
+        }
     }
 }


### PR DESCRIPTION
# Description

Currently, YubiKeyDeviceListener only exposes a singleton instance with no way for a consumer to reset it once it is started. The constructor is private, so the consumer has no option to use a private instance.

This adds the ability for the consumer to reset the lazy-initialized singleton so that the listen thread doesn't stick around.

Also, even though this class implemented IDisposable, most things that need to be in the Dispose method weren't there, including a way to stop the thread.

The listen thread is now replaced by an asynchronous task that doesn't consume a system thread while it's not working.

Fixes # YESDK-1313

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* Firmware version: 5.4.3
* Yubikey model:

# Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
