### PR TITLE
Adding functionality to read and set additional pages of device info

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,4 @@
+root = true
 # Copyright 2021 Yubico AB
 # 
 # Licensed under the Apache License, Version 2.0 (the "License").
@@ -12,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-root = true
 
 # All files
 [*]
 
 # IDE0073: File header
-dotnet_diagnostic.IDE0073.severity = suggestion
+dotnet_diagnostic.ide0073.severity = suggestion
 file_header_template = Copyright 2023 Yubico AB\n\nLicensed under the Apache License, Version 2.0 (the "License").\nYou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an "AS IS" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.
+
 
 # C# files
 [*.cs]
@@ -187,30 +188,29 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers =
+dotnet_naming_symbols.interface.required_modifiers = 
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers =
+dotnet_naming_symbols.types.required_modifiers = 
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers =
+dotnet_naming_symbols.non_field_members.required_modifiers = 
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix =
-dotnet_naming_style.pascal_case.required_suffix =
-dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix =
-dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-# ReSharper properties
-resharper_space_within_single_line_array_initializer_braces=true
+
 
 #
 # Dev project rules
@@ -220,7 +220,7 @@ resharper_space_within_single_line_array_initializer_braces=true
 
 # Make this go away once the current ones are fixed.
 # CS1591: Missing XML comment for publicly visible type or member
-dotnet_diagnostic.CS1591.severity = suggestion
+dotnet_diagnostic.cs1591.severity = suggestion
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:warning
@@ -236,87 +236,96 @@ csharp_style_expression_bodied_properties = when_on_single_line:warning
 dotnet_code_quality_unused_parameters = all:warning
 
 # ReSharper properties
-resharper_align_first_arg_by_paren=false
-resharper_align_linq_query=true
-resharper_align_multiline_argument=true
-resharper_align_multiline_array_and_object_initializer=false
-resharper_align_multiline_binary_expressions_chain=false
-resharper_align_multiline_calls_chain=false
-resharper_align_multiline_expression=true
-resharper_align_multiline_extends_list=true
-resharper_align_multiline_for_stmt=false
-resharper_align_multline_type_parameter_constrains=false
-resharper_align_multline_type_parameter_list=false
-resharper_align_tuple_components=false
-resharper_blank_lines_after_control_transfer_statements=1
-resharper_blank_lines_after_multiline_statements=1
-resharper_blank_lines_before_block_statements=1
-resharper_blank_lines_before_control_transfer_statements=1
-resharper_blank_lines_before_multiline_statements=1
-resharper_blank_lines_before_single_line_comment=1
-resharper_csharp_align_multiline_argument=false
-resharper_csharp_align_multiline_expression=false
-resharper_csharp_align_multiline_parameter=true
-resharper_csharp_align_multiple_declaration=false
-resharper_csharp_indent_pars=outside
-resharper_csharp_keep_blank_lines_in_code=1
-resharper_csharp_keep_blank_lines_in_declarations=1
-resharper_csharp_new_line_before_while=true
-resharper_csharp_stick_comment=false
-resharper_indent_invocation_pars=outside
-resharper_indent_method_decl_pars=outside
-resharper_indent_nested_foreach_stmt=true
-resharper_indent_nested_for_stmt=true
-resharper_indent_nested_while_stmt=true
-resharper_indent_preprocessor_other=usual_indent
-resharper_indent_statement_pars=outside
-resharper_indent_typearg_angles=outside
-resharper_indent_typeparam_angles=outside
-resharper_keep_existing_declaration_parens_arrangement=false
-resharper_keep_existing_expr_member_arrangement=false
+resharper_align_first_arg_by_paren = false
+resharper_align_linq_query = true
+resharper_align_multiline_argument = true
+resharper_align_multiline_array_and_object_initializer = false
+resharper_align_multiline_binary_expressions_chain = false
+resharper_align_multiline_calls_chain = false
+resharper_align_multiline_expression = true
+resharper_align_multiline_extends_list = true
+resharper_align_multiline_for_stmt = false
+resharper_align_multline_type_parameter_constrains = false
+resharper_align_multline_type_parameter_list = false
+resharper_align_tuple_components = false
+resharper_blank_lines_after_control_transfer_statements = 1
+resharper_blank_lines_before_single_line_comment = 1
+resharper_csharp_align_multiline_argument = false
+resharper_csharp_align_multiline_expression = false
+resharper_csharp_align_multiline_parameter = true
+resharper_csharp_align_multiple_declaration = false
+resharper_csharp_indent_pars = outside
+resharper_csharp_keep_blank_lines_in_code = 1
+resharper_csharp_keep_blank_lines_in_declarations = 1
+resharper_csharp_new_line_before_while = true
+resharper_csharp_stick_comment = false
+resharper_indent_invocation_pars = outside
+resharper_indent_method_decl_pars = outside
+resharper_indent_nested_foreach_stmt = true
+resharper_indent_nested_for_stmt = true
+resharper_indent_nested_while_stmt = true
+resharper_indent_preprocessor_other = usual_indent
+resharper_indent_statement_pars = outside
+resharper_indent_typearg_angles = outside
+resharper_indent_typeparam_angles = outside
+resharper_keep_existing_declaration_parens_arrangement = false
+resharper_keep_existing_expr_member_arrangement = false
+
+resharper_space_within_single_line_array_initializer_braces = true
+
+resharper_arguments_skip_single = true
+resharper_blank_lines_after_multiline_statements = 1
+resharper_blank_lines_before_block_statements = 0
+resharper_blank_lines_before_control_transfer_statements = 0
+resharper_blank_lines_before_multiline_statements = 0
+resharper_csharp_max_line_length = 120
+resharper_csharp_wrap_after_invocation_lpar = true
+resharper_csharp_wrap_parameters_style = chop_if_long
+resharper_parentheses_redundancy_style = remove
+
 # CA1822: Mark members as static
 # Changing public members to static would be a breaking change,
 # so only run this test on private and internal members
-dotnet_code_quality.CA1822.api_surface = private, internal
+dotnet_code_quality.ca1822.api_surface = private, internal
 
 # CA1024: Use properties where appropriate
-dotnet_diagnostic.CA1024.severity = none
+dotnet_diagnostic.ca1024.severity = none
 
 # CA1027: Mark enums with FlagsAttribute
-dotnet_diagnostic.CA1027.severity = none
+dotnet_diagnostic.ca1027.severity = none
 
 # CA1028: Enum storage should be Int32
-dotnet_diagnostic.CA1028.severity = none
+dotnet_diagnostic.ca1028.severity = none
 
 # Not going to use LoggerMessage delegates.
-dotnet_diagnostic.CA1848.severity = none
+dotnet_diagnostic.ca1848.severity = none
 
 # This is a .NET bug.
 # https://github.com/dotnet/roslyn-analyzers/issues/5626
-dotnet_diagnostic.CA2254.severity = none
+dotnet_diagnostic.ca2254.severity = none
 
 # This is a .NET bug.
 # https://github.com/dotnet/roslyn-analyzers/issues/5479
-dotnet_diagnostic.CA2101.severity = none
+dotnet_diagnostic.ca2101.severity = none
 
 # Hitting a weird CA1508 issue.
-dotnet_diagnostic.CA1508.severity = none
+dotnet_diagnostic.ca1508.severity = none
 
 # CA2244: Redundant element initialization at index '''. Object initializer
 # has another element initializer with the same index that overwrites this value
-dotnet_diagnostic.CA2244.severity = none
+dotnet_diagnostic.ca2244.severity = none
 
 # CA2201: Exception type System.Exception is not sufficiently specific
-dotnet_diagnostic.CA2201.severity = none
+dotnet_diagnostic.ca2201.severity = none
 
 # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = none
+dotnet_diagnostic.ca2208.severity = none
 
 # CA1014: Mark assemblies with CLSCompliantAttribute
-dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.ca1014.severity = none
 
 # CA2208: Instantiate argument exceptions correctly
-dotnet_diagnostic.CA2208.severity = none
+dotnet_diagnostic.ca2208.severity = none
 
 #
 # Test project rules
@@ -325,7 +334,7 @@ dotnet_diagnostic.CA2208.severity = none
 [**/tests/**/*.cs]
 
 # CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.ca1707.severity = none
 
 #
 # IntegrationTests project rules
@@ -334,7 +343,7 @@ dotnet_diagnostic.CA1707.severity = none
 [**/integrationTests/**/*.cs]
 
 # CA1707: Identifiers should not contain underscores
-dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.ca1707.severity = none
 
 #
 # Examples project rules
@@ -343,4 +352,4 @@ dotnet_diagnostic.CA1707.severity = none
 [**/examples/**/*.cs]
 
 # CA1014: Mark assemblies with CLSCompliant
-dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.ca1014.severity = none

--- a/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
@@ -144,16 +144,18 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         }
 
 #if Windows
+#pragma warning disable CA1825
         [Theory]
         [MemberData(nameof(GetTestData))]
         public void GetChar_GivenHidCode_ReturnsCorrectChar(KeyboardLayout layout, (char, byte)[] testData)
         {
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             foreach ((char ch, byte code) item in testData)
             {
                 Assert.Equal(item.ch, hid[item.code]);
             }
         }
+#pragma warning restore CA1825
 #endif
 
         public static IEnumerable<object[]> GetTestData()

--- a/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidTranslatorTests.cs
@@ -32,7 +32,7 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         [InlineData(KeyboardLayout.sv_SE)]
         public void GetHidCodes_GivenKeyboardLayout_ReturnsCorrectInstance(KeyboardLayout layout)
         {
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             Assert.Equal(layout, hid.Layout);
         }
 
