### PR TITLE
Adding functionality to read additional pages of device info

### DIFF
--- a/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
@@ -144,16 +144,18 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         }
 
 #if Windows
+#pragma warning disable CA1825
         [Theory]
         [MemberData(nameof(GetTestData))]
         public void GetChar_GivenHidCode_ReturnsCorrectChar(KeyboardLayout layout, (char, byte)[] testData)
         {
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             foreach ((char ch, byte code) item in testData)
             {
                 Assert.Equal(item.ch, hid[item.code]);
             }
         }
+#pragma warning restore CA1825
 #endif
 
         public static IEnumerable<object[]> GetTestData()

--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
@@ -179,7 +179,7 @@ namespace Yubico.YubiKey
                 {
                     IHidDevice { UsagePage: HidUsagePage.Fido } d => new FidoConnection(d),
                     IHidDevice { UsagePage: HidUsagePage.Keyboard } d => new KeyboardConnection(d),
-                    ISmartCardDevice d => new CcidConnection(d, application),
+                    ISmartCardDevice d => new SmartcardConnection(d, application),
                     _ => throw new NotSupportedException(ExceptionMessages.DeviceTypeNotRecognized)
                 };
 
@@ -266,7 +266,7 @@ namespace Yubico.YubiKey
                     return false;
                 }
 
-                connection = new CcidConnection(smartCardDevice, applicationId);
+                connection = new SmartcardConnection(smartCardDevice, applicationId);
                 _ = _openConnections.Add(yubiKeyDevice);
             }
             finally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
@@ -50,9 +50,9 @@ namespace Yubico.YubiKey
                 if (response.Status == ResponseStatus.Success)
                 {
                     Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
-                    foreach ((int tag, ReadOnlyMemory<byte> value) in tlvData)
+                    foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tlv in tlvData)
                     {
-                        pages.Add(tag, value);
+                        pages.Add(tlv.Key, tlv.Value);
                     }
 
                     const int moreDataTag = 0x10;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2023 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Logging;
