### PR TITLE
Fix: Add dotnet to path for failing verify-code-style GitHub Action

### DIFF
--- a/.github/workflows/check-code-formatting.yml
+++ b/.github/workflows/check-code-formatting.yml
@@ -27,7 +27,7 @@ on:
       - '**.csproj'
       - '**.sln'
       - '.github/workflows/check-code-formatting.yml'
-  
+
 jobs:
   check-code-formatting:
     runs-on: windows-2019
@@ -45,5 +45,8 @@ jobs:
       - name: Build Yubico.NET.SDK.sln
         run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
 
-      - name: Check for correct formatting 
+      - name: "Add DOTNET to path explicitly to address bug where it cannot be found"
+        run: echo "$(dirname $(readlink $(which dotnet)))" >> GITHUB_PATH
+        
+      - name: Check for correct formatting
         run: dotnet format --verify-no-changes --no-restore -v d

--- a/.github/workflows/check-code-formatting.yml
+++ b/.github/workflows/check-code-formatting.yml
@@ -30,8 +30,9 @@ on:
 
 jobs:
   check-code-formatting:
+    name: "Verify code style"
     runs-on: windows-2019
-
+    
     steps:
       - uses: actions/checkout@v4
 
@@ -47,6 +48,6 @@ jobs:
 
       - name: "Add DOTNET to path explicitly to address bug where it cannot be found"
         run: echo "$(dirname $(readlink $(which dotnet)))" >> GITHUB_PATH
-        
+
       - name: Check for correct formatting
         run: dotnet format --verify-no-changes --no-restore -v d

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   verify-code-style:
     name: "Verify code style"
-    runs-on: windows-2019
+    runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,23 @@ jobs:
         run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
 
       - name: "Add DOTNET to path explicitly to address bug where it cannot be found"
-        run: echo "$(dirname $(readlink $(which dotnet)))" >> GITHUB_PATH
+        run: |
+          DOTNET_PATH=$(which dotnet)
+          if [ -z "$DOTNET_PATH" ]; then
+          echo "dotnet not found via which, checking /usr/share/dotnet"
+          # Finding all executables named dotnet and picking the first one
+          DOTNET_PATH=$(find /usr/share/dotnet -type f -name "dotnet" -executable | head -n 1)
+          fi
+          
+          if [ -z "$DOTNET_PATH" ]; then
+          echo "dotnet executable not found."
+          exit 1
+          else
+          echo "Using dotnet at $DOTNET_PATH"
+          DOTNET_DIR=$(dirname $(readlink -f $DOTNET_PATH))
+          echo "$DOTNET_DIR" >> $GITHUB_PATH
+          echo "Added $DOTNET_DIR to GITHUB_PATH"
+          fi
 
       - name: Check for correct formatting
         run: dotnet format --verify-no-changes --no-restore -v d

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -17,7 +17,7 @@ name: Check code formatting
 on:
   pull_request:
     branches:
-      - main
+      - 'main'
       - 'develop**'
       - 'release/**'
     paths:
@@ -29,7 +29,7 @@ on:
       - '.github/workflows/check-code-formatting.yml'
 
 jobs:
-  check-code-formatting:
+  verify-code-style:
     name: "Verify code style"
     runs-on: windows-2019
     

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -31,7 +31,7 @@ on:
 jobs:
   verify-code-style:
     name: "Verify code style"
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     
     steps:
       - uses: actions/checkout@v4
@@ -47,6 +47,7 @@ jobs:
         run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
 
       - name: "Add DOTNET to path explicitly to address bug where it cannot be found"
+        shell: bash
         run: |
           DOTNET_PATH=$(which dotnet)
           if [ -z "$DOTNET_PATH" ]; then
@@ -64,6 +65,7 @@ jobs:
           echo "$DOTNET_DIR" >> $GITHUB_PATH
           echo "Added $DOTNET_DIR to GITHUB_PATH"
           fi
+
 
       - name: Check for correct formatting
         run: dotnet format --verify-no-changes --no-restore -v d

--- a/Yubico.NET.SDK.sln
+++ b/Yubico.NET.SDK.sln
@@ -30,7 +30,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\build-nativeshims.yml = .github\workflows\build-nativeshims.yml
 		.github\workflows\build-pull-requests.yml = .github\workflows\build-pull-requests.yml
 		.github\workflows\build.yml = .github\workflows\build.yml
-		.github\workflows\check-code-formatting.yml = .github\workflows\check-code-formatting.yml
 		.github\workflows\codeql-analysis.yml = .github\workflows\codeql-analysis.yml
 		.github\workflows\upload-docs.yml = .github\workflows\upload-docs.yml
 		.github\workflows\test.yml = .github\workflows\test.yml

--- a/Yubico.NET.SDK.sln
+++ b/Yubico.NET.SDK.sln
@@ -36,6 +36,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\test-macos.yml = .github\workflows\test-macos.yml
 		.github\workflows\test-ubuntu.yml = .github\workflows\test-ubuntu.yml
 		.github\workflows\test-windows.yml = .github\workflows\test-windows.yml
+		.github\workflows\verify-code-style.yml = .github\workflows\verify-code-style.yml
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Yubico.Core", "Yubico.Core", "{45D2A3BE-5111-4890-8898-2D43DB658A40}"


### PR DESCRIPTION
# Description

This adds dotnet to the path for the often failing code format action. This fix was suggested by GitHub themselves.

Fixes # YESDK-1338

## How has this been tested?
Successfully passed three times consecutively in this PR which looks promising.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How has this been tested?
N/A
