### PR TITLE
Fix: Update ManagementKeyAlgorithm on PIV Application reset

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,14 +12,14 @@ root = true
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+# Microsoft .NET properties
 
 # All files
 [*]
 
 # IDE0073: File header
 dotnet_diagnostic.ide0073.severity = suggestion
-file_header_template = Copyright 2024 Yubico AB\n\nLicensed under the Apache License, Version 2.0 (the "License").\nYou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an "AS IS" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.
+file_header_template = Copyright 2024 Yubico AB\n\nLicensed under the Apache License, Version 2.0 (the "License").\nYou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\n    http://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an "AS IS" BASIS, \nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.
 
 
 # C# files
@@ -35,7 +35,8 @@ indent_size = 4
 indent_style = space
 tab_width = 4
 guidelines = 100, 120
-guidelines_style = 2.5px solid 40ff0000
+guidelines_style =
+2.5px solid 40ff0000
 
 # New line preferences
 end_of_line = crlf
@@ -101,7 +102,7 @@ csharp_style_conditional_delegate_call = true:warning
 
 # Modifier preferences
 csharp_prefer_static_local_function = true:warning
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:silent
 
 # Code-block preferences
 csharp_prefer_braces = true:warning
@@ -188,28 +189,27 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+# dotnet_naming_symbols.interface.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+# dotnet_naming_symbols.types.required_modifiers =
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+# dotnet_naming_symbols.non_field_members.required_modifiers =
 
 # Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+# dotnet_naming_style.pascal_case.required_prefix =
+#dotnet_naming_style.pascal_case.required_suffix =
+#dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
+# dotnet_naming_style.begins_with_i.required_suffix =
+# dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
 
 
 #
@@ -236,6 +236,7 @@ csharp_style_expression_bodied_properties = when_on_single_line:warning
 dotnet_code_quality_unused_parameters = all:warning
 
 # ReSharper properties
+resharper_csharp_wrap_ternary_expr_style = chop_always
 resharper_align_first_arg_by_paren = false
 resharper_align_linq_query = true
 resharper_align_multiline_argument = true
@@ -333,19 +334,13 @@ dotnet_diagnostic.ca2208.severity = none
 
 [**/tests/**/*.cs]
 # var preferences
-csharp_style_var_elsewhere = false:none
-csharp_style_var_for_built_in_types = false:none
-csharp_style_var_when_type_is_apparent = false:none
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_var_for_built_in_types = true:suggestion
 csharp_style_unused_value_expression_statement_preference = unused_local_variable:none
+resharper_for_simple_types = use_var
 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.ca1707.severity = none
-
-#
-# IntegrationTests project rules
-#
-
-[**/integrationTests/**/*.cs]
 
 # CA1707: Identifiers should not contain underscores
 dotnet_diagnostic.ca1707.severity = none

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pinonly.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pinonly.cs
@@ -1364,10 +1364,10 @@ namespace Yubico.YubiKey.Piv
                 try
                 {
                     // This will use PBKDF2, with the PRF of HMAC with SHA-1.
-                    #pragma warning disable CA5379, CA5387 // These warnings complain about SHA-1 and <100,000 iterations, but we use it to be backwards-compatible.
+#pragma warning disable CA5379, CA5387 // These warnings complain about SHA-1 and <100,000 iterations, but we use it to be backwards-compatible.
                     using var kdf = new Rfc2898DeriveBytes(pinData, saltData, iterations: 10000);
                     result = kdf.GetBytes(newLength);
-                    #pragma warning restore CA5379, CA5387
+#pragma warning restore CA5379, CA5387
                     Array.Copy(result, _keyBuffer, newLength);
                     KeyData = _keyData.Slice(start: 0, newLength);
                 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pinonly.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pinonly.cs
@@ -30,59 +30,59 @@ namespace Yubico.YubiKey.Piv
         private const int AdminDataDataTag = 0x005FFF00;
 
         /// <summary>
-        /// Return an enum indicating the PIN-only mode, if any, for which the
-        /// YubiKey PIV application is configured.
+        ///     Return an enum indicating the PIN-only mode, if any, for which the
+        ///     YubiKey PIV application is configured.
         /// </summary>
         /// <remarks>
-        /// PIN-only mode means that the application does not need to enter the
-        /// management key in order to perform PIV operations that normally
-        /// require it, only the PIN is needed.
-        /// <para>
-        /// See the User's Manual entry on
-        /// <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
-        /// a deeper discussion of this feature.
-        /// </para>
-        /// <para>
-        /// This returns a result based on the contents of ADMIN DATA. That
-        /// storage location contains information about PIN-protected and
-        /// PIN-derived. It is possible for a different application to overwrite
-        /// the data to make it inaccurate. That is unlikely, however, if all
-        /// applications follow good programming practices outlined by the SDK
-        /// documentation. This method will not actually verify the management
-        /// key in order to ensure the return value is correct.
-        /// </para>
-        /// <para>
-        /// If the ADMIN DATA is overwritten, it is possible to call
-        /// <see cref="TryRecoverPinOnlyMode()"/> to restore the YubiKey to a
-        /// proper PIN-only state.
-        /// </para>
-        /// <para>
-        /// Note also that it is possible that the ADMIN DATA says the YubiKey is
-        /// PIN-protected, but some app has overwritten the data in PRINTED. In
-        /// that case, this method will return a result indicating
-        /// <c>PinProtected</c>, when in reality PIN-protected is unavailable.
-        /// That is because this returns a value based only on the contents of
-        /// ADMIN DATA. The method <c>TryRecoverPinOnlyMode</c> will check more
-        /// than ADMIN DATA.
-        /// </para>
-        /// <para>
-        /// Note that the return is a bit field and the return can be one or more
-        /// of the bits set. There are bits that indicate a YubiKey is
-        /// unavailable for PIN-protected or PIN-derived. Call this method before
-        /// trying to set a YubiKey to PIN-only to make sure it is not already
-        /// set, and if not, it can be set.
-        /// </para>
-        /// <para>
-        /// Note that this returns the PIN-only mode for the PIV application on
-        /// the YubiKey, it has nothing to do with OATH, FIDO, or OpenPGP.
-        /// </para>
+        ///     PIN-only mode means that the application does not need to enter the
+        ///     management key in order to perform PIV operations that normally
+        ///     require it, only the PIN is needed.
+        ///     <para>
+        ///         See the User's Manual entry on
+        ///         <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
+        ///         a deeper discussion of this feature.
+        ///     </para>
+        ///     <para>
+        ///         This returns a result based on the contents of ADMIN DATA. That
+        ///         storage location contains information about PIN-protected and
+        ///         PIN-derived. It is possible for a different application to overwrite
+        ///         the data to make it inaccurate. That is unlikely, however, if all
+        ///         applications follow good programming practices outlined by the SDK
+        ///         documentation. This method will not actually verify the management
+        ///         key in order to ensure the return value is correct.
+        ///     </para>
+        ///     <para>
+        ///         If the ADMIN DATA is overwritten, it is possible to call
+        ///         <see cref="TryRecoverPinOnlyMode()" /> to restore the YubiKey to a
+        ///         proper PIN-only state.
+        ///     </para>
+        ///     <para>
+        ///         Note also that it is possible that the ADMIN DATA says the YubiKey is
+        ///         PIN-protected, but some app has overwritten the data in PRINTED. In
+        ///         that case, this method will return a result indicating
+        ///         <c>PinProtected</c>, when in reality PIN-protected is unavailable.
+        ///         That is because this returns a value based only on the contents of
+        ///         ADMIN DATA. The method <c>TryRecoverPinOnlyMode</c> will check more
+        ///         than ADMIN DATA.
+        ///     </para>
+        ///     <para>
+        ///         Note that the return is a bit field and the return can be one or more
+        ///         of the bits set. There are bits that indicate a YubiKey is
+        ///         unavailable for PIN-protected or PIN-derived. Call this method before
+        ///         trying to set a YubiKey to PIN-only to make sure it is not already
+        ///         set, and if not, it can be set.
+        ///     </para>
+        ///     <para>
+        ///         Note that this returns the PIN-only mode for the PIV application on
+        ///         the YubiKey, it has nothing to do with OATH, FIDO, or OpenPGP.
+        ///     </para>
         /// </remarks>
         /// <returns>
-        /// A <c>PivPinOnlyMode</c>, which is an enum indicating the mode or
-        /// modes.
+        ///     A <c>PivPinOnlyMode</c>, which is an enum indicating the mode or
+        ///     modes.
         /// </returns>
         /// <exception cref="InvalidOperationException">
-        /// The YubiKey is not able to return the ADMIN DATA.
+        ///     The YubiKey is not able to return the ADMIN DATA.
         /// </exception>
         public PivPinOnlyMode GetPinOnlyMode()
         {
@@ -90,7 +90,7 @@ namespace Yubico.YubiKey.Piv
 
             PivPinOnlyMode returnValue = PivPinOnlyMode.PinProtectedUnavailable | PivPinOnlyMode.PinDerivedUnavailable;
 
-            if (TryReadObject<AdminData>(out AdminData adminData))
+            if (TryReadObject(out AdminData adminData))
             {
                 returnValue = PivPinOnlyMode.None;
 
@@ -111,81 +111,81 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Try to recover the PIN-only state. If successful, this will
-        /// authenticate the management key and reset the ADMIN DATA and or
-        /// PRINTED storage locations.
-        /// &gt; [!WARNING]
-        /// &gt; This can overwrite the contents of ADMIN DATA and/or PRINTED. If
-        /// &gt; some other application relies on that data it will be lost.
+        ///     Try to recover the PIN-only state. If successful, this will
+        ///     authenticate the management key and reset the ADMIN DATA and or
+        ///     PRINTED storage locations.
+        ///     &gt; [!WARNING]
+        ///     &gt; This can overwrite the contents of ADMIN DATA and/or PRINTED. If
+        ///     &gt; some other application relies on that data it will be lost.
         /// </summary>
         /// <remarks>
-        /// See the User's Manual entry on
-        /// <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
-        /// a deeper discussion of this operation.
-        /// <para>
-        /// The ADMIN DATA contains information about PIN-only. The PIN-protected
-        /// management key is stored in PRINTED. Applications should never store
-        /// information in those locations, only Yubico-supplied products should
-        /// use them. However, it is possible for an application to overwrite the
-        /// contents of one or both of these storage locations, making the
-        /// PIN-only data inaccurate.
-        /// </para>
-        /// <para>
-        /// This method will obtain the data stored in the two storage locations,
-        /// and determine if they contain PIN-only data that can be used to
-        /// authenticate the management key. If it can't, it will return
-        /// <c>PivPinOnlyMode.None</c> or <c>Unavailable</c>. If it can, it will
-        /// authenticate and set the ADMIN DATA and PRINTED to contain data
-        /// compatible with correct PIN-only modes. It will return a
-        /// <c>PivPinOnlyMode</c> value indicating which mode is set.
-        /// </para>
-        /// <para>
-        /// For example, suppose the data in both is correct, and it indicates
-        /// the management key is PIN-protected. After calling this method, the
-        /// management key will be authenticated, the storage locations will not
-        /// be changed, and the return will be <c>PivPinOnlyMode.PinProtected</c>.
-        /// </para>
-        /// <para>
-        /// Another possibility is the ADMIN DATA was overwritten by some
-        /// application so it is inaccurate, but the PIN-protected data is still
-        /// in PRINTED. This method will be able to authenticate the management
-        /// key using that data. It will replace the contents of ADMIN DATA with
-        /// correct PIN-only information and return
-        /// <c>PivPinOnlyMode.PinProtected</c>.
-        /// </para>
-        /// <para>
-        /// If ADMIN DATA and PRINTED contain no data, or if ADMIN DATA contains
-        /// correct information that indicates the YubiKey is not set to PIN-only
-        /// mode, then this method will not authenticate the management key, it
-        /// will not put any data into the storage locations, and it will return
-        /// <c>PivPinOnlyMode.None</c>.
-        /// </para>
-        /// <para>
-        /// It is possible this method is not able to recover. For example,
-        /// suppose the ADMIN DATA is correct and indicates the YubiKey is
-        /// PIN-protected, but not PIN-derived (there is no salt to use to derive
-        /// a key), but the data in PRINTED is not correct. In this case, the
-        /// method will not be able to authenticate the management key as
-        /// PIN-protected. It will try to authenticate using the default
-        /// management key, and if that does not work, it will call on the
-        /// <c>KeyCollector</c> to obtain the it. If that does succeeds, it will
-        /// set ADMIN DATA to indicate the YubiKey is not PIN-protected, it will
-        /// clear the contents of PRINTED, and it will return
-        /// <c>PivPinOnlyMode.None</c>. If the <c>KeyCollector</c> is not able to
-        /// provide the management key, this method will not be able to reset the
-        /// ADMIN DATA nor PRINTED (management key authentication is necessary to
-        /// set a storage location), and will return <c>Unavailable</c>.
-        /// </para>
-        /// <para>
-        /// This method will require the PIN to be verified. It is possible that
-        /// the PIN has already been verified and this method will verify it
-        /// again. If it needs to verify the PIN, it will call on the
-        /// <c>KeyCollector</c> to obtain it.
-        /// </para>
+        ///     See the User's Manual entry on
+        ///     <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
+        ///     a deeper discussion of this operation.
+        ///     <para>
+        ///         The ADMIN DATA contains information about PIN-only. The PIN-protected
+        ///         management key is stored in PRINTED. Applications should never store
+        ///         information in those locations, only Yubico-supplied products should
+        ///         use them. However, it is possible for an application to overwrite the
+        ///         contents of one or both of these storage locations, making the
+        ///         PIN-only data inaccurate.
+        ///     </para>
+        ///     <para>
+        ///         This method will obtain the data stored in the two storage locations,
+        ///         and determine if they contain PIN-only data that can be used to
+        ///         authenticate the management key. If it can't, it will return
+        ///         <c>PivPinOnlyMode.None</c> or <c>Unavailable</c>. If it can, it will
+        ///         authenticate and set the ADMIN DATA and PRINTED to contain data
+        ///         compatible with correct PIN-only modes. It will return a
+        ///         <c>PivPinOnlyMode</c> value indicating which mode is set.
+        ///     </para>
+        ///     <para>
+        ///         For example, suppose the data in both is correct, and it indicates
+        ///         the management key is PIN-protected. After calling this method, the
+        ///         management key will be authenticated, the storage locations will not
+        ///         be changed, and the return will be <c>PivPinOnlyMode.PinProtected</c>.
+        ///     </para>
+        ///     <para>
+        ///         Another possibility is the ADMIN DATA was overwritten by some
+        ///         application so it is inaccurate, but the PIN-protected data is still
+        ///         in PRINTED. This method will be able to authenticate the management
+        ///         key using that data. It will replace the contents of ADMIN DATA with
+        ///         correct PIN-only information and return
+        ///         <c>PivPinOnlyMode.PinProtected</c>.
+        ///     </para>
+        ///     <para>
+        ///         If ADMIN DATA and PRINTED contain no data, or if ADMIN DATA contains
+        ///         correct information that indicates the YubiKey is not set to PIN-only
+        ///         mode, then this method will not authenticate the management key, it
+        ///         will not put any data into the storage locations, and it will return
+        ///         <c>PivPinOnlyMode.None</c>.
+        ///     </para>
+        ///     <para>
+        ///         It is possible this method is not able to recover. For example,
+        ///         suppose the ADMIN DATA is correct and indicates the YubiKey is
+        ///         PIN-protected, but not PIN-derived (there is no salt to use to derive
+        ///         a key), but the data in PRINTED is not correct. In this case, the
+        ///         method will not be able to authenticate the management key as
+        ///         PIN-protected. It will try to authenticate using the default
+        ///         management key, and if that does not work, it will call on the
+        ///         <c>KeyCollector</c> to obtain the it. If that does succeeds, it will
+        ///         set ADMIN DATA to indicate the YubiKey is not PIN-protected, it will
+        ///         clear the contents of PRINTED, and it will return
+        ///         <c>PivPinOnlyMode.None</c>. If the <c>KeyCollector</c> is not able to
+        ///         provide the management key, this method will not be able to reset the
+        ///         ADMIN DATA nor PRINTED (management key authentication is necessary to
+        ///         set a storage location), and will return <c>Unavailable</c>.
+        ///     </para>
+        ///     <para>
+        ///         This method will require the PIN to be verified. It is possible that
+        ///         the PIN has already been verified and this method will verify it
+        ///         again. If it needs to verify the PIN, it will call on the
+        ///         <c>KeyCollector</c> to obtain it.
+        ///     </para>
         /// </remarks>
         /// <returns>
-        /// A <c>PivPinOnlyMode</c>, which is an enum indicating the mode or
-        /// modes the YubiKey is in.
+        ///     A <c>PivPinOnlyMode</c>, which is an enum indicating the mode or
+        ///     modes the YubiKey is in.
         /// </returns>
         public PivPinOnlyMode TryRecoverPinOnlyMode()
         {
@@ -266,13 +266,13 @@ namespace Yubico.YubiKey.Piv
             // means the mgmt key is not authenticated.
             // If we can authenticate the mgmt key, then set ADMIN DATA and
             // PRINTED.
-            Func<KeyEntryData, bool>? UserKeyCollector = KeyCollector;
+            Func<KeyEntryData, bool>? userKeyCollector = KeyCollector;
             using var specialKeyCollector = new SpecialKeyCollector();
 
             try
             {
                 KeyCollector = specialKeyCollector.KeyCollectorSpecial;
-                specialKeyCollector.AuthMgmtKeyAndSave(this, UserKeyCollector);
+                specialKeyCollector.AuthMgmtKeyAndSave(this, userKeyCollector);
 
                 // If the PinDerivedUnavailable bit is not set, that means either
                 // there was no ADMIN DATA, or it was "correct". If it was
@@ -314,7 +314,7 @@ namespace Yubico.YubiKey.Piv
             }
             finally
             {
-                KeyCollector = UserKeyCollector;
+                KeyCollector = userKeyCollector;
             }
         }
 
@@ -349,7 +349,7 @@ namespace Yubico.YubiKey.Piv
                 tryPinDerived = returnValue.HasFlag(PivPinOnlyMode.PinDerived);
             }
 
-            Func<KeyEntryData, bool>? UserKeyCollector = KeyCollector;
+            Func<KeyEntryData, bool>? userKeyCollector = KeyCollector;
             using var specialKeyCollector = new SpecialKeyCollector();
 
             try
@@ -358,7 +358,7 @@ namespace Yubico.YubiKey.Piv
 
                 if (tryPinProtected)
                 {
-                    returnValue = GetPrintedPinProtectedStatus(specialKeyCollector, UserKeyCollector);
+                    returnValue = GetPrintedPinProtectedStatus(specialKeyCollector, userKeyCollector);
 
                     if (trustAdminData && returnValue.HasFlag(PivPinOnlyMode.PinProtected))
                     {
@@ -372,14 +372,14 @@ namespace Yubico.YubiKey.Piv
 
                     returnValue |= GetPinDerivedStatus(
                         adminData, returnValue.HasFlag(PivPinOnlyMode.PinProtected), specialKeyCollector,
-                        UserKeyCollector);
+                        userKeyCollector);
                 }
 
                 return returnValue;
             }
             finally
             {
-                KeyCollector = UserKeyCollector;
+                KeyCollector = userKeyCollector;
             }
         }
 
