### PR TITLE
More reliable paths/IO for IntegrationTestDeviceEnumeration

### DIFF
--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/IntegrationTestDeviceEnumeration.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/IntegrationTestDeviceEnumeration.cs
@@ -52,10 +52,9 @@ namespace Yubico.YubiKey.TestUtilities
 
         public IntegrationTestDeviceEnumeration(string? configDirectory = null)
         {
-            var allowListFilePath = Path.Combine(
-                configDirectory ?? Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "Yubico",
-                _allowlistFileName);
+            var defaultDirectory =
+                Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "Yubico");
+            var allowListFilePath = Path.Combine(configDirectory ?? defaultDirectory, _allowlistFileName);
 
             CreateIfMissing(allowListFilePath);
 
@@ -87,11 +86,12 @@ namespace Yubico.YubiKey.TestUtilities
 
         private static void CreateIfMissing(string allowListFilePath)
         {
-            _ = Directory.CreateDirectory(Path.GetDirectoryName(allowListFilePath)!);
             if (File.Exists(allowListFilePath))
             {
                 return;
             }
+
+            _ = Directory.CreateDirectory(Path.GetDirectoryName(allowListFilePath)!);
 
             var file = File.Create(allowListFilePath);
             file.Close();


### PR DESCRIPTION
# Description

The tests wouldn't pass consistently, so this adds a small delay for the IO and more reliable paths

Fixes: develop

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