+using Yubico.Core.Tlv;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey
+{
+    internal static class DeviceInfoHelper
+    {
+        /// <summary>
+        /// Fetches and aggregates device configuration details from a YubiKey using multiple APDU commands,
+        /// paging through the data as needed until all configuration data is retrieved.
+        /// This method processes the responses, accumulating TLV-encoded data into a single dictionary.
+        /// </summary>
+        /// <typeparam name="T">The type of the YubiKey response which must include data.</typeparam>
+        /// <param name="connection">The connection interface to communicate with a YubiKey.</param>
+        /// <param name="command">The command to be sent to the YubiKey. This command should be capable of handling pagination.</param>
+        /// <returns>A YubiKeyDeviceInfo object containing all relevant device information.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the command fails to retrieve successful response statuses from the YubiKey.</exception>
+        public static YubiKeyDeviceInfo GetDeviceInfo<T>(
+            IYubiKeyConnection connection,
+            IPagedGetDeviceInfoCommand<T> command) 
+            where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+        {
+            Logger log = Log.GetLogger();
+            
+            int page = 0;
+            var pages = new Dictionary<int, ReadOnlyMemory<byte>>();
+            
+            bool hasMoreData = true;
+            while (hasMoreData)
+            {
+                command.Page = (byte)page++;
+                T response = connection.SendCommand(command);
+                if (response.Status == ResponseStatus.Success)
+                {
+                    Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
+                    foreach ((int tag, ReadOnlyMemory<byte> value) in tlvData)
+                    {
+                        pages.Add(tag, value);
+                    }
+
+                    const int moreDataTag = 0x10;
+                    hasMoreData = tlvData.TryGetValue(moreDataTag, out ReadOnlyMemory<byte> hasMoreDataByte)
+                        && hasMoreDataByte.Span.Length == 1
+                        && hasMoreDataByte.Span[0] == 1;
+                }
+                else
+                {
+                    log.LogError("Failed to get device info page-{Page}: {Error} {Message}",
+                        page, response.StatusWord, response.StatusMessage);
+
+                    return new YubiKeyDeviceInfo(); // TODO What to return here? Null? Empty? Exception? 
+                }
+            }
+
+            return YubiKeyDeviceInfo.CreateFromResponseData(pages);
+        }
+        
+        /// <summary>
+        /// Attempts to create a dictionary from a TLV-encoded byte array by parsing and extracting tag-value pairs.
+        /// </summary>
+        /// <param name="tlvData">The byte array containing TLV-encoded data.</param>
+        /// <param name="result">When successful, contains a dictionary mapping integer tags to their corresponding values as byte arrays.</param>
+        /// <returns>True if the dictionary was successfully created; false otherwise.</returns>
+        public static bool TryCreateApduDictionaryFromResponseData(
+            ReadOnlyMemory<byte> tlvData, out Dictionary<int, ReadOnlyMemory<byte>> result)
+        {
+            Logger log = Log.GetLogger();
+            result = new Dictionary<int, ReadOnlyMemory<byte>>();
+
+            if (tlvData.IsEmpty)
+            {
+                log.LogWarning("ResponseAPDU data was empty!");
+                return false;
+            }
+
+            int tlvDataLength = tlvData.Span[0];
+            if (tlvDataLength == 0 || 1 + tlvDataLength > tlvData.Length)
+            {
+                log.LogWarning("TLV Data length was out of expected ranges. {Length}", tlvDataLength);
+                return false;
+            }
+
+            var tlvReader = new TlvReader(tlvData.Slice(1, tlvDataLength));
+            while (tlvReader.HasData)
+            {
+                int tag = tlvReader.PeekTag();
+                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                result.Add(tag, value);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -17,7 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
-using Yubico.YubiKey.Management.Commands;
+using Yubico.YubiKey.U2f.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -74,7 +74,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
                 using var connection = new FidoConnection(device);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 
                 log.LogInformation("Successfully read device info via FIDO interface management command.");
                 return true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -56,7 +55,8 @@ namespace Yubico.YubiKey
                 ykDeviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
+                ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
                 ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.FidoU2f;
             }
@@ -64,25 +64,21 @@ namespace Yubico.YubiKey
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromFido(IHidDevice device, [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromFido(IHidDevice device,
+                                                     [MaybeNullWhen(returnValue: false)]
+                                                     out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
-                using var fidoConnection = new FidoConnection(device);
-
-                U2f.Commands.GetDeviceInfoResponse response = fidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
-
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via FIDO interface management command.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from management application: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                using var connection = new FidoConnection(device);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new GetPagedDeviceInfoCommand());
+                
+                log.LogInformation("Successfully read device info via FIDO interface management command.");
+                return true;
+                //TODO Handle exceptions? 
             }
             catch (NotImplementedException e)
             {
@@ -100,29 +96,38 @@ namespace Yubico.YubiKey
                 ErrorHandler(e, "Must have elevated privileges in Windows to access FIDO device directly.");
             }
 
-            log.LogWarning("Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+            log.LogWarning(
+                "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+
             yubiKeyDeviceInfo = null;
+
             return false;
         }
 
-        private static bool TryGetFirmwareVersionFromFido(IHidDevice device, [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+        private static bool TryGetFirmwareVersionFromFido(IHidDevice device,
+                                                          [MaybeNullWhen(returnValue: false)]
+                                                          out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through FIDO.");
-                using var FidoConnection = new FidoConnection(device);
+                using var fidoConnection = new FidoConnection(device);
 
-                Fido2.Commands.VersionResponse response = FidoConnection.SendCommand(new Fido2.Commands.VersionCommand());
+                Fido2.Commands.VersionResponse response =
+                    fidoConnection.SendCommand(new Fido2.Commands.VersionCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData();
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
-                log.LogError("Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+
+                log.LogError("Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (NotImplementedException e)
             {
@@ -142,10 +147,11 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read firmware version through FIDO.");
             firmwareVersion = null;
+
             return false;
         }
 
-        private static void ErrorHandler(Exception exception, string message)
-            => Log.GetLogger().LogWarning(exception, message);
+        private static void ErrorHandler(Exception exception, string message) =>
+            Log.GetLogger().LogWarning(exception, message);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -71,9 +71,9 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
-                using var FidoConnection = new FidoConnection(device);
+                using var fidoConnection = new FidoConnection(device);
 
-                U2f.Commands.GetDeviceInfoResponse response = FidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
+                U2f.Commands.GetDeviceInfoResponse response = fidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Yubico.YubiKey
+{
+    public interface IGetPagedDeviceInfoCommand<out T> : IYubiKeyCommand<T>
+        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        public byte Page { get; set; }
+
+    }
+} 
+    

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
@@ -662,5 +662,7 @@ namespace Yubico.YubiKey
             byte challengeResponseTimeout,
             bool touchEjectEnabled,
             int autoEjectTimeout = 0);
+
+        void SetIsNfcRestricted(bool enabled);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
@@ -38,6 +38,11 @@ namespace Yubico.YubiKey
         /// The NFC features that are currently enabled over NFC.
         /// </summary>
         public YubiKeyCapabilities EnabledNfcCapabilities { get; }
+        
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool IsNfcRestricted { get; }
 
         /// <summary>
         /// The serial number of the YubiKey, if one is present.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Otp.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -74,7 +75,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
                 using var connection = new KeyboardConnection(device);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 //TODO Handle exceptions? 
                 return true;
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -73,18 +73,21 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
-                using var KeyboardConnection = new KeyboardConnection(device);
+                using var connection = new KeyboardConnection(device);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                //TODO Handle exceptions? 
+                return true;
 
-                Otp.Commands.GetDeviceInfoResponse response = KeyboardConnection.SendCommand(new Otp.Commands.GetDeviceInfoCommand());
+                // Otp.Commands.GetDeviceInfoResponse response = keyboardConnection.SendCommand(new Otp.Commands.GetDeviceInfoCommand());
+                //
+                // if (response.Status == ResponseStatus.Success)
+                // {
+                //     yubiKeyDeviceInfo = response.GetData();
+                //     log.LogInformation("Successfully read device info via the keyboard management command.");
+                //     return true;
+                // }
 
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via the keyboard management command.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from the keyboard management command: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                // log.LogError("Failed to get device info from the keyboard management command: {Error} {Message}", response.StatusWord, response.StatusMessage);
             }
             catch (KeyboardConnectionException e)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Management.Commands
@@ -22,6 +23,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public class GetDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
         /// <summary>
@@ -51,7 +52,7 @@ namespace Yubico.YubiKey.Management.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -60,7 +61,7 @@ namespace Yubico.YubiKey.Management.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Management.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    public sealed class GetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        private const byte GetDeviceInfoInstruction = 0x1D;
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// <see cref="YubiKeyApplication.Management"/>
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Management;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetDeviceInfoCommand"/> class.
+        /// </summary>
+        public GetPagedDeviceInfoCommand()
+        {
+            
+        }
+        
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu
+        {
+            Ins = GetDeviceInfoInstruction,
+            P1 = Page
+        };
+        
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IPagedGetDeviceInfoCommand<T> : IYubiKeyCommand<T> 
+        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+    {
+        public byte Page { get; set; }
+    } 
+    
+    // public interface IPagedGetDeviceInfoCommand : IYubiKeyCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>> 
+    // {
+    //     public byte Page { get; set; }
+    // } 
+}
+

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -24,7 +24,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
-    public sealed class GetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;
         public byte Page { get; set; }
@@ -56,20 +56,5 @@ namespace Yubico.YubiKey.Management.Commands
         public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new GetPagedDeviceInfoResponse(responseApdu);
     }
-
-    /// <summary>
-    /// TODO
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public interface IPagedGetDeviceInfoCommand<T> : IYubiKeyCommand<T> 
-        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
-    {
-        public byte Page { get; set; }
-    } 
-    
-    // public interface IPagedGetDeviceInfoCommand : IYubiKeyCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>> 
-    // {
-    //     public byte Page { get; set; }
-    // } 
 }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Management.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse,
+                                            IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu)
+            : base(responseApdu)
+        {
+            
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -32,6 +32,7 @@ namespace Yubico.YubiKey.Management.Commands
         private const byte ConfigurationUnlockPresentTag = 0x0b;
         private const byte ResetAfterConfigTag = 0x0c;
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
+        private const byte NfcRestrictedTag = 0x17;
 
 
         private byte[]? _lockCode;
@@ -100,13 +101,18 @@ namespace Yubico.YubiKey.Management.Commands
         /// updates. Useful if enabling or disabling capabilities.
         /// </summary>
         public bool ResetAfterConfig { get; set; }
-
+        
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool IsNfcRestricted { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SetDeviceInfoBaseCommand"/> class.
         /// </summary>
         protected SetDeviceInfoBaseCommand()
         {
+            
         }
 
         protected SetDeviceInfoBaseCommand(SetDeviceInfoBaseCommand baseCommand)
@@ -115,6 +121,7 @@ namespace Yubico.YubiKey.Management.Commands
             {
                 EnabledUsbCapabilities = baseCommand.EnabledUsbCapabilities;
                 EnabledNfcCapabilities = baseCommand.EnabledNfcCapabilities;
+                IsNfcRestricted = baseCommand.IsNfcRestricted;
                 ChallengeResponseTimeout = baseCommand.ChallengeResponseTimeout;
                 AutoEjectTimeout = baseCommand.AutoEjectTimeout;
                 DeviceFlags = baseCommand.DeviceFlags;
@@ -242,6 +249,11 @@ namespace Yubico.YubiKey.Management.Commands
             if (_unlockCode is byte[] unlockCode)
             {
                 buffer.WriteValue(ConfigurationUnlockPresentTag, unlockCode);
+            }
+            
+            if (IsNfcRestricted)
+            {
+                buffer.WriteByte(NfcRestrictedTag, 1);
             }
 
             return buffer.Encode();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Otp.Commands
@@ -22,6 +23,7 @@ namespace Yubico.YubiKey.Otp.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.Otp.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public class GetDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
         /// <summary>
@@ -58,7 +59,7 @@ namespace Yubico.YubiKey.Otp.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -67,7 +68,7 @@ namespace Yubico.YubiKey.Otp.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Yubico.Core.Iso7816;
-using Yubico.YubiKey.Management.Commands;
+
 
 namespace Yubico.YubiKey.Otp.Commands
 {
@@ -21,9 +21,9 @@ namespace Yubico.YubiKey.Otp.Commands
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
     /// <remarks>
-    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// This class has a corresponding partner class <see cref="GetPagedDeviceInfoResponse"/>
     /// </remarks>
-    public class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         /// <summary>
         /// Gets the YubiKeyApplication to which this command belongs.
@@ -36,9 +36,9 @@ namespace Yubico.YubiKey.Otp.Commands
         public byte Page { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PagedGetPagedDeviceInfoCommand"/> class.
+        /// Initializes a new instance of the <see cref="GetPagedDeviceInfoCommand"/> class.
         /// </summary>
-        public PagedGetPagedDeviceInfoCommand()
+        public GetPagedDeviceInfoCommand()
         {
             
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey.Otp.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    public class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.Otp
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Otp;
+
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagedGetPagedDeviceInfoCommand"/> class.
+        /// </summary>
+        public PagedGetPagedDeviceInfoCommand()
+        {
+            
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu()
+        {
+            Ins = OtpConstants.RequestSlotInstruction,
+            P1 = OtpConstants.GetDeviceInfoSlot,
+            Data = new []{Page}
+        };
+
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+    
+    
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Otp.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    public class GetPagedDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetDataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetDataCommand.cs
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.Piv.Commands
     /// will not need to use this command. For example, if you want to get a
     /// certificate from a YubiKey, use <see cref="PivSession.GetCertificate"/>.
     /// Or if you want to store/retrieve Key History, use
-    /// <see cref="PivSession.ReadObject()"/> and <see cref="PivSession.WriteObject"/>
+    /// <see cref="PivSession.ReadObject{T}()"/> and <see cref="PivSession.WriteObject"/>
     /// along with the <see cref="Piv.Objects.KeyHistory"/> class. Under the
     /// covers, these APIs will ultimately call this command. But the application
     /// that uses the SDK can simply make the specific API calls, rather than use

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/PutDataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/PutDataCommand.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.Piv.Commands
     /// not need to use this command. For example, if you want to put a
     /// certificate onto a YubiKey, use <see cref="PivSession.ImportCertificate"/>.
     /// Or if you want to store/retrieve Key History, use
-    /// <see cref="PivSession.ReadObject()"/> and <see cref="PivSession.WriteObject"/>
+    /// <see cref="PivSession.ReadObject{T}()"/> and <see cref="PivSession.WriteObject"/>
     /// along with the <see cref="Piv.Objects.KeyHistory"/> class. Under the
     /// covers, these APIs will ultimately call this command. But the application
     /// that uses the SDK can simply make the specific API calls, rather than use

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PivDataObject.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PivDataObject.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.Piv.Objects
     /// Data Object.
     /// </summary>
     /// <remarks>
-    /// Generally you will use one of the <see cref="PivSession.ReadObject()"/> methods to
+    /// Generally you will use one of the <see cref="PivSession.ReadObject{T}()"/> methods to
     /// get the specified data out of a YubiKey. The formatted data will be
     /// parsed and the resulting object will present the data in a more readable
     /// form. You can then update the data and call

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
@@ -173,7 +173,7 @@ namespace Yubico.YubiKey.Piv
         /// <xref href="UsersManualPivObjects"> PIV data objects</xref>.
         /// </para>
         /// <para>
-        /// This is the same as the <see cref="ReadObject()"/> method that takes no
+        /// This is the same as the <see cref="ReadObject{T}()"/> method that takes no
         /// arguments, except this one will get the data in the storage location
         /// specified by <c>dataTag</c>, as opposed to the defined data tag for
         /// the class <c>T</c>. This method will still expect the data to be

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Linq;
 using Yubico.Core.Devices.SmartCard;
 using Yubico.YubiKey.Pipelines;
@@ -20,14 +19,14 @@ using Yubico.YubiKey.Scp03;
 
 namespace Yubico.YubiKey
 {
-    internal class Scp03CcidConnection : CcidConnection, IScp03YubiKeyConnection
+    internal class Scp03Connection : SmartcardConnection, IScp03YubiKeyConnection
     {
         private bool _disposed;
 
         // If an Scp03ApduTransform is used, keep this copy so it can be disposed.
         private readonly Scp03ApduTransform _scp03ApduTransform;
 
-        public Scp03CcidConnection(
+        public Scp03Connection(
             ISmartCardDevice smartCardDevice,
             YubiKeyApplication yubiKeyApplication,
             StaticKeys scp03Keys)
@@ -36,7 +35,7 @@ namespace Yubico.YubiKey
             _scp03ApduTransform = SetObject(yubiKeyApplication, scp03Keys);
         }
 
-        public Scp03CcidConnection(ISmartCardDevice smartCardDevice, byte[] applicationId, StaticKeys scp03Keys)
+        public Scp03Connection(ISmartCardDevice smartCardDevice, byte[] applicationId, StaticKeys scp03Keys)
             : base(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
             YubiKeyApplication setError = YubiKeyApplication.Unknown;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03YubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03YubiKeyDevice.cs
@@ -45,12 +45,12 @@ namespace Yubico.YubiKey
 
             if (!(application is null))
             {
-                return new Scp03CcidConnection(GetSmartCardDevice(), (YubiKeyApplication)application, StaticKeys);
+                return new Scp03Connection(GetSmartCardDevice(), (YubiKeyApplication)application, StaticKeys);
             }
 
             if (!(applicationId is null))
             {
-                return new Scp03CcidConnection(GetSmartCardDevice(), applicationId, StaticKeys);
+                return new Scp03Connection(GetSmartCardDevice(), applicationId, StaticKeys);
             }
 
             return null;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -67,67 +67,74 @@ namespace Yubico.YubiKey
                 ykDeviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
+                ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
-                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath | YubiKeyCapabilities.OpenPgp | YubiKeyCapabilities.Piv | YubiKeyCapabilities.Ccid;
+                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath | YubiKeyCapabilities.OpenPgp |
+                    YubiKeyCapabilities.Piv | YubiKeyCapabilities.Ccid;
             }
 
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device, [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device,
+                                                           [MaybeNullWhen(returnValue: false)]
+                                                           out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read device info via the management application.");
-                using var smartCardConnection = new CcidConnection(device, YubiKeyApplication.Management);
+                using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
 
-                Management.Commands.GetDeviceInfoResponse response = smartCardConnection.SendCommand(new Management.Commands.GetDeviceInfoCommand());
-
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via management application.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from the management application: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogInformation("Successfully read device info via management application.");
+                return true;
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get device info from management.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get device info from management.");
             }
 
-            log.LogWarning("Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+            log.LogWarning(
+                "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+
             yubiKeyDeviceInfo = null;
+
             return false;
         }
 
         private static bool TryGetFirmwareVersionFromOtp(ISmartCardDevice device,
-            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+                                                         [MaybeNullWhen(returnValue: false)]
+                                                         out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through OTP.");
-                using var ccidConnection = new CcidConnection(device, YubiKeyApplication.Otp);
+                using var ccidConnection = new SmartcardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.ReadStatusResponse response = ccidConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
+                Otp.Commands.ReadStatusResponse response =
+                    ccidConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData().FirmwareVersion;
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
-                log.LogError("Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+
+                log.LogError("Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get firmware version from OTP.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get firmware version from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
             {
@@ -136,18 +143,20 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read firmware version through OTP. This may be expected over USB.");
             firmwareVersion = null;
+
             return false;
         }
 
         private static bool TryGetFirmwareVersionFromPiv(ISmartCardDevice device,
-            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+                                                         [MaybeNullWhen(returnValue: false)]
+                                                         out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through the PIV application.");
-                using IYubiKeyConnection connection = new CcidConnection(device, YubiKeyApplication.Piv);
+                using IYubiKeyConnection connection = new SmartcardConnection(device, YubiKeyApplication.Piv);
 
                 Piv.Commands.VersionResponse response = connection.SendCommand(new Piv.Commands.VersionCommand());
 
@@ -155,18 +164,22 @@ namespace Yubico.YubiKey
                 {
                     firmwareVersion = response.GetData();
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
 
-                log.LogError("Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get firmware version from PIV.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get firmware version from PIV.");
             }
 
             log.LogWarning("Failed to read firmware version through PIV.");
             firmwareVersion = null;
+
             return false;
         }
 
@@ -177,22 +190,26 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read serial number through the OTP application.");
-                using var ccidConnection = new CcidConnection(device, YubiKeyApplication.Otp);
+                using var ccidConnection = new SmartcardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.GetSerialNumberResponse response = ccidConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
+                Otp.Commands.GetSerialNumberResponse response =
+                    ccidConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
                     log.LogInformation("Serial number: {SerialNumber}", serialNumber);
+
                     return true;
                 }
 
-                log.LogError("Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get serial number from OTP.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get serial number from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
             {
@@ -202,6 +219,7 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read serial number through OTP.");
             serialNumber = null;
+
             return false;
         }
 
@@ -212,30 +230,35 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read serial number through the PIV application.");
-                using IYubiKeyConnection connection = new CcidConnection(device, YubiKeyApplication.Piv);
+                using IYubiKeyConnection connection = new SmartcardConnection(device, YubiKeyApplication.Piv);
 
-                Piv.Commands.GetSerialNumberResponse response = connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
+                Piv.Commands.GetSerialNumberResponse response =
+                    connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
                     log.LogInformation("Serial number: {SerialNumber}", serialNumber);
+
                     return true;
                 }
 
-                log.LogError("Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get serial number from PIV.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get serial number from PIV.");
             }
 
             log.LogWarning("Failed to read serial number through PIV.");
             serialNumber = null;
+
             return false;
         }
 
-        private static void ErrorHandler(Exception exception, string message)
-            => Log.GetLogger().LogWarning(exception, message);
+        private static void ErrorHandler(Exception exception, string message) =>
+            Log.GetLogger().LogWarning(exception, message);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.SmartCard;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -77,9 +78,9 @@ namespace Yubico.YubiKey
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device,
-                                                           [MaybeNullWhen(returnValue: false)]
-                                                           out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromManagement(
+            ISmartCardDevice device,
+            [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
@@ -87,7 +88,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management application.");
                 using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
 
                 log.LogInformation("Successfully read device info via management application.");
                 return true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
@@ -24,7 +24,7 @@ using Yubico.YubiKey.Pipelines;
 
 namespace Yubico.YubiKey
 {
-    internal class CcidConnection : IYubiKeyConnection
+    internal class SmartcardConnection : IYubiKeyConnection
     {
         private readonly Logger _log = Log.GetLogger();
 
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey
 
         public ISelectApplicationData? SelectApplicationData { get; set; }
 
-        protected CcidConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
+        protected SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
         {
             if (applicationId is null && application == YubiKeyApplication.Unknown)
             {
@@ -53,7 +53,7 @@ namespace Yubico.YubiKey
             _apduPipeline = new CommandChainingTransform(_apduPipeline);
         }
 
-        public CcidConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
+        public SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
             : this(smartCardDevice, yubiKeyApplication, null)
         {
             if (yubiKeyApplication == YubiKeyApplication.Fido2)
@@ -67,7 +67,7 @@ namespace Yubico.YubiKey
             SelectApplication();
         }
 
-        public CcidConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
+        public SmartcardConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
             : this(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
             if (applicationId.SequenceEqual(YubiKeyApplication.Fido2.GetIso7816ApplicationId()))

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.U2f.Commands
@@ -19,6 +20,10 @@ namespace Yubico.YubiKey.U2f.Commands
     /// <summary>
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public sealed class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0xC2;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.U2f.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public sealed class GetDeviceInfoResponse : U2fResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
 
@@ -51,7 +52,7 @@ namespace Yubico.YubiKey.U2f.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -60,7 +61,7 @@ namespace Yubico.YubiKey.U2f.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey.U2f.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    public sealed class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        private const byte GetDeviceInfoInstruction = 0xC2;
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.FidoU2f
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.FidoU2f;
+
+        /// <summary>
+        /// Constructs an instance of the <see cref="PagedGetPagedDeviceInfoCommand" /> class.
+        /// </summary>
+        public PagedGetPagedDeviceInfoCommand()
+        {
+            
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu
+        {
+            Ins = GetDeviceInfoInstruction,
+            Data = new []{ Page }
+        };
+
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 using Yubico.Core.Iso7816;
-using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey.U2f.Commands
 {
     /// <summary>
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
-    public sealed class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0xC2;
         public byte Page { get; set; }
@@ -34,9 +33,9 @@ namespace Yubico.YubiKey.U2f.Commands
         public YubiKeyApplication Application => YubiKeyApplication.FidoU2f;
 
         /// <summary>
-        /// Constructs an instance of the <see cref="PagedGetPagedDeviceInfoCommand" /> class.
+        /// Constructs an instance of the <see cref="GetPagedDeviceInfoCommand" /> class.
         /// </summary>
-        public PagedGetPagedDeviceInfoCommand()
+        public GetPagedDeviceInfoCommand()
         {
             
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.U2f.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    /// 
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
@@ -75,6 +75,7 @@ namespace Yubico.YubiKey
             Logger log = Log.GetLogger();
 
             log.LogInformation("FindByTransport {Transport}", transport);
+
             if (transport == Transport.None)
             {
                 throw new ArgumentException(ExceptionMessages.InvalidConnectionTypeNone, nameof(transport));
@@ -83,18 +84,14 @@ namespace Yubico.YubiKey
             // If the caller is looking only for HidFido, and this is Windows,
             // and the process is not running elevated, we can't use the YubiKey,
             // so throw an exception.
-            if (transport == Transport.HidFido)
+            if (transport == Transport.HidFido &&
+                SdkPlatformInfo.OperatingSystem == SdkPlatform.Windows &&
+                !SdkPlatformInfo.IsElevated)
             {
-                if (SdkPlatformInfo.OperatingSystem == SdkPlatform.Windows)
-                {
-                    if (!SdkPlatformInfo.IsElevated)
-                    {
-                        throw new UnauthorizedAccessException(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                ExceptionMessages.HidFidoWindowsNotElevated));
-                    }
-                }
+                throw new UnauthorizedAccessException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.HidFidoWindowsNotElevated));
             }
 
             // Return any key that has at least one overlapping available transport with the requested transports.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -39,6 +39,7 @@ namespace Yubico.YubiKey
         private const byte NfcPrePersCapabilitiesTag = 0x0d;
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
         private const byte MoreDataTag = 0x10;
+        private const byte NfcRestrictedTag = 0x17;
         private const byte TemplateStorageVersionTag = 0x20;
         private const byte ImageProcessorVersionTag = 0x21;
 
@@ -102,6 +103,8 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool ConfigurationLocked { get; set; }
+        
+        public bool IsNfcRestricted { get; set; }
 
         /// <summary>
         /// Constructs a default instance of YubiKeyDeviceInfo.
@@ -264,6 +267,10 @@ namespace Yubico.YubiKey
                         };
                         log.SensitiveLogInformation("ImageProcessorVersion: {ImageProcessorVersion}", deviceInfo.ImageProcessorVersion.ToString());
                         break;
+                    
+                    case NfcRestrictedTag:
+                        deviceInfo.IsNfcRestricted = tlvReader.ReadByte(NfcRestrictedTag) == 1;
+                        break;
 
                     default:
                         Debug.Assert(false, "Encountered an unrecognized tag in DeviceInfo. Ignoring.");
@@ -299,34 +306,31 @@ namespace Yubico.YubiKey
 
                 IsFipsSeries = IsFipsSeries || second.IsFipsSeries,
 
-                FormFactor =
-                        FormFactor != FormFactor.Unknown
-                        ? FormFactor
-                        : second.FormFactor,
+                FormFactor = FormFactor != FormFactor.Unknown
+                    ? FormFactor
+                    : second.FormFactor,
 
-                FirmwareVersion =
-                        FirmwareVersion != new FirmwareVersion()
-                        ? FirmwareVersion
-                        : second.FirmwareVersion,
+                FirmwareVersion = FirmwareVersion != new FirmwareVersion()
+                    ? FirmwareVersion
+                    : second.FirmwareVersion,
 
-                AutoEjectTimeout =
-                        DeviceFlags.HasFlag(DeviceFlags.TouchEject)
+                AutoEjectTimeout = DeviceFlags.HasFlag(DeviceFlags.TouchEject)
                         ? AutoEjectTimeout
                         : second.DeviceFlags.HasFlag(DeviceFlags.TouchEject)
                             ? second.AutoEjectTimeout
                             : default,
 
-                ChallengeResponseTimeout =
-                        ChallengeResponseTimeout != default
-                        ? ChallengeResponseTimeout
-                        : second.ChallengeResponseTimeout,
+                ChallengeResponseTimeout = ChallengeResponseTimeout != default
+                    ? ChallengeResponseTimeout
+                    : second.ChallengeResponseTimeout,
 
                 DeviceFlags = DeviceFlags | second.DeviceFlags,
 
-                ConfigurationLocked =
-                        ConfigurationLocked != default
-                        ? ConfigurationLocked
-                        : second.ConfigurationLocked,
+                ConfigurationLocked = ConfigurationLocked != default
+                    ? ConfigurationLocked
+                    : second.ConfigurationLocked,
+                
+                IsNfcRestricted = IsNfcRestricted || second.IsNfcRestricted
             };
         }
 

--- a/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
@@ -14,14 +14,8 @@
 
 using System;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using Serilog;
-using Yubico.Core.Logging;
-using Yubico.YubiKey.Fido2;
-using Yubico.YubiKey.YubiHsmAuth;
-using Yubico.YubiKey.YubiHsmAuth.Commands;
 
 namespace Yubico.YubiKey.TestApp.Plugins
 {
@@ -44,26 +38,21 @@ namespace Yubico.YubiKey.TestApp.Plugins
                 builder => builder
                     .AddSerilog(log)
                     .AddFilter(level => level >= LogLevel.Information));
+            
+            
+            
+            
+            
+            IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.All).First();
 
-            IYubiKeyDevice? yubiKey = YubiKeyDevice.FindAll().First();
+            // IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.HidFido).First();
 
-            Console.WriteLine($"YubiKey Version: {yubiKey.FirmwareVersion}");
+            Console.Error.WriteLine($"YubiKey Version: {yubiKey.FirmwareVersion}");
+            Console.Error.WriteLine("NFC Before Value: "+ yubiKey.IsNfcRestricted);
 
-            using (var hsmAuth = new YubiHsmAuthSession(yubiKey))
-            {
-                string label = "mycred";
-                byte[] password = new byte[16];
-                Encoding.ASCII.GetBytes("abc123").CopyTo(password, 0);
-                byte[] hostChallenge = { 0, 1, 2, 3, 4, 5, 6, 7 };
-                byte[] hsmDeviceChallenge = { 8, 9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15 };
-
-                var command = new GetAes128SessionKeysCommand(label, password, hostChallenge, hsmDeviceChallenge);
-
-                Console.WriteLine("Calling calculate...");
-                GetAes128SessionKeysResponse? response = hsmAuth.Connection.SendCommand(command);
-                Console.WriteLine($"Calculate returned with {response.Status}");
-            }
-
+            yubiKey.SetIsNfcRestricted(true);
+            
+            Console.Error.WriteLine("NFC AFter Value: "+ yubiKey.IsNfcRestricted);
             return true;
         }
     }

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/HollowYubiKeyDevice.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/HollowYubiKeyDevice.cs
@@ -50,6 +50,8 @@ namespace Yubico.YubiKey.TestUtilities
         /// <inheritdoc />
         public YubiKeyCapabilities EnabledNfcCapabilities { get; private set; }
 
+        public bool IsNfcRestricted { get; }
+
         /// <inheritdoc />
         public int? SerialNumber { get; private set; }
 
@@ -234,6 +236,11 @@ namespace Yubico.YubiKey.TestUtilities
         }
 
         public void SetLegacyDeviceConfiguration(YubiKeyCapabilities yubiKeyInterfaces, byte challengeResponseTimeout, bool touchEjectEnabled, int autoEjectTimeout = 0)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetIsNfcRestricted(bool enabled)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
# Description
Adding functionality to read additional pages of device info

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* Firmware version:
* Yubikey model:

# Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