@@ -46,7 +46,7 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         [InlineData(KeyboardLayout.sv_SE, new byte[] { 0x9c, 0x18, 0x05, 0x0c, 0x06, 0x12, 0x9e })]
         public void GetHidCodes_GivenString_ReturnsCorrectCodes(KeyboardLayout layout, byte[] expected)
         {
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             string s = "Yubico!";
             byte[] actual = hid.GetHidCodes(s);
             Assert.Equal(expected, actual);
@@ -62,7 +62,7 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         [InlineData(KeyboardLayout.sv_SE, new byte[] { 0x9c, 0x18, 0x05, 0x0c, 0x06, 0x12, 0x9e })]
         public void GetHidCodes_GivenCharArray_ReturnsCorrectCodes(KeyboardLayout layout, byte[] expected)
         {
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             char[] s = { 'Y', 'u', 'b', 'i', 'c', 'o', '!' };
             byte[] actual = hid.GetHidCodes(s);
             Assert.Equal(expected, actual);
@@ -79,7 +79,7 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         public void GetString_GivenHidCodes_ReturnsCorrectString(KeyboardLayout layout, byte[] input)
         {
             string expected = "Yubico!";
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(layout);
+            var hid = HidCodeTranslator.GetInstance(layout);
             string actual = hid.GetString(input);
             Assert.Equal(expected, actual);
         }
@@ -97,8 +97,8 @@ namespace Yubico.Core.Devices.Hid.UnitTests
             // Since ModHex is a subset of all supported keyboard layouts, this
             // will confirm that all ModHex HID codes are the same in non-ModHex
             // layouts.
-            HidCodeTranslator testHid = HidCodeTranslator.GetInstance(layout);
-            HidCodeTranslator modHexHid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
+            var testHid = HidCodeTranslator.GetInstance(layout);
+            var modHexHid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
             foreach (byte code in modHexHid.SupportedHidCodes)
             {
                 Assert.Equal(modHexHid[code], testHid[code]);
@@ -117,8 +117,8 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         {
             // Since ModHex is a subset of all keyboard layouts, this will confirm
             // that all ModHex chars are the same in non-ModHex layouts.
-            HidCodeTranslator testHid = HidCodeTranslator.GetInstance(layout);
-            HidCodeTranslator modHexHid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
+            var testHid = HidCodeTranslator.GetInstance(layout);
+            var modHexHid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
             foreach (char ch in modHexHid.SupportedCharacters)
             {
                 Assert.Equal(modHexHid[ch], testHid[ch]);
@@ -137,7 +137,7 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         {
             // Since ModHex is a subset of all keyboard layouts, this will confirm
             // that all ModHex chars are the same in non-ModHex layouts.
-            HidCodeTranslator hid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
+            var hid = HidCodeTranslator.GetInstance(KeyboardLayout.ModHex);
             byte[] modHexCodes = hid.SupportedHidCodes;
             string decoded = HidCodeTranslator.GetInstance(layout).GetString(modHexCodes);
             Assert.Equal(hid.SupportedCharactersString, decoded);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
@@ -179,7 +179,7 @@ namespace Yubico.YubiKey
                 {
                     IHidDevice { UsagePage: HidUsagePage.Fido } d => new FidoConnection(d),
                     IHidDevice { UsagePage: HidUsagePage.Keyboard } d => new KeyboardConnection(d),
-                    ISmartCardDevice d => new CcidConnection(d, application),
+                    ISmartCardDevice d => new SmartcardConnection(d, application),
                     _ => throw new NotSupportedException(ExceptionMessages.DeviceTypeNotRecognized)
                 };
 
@@ -266,7 +266,7 @@ namespace Yubico.YubiKey
                     return false;
                 }
 
-                connection = new CcidConnection(smartCardDevice, applicationId);
+                connection = new SmartcardConnection(smartCardDevice, applicationId);
                 _ = _openConnections.Add(yubiKeyDevice);
             }
             finally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionManager.cs
@@ -179,7 +179,7 @@ namespace Yubico.YubiKey
                 {
                     IHidDevice { UsagePage: HidUsagePage.Fido } d => new FidoConnection(d),
                     IHidDevice { UsagePage: HidUsagePage.Keyboard } d => new KeyboardConnection(d),
-                    ISmartCardDevice d => new SmartcardConnection(d, application),
+                    ISmartCardDevice d => new SmartCardConnection(d, application),
                     _ => throw new NotSupportedException(ExceptionMessages.DeviceTypeNotRecognized)
                 };
 
@@ -266,7 +266,7 @@ namespace Yubico.YubiKey
                     return false;
                 }
 
-                connection = new SmartcardConnection(smartCardDevice, applicationId);
+                connection = new SmartCardConnection(smartCardDevice, applicationId);
                 _ = _openConnections.Add(yubiKeyDevice);
             }
             finally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
@@ -50,9 +50,9 @@ namespace Yubico.YubiKey
                 if (response.Status == ResponseStatus.Success)
                 {
                     Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
-                    foreach ((int tag, ReadOnlyMemory<byte> value) in tlvData)
+                    foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tlv in tlvData)
                     {
-                        pages.Add(tag, value);
+                        pages.Add(tlv.Key, tlv.Value);
                     }
 
                     const int moreDataTag = 0x10;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
@@ -1,0 +1,111 @@
+﻿// Copyright 2023 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Logging;
+using Yubico.Core.Tlv;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey
+{
+    internal static class DeviceInfoHelper
+    {
+        /// <summary>
+        /// Fetches and aggregates device configuration details from a YubiKey using multiple APDU commands,
+        /// paging through the data as needed until all configuration data is retrieved.
+        /// This method processes the responses, accumulating TLV-encoded data into a single dictionary.
+        /// </summary>
+        /// <typeparam name="T">The type of the YubiKey response which must include data.</typeparam>
+        /// <param name="connection">The connection interface to communicate with a YubiKey.</param>
+        /// <param name="command">The command to be sent to the YubiKey. This command should be capable of handling pagination.</param>
+        /// <returns>A YubiKeyDeviceInfo object containing all relevant device information.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the command fails to retrieve successful response statuses from the YubiKey.</exception>
+        public static YubiKeyDeviceInfo GetDeviceInfo<T>(
+            IYubiKeyConnection connection,
+            IPagedGetDeviceInfoCommand<T> command) 
+            where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+        {
+            Logger log = Log.GetLogger();
+            
+            int page = 0;
+            var pages = new Dictionary<int, ReadOnlyMemory<byte>>();
+            
+            bool hasMoreData = true;
+            while (hasMoreData)
+            {
+                command.Page = (byte)page++;
+                T response = connection.SendCommand(command);
+                if (response.Status == ResponseStatus.Success)
+                {
+                    Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
+                    foreach ((int tag, ReadOnlyMemory<byte> value) in tlvData)
+                    {
+                        pages.Add(tag, value);
+                    }
+
+                    const int moreDataTag = 0x10;
+                    hasMoreData = tlvData.TryGetValue(moreDataTag, out ReadOnlyMemory<byte> hasMoreDataByte)
+                        && hasMoreDataByte.Span.Length == 1
+                        && hasMoreDataByte.Span[0] == 1;
+                }
+                else
+                {
+                    log.LogError("Failed to get device info page-{Page}: {Error} {Message}",
+                        page, response.StatusWord, response.StatusMessage);
+
+                    return new YubiKeyDeviceInfo(); // TODO What to return here? Null? Empty? Exception? 
+                }
+            }
+
+            return YubiKeyDeviceInfo.CreateFromResponseData(pages);
+        }
+        
+        /// <summary>
+        /// Attempts to create a dictionary from a TLV-encoded byte array by parsing and extracting tag-value pairs.
+        /// </summary>
+        /// <param name="tlvData">The byte array containing TLV-encoded data.</param>
+        /// <param name="result">When successful, contains a dictionary mapping integer tags to their corresponding values as byte arrays.</param>
+        /// <returns>True if the dictionary was successfully created; false otherwise.</returns>
+        public static bool TryCreateApduDictionaryFromResponseData(
+            ReadOnlyMemory<byte> tlvData, out Dictionary<int, ReadOnlyMemory<byte>> result)
+        {
+            Logger log = Log.GetLogger();
+            result = new Dictionary<int, ReadOnlyMemory<byte>>();
+
+            if (tlvData.IsEmpty)
+            {
+                log.LogWarning("ResponseAPDU data was empty!");
+                return false;
+            }
+
+            int tlvDataLength = tlvData.Span[0];
+            if (tlvDataLength == 0 || 1 + tlvDataLength > tlvData.Length)
+            {
+                log.LogWarning("TLV Data length was out of expected ranges. {Length}", tlvDataLength);
+                return false;
+            }
+
+            var tlvReader = new TlvReader(tlvData.Slice(1, tlvDataLength));
+            while (tlvReader.HasData)
+            {
+                int tag = tlvReader.PeekTag();
+                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                result.Add(tag, value);
+            }
+
+            return true;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/DeviceInfoHelper.cs
@@ -31,7 +31,7 @@ namespace Yubico.YubiKey
         /// <typeparam name="TCommand">The specific type of IGetPagedDeviceInfoCommand, e.g. GetPagedDeviceInfoCommand, which will then allow for returning the appropriate response.</typeparam>
         /// <param name="connection">The connection interface to communicate with a YubiKey.</param>
         /// <returns>A YubiKeyDeviceInfo? object containing all relevant device information if successful, otherwise null.</returns>
-        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(IYubiKeyConnection connection) 
+        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(IYubiKeyConnection connection)
             where TCommand : IGetPagedDeviceInfoCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>>, new()
         {
             int page = 0;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoConnection.cs
@@ -50,7 +50,6 @@ namespace Yubico.YubiKey
             where TResponse : IYubiKeyResponse
         {
             CommandApdu commandApdu = yubiKeyCommand.CreateCommandApdu();
-
             ResponseApdu responseApdu = _apduPipeline.Invoke(commandApdu, yubiKeyCommand.GetType(), typeof(TResponse));
 
             return yubiKeyCommand.CreateResponseForApdu(responseApdu);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -17,7 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
-using Yubico.YubiKey.Management.Commands;
+using Yubico.YubiKey.U2f.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -74,7 +74,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
                 using var connection = new FidoConnection(device);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 
                 log.LogInformation("Successfully read device info via FIDO interface management command.");
                 return true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -74,11 +74,13 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
                 using var connection = new FidoConnection(device);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 
-                log.LogInformation("Successfully read device info via FIDO interface management command.");
-                return true;
-                //TODO Handle exceptions? 
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
+                if (yubiKeyDeviceInfo is {})
+                {
+                    log.LogInformation("Successfully read device info via FIDO interface management command.");
+                    return true;    
+                }
             }
             catch (NotImplementedException e)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -103,7 +103,6 @@ namespace Yubico.YubiKey
                 "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
 
             deviceInfo = null;
-
             return false;
         }
 
@@ -128,7 +127,8 @@ namespace Yubico.YubiKey
                     return true;
                 }
 
-                log.LogError("Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord,
+                log.LogError(
+                    "Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord,
                     response.StatusMessage);
             }
             catch (NotImplementedException e)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -13,12 +13,11 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Microsoft.Extensions.Logging;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -56,7 +55,8 @@ namespace Yubico.YubiKey
                 ykDeviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
+                ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
                 ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.FidoU2f;
             }
@@ -64,25 +64,21 @@ namespace Yubico.YubiKey
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromFido(IHidDevice device, [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromFido(IHidDevice device,
+                                                     [MaybeNullWhen(returnValue: false)]
+                                                     out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
-                using var fidoConnection = new FidoConnection(device);
-
-                U2f.Commands.GetDeviceInfoResponse response = fidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
-
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via FIDO interface management command.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from management application: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                using var connection = new FidoConnection(device);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new GetPagedDeviceInfoCommand());
+                
+                log.LogInformation("Successfully read device info via FIDO interface management command.");
+                return true;
+                //TODO Handle exceptions? 
             }
             catch (NotImplementedException e)
             {
@@ -100,29 +96,38 @@ namespace Yubico.YubiKey
                 ErrorHandler(e, "Must have elevated privileges in Windows to access FIDO device directly.");
             }
 
-            log.LogWarning("Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+            log.LogWarning(
+                "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+
             yubiKeyDeviceInfo = null;
+
             return false;
         }
 
-        private static bool TryGetFirmwareVersionFromFido(IHidDevice device, [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+        private static bool TryGetFirmwareVersionFromFido(IHidDevice device,
+                                                          [MaybeNullWhen(returnValue: false)]
+                                                          out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through FIDO.");
-                using var FidoConnection = new FidoConnection(device);
+                using var fidoConnection = new FidoConnection(device);
 
-                Fido2.Commands.VersionResponse response = FidoConnection.SendCommand(new Fido2.Commands.VersionCommand());
+                Fido2.Commands.VersionResponse response =
+                    fidoConnection.SendCommand(new Fido2.Commands.VersionCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData();
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
-                log.LogError("Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+
+                log.LogError("Reading firmware version via FIDO failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (NotImplementedException e)
             {
@@ -142,10 +147,11 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read firmware version through FIDO.");
             firmwareVersion = null;
+
             return false;
         }
 
-        private static void ErrorHandler(Exception exception, string message)
-            => Log.GetLogger().LogWarning(exception, message);
+        private static void ErrorHandler(Exception exception, string message) =>
+            Log.GetLogger().LogWarning(exception, message);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -71,9 +71,9 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
-                using var FidoConnection = new FidoConnection(device);
+                using var fidoConnection = new FidoConnection(device);
 
-                U2f.Commands.GetDeviceInfoResponse response = FidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
+                U2f.Commands.GetDeviceInfoResponse response = fidoConnection.SendCommand(new U2f.Commands.GetDeviceInfoCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -74,12 +74,12 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
                 using var connection = new FidoConnection(device);
-                
+
                 yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
-                if (yubiKeyDeviceInfo is {})
+                if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via FIDO interface management command.");
-                    return true;    
+                    return true;
                 }
             }
             catch (NotImplementedException e)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -75,7 +75,7 @@ namespace Yubico.YubiKey
                 log.LogInformation("Attempting to read device info via the FIDO interface management command.");
                 using var connection = new FidoConnection(device);
 
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
+                yubiKeyDeviceInfo = GetDeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via FIDO interface management command.");

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
@@ -30,13 +30,17 @@ namespace Yubico.YubiKey
         /// <typeparam name="TCommand">The specific type of IGetPagedDeviceInfoCommand, e.g. GetPagedDeviceInfoCommand, which will then allow for returning the appropriate response.</typeparam>
         /// <param name="connection">The connection interface to communicate with a YubiKey.</param>
         /// <returns>A YubiKeyDeviceInfo? object containing all relevant device information if successful, otherwise null.</returns>
-        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(IYubiKeyConnection connection)
-            where TCommand : IGetPagedDeviceInfoCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>>, new()
+        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(
+            IYubiKeyConnection connection)
+            where TCommand
+            : IGetPagedDeviceInfoCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>>,
+            new()
         {
             int page = 0;
             var combinedPages = new Dictionary<int, ReadOnlyMemory<byte>>();
 
             bool hasMoreData = true;
+
             while (hasMoreData)
             {
                 IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> response =
@@ -45,19 +49,22 @@ namespace Yubico.YubiKey
                 if (response.Status == ResponseStatus.Success)
                 {
                     Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
+
                     foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tlv in tlvData)
                     {
                         combinedPages.Add(tlv.Key, tlv.Value);
                     }
 
                     const int moreDataTag = 0x10;
+
                     hasMoreData = tlvData.TryGetValue(moreDataTag, out ReadOnlyMemory<byte> hasMoreDataByte)
                         && hasMoreDataByte.Span.Length == 1
                         && hasMoreDataByte.Span[0] == 1;
                 }
                 else
                 {
-                    Logger.LogError("Failed to get device info page-{Page}: {Error} {Message}", page,
+                    Logger.LogError(
+                        "Failed to get device info page-{Page}: {Error} {Message}", page,
                         response.StatusWord, response.StatusMessage);
 
                     return null;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
@@ -34,7 +34,7 @@ namespace Yubico.YubiKey
             where TCommand : IGetPagedDeviceInfoCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>>, new()
         {
             int page = 0;
-            var pages = new Dictionary<int, ReadOnlyMemory<byte>>();
+            var combinedPages = new Dictionary<int, ReadOnlyMemory<byte>>();
 
             bool hasMoreData = true;
             while (hasMoreData)
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey
                     Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
                     foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tlv in tlvData)
                     {
-                        pages.Add(tlv.Key, tlv.Value);
+                        combinedPages.Add(tlv.Key, tlv.Value);
                     }
 
                     const int moreDataTag = 0x10;
@@ -64,7 +64,7 @@ namespace Yubico.YubiKey
                 }
             }
 
-            return YubiKeyDeviceInfo.CreateFromResponseData(pages);
+            return YubiKeyDeviceInfo.CreateFromResponseData(combinedPages);
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Collections.Generic;
 using Yubico.Core.Logging;
-using Yubico.Core.Tlv;
 
 namespace Yubico.YubiKey
 {
@@ -66,42 +65,6 @@ namespace Yubico.YubiKey
             }
 
             return YubiKeyDeviceInfo.CreateFromResponseData(pages);
-        }
-
-        /// <summary>
-        /// Attempts to create a dictionary from a TLV-encoded byte array by parsing and extracting tag-value pairs.
-        /// </summary>
-        /// <param name="tlvData">The byte array containing TLV-encoded data.</param>
-        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
-        public static Dictionary<int, ReadOnlyMemory<byte>>? CreateApduDictionaryFromResponseData(
-            ReadOnlyMemory<byte> tlvData)
-        {
-            if (tlvData.IsEmpty)
-            {
-                Logger.LogWarning("ResponseAPDU data was empty!");
-                return null;
-            }
-
-            // Certain transports (such as OTP keyboard) may return a buffer that is larger than the
-            // overall TLV size. We want to make sure we're only parsing over real TLV data here, so
-            // check the first byte to get the overall TLV length and slice accordingly.
-            int tlvDataLength = tlvData.Span[0];
-            if (tlvDataLength == 0 || 1 + tlvDataLength > tlvData.Length)
-            {
-                Logger.LogWarning("TLV Data length was out of expected ranges. {Length}", tlvDataLength);
-                return null;
-            }
-
-            var result = new Dictionary<int, ReadOnlyMemory<byte>>();
-            var tlvReader = new TlvReader(tlvData.Slice(1, tlvDataLength));
-            while (tlvReader.HasData)
-            {
-                int tag = tlvReader.PeekTag();
-                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
-                result.Add(tag, value);
-            }
-
-            return result;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
@@ -19,7 +19,7 @@ using Yubico.Core.Tlv;
 
 namespace Yubico.YubiKey
 {
-    internal static class DeviceInfoHelper
+    internal static class GetDeviceInfoHelper
     {
         private static readonly Logger Logger = Log.GetLogger();
 
@@ -82,6 +82,9 @@ namespace Yubico.YubiKey
                 return null;
             }
 
+            // Certain transports (such as OTP keyboard) may return a buffer that is larger than the
+            // overall TLV size. We want to make sure we're only parsing over real TLV data here, so
+            // check the first byte to get the overall TLV length and slice accordingly.
             int tlvDataLength = tlvData.Span[0];
             if (tlvDataLength == 0 || 1 + tlvDataLength > tlvData.Length)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoResponseHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoResponseHelper.cs
@@ -1,0 +1,90 @@
+// Copyright 2023 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+using Yubico.Core.Logging;
+using Yubico.Core.Tlv;
+
+namespace Yubico.YubiKey
+{
+    internal static class GetDeviceInfoResponseHelper
+    {
+        private static readonly Logger Logger = Log.GetLogger();
+
+        /// <summary>
+        /// Attempts to create a dictionary from a TLV-encoded byte array by parsing and extracting tag-value pairs.
+        /// </summary>
+        /// <param name="tlvData">The byte array containing TLV-encoded data.</param>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        internal static Dictionary<int, ReadOnlyMemory<byte>>? CreateApduDictionaryFromResponseData(
+            ReadOnlyMemory<byte> tlvData)
+        {
+            if (tlvData.IsEmpty)
+            {
+                Logger.LogWarning("ResponseAPDU data was empty!");
+                return null;
+            }
+
+            // Certain transports (such as OTP keyboard) may return a buffer that is larger than the
+            // overall TLV size. We want to make sure we're only parsing over real TLV data here, so
+            // check the first byte to get the overall TLV length and slice accordingly.
+            int tlvDataLength = tlvData.Span[0];
+            if (tlvDataLength == 0 || 1 + tlvDataLength > tlvData.Length)
+            {
+                Logger.LogWarning("TLV Data length was out of expected ranges. {Length}", tlvDataLength);
+                return null;
+            }
+
+            var result = new Dictionary<int, ReadOnlyMemory<byte>>();
+            var tlvReader = new TlvReader(tlvData.Slice(1, tlvDataLength));
+            while (tlvReader.HasData)
+            {
+                int tag = tlvReader.PeekTag();
+                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                result.Add(tag, value);
+            }
+
+            return result;
+        }
+
+        internal static Dictionary<int, ReadOnlyMemory<byte>> ParseResponse(
+            ResponseApdu responseApdu,
+            ResponseStatus status,
+            string statusMessage,
+            string responseClass)
+        {
+            if (status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(statusMessage);
+            }
+
+            if (responseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = responseClass,
+                    ActualDataLength = responseApdu.Data.Length
+                };
+            }
+
+            Dictionary<int, ReadOnlyMemory<byte>>? result = CreateApduDictionaryFromResponseData(responseApdu.Data);
+            return result ?? throw new MalformedYubiKeyResponseException
+            {
+                ResponseClass = responseClass,
+            };
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
@@ -22,5 +22,5 @@ namespace Yubico.YubiKey
         /// </summary>
         public byte Page { get; set; }
     }
-} 
-    
+}
+

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Yubico.YubiKey
+{
+    public interface IGetPagedDeviceInfoCommand<out T> : IYubiKeyCommand<T>
+        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        public byte Page { get; set; }
+
+    }
+} 
+    

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IGetPagedDeviceInfoCommand.cs
@@ -3,11 +3,24 @@ using System.Collections.Generic;
 
 namespace Yubico.YubiKey
 {
+    /// <summary>
+    /// Defines the contract for a command to retrieve paged device information associated with a YubiKey.
+    /// </summary>
+    /// <typeparam name="T">The type of the response expected from the command, which must implement
+    /// the <see cref="IYubiKeyResponseWithData{TData}"/> interface, where TData is a dictionary
+    /// mapping integers to <see cref="ReadOnlyMemory{T}"/> of bytes. This dictionary represents
+    /// the paged data, with each entry corresponding to a different page of Tlv-encoded device information.</typeparam>
+    /// <remarks>
+    /// Implementors should ensure that the command handles pagination correctly and that the <see cref="Page"/>
+    /// property is utilized to request specific pages of device information.
+    /// </remarks>
     public interface IGetPagedDeviceInfoCommand<out T> : IYubiKeyCommand<T>
         where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
+        /// <summary>
+        /// Gets or sets the page number of the device information to retrieve
+        /// </summary>
         public byte Page { get; set; }
-
     }
 } 
     

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
@@ -663,6 +663,14 @@ namespace Yubico.YubiKey
             bool touchEjectEnabled,
             int autoEjectTimeout = 0);
 
+
+        /// <summary>
+        /// Sets the <see cref="IYubiKeyDeviceInfo.IsNfcRestricted"/> on the <see cref="YubiKeyDeviceInfo"/> 
+        /// <exception cref="InvalidOperationException">
+        /// The command failed to complete.
+        /// </exception>
+        /// </summary>
+        /// <param name="enabled">Set this value to true to enable, otherwise false</param>
         void SetIsNfcRestricted(bool enabled);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
@@ -666,11 +666,11 @@ namespace Yubico.YubiKey
 
         /// <summary>
         /// Sets the <see cref="IYubiKeyDeviceInfo.IsNfcRestricted"/> on the <see cref="YubiKeyDeviceInfo"/> 
+        /// </summary>
+        /// <param name="enabled">Set this value to true to enable, otherwise false</param>
         /// <exception cref="InvalidOperationException">
         /// The command failed to complete.
         /// </exception>
-        /// </summary>
-        /// <param name="enabled">Set this value to true to enable, otherwise false</param>
         void SetIsNfcRestricted(bool enabled);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
@@ -662,5 +662,7 @@ namespace Yubico.YubiKey
             byte challengeResponseTimeout,
             bool touchEjectEnabled,
             int autoEjectTimeout = 0);
+
+        void SetIsNfcRestricted(bool enabled);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey
         /// The NFC features that are currently enabled over NFC.
         /// </summary>
         public YubiKeyCapabilities EnabledNfcCapabilities { get; }
-        
+
         /// <summary>
         /// TODO
         /// </summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
@@ -121,7 +121,7 @@ namespace Yubico.YubiKey
         /// Indicates whether or not the YubiKey's configuration has been locked by the user.
         /// </summary>
         public bool ConfigurationLocked { get; }
-        
+
         /// <summary>
         /// Indicates if this device has temporarily disabled NFC.
         /// </summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
@@ -40,11 +40,6 @@ namespace Yubico.YubiKey
         public YubiKeyCapabilities EnabledNfcCapabilities { get; }
 
         /// <summary>
-        /// TODO
-        /// </summary>
-        public bool IsNfcRestricted { get; }
-
-        /// <summary>
         /// The serial number of the YubiKey, if one is present.
         /// </summary>
         public int? SerialNumber { get; }
@@ -126,5 +121,10 @@ namespace Yubico.YubiKey
         /// Indicates whether or not the YubiKey's configuration has been locked by the user.
         /// </summary>
         public bool ConfigurationLocked { get; }
+        
+        /// <summary>
+        /// Indicates if this device has temporarily disabled NFC.
+        /// </summary>
+        public bool IsNfcRestricted { get; }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDeviceInfo.cs
@@ -38,6 +38,11 @@ namespace Yubico.YubiKey
         /// The NFC features that are currently enabled over NFC.
         /// </summary>
         public YubiKeyCapabilities EnabledNfcCapabilities { get; }
+        
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool IsNfcRestricted { get; }
 
         /// <summary>
         /// The serial number of the YubiKey, if one is present.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.Hid;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Otp.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -74,7 +75,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
                 using var connection = new KeyboardConnection(device);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 //TODO Handle exceptions? 
                 return true;
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -75,20 +75,14 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
                 using var connection = new KeyboardConnection(device);
+
                 yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
-                //TODO Handle exceptions? 
-                return true;
-
-                // Otp.Commands.GetDeviceInfoResponse response = keyboardConnection.SendCommand(new Otp.Commands.GetDeviceInfoCommand());
-                //
-                // if (response.Status == ResponseStatus.Success)
-                // {
-                //     yubiKeyDeviceInfo = response.GetData();
-                //     log.LogInformation("Successfully read device info via the keyboard management command.");
-                //     return true;
-                // }
-
-                // log.LogError("Failed to get device info from the keyboard management command: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                if (yubiKeyDeviceInfo is {})
+                {
+                    log.LogInformation("Successfully read device info via the keyboard management command.");
+                    return true;    
+                }
+                
             }
             catch (KeyboardConnectionException e)
             {
@@ -103,7 +97,7 @@ namespace Yubico.YubiKey
                 ErrorHandler(e, "The KeyboardTransform.HandleStatusInstruction has invalid StatusReport format " +
                     "or The GetDeviceInfoResponse.GetData response data length is too long.");
             }
-
+            
             log.LogWarning("Failed to read device info through the keyboard management command. This may be expected for older YubiKeys.");
             yubiKeyDeviceInfo = null;
             return false;
@@ -116,9 +110,9 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read serial number through the keybaord interface.");
-                using var KeyboardConnection = new KeyboardConnection(device);
+                using var keyboardConnection = new KeyboardConnection(device);
 
-                Otp.Commands.GetSerialNumberResponse response = KeyboardConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
+                Otp.Commands.GetSerialNumberResponse response = keyboardConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
@@ -154,9 +148,9 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read firmware version through the keyboard interface.");
-                using var KeyboardConnection = new KeyboardConnection(device);
+                using var keyboardConnection = new KeyboardConnection(device);
 
-                Otp.Commands.ReadStatusResponse response = KeyboardConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
+                Otp.Commands.ReadStatusResponse response = keyboardConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -77,12 +77,12 @@ namespace Yubico.YubiKey
                 using var connection = new KeyboardConnection(device);
 
                 yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
-                if (yubiKeyDeviceInfo is {})
+                if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via the keyboard management command.");
-                    return true;    
+                    return true;
                 }
-                
+
             }
             catch (KeyboardConnectionException e)
             {
@@ -97,7 +97,7 @@ namespace Yubico.YubiKey
                 ErrorHandler(e, "The KeyboardTransform.HandleStatusInstruction has invalid StatusReport format " +
                     "or The GetDeviceInfoResponse.GetData response data length is too long.");
             }
-            
+
             log.LogWarning("Failed to read device info through the keyboard management command. This may be expected for older YubiKeys.");
             yubiKeyDeviceInfo = null;
             return false;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -73,18 +73,21 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
-                using var KeyboardConnection = new KeyboardConnection(device);
+                using var connection = new KeyboardConnection(device);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                //TODO Handle exceptions? 
+                return true;
 
-                Otp.Commands.GetDeviceInfoResponse response = KeyboardConnection.SendCommand(new Otp.Commands.GetDeviceInfoCommand());
+                // Otp.Commands.GetDeviceInfoResponse response = keyboardConnection.SendCommand(new Otp.Commands.GetDeviceInfoCommand());
+                //
+                // if (response.Status == ResponseStatus.Success)
+                // {
+                //     yubiKeyDeviceInfo = response.GetData();
+                //     log.LogInformation("Successfully read device info via the keyboard management command.");
+                //     return true;
+                // }
 
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via the keyboard management command.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from the keyboard management command: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                // log.LogError("Failed to get device info from the keyboard management command: {Error} {Message}", response.StatusWord, response.StatusMessage);
             }
             catch (KeyboardConnectionException e)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -76,7 +76,7 @@ namespace Yubico.YubiKey
                 log.LogInformation("Attempting to read device info via the management command over the keyboard interface.");
                 using var connection = new KeyboardConnection(device);
 
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
+                yubiKeyDeviceInfo = GetDeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via the keyboard management command.");

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
@@ -23,7 +23,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
-    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
+    [Obsolete("This class has been replaced by nameof(GetPagedDeviceInfoCommand)")]
     public class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Management.Commands
@@ -22,6 +23,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public class GetDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
         /// <summary>
@@ -51,7 +52,7 @@ namespace Yubico.YubiKey.Management.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -60,7 +61,7 @@ namespace Yubico.YubiKey.Management.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,75 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Management.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    public sealed class GetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        private const byte GetDeviceInfoInstruction = 0x1D;
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// <see cref="YubiKeyApplication.Management"/>
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Management;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetDeviceInfoCommand"/> class.
+        /// </summary>
+        public GetPagedDeviceInfoCommand()
+        {
+            
+        }
+        
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu
+        {
+            Ins = GetDeviceInfoInstruction,
+            P1 = Page
+        };
+        
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+
+    /// <summary>
+    /// TODO
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    public interface IPagedGetDeviceInfoCommand<T> : IYubiKeyCommand<T> 
+        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+    {
+        public byte Page { get; set; }
+    } 
+    
+    // public interface IPagedGetDeviceInfoCommand : IYubiKeyCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>> 
+    // {
+    //     public byte Page { get; set; }
+    // } 
+}
+

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -27,6 +27,8 @@ namespace Yubico.YubiKey.Management.Commands
     public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;
