### PR TITLE
Add dotnet to path for failing code format 

### DIFF
--- a/.github/workflows/check-code-formatting.yml
+++ b/.github/workflows/check-code-formatting.yml
@@ -27,7 +27,7 @@ on:
       - '**.csproj'
       - '**.sln'
       - '.github/workflows/check-code-formatting.yml'
-  
+
 jobs:
   check-code-formatting:
     runs-on: windows-2019
@@ -45,5 +45,8 @@ jobs:
       - name: Build Yubico.NET.SDK.sln
         run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
 
-      - name: Check for correct formatting 
+      - name: "Add DOTNET to path explicitly to address bug where it cannot be found"
+        run: echo "$(dirname $(readlink $(which dotnet)))" >> GITHUB_PATH
+        
+      - name: Check for correct formatting
         run: dotnet format --verify-no-changes --no-restore -v d


### PR DESCRIPTION
# Description

This adds dotnet to the path for the often failing code format action. This fix was suggested by GitHub themselves.

Fixes # YESDK-1338

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
N/A