@@ -392,8 +392,9 @@ namespace Yubico.YubiKey.Piv
         // authenticates, return PinProtected. If not, return Unavailable.
         // If there is data but it is not PinProtectedData, the pinProtect object
         // will be empty and return Unavailable.
-        private PivPinOnlyMode GetPrintedPinProtectedStatus(SpecialKeyCollector specialKeyCollector,
-                                                            Func<KeyEntryData, bool>? UserKeyCollector)
+        private PivPinOnlyMode GetPrintedPinProtectedStatus(
+            SpecialKeyCollector specialKeyCollector,
+            Func<KeyEntryData, bool>? userKeyCollector)
         {
             // We could call the ReadObject method, but if the PIN is not
             // verified, ReadObject won't collect and save it.
@@ -404,7 +405,7 @@ namespace Yubico.YubiKey.Piv
 
             if (getDataResponse.Status == ResponseStatus.AuthenticationRequired)
             {
-                specialKeyCollector.VerifyPinAndSave(this, UserKeyCollector);
+                specialKeyCollector.VerifyPinAndSave(this, userKeyCollector);
                 getDataResponse = Connection.SendCommand(getDataCommand);
             }
 
@@ -429,7 +430,7 @@ namespace Yubico.YubiKey.Piv
                         specialKeyCollector.SetKeyData(
                             SpecialKeyCollector.SetKeyDataBuffer,
                             (ReadOnlyMemory<byte>)pinProtect.ManagementKey,
-                            false,
+                            isNewKey: false,
                             ManagementKeyAlgorithm);
 
                         return PivPinOnlyMode.PinProtected;
@@ -455,10 +456,11 @@ namespace Yubico.YubiKey.Piv
         // This will update the adminData object passed in with the contents of
         // the ADMIN DATA storage location. This method expects the adminData to
         // be empty.
-        private PivPinOnlyMode GetPinDerivedStatus(AdminData adminData,
-                                                   bool isPinProtected,
-                                                   SpecialKeyCollector specialKeyCollector,
-                                                   Func<KeyEntryData, bool>? UserKeyCollector)
+        private PivPinOnlyMode GetPinDerivedStatus(
+            AdminData adminData,
+            bool isPinProtected,
+            SpecialKeyCollector specialKeyCollector,
+            Func<KeyEntryData, bool>? userKeyCollector)
         {
             // We could use the TryReadObject to get the admin data, but that
             // returns a new object. We need to fill the incoming object with the
@@ -482,7 +484,7 @@ namespace Yubico.YubiKey.Piv
 
                     // If we have already collected the PIN, this call will do
                     // nothing (it won't collect it again).
-                    specialKeyCollector.VerifyPinAndSave(this, UserKeyCollector);
+                    specialKeyCollector.VerifyPinAndSave(this, userKeyCollector);
 
                     // If we're already PIN-protected, then the current mgmt key
                     // is the PIN-protected value. So put the derived key into
@@ -493,9 +495,8 @@ namespace Yubico.YubiKey.Piv
 
                     if (isPinProtected)
                     {
-                        if (MemoryExtensions.SequenceEqual(
-                                specialKeyCollector.GetCurrentMgmtKey().Span,
-                                specialKeyCollector.GetNewMgmtKey().Span))
+                        if (specialKeyCollector.GetCurrentMgmtKey().Span
+                            .SequenceEqual(specialKeyCollector.GetNewMgmtKey().Span))
                         {
                             return PivPinOnlyMode.PinDerived;
                         }
@@ -514,254 +515,255 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Set the YubiKey's PIV application to be PIN-only with a PIN-derived
-        /// and/or PIN-Protected Triple-DES management key . This sets the
-        /// YubiKey to either
-        /// <code>
+        ///     Set the YubiKey's PIV application to be PIN-only with a PIN-derived
+        ///     and/or PIN-Protected Triple-DES management key . This sets the
+        ///     YubiKey to either
+        ///     <code>
         ///   PivPinOnlyMode.PinProtected
         ///   PivPinOnlyMode.PinDerived
         ///   PivPinOnlyMode.PinProtected | PivPinOnlyMode.PinDerived
         ///   PivPinOnlyMode.None
         /// </code>
-        /// If the YubiKey is set to PinProtected, PinDerived, or both, the PUK
-        /// will also be blocked.
-        /// &gt; [!WARNING]
-        /// &gt; You should not set a YubiKey for PIN-derived, this feature is
-        /// &gt; provided only for backwards compatibility.
+        ///     If the YubiKey is set to PinProtected, PinDerived, or both, the PUK
+        ///     will also be blocked.
+        ///     &gt; [!WARNING]
+        ///     &gt; You should not set a YubiKey for PIN-derived, this feature is
+        ///     &gt; provided only for backwards compatibility.
         /// </summary>
         /// <remarks>
-        /// PIN-only mode means that the application does not need to enter the
-        /// management key in order to perform PIV operations that normally
-        /// require it, only the PIN is needed.
-        /// <para>
-        /// See the documentation for
-        /// <see cref="SetPinOnlyMode(PivPinOnlyMode, PivAlgorithm)"/> and the
-        /// User's Manual entry on
-        /// <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
-        /// a deeper discussion of this feature.
-        /// </para>
-        /// <para>
-        /// Note that this sets the PIV application on the specific YubiKey to a
-        /// PIN-only mode, it has nothing to do with OATH, FIDO, or OpenPGP.
-        /// </para>
-        /// <para>
-        /// Note also that this will make sure that the management key algorithm
-        /// will be Triple-DES, even if the current management key is a different
-        /// algorithm. This behavior matches how this method operated in previous
-        /// versions of the SDK.
-        /// </para>
+        ///     PIN-only mode means that the application does not need to enter the
+        ///     management key in order to perform PIV operations that normally
+        ///     require it, only the PIN is needed.
+        ///     <para>
+        ///         See the documentation for
+        ///         <see cref="SetPinOnlyMode(PivPinOnlyMode, PivAlgorithm)" /> and the
+        ///         User's Manual entry on
+        ///         <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
+        ///         a deeper discussion of this feature.
+        ///     </para>
+        ///     <para>
+        ///         Note that this sets the PIV application on the specific YubiKey to a
+        ///         PIN-only mode, it has nothing to do with OATH, FIDO, or OpenPGP.
+        ///     </para>
+        ///     <para>
+        ///         Note also that this will make sure that the management key algorithm
+        ///         will be Triple-DES, even if the current management key is a different
+        ///         algorithm. This behavior matches how this method operated in previous
+        ///         versions of the SDK.
+        ///     </para>
         /// </remarks>
         /// <param name="pinOnlyMode">
-        /// The mode to which the YubiKey is to be set.
+        ///     The mode to which the YubiKey is to be set.
         /// </param>
         /// <exception cref="InvalidOperationException">
-        /// There is no <c>KeyCollector</c> loaded, one of the keys provided was
-        /// not a valid Triple-DES key, the data stored on the YubiKey is
-        /// incompatible with PIN-only, or the YubiKey had some other error, such
-        /// as unreliable connection.
+        ///     There is no <c>KeyCollector</c> loaded, one of the keys provided was
+        ///     not a valid Triple-DES key, the data stored on the YubiKey is
+        ///     incompatible with PIN-only, or the YubiKey had some other error, such
+        ///     as unreliable connection.
         /// </exception>
         /// <exception cref="OperationCanceledException">
-        /// The user canceled management key or PIN collection.
+        ///     The user canceled management key or PIN collection.
         /// </exception>
         /// <exception cref="SecurityException">
-        /// Mutual authentication was performed and the YubiKey was not
-        /// authenticated, or the remaining retries count indicates the PIN is
-        /// blocked.
+        ///     Mutual authentication was performed and the YubiKey was not
+        ///     authenticated, or the remaining retries count indicates the PIN is
+        ///     blocked.
         /// </exception>
         public void SetPinOnlyMode(PivPinOnlyMode pinOnlyMode) => SetPinOnlyMode(pinOnlyMode, PivAlgorithm.TripleDes);
 
         /// <summary>
-        /// Set the YubiKey's PIV application to be PIN-only with a PIN-derived
-        /// and/or PIN-Protected management key of the specified algorithm. This
-        /// sets the YubiKey to either
-        /// <code>
+        ///     Set the YubiKey's PIV application to be PIN-only with a PIN-derived
+        ///     and/or PIN-Protected management key of the specified algorithm. This
+        ///     sets the YubiKey to either
+        ///     <code>
         ///   PivPinOnlyMode.PinProtected
         ///   PivPinOnlyMode.PinDerived
         ///   PivPinOnlyMode.PinProtected | PivPinOnlyMode.PinDerived
         ///   PivPinOnlyMode.None
         /// </code>
-        /// If the YubiKey is set to PinProtected, PinDerived, or both, the PUK
-        /// will also be blocked.
-        /// &gt; [!WARNING]
-        /// &gt; You should not set a YubiKey for PIN-derived, this feature is
-        /// &gt; provided only for backwards compatibility.
+        ///     If the YubiKey is set to PinProtected, PinDerived, or both, the PUK
+        ///     will also be blocked.
+        ///     &gt; [!WARNING]
+        ///     &gt; You should not set a YubiKey for PIN-derived, this feature is
+        ///     &gt; provided only for backwards compatibility.
         /// </summary>
         /// <remarks>
-        /// PIN-only mode means that the application does not need to enter the
-        /// management key in order to perform PIV operations that normally
-        /// require it, only the PIN is needed.
-        /// <para>
-        /// See the User's Manual entry on
-        /// <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
-        /// a deeper discussion of this feature.
-        /// </para>
-        /// <para>
-        /// Note that this sets the PIV application on the specific YubiKey to a
-        /// PIN-only mode, it has nothing to do with OATH, FIDO, or OpenPGP.
-        /// </para>
-        /// <para>
-        /// Upon successful completion of this method, the PUK will be blocked.
-        /// </para>
-        /// <para>
-        /// The management key derived and/or stored in PRINTED will be for the
-        /// specified algorithm. For all YubiKeys, <c>TripleDes</c> is a valid
-        /// algorithm. For YubiKeys 5.4.2 and later, it is possible to set the
-        /// management key to an AES key. Before setting the
-        /// <c>mgmtKeyAlgorithm</c> arg to an AES algorithm, make sure it is
-        /// allowed on the YubiKey. You can use the <c>HasFeature</c> call. For
-        /// example,
-        /// <code language="csharp">
+        ///     PIN-only mode means that the application does not need to enter the
+        ///     management key in order to perform PIV operations that normally
+        ///     require it, only the PIN is needed.
+        ///     <para>
+        ///         See the User's Manual entry on
+        ///         <xref href="UsersManualPivPinOnlyMode"> PIV PIN-only mode</xref> for
+        ///         a deeper discussion of this feature.
+        ///     </para>
+        ///     <para>
+        ///         Note that this sets the PIV application on the specific YubiKey to a
+        ///         PIN-only mode, it has nothing to do with OATH, FIDO, or OpenPGP.
+        ///     </para>
+        ///     <para>
+        ///         Upon successful completion of this method, the PUK will be blocked.
+        ///     </para>
+        ///     <para>
+        ///         The management key derived and/or stored in PRINTED will be for the
+        ///         specified algorithm. For all YubiKeys, <c>TripleDes</c> is a valid
+        ///         algorithm. For YubiKeys 5.4.2 and later, it is possible to set the
+        ///         management key to an AES key. Before setting the
+        ///         <c>mgmtKeyAlgorithm</c> arg to an AES algorithm, make sure it is
+        ///         allowed on the YubiKey. You can use the <c>HasFeature</c> call. For
+        ///         example,
+        ///         <code language="csharp">
         ///   PivAlgorithm mgmtKeyAlgorithm = yubiKey.HasFeature(YubiKeyFeature.PivAesManagementKey) ?
         ///       PivAlgorithm.Aes128 : PivAlgorithm.TripleDes;
         ///   pivSession.SetPinOnlyMode(PivPinOnlyMode.PinProtected, mgmtKeyAlgorithm);
         /// </code>
-        /// If the algorithm is not supported by the YubiKey, this method will
-        /// throw an exception. It will not change the YubiKey, it will not set
-        /// it to PIN-only.
-        /// </para>
-        /// <para>
-        /// If the YubiKey is already set to the specified PIN-protected mode and
-        /// algorithm, this will not reset the YubiKey, but will simply
-        /// authenticate the management key.
-        /// </para>
-        /// <para>
-        /// If the YubiKey is already set to PIN-only, but not the specified
-        /// mode, this method will make sure the YubiKey is set to both PIN-only
-        /// modes.
-        /// </para>
-        /// <para>
-        /// If the YubiKey is already set to PIN-only, but not the specified
-        /// algorithm, this method will change to a new management key of the
-        /// specified algorithm.
-        /// </para>
-        /// <para>
-        /// If the requested <c>pinOnlyMode</c> is both, then this will make sure
-        /// the YubiKey is both PIN-protected and PIN-derived.
-        /// </para>
-        /// <para>
-        /// If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
-        /// currently set to PIN-only (and neither PinProtected nor PinDerived is
-        /// Unavailable), this method will remove the contents of the storage
-        /// locations ADMIN DATA and PRINTED, and reset the management key to the
-        /// default:
-        /// <code>
+        ///         If the algorithm is not supported by the YubiKey, this method will
+        ///         throw an exception. It will not change the YubiKey, it will not set
+        ///         it to PIN-only.
+        ///     </para>
+        ///     <para>
+        ///         If the YubiKey is already set to the specified PIN-protected mode and
+        ///         algorithm, this will not reset the YubiKey, but will simply
+        ///         authenticate the management key.
+        ///     </para>
+        ///     <para>
+        ///         If the YubiKey is already set to PIN-only, but not the specified
+        ///         mode, this method will make sure the YubiKey is set to both PIN-only
+        ///         modes.
+        ///     </para>
+        ///     <para>
+        ///         If the YubiKey is already set to PIN-only, but not the specified
+        ///         algorithm, this method will change to a new management key of the
+        ///         specified algorithm.
+        ///     </para>
+        ///     <para>
+        ///         If the requested <c>pinOnlyMode</c> is both, then this will make sure
+        ///         the YubiKey is both PIN-protected and PIN-derived.
+        ///     </para>
+        ///     <para>
+        ///         If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
+        ///         currently set to PIN-only (and neither PinProtected nor PinDerived is
+        ///         Unavailable), this method will remove the contents of the storage
+        ///         locations ADMIN DATA and PRINTED, and reset the management key to the
+        ///         default:
+        ///         <code>
         ///   Triple-DES
         ///   0x01 02 03 04 05 06 07 08
         ///     01 02 03 04 05 06 07 08
         ///     01 02 03 04 05 06 07 08
         /// </code>
-        /// In this case, the <c>mgmtKeyAlgorithm</c> arg will be ignored, the
-        /// management key's algorithm after removing PIN-only status will be
-        /// Triple-DES. The touch policy of the management key will also be set
-        /// to the default (Never). Note that the management key must be
-        /// authenticated and the PIN verified in order to perform this task.
-        /// This method will authenticate the management key using the PIN-only
-        /// mode to which the YubiKey is currently set, then clear the contents.
-        /// It will then change the management key to the default value. Hence,
-        /// after setting the YubiKey out of PIN-only mode, you should change the
-        /// management key. Note also that the PUK will still be blocked. The
-        /// only way to unblock the PUK is to reset the retry counts. This will
-        /// set both the PIN and PUK to their default values. Resetting the retry
-        /// counts requires management key authentication.
-        /// </para>
-        /// <para>
-        /// If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
-        /// currently set to one PIN-only mode, but the other is Unavailable,
-        /// this method will clear the one that is set but leave the one that is
-        /// Unavailable as is. For example, suppose the current mode is
-        /// <c>PinProtected | PinDerivedUnavailable</c>, then after setting to
-        /// None, the PRINTED storage area will be empty and the ADMIN DATA
-        /// storage area will be left as is.
-        /// </para>
-        /// <para>
-        /// If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
-        /// currently NOT set to either PIN-only modes, this method will do
-        /// nothing. It will not remove anything from ADMIN DATA or PRINTED, it
-        /// will not try to authenticate the management key, nor will it try to
-        /// verify the PIN. It will not change the management to the default. It
-        /// will ignore the <c>mgmtKeyAlgorithm</c> argument.
-        /// </para>
-        /// <para>
-        /// If a YubiKey is currently set to both modes, and you call this
-        /// method with only one of the modes, this method will NOT "remove" the
-        /// other mode.
-        /// </para>
-        /// <para>
-        /// If a YubiKey is currently set to both PIN-only modes and you want to
-        /// "remove" one of them, call this method and set the YubiKey to
-        /// <c>None</c>, then call this method a second time and set the YubiKey
-        /// to the desired mode.
-        /// </para>
-        /// <para>
-        /// In order to set the YubiKey to be PIN-only, this method must
-        /// authenticate the management key. Even if the management key is already
-        /// authenticated, this method will authenticate. It will try to
-        /// authenticate using the PIN-only techniques, and if that does not
-        /// work, it will try to authenticate using the default management key. If
-        /// either of those techniques works, the user will not have to enter the
-        /// management key. But if the YubiKey is not PIN-only, and the default
-        /// management key does not authenticate, the method will call on the
-        /// <c>KeyCollector</c> to obtain the correct value.
-        /// </para>
-        /// <para>
-        /// If the mode to set is PIN-protected, then this method will use the
-        /// existing mgmt key, unless it is the default. In that case, this
-        /// method will generate a new, random mgmt key, set the YubiKey with
-        /// this new value, and PIN-protect the new key.
-        /// </para>
-        /// <para>
-        /// This method also requires the PIN to be verified. If setting to
-        /// PIN-derived, even if the PIN is already verified, this method will
-        /// call on the <c>KeyCollector</c> to obtain the PIN. If setting to
-        /// PIN-protected, this method will verify the PIN only if it has not yet
-        /// been verified.
-        /// </para>
-        /// <para>
-        /// Note that this method will throw an exception if the current contents
-        /// of ADMIN DATA and/or PRINTED are not compatible with PIN-only mode.
-        /// If there are no current contents, then this method will set one or
-        /// both of those storage locations with appropriate data. But if there
-        /// is already something in one or both, and it is not PIN-only
-        /// information, then this method will not replace that data, it will
-        /// throw an exception.
-        /// </para>
+        ///         In this case, the <c>mgmtKeyAlgorithm</c> arg will be ignored, the
+        ///         management key's algorithm after removing PIN-only status will be
+        ///         Triple-DES. The touch policy of the management key will also be set
+        ///         to the default (Never). Note that the management key must be
+        ///         authenticated and the PIN verified in order to perform this task.
+        ///         This method will authenticate the management key using the PIN-only
+        ///         mode to which the YubiKey is currently set, then clear the contents.
+        ///         It will then change the management key to the default value. Hence,
+        ///         after setting the YubiKey out of PIN-only mode, you should change the
+        ///         management key. Note also that the PUK will still be blocked. The
+        ///         only way to unblock the PUK is to reset the retry counts. This will
+        ///         set both the PIN and PUK to their default values. Resetting the retry
+        ///         counts requires management key authentication.
+        ///     </para>
+        ///     <para>
+        ///         If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
+        ///         currently set to one PIN-only mode, but the other is Unavailable,
+        ///         this method will clear the one that is set but leave the one that is
+        ///         Unavailable as is. For example, suppose the current mode is
+        ///         <c>PinProtected | PinDerivedUnavailable</c>, then after setting to
+        ///         None, the PRINTED storage area will be empty and the ADMIN DATA
+        ///         storage area will be left as is.
+        ///     </para>
+        ///     <para>
+        ///         If the input <c>pinOnlyMode</c> is <c>None</c>, and the YubiKey is
+        ///         currently NOT set to either PIN-only modes, this method will do
+        ///         nothing. It will not remove anything from ADMIN DATA or PRINTED, it
+        ///         will not try to authenticate the management key, nor will it try to
+        ///         verify the PIN. It will not change the management to the default. It
+        ///         will ignore the <c>mgmtKeyAlgorithm</c> argument.
+        ///     </para>
+        ///     <para>
+        ///         If a YubiKey is currently set to both modes, and you call this
+        ///         method with only one of the modes, this method will NOT "remove" the
+        ///         other mode.
+        ///     </para>
+        ///     <para>
+        ///         If a YubiKey is currently set to both PIN-only modes and you want to
+        ///         "remove" one of them, call this method and set the YubiKey to
+        ///         <c>None</c>, then call this method a second time and set the YubiKey
+        ///         to the desired mode.
+        ///     </para>
+        ///     <para>
+        ///         In order to set the YubiKey to be PIN-only, this method must
+        ///         authenticate the management key. Even if the management key is already
+        ///         authenticated, this method will authenticate. It will try to
+        ///         authenticate using the PIN-only techniques, and if that does not
+        ///         work, it will try to authenticate using the default management key. If
+        ///         either of those techniques works, the user will not have to enter the
+        ///         management key. But if the YubiKey is not PIN-only, and the default
+        ///         management key does not authenticate, the method will call on the
+        ///         <c>KeyCollector</c> to obtain the correct value.
+        ///     </para>
+        ///     <para>
+        ///         If the mode to set is PIN-protected, then this method will use the
+        ///         existing mgmt key, unless it is the default. In that case, this
+        ///         method will generate a new, random mgmt key, set the YubiKey with
+        ///         this new value, and PIN-protect the new key.
+        ///     </para>
+        ///     <para>
+        ///         This method also requires the PIN to be verified. If setting to
+        ///         PIN-derived, even if the PIN is already verified, this method will
+        ///         call on the <c>KeyCollector</c> to obtain the PIN. If setting to
+        ///         PIN-protected, this method will verify the PIN only if it has not yet
+        ///         been verified.
+        ///     </para>
+        ///     <para>
+        ///         Note that this method will throw an exception if the current contents
+        ///         of ADMIN DATA and/or PRINTED are not compatible with PIN-only mode.
+        ///         If there are no current contents, then this method will set one or
+        ///         both of those storage locations with appropriate data. But if there
+        ///         is already something in one or both, and it is not PIN-only
+        ///         information, then this method will not replace that data, it will
+        ///         throw an exception.
+        ///     </para>
         /// </remarks>
         /// <param name="pinOnlyMode">
-        /// The mode to which the YubiKey is to be set.
+        ///     The mode to which the YubiKey is to be set.
         /// </param>
         /// <param name="mgmtKeyAlgorithm">
-        /// The algorithm to which the management key will be set.
+        ///     The algorithm to which the management key will be set.
         /// </param>
         /// <exception cref="InvalidOperationException">
-        /// There is no <c>KeyCollector</c> loaded, one of the keys provided was
-        /// not a valid Triple-DES key, the data stored on the YubiKey is
-        /// incompatible with PIN-only, or the YubiKey had some other error, such
-        /// as unreliable connection.
+        ///     There is no <c>KeyCollector</c> loaded, one of the keys provided was
+        ///     not a valid Triple-DES key, the data stored on the YubiKey is
+        ///     incompatible with PIN-only, or the YubiKey had some other error, such
+        ///     as unreliable connection.
         /// </exception>
         /// <exception cref="OperationCanceledException">
-        /// The user canceled management key or PIN collection.
+        ///     The user canceled management key or PIN collection.
         /// </exception>
         /// <exception cref="SecurityException">
-        /// Mutual authentication was performed and the YubiKey was not
-        /// authenticated, or the remaining retries count indicates the PIN is
-        /// blocked.
+        ///     Mutual authentication was performed and the YubiKey was not
+        ///     authenticated, or the remaining retries count indicates the PIN is
+        ///     blocked.
         /// </exception>
         public void SetPinOnlyMode(PivPinOnlyMode pinOnlyMode, PivAlgorithm mgmtKeyAlgorithm)
         {
-            _log.LogInformation("Set a YubiKey to PIV PIN-only mode: {0}, mgmt key alg = {1}.",
+            _log.LogInformation(
+                "Set a YubiKey to PIV PIN-only mode: {0}, mgmt key alg = {1}.",
                 pinOnlyMode.ToString(), mgmtKeyAlgorithm.ToString());
 
-            Func<KeyEntryData, bool>? UserKeyCollector = KeyCollector;
+            Func<KeyEntryData, bool>? userKeyCollector = KeyCollector;
             using var specialKeyCollector = new SpecialKeyCollector();
 
             try
             {
                 KeyCollector = specialKeyCollector.KeyCollectorSpecial;
-                SetPinOnlyMode(specialKeyCollector, UserKeyCollector, pinOnlyMode, mgmtKeyAlgorithm);
+                SetPinOnlyMode(specialKeyCollector, userKeyCollector, pinOnlyMode, mgmtKeyAlgorithm);
             }
             finally
             {
-                KeyCollector = UserKeyCollector;
+                KeyCollector = userKeyCollector;
             }
         }
 
@@ -778,7 +780,7 @@ namespace Yubico.YubiKey.Piv
                 pinToUse = new ReadOnlyMemory<byte>(new byte[] { 0x31, 0x32, 0x33, 0x34, 0x35, 0x36 });
             }
 
-            Func<KeyEntryData, bool>? UserKeyCollector = KeyCollector;
+            Func<KeyEntryData, bool>? userKeyCollector = KeyCollector;
             using var specialKeyCollector = new SpecialKeyCollector();
 
             try
@@ -787,12 +789,12 @@ namespace Yubico.YubiKey.Piv
 
                 if (specialKeyCollector.TrySetPin(this, pinToUse, out retriesRemaining))
                 {
-                    SetPinOnlyMode(specialKeyCollector, UserKeyCollector, pinOnlyMode, ManagementKeyAlgorithm);
+                    SetPinOnlyMode(specialKeyCollector, userKeyCollector, pinOnlyMode, ManagementKeyAlgorithm);
                 }
             }
             finally
             {
-                KeyCollector = UserKeyCollector;
+                KeyCollector = userKeyCollector;
             }
         }
 
@@ -802,10 +804,11 @@ namespace Yubico.YubiKey.Piv
         // KeyCollector to obtain it.
         // This method assumes that the caller has set this PivSession's
         // KeyCollector to the special, and will reset it to the User's when done.
-        private void SetPinOnlyMode(SpecialKeyCollector specialKeyCollector,
-                                    Func<KeyEntryData, bool>? UserKeyCollector,
-                                    PivPinOnlyMode pinOnlyMode,
-                                    PivAlgorithm mgmtKeyAlgorithm)
+        private void SetPinOnlyMode(
+            SpecialKeyCollector specialKeyCollector,
+            Func<KeyEntryData, bool>? userKeyCollector,
+            PivPinOnlyMode pinOnlyMode,
+            PivAlgorithm mgmtKeyAlgorithm)
         {
             if (pinOnlyMode.HasFlag(PivPinOnlyMode.PinProtectedUnavailable)
                 || pinOnlyMode.HasFlag(PivPinOnlyMode.PinDerivedUnavailable))
@@ -818,7 +821,7 @@ namespace Yubico.YubiKey.Piv
 
             // If the YubiKey does not allow AES, but the caller specified AES,
             // throw an exception.
-            CheckManagementKeyAlgorithm(mgmtKeyAlgorithm, false);
+            CheckManagementKeyAlgorithm(mgmtKeyAlgorithm, checkMode: false);
 
             // Determine if we are using a new algorithm for this Set.
             // Later on, we'll use this to determine if we need to Clear the
@@ -836,7 +839,7 @@ namespace Yubico.YubiKey.Piv
             // Or some other reason.
             PivPinOnlyMode newMode = PivPinOnlyMode.None;
 
-            PivPinOnlyMode currentMode = GetPrintedPinProtectedStatus(specialKeyCollector, UserKeyCollector);
+            PivPinOnlyMode currentMode = GetPrintedPinProtectedStatus(specialKeyCollector, userKeyCollector);
 
             PinOnlyCheck pinOnlyCheck = CheckPinOnlyStatus(
                 currentMode, pinOnlyMode, PivPinOnlyMode.PinProtected, PivPinOnlyMode.PinProtectedUnavailable,
@@ -847,7 +850,7 @@ namespace Yubico.YubiKey.Piv
             if (pinOnlyCheck == PinOnlyCheck.CanContinue)
             {
                 currentMode |= GetPinDerivedStatus(
-                    adminData, currentMode.HasFlag(PivPinOnlyMode.PinProtected), specialKeyCollector, UserKeyCollector);
+                    adminData, currentMode.HasFlag(PivPinOnlyMode.PinProtected), specialKeyCollector, userKeyCollector);
 
                 pinOnlyCheck = CheckPinOnlyStatus(
                     currentMode, pinOnlyMode, PivPinOnlyMode.PinDerived, PivPinOnlyMode.PinDerivedUnavailable,
@@ -887,7 +890,7 @@ namespace Yubico.YubiKey.Piv
 
                 // This will either return with the mgmt key authenticated,
                 // or it will throw an exception.
-                specialKeyCollector.AuthMgmtKeyAndSave(this, UserKeyCollector);
+                specialKeyCollector.AuthMgmtKeyAndSave(this, userKeyCollector);
 
                 // If we reach this code, we can also set newAlgorithm to false.
                 // If this is true, we're going to later on Clear the YubiKey of
@@ -934,7 +937,7 @@ namespace Yubico.YubiKey.Piv
                 // mode is Derived. We need to set Derived, but then reset
                 // Protected to the Derived value.
                 SetYubiKeyPinDerived(
-                    adminData, currentMode, mgmtKeyAlgorithm, specialKeyCollector, UserKeyCollector, ref newMode);
+                    adminData, currentMode, mgmtKeyAlgorithm, specialKeyCollector, userKeyCollector, ref newMode);
             }
 
             if (newMode.HasFlag(PivPinOnlyMode.PinProtected))
@@ -956,12 +959,13 @@ namespace Yubico.YubiKey.Piv
         // testedUnavailable.
         // Set newMode and return a value based on the results of the comparison
         // The tested arg is what we're testing for, PinProtected or PinDerived.
-        private static PinOnlyCheck CheckPinOnlyStatus(PivPinOnlyMode currentMode,
-                                                       PivPinOnlyMode pinOnlyMode,
-                                                       PivPinOnlyMode tested,
-                                                       PivPinOnlyMode testedUnavailable,
-                                                       bool newAlgorithm,
-                                                       ref PivPinOnlyMode newMode)
+        private static PinOnlyCheck CheckPinOnlyStatus(
+            PivPinOnlyMode currentMode,
+            PivPinOnlyMode pinOnlyMode,
+            PivPinOnlyMode tested,
+            PivPinOnlyMode testedUnavailable,
+            bool newAlgorithm,
+            ref PivPinOnlyMode newMode)
         {
             // Look at PinProtected.
             // At this point, if the requested mode is PinProtected, and the
@@ -1030,14 +1034,15 @@ namespace Yubico.YubiKey.Piv
             }
 
             specialKeyCollector.SetKeyData(
-                SpecialKeyCollector.SetKeyDataDefault, ReadOnlyMemory<byte>.Empty, true, PivAlgorithm.TripleDes);
+                SpecialKeyCollector.SetKeyDataDefault, ReadOnlyMemory<byte>.Empty, isNewKey: true,
+                PivAlgorithm.TripleDes);
 
             specialKeyCollector.ChangeManagementKey(this, PivAlgorithm.TripleDes);
         }
 
         private void PutEmptyData(int dataTag)
         {
-            byte[] emptyObject = new byte[] { 0x53, 0x00 };
+            byte[] emptyObject = { 0x53, 0x00 };
 
             var putCmd = new PutDataCommand(dataTag, emptyObject);
             PutDataResponse putRsp = Connection.SendCommand(putCmd);
@@ -1058,17 +1063,18 @@ namespace Yubico.YubiKey.Piv
         // PIN-protected. If that's the case, authMode will be set to
         // PinProtected. Set the ref arg setPinProtected to true in this case.
         // Otherwise, leave that arg alone.
-        private void SetYubiKeyPinDerived(AdminData adminData,
-                                          PivPinOnlyMode currentMode,
-                                          PivAlgorithm mgmtKeyAlgorithm,
-                                          SpecialKeyCollector specialKeyCollector,
-                                          Func<KeyEntryData, bool>? UserKeyCollector,
-                                          ref PivPinOnlyMode newMode)
+        private void SetYubiKeyPinDerived(
+            AdminData adminData,
+            PivPinOnlyMode currentMode,
+            PivAlgorithm mgmtKeyAlgorithm,
+            SpecialKeyCollector specialKeyCollector,
+            Func<KeyEntryData, bool>? userKeyCollector,
+            ref PivPinOnlyMode newMode)
         {
             // We need the actual PIN in order to derive the mgmt key, so even if
             // the PIN has already been verified, collect it.
             // This method will do nothing if the PIN has already been collected.
-            specialKeyCollector.VerifyPinAndSave(this, UserKeyCollector);
+            specialKeyCollector.VerifyPinAndSave(this, userKeyCollector);
 
             // If the currentMode says the mgmt key had been authenticated using
             // PinProtected, we're going to "delete" that management key and set
@@ -1081,7 +1087,7 @@ namespace Yubico.YubiKey.Piv
             }
 
             ReadOnlyMemory<byte> salt = specialKeyCollector.DeriveKeyData
-                (ReadOnlyMemory<byte>.Empty, mgmtKeyAlgorithm, true);
+                (ReadOnlyMemory<byte>.Empty, mgmtKeyAlgorithm, isNewKey: true);
 
             // Call this method instead of the PivSession.Change method directly,
             // because this method will update the current key with the new key.
@@ -1099,14 +1105,15 @@ namespace Yubico.YubiKey.Piv
         // If the current key in specialKeyCollector is not the default, use that
         // key data. That data is either the "pre-existing" mgmt key data, or it
         // is the PIN-derived data.
-        private void SetYubiKeyPinProtected(AdminData adminData,
-                                            PivAlgorithm mgmtKeyAlgorithm,
-                                            SpecialKeyCollector specialKeyCollector)
+        private void SetYubiKeyPinProtected(
+            AdminData adminData,
+            PivAlgorithm mgmtKeyAlgorithm,
+            SpecialKeyCollector specialKeyCollector)
         {
             if (specialKeyCollector.IsCurrentKeyDefault())
             {
                 specialKeyCollector.SetKeyData(
-                    SpecialKeyCollector.SetKeyDataRandom, ReadOnlyMemory<byte>.Empty, true, mgmtKeyAlgorithm);
+                    SpecialKeyCollector.SetKeyDataRandom, ReadOnlyMemory<byte>.Empty, isNewKey: true, mgmtKeyAlgorithm);
 
                 specialKeyCollector.ChangeManagementKey(this, mgmtKeyAlgorithm);
             }
@@ -1147,10 +1154,10 @@ namespace Yubico.YubiKey.Piv
 
             mode = PivPinOnlyMode.None;
 
-            Func<KeyEntryData, bool>? UserKeyCollector = KeyCollector;
+            Func<KeyEntryData, bool>? userKeyCollector = KeyCollector;
             using var specialKeyCollector = new SpecialKeyCollector();
 
-            bool isValid = TryReadObject<AdminData>(out AdminData adminData);
+            bool isValid = TryReadObject(out AdminData adminData);
 
             try
             {
@@ -1164,8 +1171,8 @@ namespace Yubico.YubiKey.Piv
                 // In order to do that we need to verify the PIN.
                 isValid = pin.Length switch
                 {
-                    0 => specialKeyCollector.TryVerifyPinAndSave(this, UserKeyCollector, out retriesRemaining),
-                    _ => specialKeyCollector.TrySetPin(this, pin, out retriesRemaining),
+                    0 => specialKeyCollector.TryVerifyPinAndSave(this, userKeyCollector, out retriesRemaining),
+                    _ => specialKeyCollector.TrySetPin(this, pin, out retriesRemaining)
                 };
 
                 if (!isValid)
@@ -1175,10 +1182,11 @@ namespace Yubico.YubiKey.Piv
 
                 var salt = (ReadOnlyMemory<byte>)adminData.Salt;
 
-                _ = specialKeyCollector.DeriveKeyData(salt, ManagementKeyAlgorithm, false);
+                _ = specialKeyCollector.DeriveKeyData(salt, ManagementKeyAlgorithm, isNewKey: false);
 
                 specialKeyCollector.SetKeyData(
-                    SpecialKeyCollector.SetKeyDataDefault, ReadOnlyMemory<byte>.Empty, true, PivAlgorithm.TripleDes);
+                    SpecialKeyCollector.SetKeyDataDefault, ReadOnlyMemory<byte>.Empty, isNewKey: true,
+                    PivAlgorithm.TripleDes);
 
                 // If this fails, then the mgmt key is not PIN-derived from the
                 // PIN and salt, so we'll say it is not PIN-derived.
@@ -1198,7 +1206,7 @@ namespace Yubico.YubiKey.Piv
                 // Will we need to set the YubiKey to PIN-protected as well?
                 // If there is data in PRINTED, and it contains the same mgmt key
                 // that was derived from the PIN and Salt, then yes.
-                isValid = TryReadObject<PinProtectedData>(out PinProtectedData pinProtect);
+                isValid = TryReadObject(out PinProtectedData pinProtect);
 
                 using (pinProtect)
                 {
@@ -1206,9 +1214,7 @@ namespace Yubico.YubiKey.Piv
                     {
                         var mgmtKey = (ReadOnlyMemory<byte>)pinProtect.ManagementKey;
 
-                        if (MemoryExtensions.SequenceEqual(
-                                specialKeyCollector.GetCurrentMgmtKey().Span,
-                                mgmtKey.Span))
+                        if (specialKeyCollector.GetCurrentMgmtKey().Span.SequenceEqual(mgmtKey.Span))
                         {
                             mode |= PivPinOnlyMode.PinProtected;
                         }
@@ -1229,7 +1235,7 @@ namespace Yubico.YubiKey.Piv
             finally
             {
                 adminData.Dispose();
-                KeyCollector = UserKeyCollector;
+                KeyCollector = userKeyCollector;
             }
 
             return true;
@@ -1239,7 +1245,7 @@ namespace Yubico.YubiKey.Piv
         {
             Unavailable = 0,
             Complete = 1,
-            CanContinue = 2,
+            CanContinue = 2
         }
 
         // This class keeps track of the key data and its length.
@@ -1286,7 +1292,7 @@ namespace Yubico.YubiKey.Piv
                 {
                     PivAlgorithm.Aes128 => 16,
                     PivAlgorithm.Aes256 => 32,
-                    _ => 24,
+                    _ => 24
                 };
 
                 if (!newData.IsEmpty)
@@ -1299,12 +1305,12 @@ namespace Yubico.YubiKey.Piv
 
                     do
                     {
-                        randomObject.GetBytes(_keyBuffer, 0, newLength);
+                        randomObject.GetBytes(_keyBuffer, offset: 0, newLength);
                     }
                     while (IsKeyDataWeak(algorithm));
                 }
 
-                KeyData = _keyData.Slice(0, newLength);
+                KeyData = _keyData.Slice(start: 0, newLength);
             }
 
             // Derive a key of the appropriate length (based on algorithm), using
@@ -1312,8 +1318,10 @@ namespace Yubico.YubiKey.Piv
             // Return the salt.
             // It is the responsibility of the caller to make sure the pin is the
             // correct length.
-            public ReadOnlyMemory<byte> DeriveKeyData(ReadOnlyMemory<byte> pin, ReadOnlyMemory<byte> salt,
-                                                      PivAlgorithm algorithm)
+            public ReadOnlyMemory<byte> DeriveKeyData(
+                ReadOnlyMemory<byte> pin,
+                ReadOnlyMemory<byte> salt,
+                PivAlgorithm algorithm)
             {
                 ReadOnlyMemory<byte> returnValue = salt;
 
@@ -1325,7 +1333,7 @@ namespace Yubico.YubiKey.Piv
 
                     do
                     {
-                        randomObject.GetBytes(saltData, 0, PinDerivedSaltLength);
+                        randomObject.GetBytes(saltData, offset: 0, PinDerivedSaltLength);
                         PerformKeyDerive(pin, saltData, algorithm);
                     }
                     while (IsKeyDataWeak(algorithm));
@@ -1347,7 +1355,7 @@ namespace Yubico.YubiKey.Piv
                 {
                     PivAlgorithm.Aes128 => 16,
                     PivAlgorithm.Aes256 => 32,
-                    _ => 24,
+                    _ => 24
                 };
 
                 byte[] result = Array.Empty<byte>();
@@ -1356,12 +1364,12 @@ namespace Yubico.YubiKey.Piv
                 try
                 {
                     // This will use PBKDF2, with the PRF of HMAC with SHA-1.
-#pragma warning disable CA5379, CA5387 // These warnings complain about SHA-1 and <100,000 iterations, but we use it to be backwards-compatible.
-                    using var kdf = new Rfc2898DeriveBytes(pinData, saltData, 10000);
+                    #pragma warning disable CA5379, CA5387 // These warnings complain about SHA-1 and <100,000 iterations, but we use it to be backwards-compatible.
+                    using var kdf = new Rfc2898DeriveBytes(pinData, saltData, iterations: 10000);
                     result = kdf.GetBytes(newLength);
-#pragma warning restore CA5379, CA5387
+                    #pragma warning restore CA5379, CA5387
                     Array.Copy(result, _keyBuffer, newLength);
-                    KeyData = _keyData.Slice(0, newLength);
+                    KeyData = _keyData.Slice(start: 0, newLength);
                 }
                 finally
                 {
@@ -1379,8 +1387,9 @@ namespace Yubico.YubiKey.Piv
             {
                 if (algorithm == PivAlgorithm.TripleDes)
                 {
-                    if (MemoryExtensions.SequenceEqual(_keyData.Span.Slice(0, 8), _keyData.Span.Slice(8, 8))
-                        || MemoryExtensions.SequenceEqual(_keyData.Span.Slice(8, 8), _keyData.Span.Slice(16, 8)))
+                    if (_keyData.Span.Slice(start: 0, length: 8).SequenceEqual(_keyData.Span.Slice(start: 8, length: 8))
+                        || _keyData.Span.Slice(start: 8, length: 8)
+                            .SequenceEqual(_keyData.Span.Slice(start: 16, length: 8)))
                     {
                         return true;
                     }
@@ -1408,12 +1417,13 @@ namespace Yubico.YubiKey.Piv
 
             public SpecialKeyCollector()
             {
-                _defaultKey = new Memory<byte>(new byte[]
-                {
-                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-                    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
-                });
+                _defaultKey = new Memory<byte>(
+                    new byte[]
+                    {
+                        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+                        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08
+                    });
 
                 _currentKey = new MgmtKeyHolder();
                 _newKey = new MgmtKeyHolder();
@@ -1451,8 +1461,7 @@ namespace Yubico.YubiKey.Piv
             }
 
             // Check to see if the data is the default mgmt key.
-            public bool IsCurrentKeyDefault() =>
-                MemoryExtensions.SequenceEqual(_defaultKey.Span, _currentKey.KeyData.Span);
+            public bool IsCurrentKeyDefault() => _defaultKey.Span.SequenceEqual(_currentKey.KeyData.Span);
 
             // Set either the current or new mgmt key.
             // Set to either the data in the buffer, new random data, or the
@@ -1511,7 +1520,7 @@ namespace Yubico.YubiKey.Piv
             {
                 MgmtKeyHolder dest = isNewKey ? _newKey : _currentKey;
 
-                return dest.DeriveKeyData(_pinMemory.Slice(0, _pinLength), salt, algorithm);
+                return dest.DeriveKeyData(_pinMemory.Slice(start: 0, _pinLength), salt, algorithm);
             }
 
             // Change the management key from what is in current to what is in
@@ -1520,14 +1529,14 @@ namespace Yubico.YubiKey.Piv
             public void ChangeManagementKey(PivSession pivSession, PivAlgorithm algorithm)
             {
                 pivSession.ChangeManagementKey(PivTouchPolicy.Never, algorithm);
-                SetKeyData(SetKeyDataBuffer, _newKey.KeyData, false, algorithm);
+                SetKeyData(SetKeyDataBuffer, _newKey.KeyData, isNewKey: false, algorithm);
             }
 
             // Obtain the mgmt key and authenticate it, make sure the mgmt key is set
             // in the SpecialKeyCollector.
             // This method assumes the special key collector is in a state just after
             // instantiation.
-            // If the user cancels (the UserKeyCollector returns false), this method
+            // If the user cancels (the userKeyCollector returns false), this method
             // will throw an exception.
             // This method assumes the special key collector is in the PivSession's
             // KeyCollector and it expects the default mgmt key is the current key.
@@ -1538,8 +1547,9 @@ namespace Yubico.YubiKey.Piv
             // exception.
             // Upon completion of this method, the correct mgmt key is in the current
             // key.
-            public void AuthMgmtKeyAndSave(PivSession pivSession,
-                                           Func<KeyEntryData, bool>? UserKeyCollector)
+            public void AuthMgmtKeyAndSave(
+                PivSession pivSession,
+                Func<KeyEntryData, bool>? userKeyCollector)
             {
                 // First, try the default key. If it works, we're done.
                 // If we reach this point, the special key collector has just been
@@ -1551,7 +1561,7 @@ namespace Yubico.YubiKey.Piv
 
                 // If the default did not authenticate, use the caller-supplied
                 // KeyCollector to obtain the key.
-                if (UserKeyCollector is null)
+                if (userKeyCollector is null)
                 {
                     throw new InvalidOperationException(
                         string.Format(
@@ -1559,16 +1569,17 @@ namespace Yubico.YubiKey.Piv
                             ExceptionMessages.MissingKeyCollector));
                 }
 
-                var keyEntryData = new KeyEntryData()
+                var keyEntryData = new KeyEntryData
                 {
-                    Request = KeyEntryRequest.AuthenticatePivManagementKey,
+                    Request = KeyEntryRequest.AuthenticatePivManagementKey
                 };
 
                 try
                 {
-                    while (UserKeyCollector(keyEntryData))
+                    while (userKeyCollector(keyEntryData))
                     {
-                        SetKeyData(SetKeyDataBuffer, keyEntryData.GetCurrentValue(), false,
+                        SetKeyData(
+                            SetKeyDataBuffer, keyEntryData.GetCurrentValue(), isNewKey: false,
                             pivSession.ManagementKeyAlgorithm);
 
                         if (pivSession.TryAuthenticateWithKeyCollector(true))
@@ -1584,7 +1595,7 @@ namespace Yubico.YubiKey.Piv
                     keyEntryData.Clear();
 
                     keyEntryData.Request = KeyEntryRequest.Release;
-                    _ = UserKeyCollector(keyEntryData);
+                    _ = userKeyCollector(keyEntryData);
                 }
 
                 // If the user cancels, throw the canceled exception.
@@ -1603,12 +1614,13 @@ namespace Yubico.YubiKey.Piv
             // If the PIN is already collected, do nothing.
             // If not, obtain the PIN and verify it, set the PinCollected
             // property.
-            // If the If the user cancels (the UserKeyCollector returns false),
+            // If the If the user cancels (the userKeyCollector returns false),
             // this method will throw an exception.
-            public void VerifyPinAndSave(PivSession pivSession,
-                                         Func<KeyEntryData, bool>? UserKeyCollector)
+            public void VerifyPinAndSave(
+                PivSession pivSession,
+                Func<KeyEntryData, bool>? userKeyCollector)
             {
-                if (!TryVerifyPinAndSave(pivSession, UserKeyCollector, out _))
+                if (!TryVerifyPinAndSave(pivSession, userKeyCollector, out _))
                 {
                     // If the user cancels, throw the canceled exception.
                     throw new OperationCanceledException(
@@ -1620,9 +1632,10 @@ namespace Yubico.YubiKey.Piv
 
             // Verify the PIN and save it in this.
             // If the user cancels, return false.
-            public bool TryVerifyPinAndSave(PivSession pivSession,
-                                            Func<KeyEntryData, bool>? UserKeyCollector,
-                                            out int? retriesRemaining)
+            public bool TryVerifyPinAndSave(
+                PivSession pivSession,
+                Func<KeyEntryData, bool>? userKeyCollector,
+                out int? retriesRemaining)
             {
                 retriesRemaining = null;
 
@@ -1631,7 +1644,7 @@ namespace Yubico.YubiKey.Piv
                     return true;
                 }
 
-                if (UserKeyCollector is null)
+                if (userKeyCollector is null)
                 {
                     throw new InvalidOperationException(
                         string.Format(
@@ -1639,14 +1652,14 @@ namespace Yubico.YubiKey.Piv
                             ExceptionMessages.MissingKeyCollector));
                 }
 
-                var keyEntryData = new KeyEntryData()
+                var keyEntryData = new KeyEntryData
                 {
-                    Request = KeyEntryRequest.VerifyPivPin,
+                    Request = KeyEntryRequest.VerifyPivPin
                 };
 
                 try
                 {
-                    while (UserKeyCollector(keyEntryData))
+                    while (userKeyCollector(keyEntryData))
                     {
                         if (TrySetPin(pivSession, keyEntryData.GetCurrentValue(), out retriesRemaining))
                         {
@@ -1662,7 +1675,7 @@ namespace Yubico.YubiKey.Piv
                     keyEntryData.Clear();
 
                     keyEntryData.Request = KeyEntryRequest.Release;
-                    _ = UserKeyCollector(keyEntryData);
+                    _ = userKeyCollector(keyEntryData);
                 }
 
                 // We reach this point if the user cancels.
@@ -1713,7 +1726,7 @@ namespace Yubico.YubiKey.Piv
                         return true;
 
                     case KeyEntryRequest.VerifyPivPin:
-                        keyEntryData.SubmitValue(_pinMemory.Slice(0, _pinLength).Span);
+                        keyEntryData.SubmitValue(_pinMemory.Slice(start: 0, _pinLength).Span);
 
                         return true;
                 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -238,7 +238,7 @@ namespace Yubico.YubiKey.Piv
                 : yubiKey.ConnectScp03(YubiKeyApplication.Piv, scp03Keys);
 
             ResetAuthenticationStatus();
-            GetManagementKey(yubiKey);
+            UpdateManagementKey(yubiKey);
 
             _yubiKeyDevice = yubiKey;
             _disposed = false;
@@ -433,7 +433,7 @@ namespace Yubico.YubiKey.Piv
             }
 
             ResetAuthenticationStatus();
-            GetManagementKey(_yubiKeyDevice);
+            UpdateManagementKey(_yubiKeyDevice);
         }
 
         /// <summary>
@@ -492,7 +492,7 @@ namespace Yubico.YubiKey.Piv
         ///     <see cref="AuthenticateManagementKey" /> which may in turn throw its' own exceptions.
         /// </remarks>
         /// <param name="slotToClear">The Yubikey slot of the key you want to clear. This must be a valid slot number.</param>
-        /// <seealso cref="PivSlot"/>
+        /// <seealso cref="PivSlot" />
         /// <exception cref="InvalidOperationException">
         ///     Either the call to the Yubikey was unsuccessful or
         ///     there wasn't any <c>KeyCollector</c> loaded, the key provided was not a valid Triple-DES key, or the YubiKey
@@ -595,7 +595,7 @@ namespace Yubico.YubiKey.Piv
                     ExceptionMessages.ApplicationResetFailure));
         }
 
-        private void GetManagementKey(IYubiKeyDevice yubiKey) =>
+        private void UpdateManagementKey(IYubiKeyDevice yubiKey) =>
             ManagementKeyAlgorithm = yubiKey.HasFeature(YubiKeyFeature.PivAesManagementKey)
                 ? GetManagementKeyAlgorithm()
                 : PivAlgorithm.TripleDes; // Default for keys with firmware version < 5.7

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -24,15 +24,15 @@ using Yubico.YubiKey.Scp03;
 namespace Yubico.YubiKey.Piv
 {
     /// <summary>
-    /// Create a session and perform PIV operations within that session.
+    ///     Create a session and perform PIV operations within that session.
     /// </summary>
     /// <remarks>
-    /// When you need to perform PIV operations, instantiate this class to create
-    /// a session, then call on the methods in the class.
-    /// <para>
-    /// Generally you will choose the YubiKey to use by building an instance of
-    /// <see cref="IYubiKeyDevice"/>. This object will represent the actual hardware.
-    /// <code language="csharp">
+    ///     When you need to perform PIV operations, instantiate this class to create
+    ///     a session, then call on the methods in the class.
+    ///     <para>
+    ///         Generally you will choose the YubiKey to use by building an instance of
+    ///         <see cref="IYubiKeyDevice" />. This object will represent the actual hardware.
+    ///         <code language="csharp">
     ///   IYubiKeyDevice SelectYubiKey()
     ///   {
     ///       IEnumerable&lt;IYubiKeyDevice&gt; yubiKeyList = YubiKey.FindAll();
@@ -46,100 +46,101 @@ namespace Yubico.YubiKey.Piv
     ///       }
     ///   }
     /// </code>
-    /// </para>
-    /// <para>
-    /// Once you have the YubiKey to use, you will build an instance of this
-    /// <c>PivSession</c> class to represent the PIV application on the hardware.
-    /// Because this class implements <c>IDisposable</c>, use the <c>using</c>
-    /// keyword. For example,
-    /// <code language="csharp">
+    ///     </para>
+    ///     <para>
+    ///         Once you have the YubiKey to use, you will build an instance of this
+    ///         <c>PivSession</c> class to represent the PIV application on the hardware.
+    ///         Because this class implements <c>IDisposable</c>, use the <c>using</c>
+    ///         keyword. For example,
+    ///         <code language="csharp">
     ///     IYubiKeyDevice yubiKeyToUse = SelectYubiKey();
     ///     using (var piv = new PivSession(yubiKeyToUse))
     ///     {
     ///         /* Perform PIV operations. */
     ///     }
     /// </code>
-    /// </para>
-    /// <para>
-    /// If this class is used as part of a <c>using</c> expression, when the
-    /// session goes out of scope, the <c>Dispose</c> method will be called to
-    /// dispose the active PIV session, clearing any authenticated state, and
-    /// ultimately releasing the connection to the YubiKey.
-    /// </para>
-    /// <para> Note that while a session is open, any management key authentication
-    /// and PIN verification will be active. That is, you need to authenticate
-    /// the management key or verify the PIN only once per session. Touch might
-    /// be needed more than once.
-    /// </para>
-    /// <para>
-    /// There are some exceptions to the "verify the PIN once per session" rule.
-    /// For example, to change a PIN, you need to enter the current and new PIN,
-    /// even if the current PIN has been verified. The documentation for each
-    /// method in this class will indicate if the PIN is needed, and if so, must
-    /// it be verified or entered. See also the User's Manual entries on the
-    /// <xref href="UsersManualPinPukMgmtKey"> PIV PIN, PUK, and Management Key</xref>
-    /// and <xref href="UsersManualPivAccessControl"> PIV commands access control</xref>.
-    /// </para>
-    /// <para>
-    /// Note that PIN/PUK/Management Key verification or authentication will
-    /// happen automatically when you call a method that needs it. You can
-    /// call the <c>TryVerifyPin</c> or <c>TryAuthenticateManagementKey</c>
-    /// methods if you want, but any method that can be executed only if the PIN
-    /// and/or management key has been verified or authenticated will determine
-    /// if the appropriate values have been verified/authenticated, and if not,
-    /// will make the appropriate calls to do so. The caller must supply a
-    /// PIN/PUK/management key collector delegate (callback).
-    /// </para>
-    /// <para>
-    /// This class needs a delegate (callback): a method to enter the PIN, PUK,
-    /// or management key. Although some operations will not need this delegate,
-    /// any useful application will almost certainly call one or more methods
-    /// that do need it. You will need to set the appropriate property after
-    /// instantiating this class.
-    /// <code language="csharp">
+    ///     </para>
+    ///     <para>
+    ///         If this class is used as part of a <c>using</c> expression, when the
+    ///         session goes out of scope, the <c>Dispose</c> method will be called to
+    ///         dispose the active PIV session, clearing any authenticated state, and
+    ///         ultimately releasing the connection to the YubiKey.
+    ///     </para>
+    ///     <para>
+    ///         Note that while a session is open, any management key authentication
+    ///         and PIN verification will be active. That is, you need to authenticate
+    ///         the management key or verify the PIN only once per session. Touch might
+    ///         be needed more than once.
+    ///     </para>
+    ///     <para>
+    ///         There are some exceptions to the "verify the PIN once per session" rule.
+    ///         For example, to change a PIN, you need to enter the current and new PIN,
+    ///         even if the current PIN has been verified. The documentation for each
+    ///         method in this class will indicate if the PIN is needed, and if so, must
+    ///         it be verified or entered. See also the User's Manual entries on the
+    ///         <xref href="UsersManualPinPukMgmtKey"> PIV PIN, PUK, and Management Key</xref>
+    ///         and <xref href="UsersManualPivAccessControl"> PIV commands access control</xref>.
+    ///     </para>
+    ///     <para>
+    ///         Note that PIN/PUK/Management Key verification or authentication will
+    ///         happen automatically when you call a method that needs it. You can
+    ///         call the <c>TryVerifyPin</c> or <c>TryAuthenticateManagementKey</c>
+    ///         methods if you want, but any method that can be executed only if the PIN
+    ///         and/or management key has been verified or authenticated will determine
+    ///         if the appropriate values have been verified/authenticated, and if not,
+    ///         will make the appropriate calls to do so. The caller must supply a
+    ///         PIN/PUK/management key collector delegate (callback).
+    ///     </para>
+    ///     <para>
+    ///         This class needs a delegate (callback): a method to enter the PIN, PUK,
+    ///         or management key. Although some operations will not need this delegate,
+    ///         any useful application will almost certainly call one or more methods
+    ///         that do need it. You will need to set the appropriate property after
+    ///         instantiating this class.
+    ///         <code language="csharp">
     ///   using (var pivSession = new PivSession(yubiKeyToUse))
     ///   {
     ///       KeyCollector = SomeCollectorDelegate;
     ///   };
     /// </code>
-    /// </para>
-    /// <para>
-    /// You supply the delegate as the <c>KeyCollector</c> property. See also the
-    /// User's Manual entry on
-    /// <xref href="UsersManualDelegatesInSdk"> delegates in the SDK</xref>.
-    /// </para>
-    /// <para>
-    /// Note that the YubiKey is manufactured with default PIN, PUK, and
-    /// management key values. This is a requirement of the PIV standard.
-    /// <code>
+    ///     </para>
+    ///     <para>
+    ///         You supply the delegate as the <c>KeyCollector</c> property. See also the
+    ///         User's Manual entry on
+    ///         <xref href="UsersManualDelegatesInSdk"> delegates in the SDK</xref>.
+    ///     </para>
+    ///     <para>
+    ///         Note that the YubiKey is manufactured with default PIN, PUK, and
+    ///         management key values. This is a requirement of the PIV standard.
+    ///         <code>
     ///    management key (hex): 01 02 03 04 05 06 07 08
     ///                          01 02 03 04 05 06 07 08
     ///                          01 02 03 04 05 06 07 08
-    ///
+    /// 
     ///    PIN (hex): 31 32 33 34 35 36
     ///    as an ASCII string, this would be "123456"
-    ///
+    /// 
     ///    PUK (hex): 31 32 33 34 35 36 37 38
     ///    as an ASCII string, this would be "12345678"
     /// </code>
-    /// </para>
-    /// <para>
-    /// The PIN, PUK, and management key are supplied as byte arrays. The reason
-    /// is that they can be binary data (they are not necessarily strings, ASCII
-    /// or otherwise), and a byte array can be overwritten to limit the contents'
-    /// exposure. See the User's Manual entries on
-    /// <xref href="UsersManualSensitive"> sensitive data</xref>.
-    /// </para>
-    /// <para>
-    /// This class will also need a random number generator and a Triple-DES
-    /// encryptor/decryptor. It will get them from
-    /// <see cref="CryptographyProviders"/>. That class will return default
-    /// implementations, unless you replace them. Very few applications will
-    /// choose to replace the defaults, but if you want to, see the documentation
-    /// for that class and the User's Manual entry on
-    /// <xref href="UsersManualAlternateCrypto"> alternate crypto implementations</xref>
-    /// to learn how to do so.
-    /// </para>
+    ///     </para>
+    ///     <para>
+    ///         The PIN, PUK, and management key are supplied as byte arrays. The reason
+    ///         is that they can be binary data (they are not necessarily strings, ASCII
+    ///         or otherwise), and a byte array can be overwritten to limit the contents'
+    ///         exposure. See the User's Manual entries on
+    ///         <xref href="UsersManualSensitive"> sensitive data</xref>.
+    ///     </para>
+    ///     <para>
+    ///         This class will also need a random number generator and a Triple-DES
+    ///         encryptor/decryptor. It will get them from
+    ///         <see cref="CryptographyProviders" />. That class will return default
+    ///         implementations, unless you replace them. Very few applications will
+    ///         choose to replace the defaults, but if you want to, see the documentation
+    ///         for that class and the User's Manual entry on
+    ///         <xref href="UsersManualAlternateCrypto"> alternate crypto implementations</xref>
+    ///         to learn how to do so.
+    ///     </para>
     /// </remarks>
     public sealed partial class PivSession : IDisposable
     {
@@ -155,13 +156,13 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Create an instance of <c>PivSession</c>, the object that represents
-        /// the PIV application on the YubiKey.
+        ///     Create an instance of <c>PivSession</c>, the object that represents
+        ///     the PIV application on the YubiKey.
         /// </summary>
         /// <remarks>
-        /// Because this class implements <c>IDisposable</c>, use the <c>using</c>
-        /// keyword. For example,
-        /// <code language="csharp">
+        ///     Because this class implements <c>IDisposable</c>, use the <c>using</c>
+        ///     keyword. For example,
+        ///     <code language="csharp">
         ///     IYubiKeyDevice yubiKeyToUse = SelectYubiKey();
         ///     using (var piv = new PivSession(yubiKeyToUse))
         ///     {
@@ -170,30 +171,30 @@ namespace Yubico.YubiKey.Piv
         /// </code>
         /// </remarks>
         /// <param name="yubiKey">
-        /// The object that represents the actual YubiKey which will perform the
-        /// operations.
+        ///     The object that represents the actual YubiKey which will perform the
+        ///     operations.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// The <c>yubiKey</c> argument is null.
+        ///     The <c>yubiKey</c> argument is null.
         /// </exception>
         public PivSession(IYubiKeyDevice yubiKey)
-            : this(null, yubiKey)
+            : this(scp03Keys: null, yubiKey)
         {
         }
 
         /// <summary>
-        /// Create an instance of <c>PivSession</c>, the object that represents
-        /// the PIV application on the YubiKey. The communication between the SDK
-        /// and the YubiKey will be protected by SCP03.
+        ///     Create an instance of <c>PivSession</c>, the object that represents
+        ///     the PIV application on the YubiKey. The communication between the SDK
+        ///     and the YubiKey will be protected by SCP03.
         /// </summary>
         /// <remarks>
-        /// See the User's Manual entry on
-        /// <xref href="UsersManualScp03"> SCP03 </xref> for more information on
-        /// this communication protocol.
-        /// <para>
-        /// Because this class implements <c>IDisposable</c>, use the <c>using</c>
-        /// keyword. For example,
-        /// <code language="csharp">
+        ///     See the User's Manual entry on
+        ///     <xref href="UsersManualScp03"> SCP03 </xref> for more information on
+        ///     this communication protocol.
+        ///     <para>
+        ///         Because this class implements <c>IDisposable</c>, use the <c>using</c>
+        ///         keyword. For example,
+        ///         <code language="csharp">
         ///     IYubiKeyDevice yubiKeyToUse = SelectYubiKey();
         ///     // Assume you have some method that obtains the appropriate SCP03
         ///     // key set.
@@ -203,20 +204,20 @@ namespace Yubico.YubiKey.Piv
         ///         /* Perform PIV operations. */
         ///     }
         /// </code>
-        /// </para>
+        ///     </para>
         /// </remarks>
         /// <param name="yubiKey">
-        /// The object that represents the actual YubiKey which will perform the
-        /// operations.
+        ///     The object that represents the actual YubiKey which will perform the
+        ///     operations.
         /// </param>
         /// <param name="scp03Keys">
-        /// The SCP03 key set to use in establishing the connection.
+        ///     The SCP03 key set to use in establishing the connection.
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// The <c>yubiKey</c> argument is null.
+        ///     The <c>yubiKey</c> argument is null.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        /// This exception is thrown when unable to determine the management key type.
+        ///     This exception is thrown when unable to determine the management key type.
         /// </exception>
         public PivSession(IYubiKeyDevice yubiKey, StaticKeys scp03Keys)
             : this(scp03Keys, yubiKey)
@@ -237,62 +238,47 @@ namespace Yubico.YubiKey.Piv
                 : yubiKey.ConnectScp03(YubiKeyApplication.Piv, scp03Keys);
 
             ResetAuthenticationStatus();
-
-            ManagementKeyAlgorithm = yubiKey.HasFeature(YubiKeyFeature.PivAesManagementKey)
-                ? GetManagementKeyAlgorithm()
-                : PivAlgorithm.TripleDes; // Default for keys with firmware version < 5.7
+            GetManagementKey(yubiKey);
 
             _yubiKeyDevice = yubiKey;
             _disposed = false;
         }
 
-        private PivAlgorithm GetManagementKeyAlgorithm()
-        {
-            GetMetadataResponse response = Connection.SendCommand(new GetMetadataCommand(PivSlot.Management));
-            if (response.Status != ResponseStatus.Success)
-            {
-                throw new InvalidOperationException(response.StatusMessage);
-            }
-
-            PivMetadata metadata = response.GetData();
-            return metadata.Algorithm;
-        }
-
         /// <summary>
-        /// The object that represents the connection to the YubiKey. Most
-        /// applications will ignore this, but it can be used to call Commands
-        /// directly.
+        ///     The object that represents the connection to the YubiKey. Most
+        ///     applications will ignore this, but it can be used to call Commands
+        ///     directly.
         /// </summary>
-        public IYubiKeyConnection Connection { get; private set; }
+        public IYubiKeyConnection Connection { get; }
 
         /// <summary>
-        /// The Delegate this class will call when it needs a PIN, PUK, or
-        /// management key.
+        ///     The Delegate this class will call when it needs a PIN, PUK, or
+        ///     management key.
         /// </summary>
         /// <remarks>
-        /// The delegate provided will read the <c>KeyEntryData</c> which
-        /// contains the information needed to determine what to collect and
-        /// methods to submit what was collected. The delegate will return
-        /// <c>true</c> for success or <c>false</c> for "cancel". A cancel will
-        /// usually happen when the user has clicked a "Cancel" button. That is
-        /// often the case when the user has entered the wrong value a number of
-        /// times, the remaining tries count is getting low, and they would like
-        /// to stop trying before the YubiKey is blocked.
-        /// <para>
-        /// Note that the SDK will call the <c>KeyCollector</c> with a
-        /// <c>Request</c> of <c>Release</c> when the process completes. In this
-        /// case, the <c>KeyCollector</c> MUST NOT throw an exception. The
-        /// <c>Release</c> is called from inside a <c>finally</c> block, and it
-        /// is a bad idea to throw exceptions from inside <c>finally</c>.
-        /// </para>
+        ///     The delegate provided will read the <c>KeyEntryData</c> which
+        ///     contains the information needed to determine what to collect and
+        ///     methods to submit what was collected. The delegate will return
+        ///     <c>true</c> for success or <c>false</c> for "cancel". A cancel will
+        ///     usually happen when the user has clicked a "Cancel" button. That is
+        ///     often the case when the user has entered the wrong value a number of
+        ///     times, the remaining tries count is getting low, and they would like
+        ///     to stop trying before the YubiKey is blocked.
+        ///     <para>
+        ///         Note that the SDK will call the <c>KeyCollector</c> with a
+        ///         <c>Request</c> of <c>Release</c> when the process completes. In this
+        ///         case, the <c>KeyCollector</c> MUST NOT throw an exception. The
+        ///         <c>Release</c> is called from inside a <c>finally</c> block, and it
+        ///         is a bad idea to throw exceptions from inside <c>finally</c>.
+        ///     </para>
         /// </remarks>
         public Func<KeyEntryData, bool>? KeyCollector { get; set; }
 
         /// <summary>
-        /// When the PivSession object goes out of scope, this method is called.
-        /// It will close the session. The most important function of closing a
-        /// session is to "un-authenticate" the management key and "un-verify"
-        /// the PIN.
+        ///     When the PivSession object goes out of scope, this method is called.
+        ///     It will close the session. The most important function of closing a
+        ///     session is to "un-authenticate" the management key and "un-verify"
+        ///     the PIN.
         /// </summary>
 
         // Note that .NET recommends a Dispose method call Dispose(true) and
@@ -320,6 +306,23 @@ namespace Yubico.YubiKey.Piv
             _disposed = true;
         }
 
+        private void GetManagementKey(IYubiKeyDevice yubiKey) =>
+            ManagementKeyAlgorithm = yubiKey.HasFeature(YubiKeyFeature.PivAesManagementKey)
+                ? GetManagementKeyAlgorithm()
+                : PivAlgorithm.TripleDes; // Default for keys with firmware version < 5.7
+
+        private PivAlgorithm GetManagementKeyAlgorithm()
+        {
+            GetMetadataResponse response = Connection.SendCommand(new GetMetadataCommand(PivSlot.Management));
+            if (response.Status != ResponseStatus.Success)
+            {
+                throw new InvalidOperationException(response.StatusMessage);
+            }
+
+            PivMetadata metadata = response.GetData();
+            return metadata.Algorithm;
+        }
+
         // Reset any fields and properties related to authentication or
         // verification to the initial state: not authenticated, verified, etc.
         private void ResetAuthenticationStatus()
@@ -330,16 +333,16 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Get information about the specified slot.
+        ///     Get information about the specified slot.
         /// </summary>
         /// <remarks>
-        /// This feature is available only on YubiKeys 5.3 and later. If you call
-        /// this method on an earlier YubiKey, it will throw an exception. A good
-        /// idea is to verify that the version number is valid before calling.
-        /// <code language="csharp">
+        ///     This feature is available only on YubiKeys 5.3 and later. If you call
+        ///     this method on an earlier YubiKey, it will throw an exception. A good
+        ///     idea is to verify that the version number is valid before calling.
+        ///     <code language="csharp">
         ///     IEnumerable&lt;IYubiKeyDevice&gt; list = YubiKey.FindByTransport(Transport.UsbSmartCard);
         ///     IYubiKeyDevice yubiKey = list.First();
-        ///
+        /// 
         ///     using (var pivSession = new PivSession(yubiKey))
         ///     {
         ///         if (yubiKey.FirmwareVersion &gt;= new FirmwareVersion(5, 3, 0))
@@ -349,27 +352,27 @@ namespace Yubico.YubiKey.Piv
         ///         }
         ///     }
         /// </code>
-        /// <para>
-        /// See the User's Manual
-        /// <xref href="UsersManualPivCommands#get-metadata"> entry on getting metadata</xref>
-        /// for specific information about what information is returned. Different
-        /// slots return different sets of data. That page also lists the valid
-        /// slots for which metadata is available.
-        /// </para>
+        ///     <para>
+        ///         See the User's Manual
+        ///         <xref href="UsersManualPivCommands#get-metadata"> entry on getting metadata</xref>
+        ///         for specific information about what information is returned. Different
+        ///         slots return different sets of data. That page also lists the valid
+        ///         slots for which metadata is available.
+        ///     </para>
         /// </remarks>
         /// <param name="slotNumber">
-        /// The slot for which the information is requested.
+        ///     The slot for which the information is requested.
         /// </param>
         /// <returns>
-        /// A new instance of a <c>PivMetadata</c> object containing information
-        /// about the given slot.
+        ///     A new instance of a <c>PivMetadata</c> object containing information
+        ///     about the given slot.
         /// </returns>
         /// <exception cref="ArgumentException">
-        /// The slot specified is not valid for getting metadata.
+        ///     The slot specified is not valid for getting metadata.
         /// </exception>
         /// <exception cref="InvalidOperationException">
-        /// The YubiKey queried does not support metadata, or the operation could
-        /// not be completed because of some error such as unreliable connection.
+        ///     The YubiKey queried does not support metadata, or the operation could
+        ///     not be completed because of some error such as unreliable connection.
         /// </exception>
         public PivMetadata GetMetadata(byte slotNumber)
         {
@@ -390,136 +393,90 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Reset the PIV application to the default state.
+        ///     Reset the PIV application to the default state.
         /// </summary>
         /// <remarks>
-        /// This will delete all keys and certs in all the asymmetric key slots
-        /// other than F9, delete any added information to the data elements and
-        /// set the PIN, PUK, and management key to their default values. That
-        /// is, this will set the PIV application's state to what it was upon
-        /// manufacture. See the User's Manual entries on the
-        /// <xref href="UsersManualPinPukMgmtKey"> PIV PIN, PUK, and management key </xref>
-        /// and <xref href="UsersManualPivGetAndPutData"> data elements</xref>
-        /// for more information on the defaults and data added to elements.
-        /// <para>
-        /// Note that this has no effect on the other YubiKey applications. This
-        /// does NOT reset OTP, OATH, OpenPgp Card, FIDO U2F, or FIDO2.
-        /// </para>
-        /// <para>
-        /// Users will generally want to reset only if both the PIN and PUK are
-        /// blocked. If a PIN has been blocked, it can only be restored using the
-        /// PUK, but if the PUK is also blocked, there is no way to recover the
-        /// PIN. Once there is no PIN, and no way to recover it, there is very
-        /// little useful work the PIV application on a YubiKey can do. Resetting
-        /// the application does not make the situation worse, but it does
-        /// improve things somewhat, because the PIV application is usable again,
-        /// just with new key pairs.
-        /// </para>
-        /// <para>
-        /// However, it is important to note that this method will reset the PIV
-        /// application even if the PIN and/or PUK are not blocked. The YubiKey
-        /// will not allow itself to be reset until both the PIN and PUK are
-        /// blocked. This method will take steps necessary to block the PIN and
-        /// PUK, then call on the YubiKey to reset.
-        /// </para>
+        ///     This will delete all keys and certs in all the asymmetric key slots
+        ///     other than F9, delete any added information to the data elements and
+        ///     set the PIN, PUK, and management key to their default values. That
+        ///     is, this will set the PIV application's state to what it was upon
+        ///     manufacture. See the User's Manual entries on the
+        ///     <xref href="UsersManualPinPukMgmtKey"> PIV PIN, PUK, and management key </xref>
+        ///     and <xref href="UsersManualPivGetAndPutData"> data elements</xref>
+        ///     for more information on the defaults and data added to elements.
+        ///     <para>
+        ///         Note that this has no effect on the other YubiKey applications. This
+        ///         does NOT reset OTP, OATH, OpenPgp Card, FIDO U2F, or FIDO2.
+        ///     </para>
+        ///     <para>
+        ///         Users will generally want to reset only if both the PIN and PUK are
+        ///         blocked. If a PIN has been blocked, it can only be restored using the
+        ///         PUK, but if the PUK is also blocked, there is no way to recover the
+        ///         PIN. Once there is no PIN, and no way to recover it, there is very
+        ///         little useful work the PIV application on a YubiKey can do. Resetting
+        ///         the application does not make the situation worse, but it does
+        ///         improve things somewhat, because the PIV application is usable again,
+        ///         just with new key pairs.
+        ///     </para>
+        ///     <para>
+        ///         However, it is important to note that this method will reset the PIV
+        ///         application even if the PIN and/or PUK are not blocked. The YubiKey
+        ///         will not allow itself to be reset until both the PIN and PUK are
+        ///         blocked. This method will take steps necessary to block the PIN and
+        ///         PUK, then call on the YubiKey to reset.
+        ///     </para>
         /// </remarks>
         /// <exception cref="SecurityException">
-        /// The application could not be reset because of some error such as
-        /// unreliable connection.
+        ///     The application could not be reset because of some error such as
+        ///     unreliable connection.
         /// </exception>
         public void ResetApplication()
         {
-            _log.LogInformation("Reset the PIV application.");
+            _log.LogInformation("Resetting the PIV application.");
 
             // To reset, both the PIN and PUK must be blocked.
-            if (BlockPinOrPuk(PivSlot.Pin))
+            TryBlock(PivSlot.Pin);
+            TryBlock(PivSlot.Puk);
+
+            var resetCommand = new ResetPivCommand();
+            ResetPivResponse resetResponse = Connection.SendCommand(resetCommand);
+
+            if (resetResponse.Status != ResponseStatus.Success)
             {
-                if (BlockPinOrPuk(PivSlot.Puk))
-                {
-                    var resetCommand = new ResetPivCommand();
-                    ResetPivResponse resetResponse = Connection.SendCommand(resetCommand);
-
-                    if (resetResponse.Status == ResponseStatus.Success)
-                    {
-                        ResetAuthenticationStatus();
-
-                        return;
-                    }
-                }
+                throw new SecurityException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.ApplicationResetFailure));
             }
 
-            throw new SecurityException(
-                string.Format(
-                    CultureInfo.CurrentCulture,
-                    ExceptionMessages.ApplicationResetFailure));
-        }
-
-        // Block the PIN or PUK
-        // To get the PIN or PUK into a blocked state, try to change it. Each
-        // time the current PIN/PUK entered is incorrect, the retries remaining
-        // count is decremented. When it hits zero, it is blocked, return true.
-        // Call the ChangeReferenceDataCommand with arbitrary current and new
-        // PIN/PUK values. They must be different. If the arbitrary current value
-        // happens to be correct, the first call to change the PIN/PUK will work
-        // and it will become the new PIN/PUK. For the next call, use the same
-        // current value, which is now the wrong current value.
-        // If the slotNumber argument is PivSlot.Pin, block the PIN, if it is
-        // PivSlot.Puk, block the PUK.
-        private bool BlockPinOrPuk(byte slotNumber)
-        {
-            _log.LogInformation($"Block the {(slotNumber == 0x80 ? "PIN" : "PUK")}.");
-            int retriesRemaining;
-
-            do
-            {
-                byte[] currentValue = new byte[]
-                {
-                    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01
-                };
-
-                byte[] newValue = new byte[]
-                {
-                    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22
-                };
-
-                var changeCommand = new ChangeReferenceDataCommand(slotNumber, currentValue, newValue);
-                ChangeReferenceDataResponse changeResponse = Connection.SendCommand(changeCommand);
-
-                if (changeResponse.Status == ResponseStatus.Failed)
-                {
-                    return false;
-                }
-
-                retriesRemaining = changeResponse.GetData() ?? 1;
-            }
-            while (retriesRemaining > 0);
-
-            return true;
+            ResetAuthenticationStatus();
+            GetManagementKey(_yubiKeyDevice);
         }
 
         /// <summary>
-        /// Moves a key from one slot to another.
-        /// The source slot must not be the <see cref="PivSlot.Attestation"/>-slot and the destination slot must be empty.
+        ///     Moves a key from one slot to another.
+        ///     The source slot must not be the <see cref="PivSlot.Attestation" />-slot and the destination slot must be empty.
         /// </summary>
-        /// <remarks>Internally this method attempts to authenticate to the Yubikey by calling
-        /// <see cref="AuthenticateManagementKey"/> which may in turn throw its' own exceptions.
+        /// <remarks>
+        ///     Internally this method attempts to authenticate to the Yubikey by calling
+        ///     <see cref="AuthenticateManagementKey" /> which may in turn throw its' own exceptions.
         /// </remarks>
         /// <param name="sourceSlot">The Yubikey slot of the key you want to delete. This must be a valid slot number.</param>
         /// <param name="destinationSlot">The target Yubikey slot for the key you want to delete. This must be a valid slot number.</param>
         /// <exception cref="InvalidOperationException">
-        /// There is no <c>KeyCollector</c> loaded, the key provided was not a
-        /// valid Triple-DES key, or the YubiKey had some other error, such as
-        /// unreliable connection.
+        ///     There is no <c>KeyCollector</c> loaded, the key provided was not a
+        ///     valid Triple-DES key, or the YubiKey had some other error, such as
+        ///     unreliable connection.
         /// </exception>
         /// <exception cref="MalformedYubiKeyResponseException">
-        /// The YubiKey returned malformed data and authentication, either single
-        /// or double, could not be performed.
+        ///     The YubiKey returned malformed data and authentication, either single
+        ///     or double, could not be performed.
         /// </exception>
         /// <exception cref="OperationCanceledException">
-        /// The user canceled management key collection.
+        ///     The user canceled management key collection.
         /// </exception>
         /// <exception cref="SecurityException">
-        /// Mutual authentication was performed and the YubiKey was not authenticated.
+        ///     Mutual authentication was performed and the YubiKey was not authenticated.
         /// </exception>
         /// <exception cref="NotSupportedException">Thrown when the Yubikey doesn't support the Move-operation.</exception>
         public void MoveKey(byte sourceSlot, byte destinationSlot)
@@ -545,29 +502,30 @@ namespace Yubico.YubiKey.Piv
         }
 
         /// <summary>
-        /// Deletes/clears any key at a given <see cref="PivSlot"/>.
+        ///     Deletes/clears any key at a given <see cref="PivSlot" />.
         /// </summary>
-        /// <remarks>Internally this method attempts to authenticate to the Yubikey by calling
-        /// <see cref="AuthenticateManagementKey"/> which may in turn throw its' own exceptions.
+        /// <remarks>
+        ///     Internally this method attempts to authenticate to the Yubikey by calling
+        ///     <see cref="AuthenticateManagementKey" /> which may in turn throw its' own exceptions.
         /// </remarks>
         /// <param name="slotToClear">The Yubikey slot of the key you want to clear. This must be a valid slot number.</param>
-        /// <seealso cref="PivSlot"/>
+        /// <seealso cref="PivSlot" />
         /// <exception cref="InvalidOperationException">
-        /// Either the call to the Yubikey was unsuccessful or 
-        /// there wasn't any <c>KeyCollector</c> loaded, the key provided was not a valid Triple-DES key, or the YubiKey
-        /// had some other error, such as unreliable connection. Refer to the specific exception message.
+        ///     Either the call to the Yubikey was unsuccessful or
+        ///     there wasn't any <c>KeyCollector</c> loaded, the key provided was not a valid Triple-DES key, or the YubiKey
+        ///     had some other error, such as unreliable connection. Refer to the specific exception message.
         /// </exception>
         /// <exception cref="MalformedYubiKeyResponseException">
-        /// The YubiKey returned malformed data and authentication, either single or double, could not be performed.
+        ///     The YubiKey returned malformed data and authentication, either single or double, could not be performed.
         /// </exception>
         /// <exception cref="OperationCanceledException">
-        /// The user canceled management key collection.
+        ///     The user canceled management key collection.
         /// </exception>
         /// <exception cref="SecurityException">
-        /// Mutual authentication was performed and the YubiKey was not authenticated.
+        ///     Mutual authentication was performed and the YubiKey was not authenticated.
         /// </exception>
         /// <exception cref="NotSupportedException">Thrown when the Yubikey doesn't support the Delete-operation.</exception>
-        /// <seealso cref="AuthenticateManagementKey"/>
+        /// <seealso cref="AuthenticateManagementKey" />
         public void DeleteKey(byte slotToClear)
         {
             _yubiKeyDevice.ThrowOnMissingFeature(YubiKeyFeature.PivMoveOrDeleteKey);
@@ -595,6 +553,62 @@ namespace Yubico.YubiKey.Piv
                 : "No data received from Yubikey after attempted delete on slot {targetSlot}, indicating that was likely empty to begin with.";
 
             _log.LogInformation(logMessage, slotToClear);
+        }
+
+        // Block the PIN or PUK
+        // To get the PIN or PUK into a blocked state, try to change it. Each
+        // time the current PIN/PUK entered is incorrect, the retries remaining
+        // count is decremented. When it hits zero, it is blocked, return true.
+        // Call the ChangeReferenceDataCommand with arbitrary current and new
+        // PIN/PUK values. They must be different. If the arbitrary current value
+        // happens to be correct, the first call to change the PIN/PUK will work
+        // and it will become the new PIN/PUK. For the next call, use the same
+        // current value, which is now the wrong current value.
+        // If the slotNumber argument is PivSlot.Pin, block the PIN, if it is
+        // PivSlot.Puk, block the PUK.
+        private bool BlockPinOrPuk(byte slotNumber)
+        {
+            _log.LogInformation($"Block the {(slotNumber == 0x80 ? "PIN" : "PUK")}.");
+            int retriesRemaining;
+
+            do
+            {
+                byte[] currentValue =
+                {
+                    0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01, 0x01
+                };
+
+                byte[] newValue =
+                {
+                    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22
+                };
+
+                var changeCommand = new ChangeReferenceDataCommand(slotNumber, currentValue, newValue);
+                ChangeReferenceDataResponse changeResponse = Connection.SendCommand(changeCommand);
+
+                if (changeResponse.Status == ResponseStatus.Failed)
+                {
+                    return false;
+                }
+
+                retriesRemaining = changeResponse.GetData() ?? 1;
+            }
+            while (retriesRemaining > 0);
+
+            return true;
+        }
+
+        private void TryBlock(byte slot)
+        {
+            if (BlockPinOrPuk(slot))
+            {
+                return;
+            }
+
+            throw new SecurityException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ExceptionMessages.ApplicationResetFailure));
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -226,7 +226,10 @@ namespace Yubico.YubiKey.Piv
 
         private PivSession(StaticKeys? scp03Keys, IYubiKeyDevice yubiKey)
         {
-            _log.LogInformation("Create a new instance of PivSession" + (scp03Keys is null ? "." : " over SCP03"));
+            _log.LogInformation(
+                "Create a new instance of PivSession" + (scp03Keys is null
+                    ? "."
+                    : " over SCP03"));
 
             if (yubiKey is null)
             {
@@ -433,6 +436,10 @@ namespace Yubico.YubiKey.Piv
             }
 
             ResetAuthenticationStatus();
+
+            // As resetting the PIV application resets the management key,
+            // the management key must be updated to account for the case when the previous management key type
+            // was not the default key type.
             UpdateManagementKey(_yubiKeyDevice);
         }
 


### PR DESCRIPTION
# Description

This fix addresses a situation in which the `ManagementKeyAlgorithm` used to authenticate to the Yubikey could be wrong after an Piv application reset, by updating the `ManagementKeyAlgorithm` on reset.

Fixes # YESDK-1342

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?

Added integrationtests 

**Test configuration**:
* Firmware version: 5.7, 5.4.3
* Yubikey model: YK5, USBA

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