+        
+        /// <inheritdoc />
         public byte Page { get; set; }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -27,7 +27,7 @@ namespace Yubico.YubiKey.Management.Commands
     public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;
-        
+
         /// <inheritdoc />
         public byte Page { get; set; }
 
@@ -44,16 +44,16 @@ namespace Yubico.YubiKey.Management.Commands
         /// </summary>
         public GetPagedDeviceInfoCommand()
         {
-            
+
         }
-        
+
         /// <inheritdoc />
         public CommandApdu CreateCommandApdu() => new CommandApdu
         {
             Ins = GetDeviceInfoInstruction,
             P1 = Page
         };
-        
+
         /// <inheritdoc />
         public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new GetPagedDeviceInfoResponse(responseApdu);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoCommand.cs
@@ -24,7 +24,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
-    public sealed class GetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0x1D;
         public byte Page { get; set; }
@@ -56,20 +56,5 @@ namespace Yubico.YubiKey.Management.Commands
         public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new GetPagedDeviceInfoResponse(responseApdu);
     }
-
-    /// <summary>
-    /// TODO
-    /// </summary>
-    /// <typeparam name="T"></typeparam>
-    public interface IPagedGetDeviceInfoCommand<T> : IYubiKeyCommand<T> 
-        where T : IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
-    {
-        public byte Page { get; set; }
-    } 
-    
-    // public interface IPagedGetDeviceInfoCommand : IYubiKeyCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>> 
-    // {
-    //     public byte Page { get; set; }
-    // } 
 }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -42,28 +42,6 @@ namespace Yubico.YubiKey.Management.Commands
         /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
         /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
-        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
-        {
-            if (Status != ResponseStatus.Success)
-            {
-                throw new InvalidOperationException(StatusMessage);
-            }
-
-            if (ResponseApdu.Data.Length > 255)
-            {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                    ActualDataLength = ResponseApdu.Data.Length
-                };
-            }
-
-            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-
-            return result ?? throw new MalformedYubiKeyResponseException
-            {
-                ResponseClass = nameof(GetPagedDeviceInfoResponse),
-            };
-        }
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.Management.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
             
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -59,15 +59,12 @@ namespace Yubico.YubiKey.Management.Commands
                 };
             }
 
-            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            
+            return result ?? throw new MalformedYubiKeyResponseException
             {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                };
-            }
-
-            return result;
+                ResponseClass = nameof(GetPagedDeviceInfoResponse),
+            };
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,73 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Management.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse,
+                                            IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu)
+            : base(responseApdu)
+        {
+            
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -22,8 +22,7 @@ namespace Yubico.YubiKey.Management.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
-    public class GetPagedDeviceInfoResponse : YubiKeyResponse,
-                                            IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
         /// <summary>
         /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -42,6 +42,7 @@ namespace Yubico.YubiKey.Management.Commands
         /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
         /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
-        public Dictionary<int, ReadOnlyMemory<byte>> GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
+        public Dictionary<int, ReadOnlyMemory<byte>>
+            GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.Management.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
 
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetPagedDeviceInfoResponse.cs
@@ -34,7 +34,7 @@ namespace Yubico.YubiKey.Management.Commands
         public GetPagedDeviceInfoResponse(ResponseApdu responseApdu)
             : base(responseApdu)
         {
-            
+
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Yubico.YubiKey.Management.Commands
             }
 
             Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-            
+
             return result ?? throw new MalformedYubiKeyResponseException
             {
                 ResponseClass = nameof(GetPagedDeviceInfoResponse),

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -105,7 +105,7 @@ namespace Yubico.YubiKey.Management.Commands
         /// <summary>
         /// Allows setting of the <see cref="YubiKeyDeviceInfo.IsNfcRestricted"/> property
         /// </summary>
-        public bool IsNfcRestricted { get; set; }
+        public bool RestrictNfc { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SetDeviceInfoBaseCommand"/> class.
@@ -121,7 +121,7 @@ namespace Yubico.YubiKey.Management.Commands
             {
                 EnabledUsbCapabilities = baseCommand.EnabledUsbCapabilities;
                 EnabledNfcCapabilities = baseCommand.EnabledNfcCapabilities;
-                IsNfcRestricted = baseCommand.IsNfcRestricted;
+                RestrictNfc = baseCommand.RestrictNfc;
                 ChallengeResponseTimeout = baseCommand.ChallengeResponseTimeout;
                 AutoEjectTimeout = baseCommand.AutoEjectTimeout;
                 DeviceFlags = baseCommand.DeviceFlags;
@@ -251,7 +251,7 @@ namespace Yubico.YubiKey.Management.Commands
                 buffer.WriteValue(ConfigurationUnlockPresentTag, unlockCode);
             }
 
-            if (IsNfcRestricted)
+            if (RestrictNfc)
             {
                 buffer.WriteByte(NfcRestrictedTag, 1);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -101,7 +101,7 @@ namespace Yubico.YubiKey.Management.Commands
         /// updates. Useful if enabling or disabling capabilities.
         /// </summary>
         public bool ResetAfterConfig { get; set; }
-        
+
         /// <summary>
         /// TODO
         /// </summary>
@@ -112,7 +112,7 @@ namespace Yubico.YubiKey.Management.Commands
         /// </summary>
         protected SetDeviceInfoBaseCommand()
         {
-            
+
         }
 
         protected SetDeviceInfoBaseCommand(SetDeviceInfoBaseCommand baseCommand)
@@ -250,7 +250,7 @@ namespace Yubico.YubiKey.Management.Commands
             {
                 buffer.WriteValue(ConfigurationUnlockPresentTag, unlockCode);
             }
-            
+
             if (IsNfcRestricted)
             {
                 buffer.WriteByte(NfcRestrictedTag, 1);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -103,7 +103,7 @@ namespace Yubico.YubiKey.Management.Commands
         public bool ResetAfterConfig { get; set; }
 
         /// <summary>
-        /// TODO
+        /// Allows setting of the <see cref="YubiKeyDeviceInfo.IsNfcRestricted"/> property
         /// </summary>
         public bool IsNfcRestricted { get; set; }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -34,7 +34,6 @@ namespace Yubico.YubiKey.Management.Commands
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
         private const byte NfcRestrictedTag = 0x17;
 
-
         private byte[]? _lockCode;
         private byte[]? _unlockCode;
 
@@ -117,19 +116,21 @@ namespace Yubico.YubiKey.Management.Commands
 
         protected SetDeviceInfoBaseCommand(SetDeviceInfoBaseCommand baseCommand)
         {
-            if (!(baseCommand is null))
+            if (baseCommand is null)
             {
-                EnabledUsbCapabilities = baseCommand.EnabledUsbCapabilities;
-                EnabledNfcCapabilities = baseCommand.EnabledNfcCapabilities;
-                RestrictNfc = baseCommand.RestrictNfc;
-                ChallengeResponseTimeout = baseCommand.ChallengeResponseTimeout;
-                AutoEjectTimeout = baseCommand.AutoEjectTimeout;
-                DeviceFlags = baseCommand.DeviceFlags;
-                ResetAfterConfig = baseCommand.ResetAfterConfig;
-
-                _lockCode = baseCommand._lockCode;
-                _unlockCode = baseCommand._unlockCode;
+                return;
             }
+
+            EnabledUsbCapabilities = baseCommand.EnabledUsbCapabilities;
+            EnabledNfcCapabilities = baseCommand.EnabledNfcCapabilities;
+            ChallengeResponseTimeout = baseCommand.ChallengeResponseTimeout;
+            AutoEjectTimeout = baseCommand.AutoEjectTimeout;
+            DeviceFlags = baseCommand.DeviceFlags;
+            ResetAfterConfig = baseCommand.ResetAfterConfig;
+            RestrictNfc = baseCommand.RestrictNfc;
+
+            _lockCode = baseCommand._lockCode;
+            _unlockCode = baseCommand._unlockCode;
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -32,6 +32,7 @@ namespace Yubico.YubiKey.Management.Commands
         private const byte ConfigurationUnlockPresentTag = 0x0b;
         private const byte ResetAfterConfigTag = 0x0c;
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
+        private const byte NfcRestrictedTag = 0x17;
 
 
         private byte[]? _lockCode;
@@ -100,13 +101,18 @@ namespace Yubico.YubiKey.Management.Commands
         /// updates. Useful if enabling or disabling capabilities.
         /// </summary>
         public bool ResetAfterConfig { get; set; }
-
+        
+        /// <summary>
+        /// TODO
+        /// </summary>
+        public bool IsNfcRestricted { get; set; }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SetDeviceInfoBaseCommand"/> class.
         /// </summary>
         protected SetDeviceInfoBaseCommand()
         {
+            
         }
 
         protected SetDeviceInfoBaseCommand(SetDeviceInfoBaseCommand baseCommand)
@@ -115,6 +121,7 @@ namespace Yubico.YubiKey.Management.Commands
             {
                 EnabledUsbCapabilities = baseCommand.EnabledUsbCapabilities;
                 EnabledNfcCapabilities = baseCommand.EnabledNfcCapabilities;
+                IsNfcRestricted = baseCommand.IsNfcRestricted;
                 ChallengeResponseTimeout = baseCommand.ChallengeResponseTimeout;
                 AutoEjectTimeout = baseCommand.AutoEjectTimeout;
                 DeviceFlags = baseCommand.DeviceFlags;
@@ -242,6 +249,11 @@ namespace Yubico.YubiKey.Management.Commands
             if (_unlockCode is byte[] unlockCode)
             {
                 buffer.WriteValue(ConfigurationUnlockPresentTag, unlockCode);
+            }
+            
+            if (IsNfcRestricted)
+            {
+                buffer.WriteByte(NfcRestrictedTag, 1);
             }
 
             return buffer.Encode();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Otp.Commands
@@ -22,6 +23,7 @@ namespace Yubico.YubiKey.Otp.Commands
     /// <remarks>
     /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
     /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.Otp.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public class GetDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
         /// <summary>
@@ -58,7 +59,7 @@ namespace Yubico.YubiKey.Otp.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -67,7 +68,7 @@ namespace Yubico.YubiKey.Otp.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -33,6 +33,7 @@ namespace Yubico.YubiKey.Otp.Commands
         /// </value>
         public YubiKeyApplication Application => YubiKeyApplication.Otp;
 
+        /// <inheritdoc />
         public byte Page { get; set; }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Yubico.Core.Iso7816;
-using Yubico.YubiKey.Management.Commands;
+
 
 namespace Yubico.YubiKey.Otp.Commands
 {
@@ -21,9 +21,9 @@ namespace Yubico.YubiKey.Otp.Commands
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
     /// <remarks>
-    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// This class has a corresponding partner class <see cref="GetPagedDeviceInfoResponse"/>
     /// </remarks>
-    public class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         /// <summary>
         /// Gets the YubiKeyApplication to which this command belongs.
@@ -36,9 +36,9 @@ namespace Yubico.YubiKey.Otp.Commands
         public byte Page { get; set; }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PagedGetPagedDeviceInfoCommand"/> class.
+        /// Initializes a new instance of the <see cref="GetPagedDeviceInfoCommand"/> class.
         /// </summary>
-        public PagedGetPagedDeviceInfoCommand()
+        public GetPagedDeviceInfoCommand()
         {
             
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,60 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey.Otp.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    public class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.Otp
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Otp;
+
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PagedGetPagedDeviceInfoCommand"/> class.
+        /// </summary>
+        public PagedGetPagedDeviceInfoCommand()
+        {
+            
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu()
+        {
+            Ins = OtpConstants.RequestSlotInstruction,
+            P1 = OtpConstants.GetDeviceInfoSlot,
+            Data = new []{Page}
+        };
+
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+    
+    
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoCommand.cs
@@ -41,7 +41,7 @@ namespace Yubico.YubiKey.Otp.Commands
         /// </summary>
         public GetPagedDeviceInfoCommand()
         {
-            
+
         }
 
         /// <inheritdoc />
@@ -49,13 +49,13 @@ namespace Yubico.YubiKey.Otp.Commands
         {
             Ins = OtpConstants.RequestSlotInstruction,
             P1 = OtpConstants.GetDeviceInfoSlot,
-            Data = new []{Page}
+            Data = new[] { Page }
         };
 
         /// <inheritdoc />
         public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new GetPagedDeviceInfoResponse(responseApdu);
     }
-    
-    
+
+
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.Otp.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
             
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.Otp.Commands
             }
 
             Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-            
+
             return result ?? throw new MalformedYubiKeyResponseException
             {
                 ResponseClass = nameof(GetPagedDeviceInfoResponse),

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -22,8 +22,7 @@ namespace Yubico.YubiKey.Otp.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
-    public class GetPagedDeviceInfoResponse : OtpResponse,
-                                              IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    public class GetPagedDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
         /// <summary>
         /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
@@ -42,28 +41,7 @@ namespace Yubico.YubiKey.Otp.Commands
         /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
         /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
-        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
-        {
-            if (Status != ResponseStatus.Success)
-            {
-                throw new InvalidOperationException(StatusMessage);
-            }
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
 
-            if (ResponseApdu.Data.Length > 255)
-            {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                    ActualDataLength = ResponseApdu.Data.Length
-                };
-            }
-
-            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-
-            return result ?? throw new MalformedYubiKeyResponseException
-            {
-                ResponseClass = nameof(GetPagedDeviceInfoResponse),
-            };
-        }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Otp.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    public class GetPagedDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.Otp.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
 
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetPagedDeviceInfoResponse.cs
@@ -22,7 +22,8 @@ namespace Yubico.YubiKey.Otp.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
-    public class GetPagedDeviceInfoResponse : OtpResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    public class GetPagedDeviceInfoResponse : OtpResponse,
+                                              IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
         /// <summary>
         /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
@@ -33,7 +34,6 @@ namespace Yubico.YubiKey.Otp.Commands
         public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
             base(responseApdu)
         {
-
         }
 
         /// <summary>
@@ -58,15 +58,12 @@ namespace Yubico.YubiKey.Otp.Commands
                 };
             }
 
-            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            
+            return result ?? throw new MalformedYubiKeyResponseException
             {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                };
-            }
-
-            return result;
+                ResponseClass = nameof(GetPagedDeviceInfoResponse),
+            };
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetDataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetDataCommand.cs
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.Piv.Commands
     /// will not need to use this command. For example, if you want to get a
     /// certificate from a YubiKey, use <see cref="PivSession.GetCertificate"/>.
     /// Or if you want to store/retrieve Key History, use
-    /// <see cref="PivSession.ReadObject()"/> and <see cref="PivSession.WriteObject"/>
+    /// <see cref="PivSession.ReadObject{T}()"/> and <see cref="PivSession.WriteObject"/>
     /// along with the <see cref="Piv.Objects.KeyHistory"/> class. Under the
     /// covers, these APIs will ultimately call this command. But the application
     /// that uses the SDK can simply make the specific API calls, rather than use

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/PutDataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/PutDataCommand.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.Piv.Commands
     /// not need to use this command. For example, if you want to put a
     /// certificate onto a YubiKey, use <see cref="PivSession.ImportCertificate"/>.
     /// Or if you want to store/retrieve Key History, use
-    /// <see cref="PivSession.ReadObject()"/> and <see cref="PivSession.WriteObject"/>
+    /// <see cref="PivSession.ReadObject{T}()"/> and <see cref="PivSession.WriteObject"/>
     /// along with the <see cref="Piv.Objects.KeyHistory"/> class. Under the
     /// covers, these APIs will ultimately call this command. But the application
     /// that uses the SDK can simply make the specific API calls, rather than use

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PivDataObject.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PivDataObject.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.Piv.Objects
     /// Data Object.
     /// </summary>
     /// <remarks>
-    /// Generally you will use one of the <see cref="PivSession.ReadObject()"/> methods to
+    /// Generally you will use one of the <see cref="PivSession.ReadObject{T}()"/> methods to
     /// get the specified data out of a YubiKey. The formatted data will be
     /// parsed and the resulting object will present the data in a more readable
     /// form. You can then update the data and call

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
@@ -173,7 +173,7 @@ namespace Yubico.YubiKey.Piv
         /// <xref href="UsersManualPivObjects"> PIV data objects</xref>.
         /// </para>
         /// <para>
-        /// This is the same as the <see cref="ReadObject()"/> method that takes no
+        /// This is the same as the <see cref="ReadObject{T}()"/> method that takes no
         /// arguments, except this one will get the data in the storage location
         /// specified by <c>dataTag</c>, as opposed to the defined data tag for
         /// the class <c>T</c>. This method will still expect the data to be

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
@@ -19,7 +19,7 @@ using Yubico.YubiKey.Scp03;
 
 namespace Yubico.YubiKey
 {
-    internal class Scp03Connection : SmartcardConnection, IScp03YubiKeyConnection
+    internal class Scp03Connection : SmartCardConnection, IScp03YubiKeyConnection
     {
         private bool _disposed;
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System;
 using System.Linq;
 using Yubico.Core.Devices.SmartCard;
 using Yubico.YubiKey.Pipelines;
@@ -20,14 +19,14 @@ using Yubico.YubiKey.Scp03;
 
 namespace Yubico.YubiKey
 {
-    internal class Scp03CcidConnection : CcidConnection, IScp03YubiKeyConnection
+    internal class Scp03Connection : SmartcardConnection, IScp03YubiKeyConnection
     {
         private bool _disposed;
 
         // If an Scp03ApduTransform is used, keep this copy so it can be disposed.
         private readonly Scp03ApduTransform _scp03ApduTransform;
 
-        public Scp03CcidConnection(
+        public Scp03Connection(
             ISmartCardDevice smartCardDevice,
             YubiKeyApplication yubiKeyApplication,
             StaticKeys scp03Keys)
@@ -36,7 +35,7 @@ namespace Yubico.YubiKey
             _scp03ApduTransform = SetObject(yubiKeyApplication, scp03Keys);
         }
 
-        public Scp03CcidConnection(ISmartCardDevice smartCardDevice, byte[] applicationId, StaticKeys scp03Keys)
+        public Scp03Connection(ISmartCardDevice smartCardDevice, byte[] applicationId, StaticKeys scp03Keys)
             : base(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
             YubiKeyApplication setError = YubiKeyApplication.Unknown;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03YubiKeyDevice.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03YubiKeyDevice.cs
@@ -45,12 +45,12 @@ namespace Yubico.YubiKey
 
             if (!(application is null))
             {
-                return new Scp03CcidConnection(GetSmartCardDevice(), (YubiKeyApplication)application, StaticKeys);
+                return new Scp03Connection(GetSmartCardDevice(), (YubiKeyApplication)application, StaticKeys);
             }
 
             if (!(applicationId is null))
             {
-                return new Scp03CcidConnection(GetSmartCardDevice(), applicationId, StaticKeys);
+                return new Scp03Connection(GetSmartCardDevice(), applicationId, StaticKeys);
             }
 
             return null;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
@@ -24,7 +24,7 @@ using Yubico.YubiKey.Pipelines;
 
 namespace Yubico.YubiKey
 {
-    internal class SmartcardConnection : IYubiKeyConnection
+    internal class SmartCardConnection : IYubiKeyConnection
     {
         private readonly Logger _log = Log.GetLogger();
 
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey
 
         public ISelectApplicationData? SelectApplicationData { get; set; }
 
-        protected SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
+        protected SmartCardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
         {
             if (applicationId is null && application == YubiKeyApplication.Unknown)
             {
@@ -53,7 +53,7 @@ namespace Yubico.YubiKey
             _apduPipeline = new CommandChainingTransform(_apduPipeline);
         }
 
-        public SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
+        public SmartCardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
             : this(smartCardDevice, yubiKeyApplication, null)
         {
             if (yubiKeyApplication == YubiKeyApplication.Fido2)
@@ -67,7 +67,7 @@ namespace Yubico.YubiKey
             SelectApplication();
         }
 
-        public SmartcardConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
+        public SmartCardConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
             : this(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
             if (applicationId.SequenceEqual(YubiKeyApplication.Fido2.GetIso7816ApplicationId()))

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -88,10 +88,13 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management application.");
                 using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
+                
                 yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
-
-                log.LogInformation("Successfully read device info via management application.");
-                return true;
+                if (yubiKeyDeviceInfo is {})
+                {
+                    log.LogInformation("Successfully read device info via management application.");
+                    return true;    
+                }
             }
             catch (Core.Iso7816.ApduException e)
             {
@@ -103,7 +106,6 @@ namespace Yubico.YubiKey
                 "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
 
             yubiKeyDeviceInfo = null;
-
             return false;
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -88,12 +88,12 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management application.");
                 using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
-                
+
                 yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
-                if (yubiKeyDeviceInfo is {})
+                if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via management application.");
-                    return true;    
+                    return true;
                 }
             }
             catch (Core.Iso7816.ApduException e)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -89,7 +89,7 @@ namespace Yubico.YubiKey
                 log.LogInformation("Attempting to read device info via the management application.");
                 using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
 
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
+                yubiKeyDeviceInfo = GetDeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
                 if (yubiKeyDeviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via management application.");

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -67,67 +67,74 @@ namespace Yubico.YubiKey
                 ykDeviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
+                ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
-                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath | YubiKeyCapabilities.OpenPgp | YubiKeyCapabilities.Piv | YubiKeyCapabilities.Ccid;
+                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath | YubiKeyCapabilities.OpenPgp |
+                    YubiKeyCapabilities.Piv | YubiKeyCapabilities.Ccid;
             }
 
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device, [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device,
+                                                           [MaybeNullWhen(returnValue: false)]
+                                                           out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read device info via the management application.");
-                using var smartCardConnection = new CcidConnection(device, YubiKeyApplication.Management);
+                using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
 
-                Management.Commands.GetDeviceInfoResponse response = smartCardConnection.SendCommand(new Management.Commands.GetDeviceInfoCommand());
-
-                if (response.Status == ResponseStatus.Success)
-                {
-                    yubiKeyDeviceInfo = response.GetData();
-                    log.LogInformation("Successfully read device info via management application.");
-                    return true;
-                }
-
-                log.LogError("Failed to get device info from the management application: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogInformation("Successfully read device info via management application.");
+                return true;
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get device info from management.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get device info from management.");
             }
 
-            log.LogWarning("Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+            log.LogWarning(
+                "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
+
             yubiKeyDeviceInfo = null;
+
             return false;
         }
 
         private static bool TryGetFirmwareVersionFromOtp(ISmartCardDevice device,
-            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+                                                         [MaybeNullWhen(returnValue: false)]
+                                                         out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through OTP.");
-                using var ccidConnection = new CcidConnection(device, YubiKeyApplication.Otp);
+                using var ccidConnection = new SmartcardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.ReadStatusResponse response = ccidConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
+                Otp.Commands.ReadStatusResponse response =
+                    ccidConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData().FirmwareVersion;
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
-                log.LogError("Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+
+                log.LogError("Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get firmware version from OTP.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get firmware version from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
             {
@@ -136,18 +143,20 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read firmware version through OTP. This may be expected over USB.");
             firmwareVersion = null;
+
             return false;
         }
 
         private static bool TryGetFirmwareVersionFromPiv(ISmartCardDevice device,
-            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+                                                         [MaybeNullWhen(returnValue: false)]
+                                                         out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through the PIV application.");
-                using IYubiKeyConnection connection = new CcidConnection(device, YubiKeyApplication.Piv);
+                using IYubiKeyConnection connection = new SmartcardConnection(device, YubiKeyApplication.Piv);
 
                 Piv.Commands.VersionResponse response = connection.SendCommand(new Piv.Commands.VersionCommand());
 
@@ -155,18 +164,22 @@ namespace Yubico.YubiKey
                 {
                     firmwareVersion = response.GetData();
                     log.LogInformation("Firmware version: {Version}", firmwareVersion.ToString());
+
                     return true;
                 }
 
-                log.LogError("Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get firmware version from PIV.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get firmware version from PIV.");
             }
 
             log.LogWarning("Failed to read firmware version through PIV.");
             firmwareVersion = null;
+
             return false;
         }
 
@@ -177,22 +190,26 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read serial number through the OTP application.");
-                using var ccidConnection = new CcidConnection(device, YubiKeyApplication.Otp);
+                using var ccidConnection = new SmartcardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.GetSerialNumberResponse response = ccidConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
+                Otp.Commands.GetSerialNumberResponse response =
+                    ccidConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
                     log.LogInformation("Serial number: {SerialNumber}", serialNumber);
+
                     return true;
                 }
 
-                log.LogError("Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get serial number from OTP.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get serial number from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
             {
@@ -202,6 +219,7 @@ namespace Yubico.YubiKey
 
             log.LogWarning("Failed to read serial number through OTP.");
             serialNumber = null;
+
             return false;
         }
 
@@ -212,30 +230,35 @@ namespace Yubico.YubiKey
             try
             {
                 log.LogInformation("Attempting to read serial number through the PIV application.");
-                using IYubiKeyConnection connection = new CcidConnection(device, YubiKeyApplication.Piv);
+                using IYubiKeyConnection connection = new SmartcardConnection(device, YubiKeyApplication.Piv);
 
-                Piv.Commands.GetSerialNumberResponse response = connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
+                Piv.Commands.GetSerialNumberResponse response =
+                    connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
                     log.LogInformation("Serial number: {SerialNumber}", serialNumber);
+
                     return true;
                 }
 
-                log.LogError("Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord, response.StatusMessage);
+                log.LogError("Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord,
+                    response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e, "An ISO 7816 application has encountered an error when trying to get serial number from PIV.");
+                ErrorHandler(e,
+                    "An ISO 7816 application has encountered an error when trying to get serial number from PIV.");
             }
 
             log.LogWarning("Failed to read serial number through PIV.");
             serialNumber = null;
+
             return false;
         }
 
-        private static void ErrorHandler(Exception exception, string message)
-            => Log.GetLogger().LogWarning(exception, message);
+        private static void ErrorHandler(Exception exception, string message) =>
+            Log.GetLogger().LogWarning(exception, message);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -23,7 +23,8 @@ namespace Yubico.YubiKey
 {
     internal static class SmartCardDeviceInfoFactory
     {
-        public static YubiKeyDeviceInfo GetDeviceInfo(ISmartCardDevice device)
+        public static YubiKeyDeviceInfo GetDeviceInfo(
+            ISmartCardDevice device)
         {
             Logger log = Log.GetLogger();
 
@@ -71,10 +72,10 @@ namespace Yubico.YubiKey
             if (deviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
                 deviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
-                deviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath | 
-                YubiKeyCapabilities.OpenPgp |
-                YubiKeyCapabilities.Piv | 
-                YubiKeyCapabilities.Ccid;
+                deviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Oath |
+                    YubiKeyCapabilities.OpenPgp |
+                    YubiKeyCapabilities.Piv |
+                    YubiKeyCapabilities.Ccid;
             }
 
             return deviceInfo;
@@ -92,15 +93,18 @@ namespace Yubico.YubiKey
                 using var connection = new SmartCardConnection(device, YubiKeyApplication.Management);
 
                 deviceInfo = GetDeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
+
                 if (deviceInfo is { })
                 {
                     log.LogInformation("Successfully read device info via management application.");
+
                     return true;
                 }
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e,
+                ErrorHandler(
+                    e,
                     "An ISO 7816 application has encountered an error when trying to get device info from management.");
             }
 
@@ -108,12 +112,13 @@ namespace Yubico.YubiKey
                 "Failed to read device info through the management interface. This may be expected for older YubiKeys.");
 
             deviceInfo = null;
+
             return false;
         }
 
-        private static bool TryGetFirmwareVersionFromOtp(ISmartCardDevice device,
-                                                         [MaybeNullWhen(returnValue: false)]
-                                                         out FirmwareVersion firmwareVersion)
+        private static bool TryGetFirmwareVersionFromOtp(
+            ISmartCardDevice device,
+            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
@@ -133,12 +138,14 @@ namespace Yubico.YubiKey
                     return true;
                 }
 
-                log.LogError("Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord,
+                log.LogError(
+                    "Reading firmware version via OTP failed with: {Error} {Message}", response.StatusWord,
                     response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e,
+                ErrorHandler(
+                    e,
                     "An ISO 7816 application has encountered an error when trying to get firmware version from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
@@ -153,7 +160,8 @@ namespace Yubico.YubiKey
         }
 
         private static bool TryGetFirmwareVersionFromPiv(
-            ISmartCardDevice device, [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
+            ISmartCardDevice device,
+            [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
         {
             Logger log = Log.GetLogger();
 
@@ -172,12 +180,14 @@ namespace Yubico.YubiKey
                     return true;
                 }
 
-                log.LogError("Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord,
+                log.LogError(
+                    "Reading firmware version via PIV failed with: {Error} {Message}", response.StatusWord,
                     response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e,
+                ErrorHandler(
+                    e,
                     "An ISO 7816 application has encountered an error when trying to get firmware version from PIV.");
             }
 
@@ -187,7 +197,9 @@ namespace Yubico.YubiKey
             return false;
         }
 
-        private static bool TryGetSerialNumberFromOtp(ISmartCardDevice device, out int? serialNumber)
+        private static bool TryGetSerialNumberFromOtp(
+            ISmartCardDevice device,
+            out int? serialNumber)
         {
             Logger log = Log.GetLogger();
 
@@ -207,12 +219,14 @@ namespace Yubico.YubiKey
                     return true;
                 }
 
-                log.LogError("Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord,
+                log.LogError(
+                    "Reading serial number via OTP failed with: {Error} {Message}", response.StatusWord,
                     response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e,
+                ErrorHandler(
+                    e,
                     "An ISO 7816 application has encountered an error when trying to get serial number from OTP.");
             }
             catch (MalformedYubiKeyResponseException e)
@@ -227,7 +241,9 @@ namespace Yubico.YubiKey
             return false;
         }
 
-        private static bool TryGetSerialNumberFromPiv(ISmartCardDevice device, out int? serialNumber)
+        private static bool TryGetSerialNumberFromPiv(
+            ISmartCardDevice device,
+            out int? serialNumber)
         {
             Logger log = Log.GetLogger();
 
@@ -247,12 +263,14 @@ namespace Yubico.YubiKey
                     return true;
                 }
 
-                log.LogError("Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord,
+                log.LogError(
+                    "Reading serial number via PIV failed with: {Error} {Message}", response.StatusWord,
                     response.StatusMessage);
             }
             catch (Core.Iso7816.ApduException e)
             {
-                ErrorHandler(e,
+                ErrorHandler(
+                    e,
                     "An ISO 7816 application has encountered an error when trying to get serial number from PIV.");
             }
 
@@ -262,7 +280,9 @@ namespace Yubico.YubiKey
             return false;
         }
 
-        private static void ErrorHandler(Exception exception, string message) =>
+        private static void ErrorHandler(
+            Exception exception,
+            string message) =>
             Log.GetLogger().LogWarning(exception, message);
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -17,6 +17,7 @@ using System.Diagnostics.CodeAnalysis;
 using Yubico.Core.Devices.SmartCard;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.DeviceExtensions;
+using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey
 {
@@ -77,9 +78,9 @@ namespace Yubico.YubiKey
             return ykDeviceInfo;
         }
 
-        private static bool TryGetDeviceInfoFromManagement(ISmartCardDevice device,
-                                                           [MaybeNullWhen(returnValue: false)]
-                                                           out YubiKeyDeviceInfo yubiKeyDeviceInfo)
+        private static bool TryGetDeviceInfoFromManagement(
+            ISmartCardDevice device,
+            [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
         {
             Logger log = Log.GetLogger();
 
@@ -87,7 +88,7 @@ namespace Yubico.YubiKey
             {
                 log.LogInformation("Attempting to read device info via the management application.");
                 using var connection = new SmartcardConnection(device, YubiKeyApplication.Management);
-                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo(connection, new Management.Commands.GetPagedDeviceInfoCommand());
+                yubiKeyDeviceInfo = DeviceInfoHelper.GetDeviceInfo<GetPagedDeviceInfoCommand>(connection);
 
                 log.LogInformation("Successfully read device info via management application.");
                 return true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
@@ -24,7 +24,7 @@ using Yubico.YubiKey.Pipelines;
 
 namespace Yubico.YubiKey
 {
-    internal class CcidConnection : IYubiKeyConnection
+    internal class SmartcardConnection : IYubiKeyConnection
     {
         private readonly Logger _log = Log.GetLogger();
 
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey
 
         public ISelectApplicationData? SelectApplicationData { get; set; }
 
-        protected CcidConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
+        protected SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication application, byte[]? applicationId)
         {
             if (applicationId is null && application == YubiKeyApplication.Unknown)
             {
@@ -53,7 +53,7 @@ namespace Yubico.YubiKey
             _apduPipeline = new CommandChainingTransform(_apduPipeline);
         }
 
-        public CcidConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
+        public SmartcardConnection(ISmartCardDevice smartCardDevice, YubiKeyApplication yubiKeyApplication)
             : this(smartCardDevice, yubiKeyApplication, null)
         {
             if (yubiKeyApplication == YubiKeyApplication.Fido2)
@@ -67,7 +67,7 @@ namespace Yubico.YubiKey
             SelectApplication();
         }
 
-        public CcidConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
+        public SmartcardConnection(ISmartCardDevice smartCardDevice, byte[] applicationId)
             : this(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
             if (applicationId.SequenceEqual(YubiKeyApplication.Fido2.GetIso7816ApplicationId()))

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartcardConnection.cs
@@ -136,7 +136,7 @@ namespace Yubico.YubiKey
 
         public TResponse SendCommand<TResponse>(IYubiKeyCommand<TResponse> yubiKeyCommand) where TResponse : IYubiKeyResponse
         {
-            using (IDisposable transaction = _smartCardConnection.BeginTransaction(out bool cardWasReset))
+            using (IDisposable _ = _smartCardConnection.BeginTransaction(out bool cardWasReset))
             {
                 if (cardWasReset)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
@@ -21,7 +21,8 @@ namespace Yubico.YubiKey.U2f.Commands
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
     /// <remarks>
-    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// THIS CLASS IS OBSOLETE. 
+    /// It has been replaced by <see cref="GetPagedDeviceInfoResponse"/>
     /// </remarks>
     [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public sealed class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.U2f.Commands
@@ -19,6 +20,10 @@ namespace Yubico.YubiKey.U2f.Commands
     /// <summary>
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
+    /// <remarks>
+    /// This class has a corresponding partner class <see cref="GetDeviceInfoResponse"/>
+    /// </remarks>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoCommand")]
     public sealed class GetDeviceInfoCommand : IYubiKeyCommand<GetDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0xC2;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
@@ -21,6 +21,7 @@ namespace Yubico.YubiKey.U2f.Commands
     /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
     /// device configuration details.
     /// </summary>
+    [Obsolete("This class has been replaced by GetPagedDeviceInfoResponse")]
     public sealed class GetDeviceInfoResponse : U2fResponse, IYubiKeyResponseWithData<YubiKeyDeviceInfo>
     {
 
@@ -51,7 +52,7 @@ namespace Yubico.YubiKey.U2f.Commands
 
             if (ResponseApdu.Data.Length > 255)
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                     ActualDataLength = ResponseApdu.Data.Length
@@ -60,7 +61,7 @@ namespace Yubico.YubiKey.U2f.Commands
 
             if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
             {
-                throw new MalformedYubiKeyResponseException()
+                throw new MalformedYubiKeyResponseException
                 {
                     ResponseClass = nameof(GetDeviceInfoResponse),
                 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -1,0 +1,55 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Management.Commands;
+
+namespace Yubico.YubiKey.U2f.Commands
+{
+    /// <summary>
+    /// Gets detailed information about the YubiKey and its current configuration.
+    /// </summary>
+    public sealed class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    {
+        private const byte GetDeviceInfoInstruction = 0xC2;
+        public byte Page { get; set; }
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.FidoU2f
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.FidoU2f;
+
+        /// <summary>
+        /// Constructs an instance of the <see cref="PagedGetPagedDeviceInfoCommand" /> class.
+        /// </summary>
+        public PagedGetPagedDeviceInfoCommand()
+        {
+            
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu() => new CommandApdu
+        {
+            Ins = GetDeviceInfoInstruction,
+            Data = new []{ Page }
+        };
+
+        /// <inheritdoc />
+        public GetPagedDeviceInfoResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetPagedDeviceInfoResponse(responseApdu);
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -39,14 +39,14 @@ namespace Yubico.YubiKey.U2f.Commands
         /// </summary>
         public GetPagedDeviceInfoCommand()
         {
-            
+
         }
 
         /// <inheritdoc />
         public CommandApdu CreateCommandApdu() => new CommandApdu
         {
             Ins = GetDeviceInfoInstruction,
-            Data = new []{ Page }
+            Data = new[] { Page }
         };
 
         /// <inheritdoc />

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -13,14 +13,13 @@
 // limitations under the License.
 
 using Yubico.Core.Iso7816;
-using Yubico.YubiKey.Management.Commands;
 
 namespace Yubico.YubiKey.U2f.Commands
 {
     /// <summary>
     /// Gets detailed information about the YubiKey and its current configuration.
     /// </summary>
-    public sealed class PagedGetPagedDeviceInfoCommand : IPagedGetDeviceInfoCommand<GetPagedDeviceInfoResponse>
+    public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0xC2;
         public byte Page { get; set; }
@@ -34,9 +33,9 @@ namespace Yubico.YubiKey.U2f.Commands
         public YubiKeyApplication Application => YubiKeyApplication.FidoU2f;
 
         /// <summary>
-        /// Constructs an instance of the <see cref="PagedGetPagedDeviceInfoCommand" /> class.
+        /// Constructs an instance of the <see cref="GetPagedDeviceInfoCommand" /> class.
         /// </summary>
-        public PagedGetPagedDeviceInfoCommand()
+        public GetPagedDeviceInfoCommand()
         {
             
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoCommand.cs
@@ -22,6 +22,8 @@ namespace Yubico.YubiKey.U2f.Commands
     public sealed class GetPagedDeviceInfoCommand : IGetPagedDeviceInfoCommand<GetPagedDeviceInfoResponse>
     {
         private const byte GetDeviceInfoInstruction = 0xC2;
+
+        /// <inheritdoc />
         public byte Page { get; set; }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -1,0 +1,72 @@
+﻿// Copyright 2021 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.U2f.Commands
+{
+    /// <summary>
+    /// The response to the <see cref="GetDeviceInfoCommand"/> command, containing the YubiKey's
+    /// device configuration details.
+    /// </summary>
+    /// 
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+    {
+        /// <summary>
+        /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The ResponseApdu returned by the YubiKey.
+        /// </param>
+        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+        }
+
+        /// <summary>
+        /// Retrieves and converts the response data from an APDU response into a dictionary of TLV tags and their corresponding values.
+        /// </summary>
+        /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
+        /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
+        {
+            if (Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (ResponseApdu.Data.Length > 255)
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                    ActualDataLength = ResponseApdu.Data.Length
+                };
+            }
+
+            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            {
+                throw new MalformedYubiKeyResponseException
+                {
+                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
+                };
+            }
+
+            return result;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -42,28 +42,6 @@ namespace Yubico.YubiKey.U2f.Commands
         /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
         /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
-        public Dictionary<int, ReadOnlyMemory<byte>> GetData()
-        {
-            if (Status != ResponseStatus.Success)
-            {
-                throw new InvalidOperationException(StatusMessage);
-            }
-
-            if (ResponseApdu.Data.Length > 255)
-            {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                    ActualDataLength = ResponseApdu.Data.Length
-                };
-            }
-
-            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-
-            return result ?? throw new MalformedYubiKeyResponseException
-            {
-                ResponseClass = nameof(GetPagedDeviceInfoResponse),
-            };
-        }
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.U2f.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
 
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.U2f.Commands
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
             
             return result ?? throw new MalformedYubiKeyResponseException
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -23,7 +23,7 @@ namespace Yubico.YubiKey.U2f.Commands
     /// device configuration details.
     /// </summary>
     /// 
-    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> 
+    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
         /// <summary>
         /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.U2f.Commands
             }
 
             Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.CreateApduDictionaryFromResponseData(ResponseApdu.Data);
-            
+
             return result ?? throw new MalformedYubiKeyResponseException
             {
                 ResponseClass = nameof(GetPagedDeviceInfoResponse),

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -23,7 +23,9 @@ namespace Yubico.YubiKey.U2f.Commands
     /// device configuration details.
     /// </summary>
     /// 
-    public class GetPagedDeviceInfoResponse : YubiKeyResponse, IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
+    public class GetPagedDeviceInfoResponse :
+        YubiKeyResponse,
+        IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>
     {
         /// <summary>
         /// Constructs a GetPagedDeviceInfoResponse instance based on a ResponseApdu received from the YubiKey.
@@ -31,7 +33,8 @@ namespace Yubico.YubiKey.U2f.Commands
         /// <param name="responseApdu">
         /// The ResponseApdu returned by the YubiKey.
         /// </param>
-        public GetPagedDeviceInfoResponse(ResponseApdu responseApdu) :
+        public GetPagedDeviceInfoResponse(
+            ResponseApdu responseApdu) :
             base(responseApdu)
         {
         }
@@ -42,6 +45,8 @@ namespace Yubico.YubiKey.U2f.Commands
         /// <returns>A dictionary mapping integer tags to their corresponding values as byte arrays.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the response status is not successful.</exception>
         /// <exception cref="MalformedYubiKeyResponseException">Thrown when the APDU data length exceeds expected bounds or if the data conversion fails.</exception>
-        public Dictionary<int, ReadOnlyMemory<byte>> GetData() => GetDeviceInfoResponseHelper.ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
+        public Dictionary<int, ReadOnlyMemory<byte>> GetData() =>
+            GetDeviceInfoResponseHelper
+                .ParseResponse(ResponseApdu, Status, StatusMessage, nameof(GetPagedDeviceInfoResponse));
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetPagedDeviceInfoResponse.cs
@@ -58,15 +58,12 @@ namespace Yubico.YubiKey.U2f.Commands
                 };
             }
 
-            if (!DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data, out Dictionary<int, ReadOnlyMemory<byte>> result))
+            Dictionary<int, ReadOnlyMemory<byte>>? result = DeviceInfoHelper.TryCreateApduDictionaryFromResponseData(ResponseApdu.Data);
+            
+            return result ?? throw new MalformedYubiKeyResponseException
             {
-                throw new MalformedYubiKeyResponseException
-                {
-                    ResponseClass = nameof(GetPagedDeviceInfoResponse),
-                };
-            }
-
-            return result;
+                ResponseClass = nameof(GetPagedDeviceInfoResponse),
+            };
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -379,7 +379,7 @@ namespace Yubico.YubiKey
                 {
                     _log.LogInformation("Connecting via the SmartCard interface.");
                     WaitForReclaimTimeout(Transport.SmartCard);
-                    return scp03Keys is null 
+                    return scp03Keys is null
                         ? new SmartCardConnection(_smartCardDevice, applicationId)
                         : new Scp03Connection(_smartCardDevice, applicationId, scp03Keys);
                 }
@@ -524,7 +524,7 @@ namespace Yubico.YubiKey
                         CultureInfo.CurrentCulture,
                         ExceptionMessages.NotSupportedByYubiKeyVersion));
             }
-            
+
             var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 RestrictNfc = enabled

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -379,8 +379,8 @@ namespace Yubico.YubiKey
                 {
                     _log.LogInformation("Connecting via the SmartCard interface.");
                     WaitForReclaimTimeout(Transport.SmartCard);
-                    return scp03Keys is null ?
-                        new SmartcardConnection(_smartCardDevice, applicationId)
+                    return scp03Keys is null 
+                        ? new SmartCardConnection(_smartCardDevice, applicationId)
                         : new Scp03Connection(_smartCardDevice, applicationId, scp03Keys);
                 }
 
@@ -426,7 +426,7 @@ namespace Yubico.YubiKey
             {
                 _log.LogInformation("Connecting via the SmartCard interface.");
                 WaitForReclaimTimeout(Transport.SmartCard);
-                return new SmartcardConnection(_smartCardDevice, (YubiKeyApplication)application);
+                return new SmartCardConnection(_smartCardDevice, (YubiKeyApplication)application);
             }
 
             _log.LogInformation("No smart card interface present. Unable to establish connection to YubiKey.");

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool IsNfcRestricted => _yubiKeyInfo.IsNfcRestricted;
-        
+
         /// <inheritdoc />
         public int? SerialNumber => _yubiKeyInfo.SerialNumber;
 
@@ -388,7 +388,7 @@ namespace Yubico.YubiKey
                 _log.LogInformation(
                     (applicationId is null ? "No application given." : "No smart card interface present.") +
                     "Unable to establish connection to YubiKey.");
-                
+
                 return null;
             }
 
@@ -522,7 +522,7 @@ namespace Yubico.YubiKey
             {
                 IsNfcRestricted = enabled
             };
-            
+
             IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
 
             if (setConfigurationResponse.Status != ResponseStatus.Success)
@@ -695,7 +695,7 @@ namespace Yubico.YubiKey
         {
             IYubiKeyConnection? connection = null;
             try
-            {       
+            {
                 IYubiKeyCommand<IYubiKeyResponse> command;
 
                 if (TryConnect(YubiKeyApplication.Management, out connection))

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -515,7 +515,7 @@ namespace Yubico.YubiKey
             }
         }
 
-        //TODO make documentation
+        /// <inheritdoc/>
         public void SetIsNfcRestricted(bool enabled)
         {
             var setCommand = new MgmtCmd.SetDeviceInfoCommand

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -85,7 +85,6 @@ namespace Yubico.YubiKey
         internal bool HasSmartCard => !(_smartCardDevice is null);
         internal bool HasHidFido => !(_hidFidoDevice is null);
         internal bool HasHidKeyboard => !(_hidKeyboardDevice is null);
-
         internal bool IsNfcDevice { get; private set; }
 
         private ISmartCardDevice? _smartCardDevice;
@@ -437,17 +436,17 @@ namespace Yubico.YubiKey
         /// <inheritdoc/>
         public void SetEnabledNfcCapabilities(YubiKeyCapabilities yubiKeyCapabilities)
         {
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 EnabledNfcCapabilities = yubiKeyCapabilities,
                 ResetAfterConfig = true,
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
+            IYubiKeyResponse response = SendConfiguration(command);
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -459,17 +458,17 @@ namespace Yubico.YubiKey
                 throw new InvalidOperationException(ExceptionMessages.MustEnableOneAvailableUsbCapability);
             }
 
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 EnabledUsbCapabilities = yubiKeyCapabilities,
                 ResetAfterConfig = true,
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
+            IYubiKeyResponse response = SendConfiguration(command);
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -481,16 +480,16 @@ namespace Yubico.YubiKey
                 throw new ArgumentOutOfRangeException(nameof(seconds));
             }
 
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 ChallengeResponseTimeout = (byte)seconds,
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
+            IYubiKeyResponse response = SendConfiguration(command);
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -502,48 +501,54 @@ namespace Yubico.YubiKey
                 throw new ArgumentOutOfRangeException(nameof(seconds));
             }
 
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 AutoEjectTimeout = seconds,
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
+            IYubiKeyResponse response = SendConfiguration(command);
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
         /// <inheritdoc/>
         public void SetIsNfcRestricted(bool enabled)
         {
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            if (!this.HasFeature(YubiKeyFeature.ManagementNfcRestricted))
             {
-                IsNfcRestricted = enabled
+                throw new NotSupportedException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.NotSupportedByYubiKeyVersion));
+            }
+            
+            var command = new MgmtCmd.SetDeviceInfoCommand
+            {
+                RestrictNfc = enabled
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
-
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            IYubiKeyResponse response = SendConfiguration(command);
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
         /// <inheritdoc/>
         public void SetDeviceFlags(DeviceFlags deviceFlags)
         {
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand
+            var command = new MgmtCmd.SetDeviceInfoCommand
             {
                 DeviceFlags = deviceFlags,
             };
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
-
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            IYubiKeyResponse response = SendConfiguration(command);
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -568,14 +573,13 @@ namespace Yubico.YubiKey
                     nameof(lockCode));
             }
 
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand();
-            setCommand.SetLockCode(lockCode);
+            var command = new MgmtCmd.SetDeviceInfoCommand();
+            command.SetLockCode(lockCode);
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
-
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            IYubiKeyResponse response = SendConfiguration(command);
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -593,15 +597,15 @@ namespace Yubico.YubiKey
                         nameof(lockCode));
             }
 
-            var setCommand = new MgmtCmd.SetDeviceInfoCommand();
-            setCommand.ApplyLockCode(lockCode);
-            setCommand.SetLockCode(_lockCodeAllZeros.Span);
+            var command = new MgmtCmd.SetDeviceInfoCommand();
+            command.ApplyLockCode(lockCode);
+            command.SetLockCode(_lockCodeAllZeros.Span);
 
-            IYubiKeyResponse setConfigurationResponse = SendConfiguration(setCommand);
+            IYubiKeyResponse response = SendConfiguration(command);
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -653,7 +657,7 @@ namespace Yubico.YubiKey
             }
             #endregion
 
-            IYubiKeyResponse setConfigurationResponse;
+            IYubiKeyResponse response;
 
             // Newer YubiKeys should use SetDeviceInfo
             if (FirmwareVersion.Major >= 5)
@@ -672,7 +676,7 @@ namespace Yubico.YubiKey
                     ResetAfterConfig = true,
                 };
 
-                setConfigurationResponse = SendConfiguration(setDeviceInfoCommand);
+                response = SendConfiguration(setDeviceInfoCommand);
             }
             else
             {
@@ -682,12 +686,12 @@ namespace Yubico.YubiKey
                     touchEjectEnabled,
                     autoEjectTimeout);
 
-                setConfigurationResponse = SendConfiguration(setLegacyDeviceConfigCommand);
+                response = SendConfiguration(setLegacyDeviceConfigCommand);
             }
 
-            if (setConfigurationResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(setConfigurationResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
@@ -75,6 +75,7 @@ namespace Yubico.YubiKey
             Logger log = Log.GetLogger();
 
             log.LogInformation("FindByTransport {Transport}", transport);
+
             if (transport == Transport.None)
             {
                 throw new ArgumentException(ExceptionMessages.InvalidConnectionTypeNone, nameof(transport));
@@ -83,18 +84,14 @@ namespace Yubico.YubiKey
             // If the caller is looking only for HidFido, and this is Windows,
             // and the process is not running elevated, we can't use the YubiKey,
             // so throw an exception.
-            if (transport == Transport.HidFido)
+            if (transport == Transport.HidFido &&
+                SdkPlatformInfo.OperatingSystem == SdkPlatform.Windows &&
+                !SdkPlatformInfo.IsElevated)
             {
-                if (SdkPlatformInfo.OperatingSystem == SdkPlatform.Windows)
-                {
-                    if (!SdkPlatformInfo.IsElevated)
-                    {
-                        throw new UnauthorizedAccessException(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                ExceptionMessages.HidFidoWindowsNotElevated));
-                    }
-                }
+                throw new UnauthorizedAccessException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.HidFidoWindowsNotElevated));
             }
 
             // Return any key that has at least one overlapping available transport with the requested transports.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -40,12 +40,14 @@ namespace Yubico.YubiKey
         private const byte NfcPrePersCapabilitiesTag = 0x0d;
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
         private const byte MoreDataTag = 0x10;
+        private const byte FreeFormTag = 0x11;
+        private const byte HidInitDelay = 0x12;
         private const byte PartNumberTag = 0x13;
         private const byte FipsCapableTag = 0x14;
         private const byte FipsApprovedTag = 0x15;
         private const byte PinComplexityTag = 0x16;
         private const byte NfcRestrictedTag = 0x17;
-        // private const byte ResetBlockedTag = 0x18;
+        private const byte ResetBlockedTag = 0x18;
         private const byte TemplateStorageVersionTag = 0x20;
         private const byte ImageProcessorVersionTag = 0x21;
 
@@ -255,6 +257,9 @@ namespace Yubico.YubiKey
                     case FipsCapableTag:
                     case FipsApprovedTag: 
                     case PinComplexityTag:
+                    case FreeFormTag:
+                    case HidInitDelay: 
+                    case ResetBlockedTag:
                         // Ignore these tags for now
                         break;
         
@@ -263,7 +268,7 @@ namespace Yubico.YubiKey
                         break;
                 }
             }
-
+            
             deviceInfo.IsFipsSeries = deviceInfo.FirmwareVersion >= _fipsFlagInclusiveLowerBound
                     ? fipsSeriesFlag
                     : deviceInfo.IsFipsVersion;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -39,6 +39,7 @@ namespace Yubico.YubiKey
         private const byte NfcPrePersCapabilitiesTag = 0x0d;
         private const byte NfcEnabledCapabilitiesTag = 0x0e;
         private const byte MoreDataTag = 0x10;
+        private const byte NfcRestrictedTag = 0x17;
         private const byte TemplateStorageVersionTag = 0x20;
         private const byte ImageProcessorVersionTag = 0x21;
 
@@ -102,6 +103,8 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool ConfigurationLocked { get; set; }
+        
+        public bool IsNfcRestricted { get; set; }
 
         /// <summary>
         /// Constructs a default instance of YubiKeyDeviceInfo.
@@ -264,6 +267,10 @@ namespace Yubico.YubiKey
                         };
                         log.SensitiveLogInformation("ImageProcessorVersion: {ImageProcessorVersion}", deviceInfo.ImageProcessorVersion.ToString());
                         break;
+                    
+                    case NfcRestrictedTag:
+                        deviceInfo.IsNfcRestricted = tlvReader.ReadByte(NfcRestrictedTag) == 1;
+                        break;
 
                     default:
                         Debug.Assert(false, "Encountered an unrecognized tag in DeviceInfo. Ignoring.");
@@ -299,34 +306,31 @@ namespace Yubico.YubiKey
 
                 IsFipsSeries = IsFipsSeries || second.IsFipsSeries,
 
-                FormFactor =
-                        FormFactor != FormFactor.Unknown
-                        ? FormFactor
-                        : second.FormFactor,
+                FormFactor = FormFactor != FormFactor.Unknown
+                    ? FormFactor
+                    : second.FormFactor,
 
-                FirmwareVersion =
-                        FirmwareVersion != new FirmwareVersion()
-                        ? FirmwareVersion
-                        : second.FirmwareVersion,
+                FirmwareVersion = FirmwareVersion != new FirmwareVersion()
+                    ? FirmwareVersion
+                    : second.FirmwareVersion,
 
-                AutoEjectTimeout =
-                        DeviceFlags.HasFlag(DeviceFlags.TouchEject)
+                AutoEjectTimeout = DeviceFlags.HasFlag(DeviceFlags.TouchEject)
                         ? AutoEjectTimeout
                         : second.DeviceFlags.HasFlag(DeviceFlags.TouchEject)
                             ? second.AutoEjectTimeout
                             : default,
 
-                ChallengeResponseTimeout =
-                        ChallengeResponseTimeout != default
-                        ? ChallengeResponseTimeout
-                        : second.ChallengeResponseTimeout,
+                ChallengeResponseTimeout = ChallengeResponseTimeout != default
+                    ? ChallengeResponseTimeout
+                    : second.ChallengeResponseTimeout,
 
                 DeviceFlags = DeviceFlags | second.DeviceFlags,
 
-                ConfigurationLocked =
-                        ConfigurationLocked != default
-                        ? ConfigurationLocked
-                        : second.ConfigurationLocked,
+                ConfigurationLocked = ConfigurationLocked != default
+                    ? ConfigurationLocked
+                    : second.ConfigurationLocked,
+                
+                IsNfcRestricted = IsNfcRestricted || second.IsNfcRestricted
             };
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -109,7 +109,8 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool ConfigurationLocked { get; set; }
-
+        
+        /// <inheritdoc />
         public bool IsNfcRestricted { get; set; }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -135,6 +135,7 @@ namespace Yubico.YubiKey
         /// True if the parsing and construction was successful, and false if
         /// <paramref name="responseApduData"/> did not meet formatting requirements.
         /// </returns>
+        [Obsolete("This has been replaced by CreateFromResponseData")]
         internal static bool TryCreateFromResponseData(
             ReadOnlyMemory<byte> responseApduData,
             [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo deviceInfo)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -109,7 +109,7 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool ConfigurationLocked { get; set; }
-        
+
         public bool IsNfcRestricted { get; set; }
 
         /// <summary>
@@ -273,7 +273,7 @@ namespace Yubico.YubiKey
                         };
                         log.SensitiveLogInformation("ImageProcessorVersion: {ImageProcessorVersion}", deviceInfo.ImageProcessorVersion.ToString());
                         break;
-                    
+
                     case NfcRestrictedTag:
                         deviceInfo.IsNfcRestricted = tlvReader.ReadByte(NfcRestrictedTag) == 1;
                         break;
@@ -306,13 +306,13 @@ namespace Yubico.YubiKey
         /// <paramref name="responseApduData"/> did not meet formatting requirements.
         /// </returns>
         internal static YubiKeyDeviceInfo CreateFromResponseData(
-            Dictionary<int,ReadOnlyMemory<byte>> responseApduData)
+            Dictionary<int, ReadOnlyMemory<byte>> responseApduData)
         {
             bool fipsSeriesFlag = false;
             bool skySeriesFlag = false;
-            
+
             var deviceInfo = new YubiKeyDeviceInfo();
-            foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tagValuePair in responseApduData)  
+            foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tagValuePair in responseApduData)
             {
                 switch (tagValuePair.Key)
                 {
@@ -388,7 +388,7 @@ namespace Yubico.YubiKey
                             Patch = ipChipVersion[2]
                         };
                         break;
-                    
+
                     case NfcRestrictedTag:
                         deviceInfo.IsNfcRestricted = tagValuePair.Value.Span[0] == 1;
                         break;
@@ -403,7 +403,7 @@ namespace Yubico.YubiKey
                         break;
                 }
             }
-            
+
             deviceInfo.IsFipsSeries = deviceInfo.FirmwareVersion >= _fipsFlagInclusiveLowerBound
                     ? fipsSeriesFlag
                     : deviceInfo.IsFipsVersion;
@@ -412,7 +412,7 @@ namespace Yubico.YubiKey
 
             return deviceInfo;
         }
-        
+
         internal YubiKeyDeviceInfo Merge(YubiKeyDeviceInfo? second)
         {
             second ??= new YubiKeyDeviceInfo();
@@ -454,7 +454,7 @@ namespace Yubico.YubiKey
                 ConfigurationLocked = ConfigurationLocked != default
                     ? ConfigurationLocked
                     : second.ConfigurationLocked,
-                
+
                 IsNfcRestricted = IsNfcRestricted || second.IsNfcRestricted
             };
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -109,7 +109,7 @@ namespace Yubico.YubiKey
 
         /// <inheritdoc />
         public bool ConfigurationLocked { get; set; }
-        
+
         /// <inheritdoc />
         public bool IsNfcRestricted { get; set; }
 
@@ -161,12 +161,11 @@ namespace Yubico.YubiKey
                 return false;
             }
 
-            var tlvReader = new TlvReader(responseApduData.Slice(1, tlvDataLength));
-
             deviceInfo = new YubiKeyDeviceInfo();
             bool fipsSeriesFlag = false;
             bool skySeriesFlag = false;
 
+            var tlvReader = new TlvReader(responseApduData.Slice(1, tlvDataLength));
             while (tlvReader.HasData)
             {
                 switch (tlvReader.PeekTag())

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -17,8 +17,6 @@ using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using Yubico.Core.Logging;
-using Yubico.Core.Tlv;
 
 namespace Yubico.YubiKey
 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -140,16 +140,15 @@ namespace Yubico.YubiKey
             ReadOnlyMemory<byte> responseApduData,
             [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo deviceInfo)
         {
-            Dictionary<int, ReadOnlyMemory<byte>>? data = GetDeviceInfoHelper.CreateApduDictionaryFromResponseData(responseApduData);
-
-            if (data is {})
+            Dictionary<int, ReadOnlyMemory<byte>>? data = GetDeviceInfoResponseHelper.CreateApduDictionaryFromResponseData(responseApduData);
+            if (data is null)
             {
-                deviceInfo = CreateFromResponseData(data);
-                return true;
+                deviceInfo = null;
+                return false;
             }
-
-            deviceInfo = null;
-            return false;
+            
+            deviceInfo = CreateFromResponseData(data);
+            return true;
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
@@ -234,5 +234,10 @@ namespace Yubico.YubiKey
         /// Yubico.YubiKey.YubiHsmAuth namespace.
         /// </summary>
         YubiHsmAuthApplication,
+        
+        /// <summary>
+        /// Allows temporarily disabling NFC (added in 5.7) 
+        /// </summary>
+        ManagementNfcRestricted,
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
@@ -234,7 +234,7 @@ namespace Yubico.YubiKey
         /// Yubico.YubiKey.YubiHsmAuth namespace.
         /// </summary>
         YubiHsmAuthApplication,
-        
+
         /// <summary>
         /// Allows temporarily disabling NFC (added in 5.7) 
         /// </summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
@@ -80,9 +80,9 @@ namespace Yubico.YubiKey
 
                 YubiKeyFeature.ManagementApplication =>
                     yubiKeyDevice.FirmwareVersion >= new FirmwareVersion(5),
-                
+
                 YubiKeyFeature.ManagementNfcRestricted =>
-                    yubiKeyDevice.FirmwareVersion >= new FirmwareVersion(5,7),
+                    yubiKeyDevice.FirmwareVersion >= new FirmwareVersion(5, 7),
 
                 YubiKeyFeature.SerialNumberVisibilityControls =>
                     yubiKeyDevice.FirmwareVersion >= FirmwareVersion.V2_2_0

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
@@ -80,6 +80,9 @@ namespace Yubico.YubiKey
 
                 YubiKeyFeature.ManagementApplication =>
                     yubiKeyDevice.FirmwareVersion >= new FirmwareVersion(5),
+                
+                YubiKeyFeature.ManagementNfcRestricted =>
+                    yubiKeyDevice.FirmwareVersion >= new FirmwareVersion(5,7),
 
                 YubiKeyFeature.SerialNumberVisibilityControls =>
                     yubiKeyDevice.FirmwareVersion >= FirmwareVersion.V2_2_0

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/CommandTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/CommandTests.cs
@@ -59,12 +59,12 @@ namespace Yubico.YubiKey.U2f
         [Trait("Category", "Simple")]
         public void RunGetDeviceInfo()
         {
-            var cmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
+            var cmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            YubiKeyDeviceInfo getData = rsp.GetData();
-            Assert.False(getData.IsFipsSeries);
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
+            Assert.False(deviceInfo.IsFipsSeries);
         }
 
         [Fact]

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/PinTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/PinTests.cs
@@ -67,11 +67,11 @@ namespace Yubico.YubiKey.U2f
                 0x41, 0x42, 0x43, 0x44, 0x45, 0x46
             };
 
-            var cmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
+            var cmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            YubiKeyDeviceInfo getData = rsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
             if (!getData.IsFipsSeries)
             {
                 return;
@@ -121,11 +121,11 @@ namespace Yubico.YubiKey.U2f
                 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37
             };
 
-            var cmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
+            var cmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            YubiKeyDeviceInfo getData = rsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
             if (!getData.IsFipsSeries)
             {
                 return;
@@ -196,14 +196,15 @@ namespace Yubico.YubiKey.U2f
         {
             isFipsMode = false;
 
-            var cmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
+            var cmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse rsp = _fidoConnection.SendCommand(cmd);
             if (rsp.Status != ResponseStatus.Success)
             {
                 return false;
             }
 
-            YubiKeyDeviceInfo getData = rsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
+
             if (!getData.IsFipsSeries ||
                 getData.FirmwareVersion >= new FirmwareVersion(5) ||
                 getData.FirmwareVersion < new FirmwareVersion(4))

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SessionRegisterTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SessionRegisterTests.cs
@@ -51,11 +51,11 @@ namespace Yubico.YubiKey.U2f
             {
                 u2fSession.KeyCollector = keyCollector.SimpleU2fKeyCollectorDelegate;
 
-                var cmd = new GetDeviceInfoCommand();
-                GetDeviceInfoResponse rsp = u2fSession.Connection.SendCommand(cmd);
+                var cmd = new GetPagedDeviceInfoCommand();
+                GetPagedDeviceInfoResponse rsp = u2fSession.Connection.SendCommand(cmd);
                 Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-                YubiKeyDeviceInfo getData = rsp.GetData();
+                var getData = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
                 if (!getData.IsFipsSeries)
                 {
                     return;

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SetDeviceInfoTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SetDeviceInfoTests.cs
@@ -80,11 +80,11 @@ namespace Yubico.YubiKey.U2f
 
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            var getCmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
+            var getCmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
             Assert.Equal(ResponseStatus.Success, getRsp.Status);
 
-            YubiKeyDeviceInfo getData = getRsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(getRsp.GetData());
             Assert.False(getData.IsFipsSeries);
         }
 
@@ -141,11 +141,11 @@ namespace Yubico.YubiKey.U2f
             rsp = _fidoConnection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            var getCmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
+            var getCmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
             Assert.Equal(ResponseStatus.Success, getRsp.Status);
 
-            YubiKeyDeviceInfo getData = getRsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(getRsp.GetData());
             Assert.Equal(0x24, getData.ChallengeResponseTimeout);
         }
 
@@ -160,11 +160,11 @@ namespace Yubico.YubiKey.U2f
             YubiKeyResponse rsp = _fidoConnection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            var getCmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
+            var getCmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse getRsp = _fidoConnection.SendCommand(getCmd);
             Assert.Equal(ResponseStatus.Success, getRsp.Status);
 
-            YubiKeyDeviceInfo getData = getRsp.GetData();
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(getRsp.GetData());
             Assert.False(getData.IsFipsSeries);
         }
     }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SimpleU2fTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/U2f/SimpleU2fTests.cs
@@ -68,12 +68,12 @@ namespace Yubico.YubiKey.U2f
             var connection = new FidoConnection(deviceToUse!);
             Assert.NotNull(connection);
 
-            var cmd = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse rsp = connection.SendCommand(cmd);
+            var cmd = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse rsp = connection.SendCommand(cmd);
             Assert.Equal(ResponseStatus.Success, rsp.Status);
 
-            YubiKeyDeviceInfo deviceInfo = rsp.GetData();
-            Assert.False(deviceInfo.ConfigurationLocked);
+            var getData = YubiKeyDeviceInfo.CreateFromResponseData(rsp.GetData());
+            Assert.False(getData.ConfigurationLocked);
         }
 
         [Fact]
@@ -83,7 +83,7 @@ namespace Yubico.YubiKey.U2f
             HidDevice deviceToUse = GetFidoHid(devices) ?? throw new InvalidOperationException();
             FidoConnection connection = new FidoConnection(deviceToUse) ?? throw new InvalidOperationException();
 
-            CommandApdu cmdApdu = new CommandApdu
+            var cmdApdu = new CommandApdu
             {
                 Ins = 0x77,
             };
@@ -103,7 +103,7 @@ namespace Yubico.YubiKey.U2f
             HidDevice deviceToUse = GetFidoHid(devices) ?? throw new InvalidOperationException();
             FidoConnection connection = new FidoConnection(deviceToUse) ?? throw new InvalidOperationException();
 
-            CommandApdu cmdApdu = new CommandApdu
+            var cmdApdu = new CommandApdu
             {
                 Ins = 0x06,
             };
@@ -176,7 +176,7 @@ namespace Yubico.YubiKey.U2f
             IYubiKeyConnection connection = new FidoConnection(deviceToUse!);
             Assert.NotNull(connection);
 
-            EchoCommand echoCommand = new EchoCommand(sendData);
+            var echoCommand = new EchoCommand(sendData);
 
             EchoResponse echoResponse = connection.SendCommand(echoCommand);
             ReadOnlyMemory<byte> echoData = echoResponse.GetData();

--- a/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
@@ -14,14 +14,8 @@
 
 using System;
 using System.Linq;
-using System.Text;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using Serilog;
-using Yubico.Core.Logging;
-using Yubico.YubiKey.Fido2;
-using Yubico.YubiKey.YubiHsmAuth;
-using Yubico.YubiKey.YubiHsmAuth.Commands;
 
 namespace Yubico.YubiKey.TestApp.Plugins
 {
@@ -44,26 +38,21 @@ namespace Yubico.YubiKey.TestApp.Plugins
                 builder => builder
                     .AddSerilog(log)
                     .AddFilter(level => level >= LogLevel.Information));
+            
+            
+            
+            
+            
+            IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.All).First();
 
-            IYubiKeyDevice? yubiKey = YubiKeyDevice.FindAll().First();
+            // IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.HidFido).First();
 
-            Console.WriteLine($"YubiKey Version: {yubiKey.FirmwareVersion}");
+            Console.Error.WriteLine($"YubiKey Version: {yubiKey.FirmwareVersion}");
+            Console.Error.WriteLine("NFC Before Value: "+ yubiKey.IsNfcRestricted);
 
-            using (var hsmAuth = new YubiHsmAuthSession(yubiKey))
-            {
-                string label = "mycred";
-                byte[] password = new byte[16];
-                Encoding.ASCII.GetBytes("abc123").CopyTo(password, 0);
-                byte[] hostChallenge = { 0, 1, 2, 3, 4, 5, 6, 7 };
-                byte[] hsmDeviceChallenge = { 8, 9, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15 };
-
-                var command = new GetAes128SessionKeysCommand(label, password, hostChallenge, hsmDeviceChallenge);
-
-                Console.WriteLine("Calling calculate...");
-                GetAes128SessionKeysResponse? response = hsmAuth.Connection.SendCommand(command);
-                Console.WriteLine($"Calculate returned with {response.Status}");
-            }
-
+            yubiKey.SetIsNfcRestricted(true);
+            
+            Console.Error.WriteLine("NFC AFter Value: "+ yubiKey.IsNfcRestricted);
             return true;
         }
     }

--- a/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/GregPlugin.cs
@@ -38,21 +38,21 @@ namespace Yubico.YubiKey.TestApp.Plugins
                 builder => builder
                     .AddSerilog(log)
                     .AddFilter(level => level >= LogLevel.Information));
-            
-            
-            
-            
-            
+
+
+
+
+
             IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.All).First();
 
             // IYubiKeyDevice? yubiKey = YubiKeyDevice.FindByTransport(Transport.HidFido).First();
 
             Console.Error.WriteLine($"YubiKey Version: {yubiKey.FirmwareVersion}");
-            Console.Error.WriteLine("NFC Before Value: "+ yubiKey.IsNfcRestricted);
+            Console.Error.WriteLine("NFC Before Value: " + yubiKey.IsNfcRestricted);
 
             yubiKey.SetIsNfcRestricted(true);
-            
-            Console.Error.WriteLine("NFC AFter Value: "+ yubiKey.IsNfcRestricted);
+
+            Console.Error.WriteLine("NFC AFter Value: " + yubiKey.IsNfcRestricted);
             return true;
         }
     }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Management/Commands/SetDeviceInfoCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Management/Commands/SetDeviceInfoCommandTests.cs
@@ -472,5 +472,18 @@ namespace Yubico.YubiKey.Management.Commands
             // Assert
             Assert.True(response is YubiKeyResponse);
         }
+        
+        [Fact]
+        public void CreateCommandApdu_RestrictNfcPresent_EncodesCorrectTlv()
+        {
+            var command = new SetDeviceInfoCommand
+            {
+               RestrictNfc = true
+            };
+            
+            ReadOnlyMemory<byte> data = command.CreateCommandApdu().Data;
+            const int nfcRestrictedTag = 0x17;
+            Assert.Equal(nfcRestrictedTag, data.Span[1]); 
+        }
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Management/Commands/SetDeviceInfoCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Management/Commands/SetDeviceInfoCommandTests.cs
@@ -472,18 +472,18 @@ namespace Yubico.YubiKey.Management.Commands
             // Assert
             Assert.True(response is YubiKeyResponse);
         }
-        
+
         [Fact]
         public void CreateCommandApdu_RestrictNfcPresent_EncodesCorrectTlv()
         {
             var command = new SetDeviceInfoCommand
             {
-               RestrictNfc = true
+                RestrictNfc = true
             };
-            
+
             ReadOnlyMemory<byte> data = command.CreateCommandApdu().Data;
             const int nfcRestrictedTag = 0x17;
-            Assert.Equal(nfcRestrictedTag, data.Span[1]); 
+            Assert.Equal(nfcRestrictedTag, data.Span[1]);
         }
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommandTests.cs
@@ -76,7 +76,7 @@ namespace Yubico.YubiKey.Otp.Commands
             var command = new GetPagedDeviceInfoCommand();
 
             int nc = command.CreateCommandApdu().Nc;
-            
+
             Assert.Equal(1, nc);
         }
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommandTests.cs
@@ -23,7 +23,7 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void CreateCommandApdu_GetClaProperty_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             byte cla = command.CreateCommandApdu().Cla;
 
@@ -33,7 +33,7 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void CreateCommandApdu_GetInsProperty_ReturnsHex01()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             byte ins = command.CreateCommandApdu().Ins;
 
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void CreateCommandApdu_GetP1Property_ReturnsHex13()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             byte p1 = command.CreateCommandApdu().P1;
 
@@ -53,7 +53,7 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void CreateCommandApdu_GetP2Property_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             byte p2 = command.CreateCommandApdu().P2;
 
@@ -61,29 +61,29 @@ namespace Yubico.YubiKey.Otp.Commands
         }
 
         [Fact]
-        public void CreateCommandApdu_GetData_ReturnsEmpty()
+        public void CreateCommandApdu_GetData_WithNewCommand_ReturnsLengthOfOnlyOne()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             ReadOnlyMemory<byte> data = command.CreateCommandApdu().Data;
 
-            Assert.True(data.IsEmpty);
+            Assert.Equal(1, data.Length);
         }
 
         [Fact]
-        public void CreateCommandApdu_GetNc_ReturnsZero()
+        public void CreateCommandApdu_GetNc_WithNewCommand_ReturnsCorrectLengthOfOnlyOne()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             int nc = command.CreateCommandApdu().Nc;
-
-            Assert.Equal(0, nc);
+            
+            Assert.Equal(1, nc);
         }
 
         [Fact]
         public void CreateCommandApdu_GetNe_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             int ne = command.CreateCommandApdu().Ne;
 
@@ -95,13 +95,13 @@ namespace Yubico.YubiKey.Otp.Commands
         {
             // Arrange
             var responseApdu = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             // Act
-            GetDeviceInfoResponse? response = command.CreateResponseForApdu(responseApdu);
+            GetPagedDeviceInfoResponse? response = command.CreateResponseForApdu(responseApdu);
 
             // Assert
-            Assert.True(response is GetDeviceInfoResponse);
+            Assert.NotNull(response);
         }
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponseTests.cs
@@ -18,7 +18,7 @@ using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Otp.Commands
 {
-    public class GetDeviceInfoResponseTests
+    public class GetPagedDeviceInfoResponseTests
     {
         private const byte UsbPrePersCapabilitiesTag = 0x01;
         private const byte SerialNumberTag = 0x02;
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.Otp.Commands
         public void Constructor_GivenNullResponseApdu_ThrowsArgumentNullExceptionFromBase()
         {
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-            static void action() => _ = new GetDeviceInfoResponse(null);
+            static void action() => _ = new GetPagedDeviceInfoResponse(null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             _ = Assert.Throws<ArgumentNullException>(action);
@@ -51,7 +51,7 @@ namespace Yubico.YubiKey.Otp.Commands
             byte sw2 = unchecked((byte)SWConstants.Success);
             var responseApdu = new ResponseApdu(new byte[] { 0, 0, 0, sw1, sw2 });
 
-            var deviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var deviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             Assert.Equal(SWConstants.Success, deviceInfoResponse.StatusWord);
         }
@@ -63,7 +63,7 @@ namespace Yubico.YubiKey.Otp.Commands
             byte sw2 = unchecked((byte)SWConstants.Success);
             var responseApdu = new ResponseApdu(new byte[] { 0, 0, 0, sw1, sw2 });
 
-            var deviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var deviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             Assert.Equal(ResponseStatus.Success, deviceInfoResponse.Status);
         }
@@ -72,7 +72,7 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_ResponseApduFailed_ThrowsInvalidOperationException()
         {
             var responseApdu = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             void action() => _ = getDeviceInfoResponse.GetData();
 
@@ -82,10 +82,11 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void GetData_UsbPrePersCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, UsbPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, UsbPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.AvailableUsbCapabilities);
         }
@@ -94,9 +95,9 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_UsbPrePersCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, UsbPrePersCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.AvailableUsbCapabilities);
         }
@@ -104,10 +105,12 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void GetData_SerialNumberTagPresent_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x06, SerialNumberTag, 0x04, 0x01, 0x02, 0x03, 0x04, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x06, SerialNumberTag, 0x04, 0x01, 0x02, 0x03, 0x04, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(0x01020304, deviceInfo.SerialNumber);
         }
@@ -115,10 +118,12 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void GetData_UsbEnabledCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, UsbEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, UsbEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.EnabledUsbCapabilities);
         }
@@ -127,9 +132,10 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_UsbEnabledCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, UsbEnabledCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.EnabledUsbCapabilities);
         }
@@ -138,10 +144,12 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_FormFactorTagPresent_SetsPropertyCorrectly()
         {
             FormFactor expectedFormFactor = FormFactor.UsbCLightning;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, FormFactorTag, 0x01, (byte)expectedFormFactor, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x03, FormFactorTag, 0x01, (byte)expectedFormFactor, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedFormFactor, deviceInfo.FormFactor);
         }
@@ -150,10 +158,15 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_FirmwareVersionTagPresent_SetsPropertyCorrectly()
         {
             var expectedVersion = new FirmwareVersion() { Major = 0x01, Minor = 0x02, Patch = 0x03 };
-            var responseApdu = new ResponseApdu(new byte[] { 0x05, FirmwareVersionTag, 0x03, expectedVersion.Major, expectedVersion.Minor, expectedVersion.Patch, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+            {
+                0x05, FirmwareVersionTag, 0x03, expectedVersion.Major, expectedVersion.Minor, expectedVersion.Patch,
+                0x90, 0x00
+            });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedVersion, deviceInfo.FirmwareVersion);
         }
@@ -163,9 +176,10 @@ namespace Yubico.YubiKey.Otp.Commands
         {
             short expectedTimeout = 0x1234;
             var responseApdu = new ResponseApdu(new byte[] { 0x04, AutoEjectTimeoutTag, 0x02, 0x12, 0x34, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedTimeout, deviceInfo.AutoEjectTimeout);
         }
@@ -174,10 +188,12 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_ChallengeResponseTimeoutTagPresent_SetsPropertyCorrectly()
         {
             byte expectedTimeout = 0x12;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, ChallengeResponseTimeoutTag, 0x01, expectedTimeout, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x03, ChallengeResponseTimeoutTag, 0x01, expectedTimeout, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedTimeout, deviceInfo.ChallengeResponseTimeout);
         }
@@ -186,10 +202,12 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_DeviceFlagsTagPresent_SetsPropertyCorrectly()
         {
             DeviceFlags deviceFlags = DeviceFlags.RemoteWakeup | DeviceFlags.TouchEject;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, DeviceFlagsTag, 0x01, (byte)deviceFlags, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu =
+                new ResponseApdu(new byte[] { 0x03, DeviceFlagsTag, 0x01, (byte)deviceFlags, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(deviceFlags, deviceInfo.DeviceFlags);
         }
@@ -198,10 +216,12 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_ConfigurationLockPresentTagPresent_SetsPropertyCorrectly()
         {
             bool expectedValue = true;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, ConfigurationLockPresentTag, 0x01, 0x01, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu =
+                new ResponseApdu(new byte[] { 0x03, ConfigurationLockPresentTag, 0x01, 0x01, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedValue, deviceInfo.ConfigurationLocked);
         }
@@ -209,10 +229,12 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void GetData_NfcPrePersCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, NfcPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, NfcPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.AvailableNfcCapabilities);
         }
@@ -221,9 +243,10 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_NfcPrePersCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, NfcPrePersCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.AvailableNfcCapabilities);
         }
@@ -231,10 +254,12 @@ namespace Yubico.YubiKey.Otp.Commands
         [Fact]
         public void GetData_NfcEnabledCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, NfcEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, NfcEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.EnabledNfcCapabilities);
         }
@@ -243,9 +268,10 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_NfcEnabledCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, NfcEnabledCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.EnabledNfcCapabilities);
         }
@@ -255,12 +281,16 @@ namespace Yubico.YubiKey.Otp.Commands
         {
             FormFactor expectedFormFactor = FormFactor.UsbAKeychain;
             var responseApdu = new ResponseApdu(
-                new byte[] { 0x03, FormFactorTag, 0x01, (byte)expectedFormFactor,
+                new byte[]
+                {
+                    0x03, FormFactorTag, 0x01, (byte)expectedFormFactor,
                     0x01, 0xFF, 0x3C,
-                    0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+                    0x90, 0x00
+                });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedFormFactor, deviceInfo.FormFactor);
         }
@@ -271,7 +301,7 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_ZeroTlvData_ThrowsMalformedYkResponse(byte[] data)
         {
             var responseApdu = new ResponseApdu(data);
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
             _ = Assert.Throws<MalformedYubiKeyResponseException>(() => getDeviceInfoResponse.GetData());
         }
 
@@ -279,7 +309,7 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_MissingLengthField_ThrowsMalformedYkResponse()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
             _ = Assert.Throws<MalformedYubiKeyResponseException>(() => getDeviceInfoResponse.GetData());
         }
 
@@ -290,7 +320,7 @@ namespace Yubico.YubiKey.Otp.Commands
         public void GetData_TooLargeLengthField_ThrowsMalformedYkResponse(byte[] data)
         {
             var responseApdu = new ResponseApdu(data);
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
             _ = Assert.Throws<MalformedYubiKeyResponseException>(() => getDeviceInfoResponse.GetData());
         }
     }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommandTests.cs
@@ -17,12 +17,12 @@ using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.U2f.Commands
 {
-    public class GetDeviceInfoCommandTests
+    public class GetPagedDeviceInfoCommandTests
     {
         [Fact]
         public void CreateCommandApdu_GetClaProperty_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             Assert.Equal(0, command.CreateCommandApdu().Cla);
         }
@@ -30,7 +30,7 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void CreateCommandApdu_GetInsProperty_Returns0xC2()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             Assert.Equal(0xC2, command.CreateCommandApdu().Ins);
         }
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void CreateCommandApdu_GetP1Property_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             Assert.Equal(0, command.CreateCommandApdu().P1);
         }
@@ -46,35 +46,35 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void CreateCommandApdu_GetP2Property_ReturnsZero()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
             Assert.Equal(0, command.CreateCommandApdu().P2);
         }
 
         [Fact]
-        public void CreateCommandApdu_GetNcProperty_ReturnsZero()
+        public void CreateCommandApdu_GetNc_WithNewCommand_ReturnsCorrectLengthOfOnlyOne()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
-            Assert.Equal(0, command.CreateCommandApdu().Nc);
+            Assert.Equal(1, command.CreateCommandApdu().Nc);
         }
 
         [Fact]
-        public void CreateCommandApdu_GetDataProperty_ReturnsEmpty()
+        public void CreateCommandApdu_GetData_WithNewCommand_ReturnsLengthOfOnlyOne()
         {
-            var command = new GetDeviceInfoCommand();
+            var command = new GetPagedDeviceInfoCommand();
 
-            Assert.True(command.CreateCommandApdu().Data.IsEmpty);
+            Assert.Equal(1, command.CreateCommandApdu().Data.Length);
         }
 
         [Fact]
         public void CreateResponseApdu_ReturnsCorrectType()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            var command = new GetDeviceInfoCommand();
-            GetDeviceInfoResponse? response = command.CreateResponseForApdu(responseApdu);
+            var command = new GetPagedDeviceInfoCommand();
+            GetPagedDeviceInfoResponse? response = command.CreateResponseForApdu(responseApdu);
 
-            _ = Assert.IsType<GetDeviceInfoResponse>(response);
+            Assert.NotNull(response);
         }
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponseTests.cs
@@ -29,7 +29,9 @@ namespace Yubico.YubiKey.U2f.Commands
         private const byte AutoEjectTimeoutTag = 0x06;
         private const byte ChallengeResponseTimeoutTag = 0x07;
         private const byte DeviceFlagsTag = 0x08;
+
         private const byte ConfigurationLockPresentTag = 0x0a;
+
         //private const byte ConfigurationUnlockTag = 0x0b;
         //private const byte ResetTag = 0x0c;
         private const byte NfcPrePersCapabilitiesTag = 0x0d;
@@ -39,7 +41,7 @@ namespace Yubico.YubiKey.U2f.Commands
         public void Constructor_GivenNullResponseApdu_ThrowsArgumentNullExceptionFromBase()
         {
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
-            static void action() => _ = new GetDeviceInfoResponse(null);
+            static void action() => _ = new GetPagedDeviceInfoResponse(null);
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
 
             _ = Assert.Throws<ArgumentNullException>(action);
@@ -52,7 +54,7 @@ namespace Yubico.YubiKey.U2f.Commands
             byte sw2 = unchecked((byte)SWConstants.Success);
             var responseApdu = new ResponseApdu(new byte[] { 0, 0, 0, sw1, sw2 });
 
-            var deviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var deviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             Assert.Equal(SWConstants.Success, deviceInfoResponse.StatusWord);
         }
@@ -64,7 +66,7 @@ namespace Yubico.YubiKey.U2f.Commands
             byte sw2 = unchecked((byte)SWConstants.Success);
             var responseApdu = new ResponseApdu(new byte[] { 0, 0, 0, sw1, sw2 });
 
-            var deviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var deviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             Assert.Equal(ResponseStatus.Success, deviceInfoResponse.Status);
         }
@@ -76,7 +78,7 @@ namespace Yubico.YubiKey.U2f.Commands
             byte sw2 = unchecked((byte)SWConstants.Success);
             var responseApdu = new ResponseApdu(new byte[] { 0, 0, 0, sw1, sw2 });
 
-            var deviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var deviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
             _ = Assert.Throws<MalformedYubiKeyResponseException>(() => deviceInfoResponse.GetData());
         }
 
@@ -86,7 +88,7 @@ namespace Yubico.YubiKey.U2f.Commands
             byte sw1 = unchecked((byte)(SWConstants.ExecutionError >> 8));
             byte sw2 = unchecked((byte)SWConstants.ExecutionError);
             var responseApdu = new ResponseApdu(new byte[] { sw1, sw2 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
             void action() => _ = getDeviceInfoResponse.GetData();
 
@@ -96,10 +98,12 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void GetData_UsbPrePersCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, UsbPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, UsbPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.AvailableUsbCapabilities);
         }
@@ -108,9 +112,10 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_UsbPrePersCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, UsbPrePersCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.AvailableUsbCapabilities);
         }
@@ -118,10 +123,12 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void GetData_SerialNumberTagPresent_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x06, SerialNumberTag, 0x04, 0x01, 0x02, 0x03, 0x04, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x06, SerialNumberTag, 0x04, 0x01, 0x02, 0x03, 0x04, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(0x01020304, deviceInfo.SerialNumber);
         }
@@ -129,10 +136,12 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void GetData_UsbEnabledCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, UsbEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, UsbEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.EnabledUsbCapabilities);
         }
@@ -141,9 +150,10 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_UsbEnabledCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, UsbEnabledCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.EnabledUsbCapabilities);
         }
@@ -152,10 +162,12 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_FormFactorTagPresent_SetsPropertyCorrectly()
         {
             FormFactor expectedFormFactor = FormFactor.UsbCLightning;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, FormFactorTag, 0x01, (byte)expectedFormFactor, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x03, FormFactorTag, 0x01, (byte)expectedFormFactor, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedFormFactor, deviceInfo.FormFactor);
         }
@@ -164,10 +176,15 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_FirmwareVersionTagPresent_SetsPropertyCorrectly()
         {
             var expectedVersion = new FirmwareVersion() { Major = 0x01, Minor = 0x02, Patch = 0x03 };
-            var responseApdu = new ResponseApdu(new byte[] { 0x05, FirmwareVersionTag, 0x03, expectedVersion.Major, expectedVersion.Minor, expectedVersion.Patch, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+            {
+                0x05, FirmwareVersionTag, 0x03, expectedVersion.Major, expectedVersion.Minor, expectedVersion.Patch,
+                0x90, 0x00
+            });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedVersion, deviceInfo.FirmwareVersion);
         }
@@ -177,9 +194,10 @@ namespace Yubico.YubiKey.U2f.Commands
         {
             short expectedTimeout = 0x1234;
             var responseApdu = new ResponseApdu(new byte[] { 0x04, AutoEjectTimeoutTag, 0x02, 0x12, 0x34, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedTimeout, deviceInfo.AutoEjectTimeout);
         }
@@ -188,10 +206,12 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_ChallengeResponseTimeoutTagPresent_SetsPropertyCorrectly()
         {
             byte expectedTimeout = 0x12;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, ChallengeResponseTimeoutTag, 0x01, expectedTimeout, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x03, ChallengeResponseTimeoutTag, 0x01, expectedTimeout, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedTimeout, deviceInfo.ChallengeResponseTimeout);
         }
@@ -200,10 +220,12 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_DeviceFlagsTagPresent_SetsPropertyCorrectly()
         {
             DeviceFlags deviceFlags = DeviceFlags.RemoteWakeup | DeviceFlags.TouchEject;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, DeviceFlagsTag, 0x01, (byte)deviceFlags, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu =
+                new ResponseApdu(new byte[] { 0x03, DeviceFlagsTag, 0x01, (byte)deviceFlags, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(deviceFlags, deviceInfo.DeviceFlags);
         }
@@ -212,10 +234,12 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_ConfigurationLockPresentTagPresent_SetsPropertyCorrectly()
         {
             bool expectedValue = true;
-            var responseApdu = new ResponseApdu(new byte[] { 0x03, ConfigurationLockPresentTag, 0x01, 0x01, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu =
+                new ResponseApdu(new byte[] { 0x03, ConfigurationLockPresentTag, 0x01, 0x01, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(expectedValue, deviceInfo.ConfigurationLocked);
         }
@@ -223,10 +247,12 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void GetData_NfcPrePersCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, NfcPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, NfcPrePersCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.AvailableNfcCapabilities);
         }
@@ -235,9 +261,10 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_NfcPrePersCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, NfcPrePersCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.AvailableNfcCapabilities);
         }
@@ -245,10 +272,12 @@ namespace Yubico.YubiKey.U2f.Commands
         [Fact]
         public void GetData_NfcEnabledCapabilitiesTagPresentAsShort_SetsPropertyCorrectly()
         {
-            var responseApdu = new ResponseApdu(new byte[] { 0x04, NfcEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var responseApdu = new ResponseApdu(new byte[]
+                { 0x04, NfcEnabledCapabilitiesTag, 0x02, 0x03, 0x3F, 0x90, 0x00 });
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal(YubiKeyCapabilities.All, deviceInfo.EnabledNfcCapabilities);
         }
@@ -257,9 +286,10 @@ namespace Yubico.YubiKey.U2f.Commands
         public void GetData_NfcEnabledCapabilitiesTagPresentAsByte_SetsPropertyCorrectly()
         {
             var responseApdu = new ResponseApdu(new byte[] { 0x03, NfcEnabledCapabilitiesTag, 0x01, 0x3F, 0x90, 0x00 });
-            var getDeviceInfoResponse = new GetDeviceInfoResponse(responseApdu);
+            var getDeviceInfoResponse = new GetPagedDeviceInfoResponse(responseApdu);
 
-            YubiKeyDeviceInfo deviceInfo = getDeviceInfoResponse.GetData();
+            var deviceInfo = YubiKeyDeviceInfo.CreateFromResponseData(getDeviceInfoResponse.GetData());
+
 
             Assert.Equal((YubiKeyCapabilities)0x3F, deviceInfo.EnabledNfcCapabilities);
         }

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/HollowYubiKeyDevice.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/HollowYubiKeyDevice.cs
@@ -50,6 +50,8 @@ namespace Yubico.YubiKey.TestUtilities
         /// <inheritdoc />
         public YubiKeyCapabilities EnabledNfcCapabilities { get; private set; }
 
+        public bool IsNfcRestricted { get; }
+
         /// <inheritdoc />
         public int? SerialNumber { get; private set; }
 
@@ -234,6 +236,11 @@ namespace Yubico.YubiKey.TestUtilities
         }
 
         public void SetLegacyDeviceConfiguration(YubiKeyCapabilities yubiKeyInterfaces, byte challengeResponseTimeout, bool touchEjectEnabled, int autoEjectTimeout = 0)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void SetIsNfcRestricted(bool enabled)
         {
             throw new NotImplementedException();
         }


### PR DESCRIPTION
# Description

This PR lets the user set the NFC_RESTRICTED value on the Yubikey by reading the additional pages of data from the Yubikey device info stored on the Yubikey. Additional work is needed to parse and present additional tags.

The change required deprecating the previous way of issuing GetDeviceInfo commands. 
Deprecated classes:
- Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoCommand.cs
- Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoCommand.cs
- Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoCommand.cs
- Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
- Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
- Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs

Fixes # YESDK-1322

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* Firmware version: 5.7,5.4
* Yubikey model: YK 5A Non FIPS

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
