### PR TITLE
Add PIV Bio extensions

### DIFF
--- a/Yubico.YubiKey/docs/users-manual/application-piv/apdu/bio-metadata.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/apdu/bio-metadata.md
@@ -1,0 +1,47 @@
+---
+uid: UsersManualBioMetadata
+---
+
+<!-- Copyright 2024 Yubico AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+
+## Get bio metadata
+
+### Command APDU Info
+
+CLA | INS | P1 | P2 | Lc | Data | Le
+:---: | :---: | :---: | :---: | :---: | :---:
+00 | F7 | 00 | 96 | (absent) | (absent) | (absent)
+
+### Response APDU Info
+
+Total Length: *9* + 2\
+Data Length: *9*
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+*bio metadata as set of TLV* | 90 | 00
+
+The data consists of a set of TLVs. The possible valid tags (T of TLV) are listed in the
+table below. The length (L of TLV) is one. The values (V of TLV) are dependent on the tags, 
+described in the table below.
+
+#### Table 1: List of Metadata Elements
+Tag | Name | Meaning | Data
+:---: | :---: | :---: | :---:
+07 | IsConfigured| state of biometric verification configuration<br/> (ie. fingerprints are enrolled) | 01 (configured)<br/> 00 (not configured)
+06 | RetriesRemaining| indicates how many biometric match retries are left| 00-03<br/>value 00 while IsConfigured is 01 indicates that biometric verification is blocked
+08 | HasTemporaryPin| indicates if a temporary PIN has been generated in the YubiKey | 01 (generated)<br/>00 (not generated)
+

--- a/Yubico.YubiKey/docs/users-manual/application-piv/apdu/verify-temporary-pin.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/apdu/verify-temporary-pin.md
@@ -1,0 +1,45 @@
+<!-- Copyright 2024 Yubico AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+
+## Verify temporary PIN
+
+### Command APDU info
+
+CLA | INS | P1 | P2 | Lc | Data | Le
+:---: | :---: | :---: | :---: | :---: | :---:
+00 | 20 | 00 | 96 | 12 | 01 10 *temporary PIN* | (absent)
+
+### Response APDU info
+
+#### Response APDU for VERIFY (success)
+
+Total Length: 2\
+Data Length: 0
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+(no data) | 90 | 00
+
+#### Response APDU for VERIFY (Invalid temporary PIN)
+
+Total Length: 2\
+Data Length: 0
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+(no data) | 63 | C0
+
+If the temporary PIN is incorrect, then the error is `63 C0`. The temporary PIN in invalidated in the YubiKey and a new one needs to be obtained.
+

--- a/Yubico.YubiKey/docs/users-manual/application-piv/apdu/verify-uv.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/apdu/verify-uv.md
@@ -1,0 +1,59 @@
+<!-- Copyright 2024 Yubico AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+
+## Verify UV 
+
+### Command APDU info
+
+CLA | INS | P1 | P2 | Lc | Data | Le
+:---: | :---: | :---: | :---: | :---: | :---:
+00 | 20 | 00 | 96 | *variable* | *variable* | (absent)
+
+The data bytes vary:
+- none  - for checking the biometric state
+- 02 00 - if temporary PIN has been requested
+- 03 00 - if biometric verification has been requested
+
+### Response APDU info
+
+#### Response APDU for VERIFY (success)
+
+Total Length: 2\
+Data Length: 0
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+(no data) | 90 | 00
+
+#### Response APDU for VERIFY (success with temporary PIN)
+
+Total Length: 18\
+Data Length: 16
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+temporary PIN | 90 | 00
+
+#### Response APDU for VERIFY (Invalid biometric match)
+
+Total Length: 2\
+Data Length: 0
+
+Data | SW1 | SW2
+:---: | :---: | :---:
+(no data) | 63 | C0 - C2
+
+If the biometric match failed, then the error is `63 CX` where *X* is the number of
+retries remaining. In the case of C0, the biometric verification becomes blocked.

--- a/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
@@ -31,7 +31,7 @@ is the one calling the YubiKey. The keys, data, and firmware running on the Yubi
 * [Get the serial number](#get-the-serial-number)
 * [Get the firmware version number](#get-the-firmware-version-number)
 * [Get metadata](#get-metadata)
-* [Get BIO metadata](#get-bio-metadata)
+* [Get Bio metadata](#get-bio-metadata)
 * [Verify the PIN](#verify)
 * [Authenticate: management key](#authenticate-management-key)
 * [Set PIN retries](#set-pin-retries)

--- a/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
@@ -31,6 +31,7 @@ is the one calling the YubiKey. The keys, data, and firmware running on the Yubi
 * [Get the serial number](#get-the-serial-number)
 * [Get the firmware version number](#get-the-firmware-version-number)
 * [Get metadata](#get-metadata)
+* [Get BIO metadata](#get-bio-metadata)
 * [Verify the PIN](#verify)
 * [Authenticate: management key](#authenticate-management-key)
 * [Set PIN retries](#set-pin-retries)
@@ -171,6 +172,34 @@ elements are returned for each slot.
 ### APDU
 
 [Technical APDU Details](apdu/metadata.md)
+___
+## Get Bio metadata
+
+This gets YubiKey's biometric metadata. 
+
+### Available
+
+YubiKey Bio Multi-protocol 5.6 and later.
+
+### SDK Classes
+
+[GetBioMetadataCommand](xref:Yubico.YubiKey.Piv.Commands.GetBioMetadataCommand)
+
+[GetBioMetadataResponse](xref:Yubico.YubiKey.Piv.Commands.GetBioMetadataResponse)
+
+### Output
+
+#### Table 1: List of Metadata Elements
+|   Name            |                  Meaning                                 |                              Data                                 |
+| :---------------: | :------------------------------------------------------: | :---------------------------------------------------------------: |
+|  IsConfigured     |  Is this device configured for biometric verification    |  bool                                                             |
+|  RetriesRemaining |  Number of remaining retries for biometric verification  |  integer, zero value means the biometric verification is blocked  |
+|  HasTemporaryPin  |  Whether a temporary PIN is generated                    |  bool                                                             |
+
+
+### APDU
+
+[Technical APDU Details](apdu/bio-metadata.md)
 ___
 ## Verify
 

--- a/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
+++ b/Yubico.YubiKey/docs/users-manual/application-piv/commands.md
@@ -33,6 +33,7 @@ is the one calling the YubiKey. The keys, data, and firmware running on the Yubi
 * [Get metadata](#get-metadata)
 * [Get Bio metadata](#get-bio-metadata)
 * [Verify the PIN](#verify)
+* [Biometric verification](#biometric-verification)
 * [Authenticate: management key](#authenticate-management-key)
 * [Set PIN retries](#set-pin-retries)
 * [Change reference data](#change-reference-data) (change the PIN or PUK)
@@ -288,6 +289,58 @@ value and `GetData` will throw an exception.
 
 [Technical APDU Details](apdu/verify.md)
 ___
+## Biometric verification
+
+With biometric verification, the users can authenticate the PIV session with a successful match of a fingerprint. To be able to execute the biometric verification, the YubiKey has to have biometrics configured and must not be blocked for using biometrics. Clients can verify the conditions by reading the properties of biometric metadata (see [Get Bio metadata](#get-bio-metadata)).
+
+The YubiKey keeps track of failed biometric matches and will block the biometric authentication if there are more than three such failures. In that case the client should use the PIN verification as soon as possible. The number of remaining biometric matches is returned in the command response's `AttemptsRemaining` property. The value is present only after a failed match.
+
+Clients can also request to generate a temporary PIN which can be used with the `VerifyTemporaryPinCommand` for authentication without the need of a biometric match. The temporary PIN is stored in YubiKey's RAM and is invalidated after the PIV session is closed or an attempt of using a wrong temporary PIN. For `PIN_OR_MATCH_ALWAYS` slot policy, the temporary PIN can be used only once.
+
+### Available
+
+YubiKey Bio Multi-Protocol keys.
+
+### SDK Classes
+
+[VerifyUvCommand](xref:Yubico.YubiKey.Piv.Commands.VerifyUvCommand)
+
+[VerifyUvResponse](xref:Yubico.YubiKey.Piv.Commands.VerifyUvResponse)
+
+[VerifyTemporaryPinCommand](xref:Yubico.YubiKey.Piv.Commands.VerifyTemporaryPinCommand)
+
+[VerifyTemporaryPinResponse](xref:Yubico.YubiKey.Piv.Commands.VerifyTemporaryPinResponse)
+
+### Input
+
+#### VerifyUvCommand
+
+Two boolean values:
+- request temporary PIN\
+if true, the YubiKey will wait for the user to perform a biometric verification (match an enrolled fingerprint) and, on success, generate a temporary PIN.
+- check only\
+when true, the YubiKey verifies internally that the biometric state is valid. No biometric verification is performed on the YubiKey. 
+
+A client application would typically call the command with `false`, `false` parameters - this will make the YubiKey request the biometric verification from the users.
+
+#### VerifyTemporaryPinCommand
+The temporary PIN is the only parameter.
+
+### Output
+
+#### VerifyUvResponse
+If temporary PIN was requested and the status is Success, the returned value is the temporary PIN.
+In case of failure (for example the fingerprint did not match), the clients should read the `AttemptsRemaining` property which contains number of remaining biometric attempts.
+
+#### VerifyTemporaryPinResponse
+No output. The Status will be Success if the temporary PIN was verified.
+
+### APDU
+
+[Technical APDU Details for VerifyUvCommand](apdu/verify-uv.md)
+
+[Technical APDU Details for VerifyTemporaryPinCommand](apdu/verify-temporary-pin.md)
+___
 ## Authenticate: management key
 
 The Authenticate command can be used to perform several cryptographic operations:
@@ -313,9 +366,9 @@ app knows it is communicating with the appropriate YubiKey. Maybe the app wants 
 it will not call on an attacker's YubiKey to perform a sensitive operation. This section
 will refer to this action as <b>YubiKey Authentication</b>.
 
-Hence, the authenticate managment key command can actually perform two different
+Hence, the authenticate management key command can actually perform two different
 operations: "single authentication" (Client Authentication only), or "mutual authentication"
-(Client Authentication and YubiKey Authenticaiton). How you call the API
+(Client Authentication and YubiKey Authentication). How you call the API
 determines which operation will be performed.
 
 The authentication is done using "challenge-response". Note that the word "response" is

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -357,18 +357,18 @@ namespace Yubico.YubiKey {
             }
         }
         
+        internal static string InvalidVerifyUvArguments {
+            get {
+                return ResourceManager.GetString("InvalidVerifyUvArguments", resourceCulture);
+            }
+        }
+
         internal static string InvalidSlotsSameSourceAndDestinationSlotsCannotBeTheSame {
             get {
                 return ResourceManager.GetString("InvalidSlotsSameSourceAndDestinationSlotsCannotBeTheSame", resourceCulture);
             }
         }
-
-        internal static string InvalidVerifyUvArguments {
-            get {
-                return ResourceManager.GetString("InvalidVerifyUvArguments", resourceCulture);
-            }
-        }        
-
+        
         internal static string InvalidAlgorithm {
             get {
                 return ResourceManager.GetString("InvalidAlgorithm", resourceCulture);
@@ -391,7 +391,7 @@ namespace Yubico.YubiKey {
             get {
                 return ResourceManager.GetString("InvalidTemporaryPinLength", resourceCulture);
             }
-        }  
+        }         
         
         internal static string InvalidPivPutDataLength {
             get {
@@ -428,7 +428,7 @@ namespace Yubico.YubiKey {
                 return ResourceManager.GetString("NotSupportedByYubiKeyVersion", resourceCulture);
             }
         }
-
+        
         internal static string BiometricVerificationNotSupported {
             get {
                 return ResourceManager.GetString("BiometricVerificationNotSupported", resourceCulture);

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -429,9 +429,9 @@ namespace Yubico.YubiKey {
             }
         }
         
-        internal static string BiometricVerificationNotSupported {
+        internal static string BioMetadataNotSupported {
             get {
-                return ResourceManager.GetString("BiometricVerificationNotSupported", resourceCulture);
+                return ResourceManager.GetString("BioMetadataNotSupported", resourceCulture);
             }
         }
         

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -362,7 +362,13 @@ namespace Yubico.YubiKey {
                 return ResourceManager.GetString("InvalidSlotsSameSourceAndDestinationSlotsCannotBeTheSame", resourceCulture);
             }
         }
-        
+
+        internal static string InvalidVerifyUvArguments {
+            get {
+                return ResourceManager.GetString("InvalidVerifyUvArguments", resourceCulture);
+            }
+        }        
+
         internal static string InvalidAlgorithm {
             get {
                 return ResourceManager.GetString("InvalidAlgorithm", resourceCulture);
@@ -380,6 +386,12 @@ namespace Yubico.YubiKey {
                 return ResourceManager.GetString("InvalidPinPukLength", resourceCulture);
             }
         }
+
+        internal static string InvalidTemporaryPinLength {
+            get {
+                return ResourceManager.GetString("InvalidTemporaryPinLength", resourceCulture);
+            }
+        }  
         
         internal static string InvalidPivPutDataLength {
             get {
@@ -414,6 +426,12 @@ namespace Yubico.YubiKey {
         internal static string NotSupportedByYubiKeyVersion {
             get {
                 return ResourceManager.GetString("NotSupportedByYubiKeyVersion", resourceCulture);
+            }
+        }
+
+        internal static string BiometricVerificationNotSupported {
+            get {
+                return ResourceManager.GetString("BiometricVerificationNotSupported", resourceCulture);
             }
         }
         

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -279,6 +279,9 @@
   <data name="InvalidSlotsSameSourceAndDestinationSlotsCannotBeTheSame" xml:space="preserve">
     <value>Source and destination slots cannot be the same.</value>
   </data>
+  <data name="InvalidVerifyUvArguments" xml:space="preserve">
+    <value>Cannot request temporary pin when doing check-only verification.</value>
+  </data>
   <data name="InvalidAlgorithm" xml:space="preserve">
     <value>The given algorithm is not valid for the given command.</value>
   </data>
@@ -288,6 +291,9 @@
   <data name="InvalidPinPukLength" xml:space="preserve">
     <value>A PIN or PUK must be 6, 7, or 8 characters long.</value>
   </data>
+  <data name="InvalidTemporaryPinLength" xml:space="preserve">
+    <value>The temporary PIN length is invalid.</value>
+  </data>  
   <data name="InvalidPivPutDataLength" xml:space="preserve">
     <value>The length of input to a Put Data operation, {0}, was invalid, the maximum is {1}.</value>
   </data>

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -306,6 +306,9 @@
   <data name="NotSupportedByYubiKeyVersion" xml:space="preserve">
     <value>This operation is not supported by this version of YubiKey.</value>
   </data>
+  <data name="BiometricVerificationNotSupported" xml:space="preserve">
+    <value>This YubiKey does not support biometric verification.</value>
+  </data>
   <data name="InvalidDataEncoding" xml:space="preserve">
     <value>The data provided does not match the expected encoding.</value>
   </data>

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -312,8 +312,8 @@
   <data name="NotSupportedByYubiKeyVersion" xml:space="preserve">
     <value>This operation is not supported by this version of YubiKey.</value>
   </data>
-  <data name="BiometricVerificationNotSupported" xml:space="preserve">
-    <value>This YubiKey does not support biometric verification.</value>
+  <data name="BioMetadataNotSupported" xml:space="preserve">
+    <value>This YubiKey does not support bio metadata.</value>
   </data>
   <data name="InvalidDataEncoding" xml:space="preserve">
     <value>The data provided does not match the expected encoding.</value>

--- a/Yubico.YubiKey/src/Resources/ResponseStatusMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ResponseStatusMessages.Designer.cs
@@ -626,6 +626,15 @@ namespace Yubico.YubiKey {
                 return ResourceManager.GetString("PivPinPukBlocked", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum number of retries for user verification (PIN or PUK) exceeded. 0 retries remaining..
+        /// </summary>
+        internal static string PivBioUvBlocked {
+            get {
+                return ResourceManager.GetString("PivBioUvBlocked", resourceCulture);
+            }
+        }        
         
         /// <summary>
         ///   Looks up a localized string similar to User verification (PIN or PUK) failed. Retries remaining: {0}..
@@ -633,6 +642,15 @@ namespace Yubico.YubiKey {
         internal static string PivPinPukFailedWithRetries {
             get {
                 return ResourceManager.GetString("PivPinPukFailedWithRetries", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to User verification (PIN or PUK) failed. Retries remaining: {0}..
+        /// </summary>
+        internal static string PivBioUVFailedWithRetries {
+            get {
+                return ResourceManager.GetString("PivBioUVFailedWithRetries", resourceCulture);
             }
         }
         

--- a/Yubico.YubiKey/src/Resources/ResponseStatusMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ResponseStatusMessages.resx
@@ -258,9 +258,15 @@
   <data name="PivPinPukBlocked" xml:space="preserve">
     <value>Maximum number of retries for user verification (PIN or PUK) exceeded. 0 retries remaining.</value>
   </data>
+  <data name="PivBioUvBlocked" xml:space="preserve">
+    <value>Maximum number of retries for biometric user verification exceeded. 0 retries remaining.</value>
+  </data>
   <data name="PivPinPukFailedWithRetries" xml:space="preserve">
     <value>User verification (PIN or PUK) failed. Retries remaining: {0}.</value>
   </data>
+  <data name="PivBioUVFailedWithRetries" xml:space="preserve">
+    <value>User biometric verification failed. Retries remaining: {0}.</value>
+  </data>  
   <data name="PivSecurityStatusNotSatisfied" xml:space="preserve">
     <value>User verification (PIN, PUK, or Management Key) or presence (touch) requirement not satisfied.</value>
   </data>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataCommand.cs
@@ -1,0 +1,83 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// Get information about Bio multi-protocol key.
+    /// </summary>
+    /// <remarks>
+    /// The Get Bio Metadata command is available on YubiKey Bio multi-protocol.
+    /// <para>
+    /// The partner Response class is <see cref="GetBioMetadataResponse"/>.
+    /// </para>
+    /// <para>
+    /// See the User's Manual
+    /// <xref href="UsersManualPivCommands#get-bio-metadata"> entry on getting bio metadata</xref>
+    /// for specific information about what information is returned. 
+    /// </para>
+    /// <para>
+    /// Example:
+    /// </para>
+    /// <code language="csharp">
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   GetBioMetadataCommand bioMetadataCommand = new GetBioMetadataCommand();
+    ///   GetBioMetadataResponse bioMetadataResponse = connection.SendCommand(bioMetadataCommand);<br/>
+    ///   if (bioMetadataResponse.Status == ResponseStatus.Success)
+    ///   {
+    ///       PivBioMetadata bioMetadata = bioMetadataResponse.GetData();
+    ///   }
+    /// </code>
+    /// </remarks>
+    public sealed class GetBioMetadataCommand : IYubiKeyCommand<GetBioMetadataResponse>
+    {
+        private const byte PivMetadataInstruction = 0xF7;
+
+        private const byte SlotOccAuth = 0x96;
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs. For this
+        /// command it's PIV.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.Piv
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Piv;
+
+        /// <summary>
+        /// Initializes a new instance of the GetBioMetadataCommand class.
+        /// </summary>
+        public GetBioMetadataCommand()
+        {
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu()
+        {
+            return new CommandApdu
+            {
+                Ins = PivMetadataInstruction,
+                P2 = SlotOccAuth,
+            };
+        }
+
+        /// <inheritdoc />
+        public GetBioMetadataResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+            new GetBioMetadataResponse(responseApdu);
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataCommand.cs
@@ -36,11 +36,11 @@ namespace Yubico.YubiKey.Piv.Commands
     /// </para>
     /// <code language="csharp">
     ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
-    ///   GetBioMetadataCommand bioMetadataCommand = new GetBioMetadataCommand();
-    ///   GetBioMetadataResponse bioMetadataResponse = connection.SendCommand(bioMetadataCommand);<br/>
-    ///   if (bioMetadataResponse.Status == ResponseStatus.Success)
+    ///   GetBioMetadataCommand command = new GetBioMetadataCommand();
+    ///   GetBioMetadataResponse response = connection.SendCommand(command);<br/>
+    ///   if (response.Status == ResponseStatus.Success)
     ///   {
-    ///       PivBioMetadata bioMetadata = bioMetadataResponse.GetData();
+    ///       PivBioMetadata data = response.GetData();
     ///   }
     /// </code>
     /// </remarks>
@@ -48,7 +48,7 @@ namespace Yubico.YubiKey.Piv.Commands
     {
         private const byte PivMetadataInstruction = 0xF7;
 
-        private const byte SlotOccAuth = 0x96;
+        private const byte OnCardComparisonAuthenticationSlot = 0x96;
 
         /// <summary>
         /// Gets the YubiKeyApplication to which this command belongs. For this
@@ -72,7 +72,7 @@ namespace Yubico.YubiKey.Piv.Commands
             return new CommandApdu
             {
                 Ins = PivMetadataInstruction,
-                P2 = SlotOccAuth,
+                P2 = OnCardComparisonAuthenticationSlot,
             };
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
@@ -1,0 +1,75 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+using System;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// The response to the get bio metadata command, containing information about a
+    /// particular key.
+    /// </summary>
+    /// <remarks>
+    /// The Get Bio Metadata command is available on Bio multi-protocol keys.
+    /// <para>
+    /// This is the partner Response class to <see cref="GetBioMetadataCommand"/>.
+    /// </para>
+    /// <para>
+    /// The data returned is a <see cref="PivBioMetadata"/>.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// </para>
+    /// <code language="csharp">
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   GetBioMetadataCommand bioMetadataCommand = new GetBioMetadataCommand();
+    ///   GetBioMetadataResponse bioMetadataResponse = connection.SendCommand(bioMetadataCommand);<br/>
+    ///   if (bioMetadataResponse.Status == ResponseStatus.Success)
+    ///   {
+    ///       PivBioMetadata bioMetadata = bioMetadataResponse.GetData();
+    ///   }
+    /// </code>
+    /// </remarks>
+    public sealed class GetBioMetadataResponse : PivResponse, IYubiKeyResponseWithData<PivBioMetadata>
+    {
+        /// <summary>
+        /// Constructs a GetBioMetadataResponse based on a ResponseApdu received from
+        /// the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The object containing the response APDU<br/>returned by the YubiKey.
+        /// </param>
+        public GetBioMetadataResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+        }
+
+        /// <summary>
+        /// Gets the bio metadata from the YubiKey response.
+        /// </summary>
+        /// <returns>
+        /// The data in the response APDU, presented as a PivBioMetadata object.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown when <see cref="YubiKeyResponse.Status"/> is not <see cref="ResponseStatus.Success"/>.
+        /// </exception>
+        public PivBioMetadata GetData() => Status switch
+        {
+            ResponseStatus.Success => new PivBioMetadata(ResponseApdu.Data.ToArray()),
+            _ => throw new InvalidOperationException(StatusMessage),
+        };
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
@@ -36,11 +36,11 @@ namespace Yubico.YubiKey.Piv.Commands
     /// </para>
     /// <code language="csharp">
     ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
-    ///   GetBioMetadataCommand bioMetadataCommand = new GetBioMetadataCommand();
-    ///   GetBioMetadataResponse bioMetadataResponse = connection.SendCommand(bioMetadataCommand);<br/>
-    ///   if (bioMetadataResponse.Status == ResponseStatus.Success)
+    ///   GetBioMetadataCommand command = new GetBioMetadataCommand();
+    ///   GetBioMetadataResponse response = connection.SendCommand(command);<br/>
+    ///   if (response.Status == ResponseStatus.Success)
     ///   {
-    ///       PivBioMetadata bioMetadata = bioMetadataResponse.GetData();
+    ///       PivBioMetadata data = response.GetData();
     ///   }
     /// </code>
     /// </remarks>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
@@ -14,12 +14,13 @@
 
 
 using System;
+using System.Globalization;
 using Yubico.Core.Iso7816;
 
 namespace Yubico.YubiKey.Piv.Commands
 {
     /// <summary>
-    /// The response to the get bio metadata command, containing information about a
+    /// The response to <see cref="GetBioMetadataCommand"/>, containing Bio Metadata about a
     /// particular key.
     /// </summary>
     /// <remarks>
@@ -72,7 +73,9 @@ namespace Yubico.YubiKey.Piv.Commands
         public PivBioMetadata GetData() => Status switch
         {
             ResponseStatus.Success => new PivBioMetadata(ResponseApdu.Data.ToArray()),
-            ResponseStatus.NoData => throw new NotSupportedException("Bio metadata not supported by this YubiKey"),
+            ResponseStatus.NoData => throw new NotSupportedException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.BioMetadataNotSupported)),
             _ => throw new InvalidOperationException(StatusMessage),
         };
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GetBioMetadataResponse.cs
@@ -63,12 +63,16 @@ namespace Yubico.YubiKey.Piv.Commands
         /// <returns>
         /// The data in the response APDU, presented as a PivBioMetadata object.
         /// </returns>
+        /// <exception cref="NotSupportedException">
+        /// Thrown when the device does not support Bio Metadata.
+        /// </exception>
         /// <exception cref="InvalidOperationException">
         /// Thrown when <see cref="YubiKeyResponse.Status"/> is not <see cref="ResponseStatus.Success"/>.
         /// </exception>
         public PivBioMetadata GetData() => Status switch
         {
             ResponseStatus.Success => new PivBioMetadata(ResponseApdu.Data.ToArray()),
+            ResponseStatus.NoData => throw new NotSupportedException("Bio metadata not supported by this YubiKey"),
             _ => throw new InvalidOperationException(StatusMessage),
         };
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
@@ -56,7 +56,7 @@ namespace Yubico.YubiKey.Piv.Commands
     public sealed class VerifyTemporaryPinCommand : IYubiKeyCommand<VerifyTemporaryPinResponse>
     {
         private const byte PivVerifyInstruction = 0x20;
-        private const byte SlotOccAuth = 0x96;
+        private const byte OnCardComparisonAuthenticationSlot = 0x96;
         private const int TemporaryPinLength = 16;
 
         private readonly ReadOnlyMemory<byte> _temporaryPin;
@@ -122,11 +122,12 @@ namespace Yubico.YubiKey.Piv.Commands
             const byte VerifyTemporaryPinTag = 0x01;
             var tlvWriter = new TlvWriter();
             tlvWriter.WriteValue(VerifyTemporaryPinTag, _temporaryPin.Span);
+            ReadOnlyMemory<byte> data = tlvWriter.Encode();
             return new CommandApdu
             {
                 Ins = PivVerifyInstruction,
-                P2 = SlotOccAuth,
-                Data = tlvWriter.Encode()
+                P2 = OnCardComparisonAuthenticationSlot,
+                Data = data
             };
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
@@ -35,25 +35,20 @@ namespace Yubico.YubiKey.Piv.Commands
     /// <code language="csharp">
     ///   /* This example assumes the application has a method to collect a PIN.
     ///   */
-    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);
-    ///   
-    ///   // request temporary PIN
-    ///   var verifyUvCommand = new VerifyUvCommand(true, false);
-    ///   
-    ///   // a biometric verification will be performed
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   /* request temporary PIN */
+    ///   var verifyUvCommand = new VerifyUvCommand(true, false);<br/>
+    ///   /* a biometric verification will be performed */
     ///   var verifyUvResponse = connection.SendCommand(verifyUvCommand);
-    ///   
     ///   if (verifyUvResponse.Status == ResponseStatus.Success) 
     ///   {
-    ///     var temporaryPin = verifyUvResponse.GetData();
-    ///     
-    ///     // using temporary PIN will not request biometric verification
-    ///     
+    ///     var temporaryPin = verifyUvResponse.GetData();<br/>
+    ///     /* using temporary PIN will not request biometric verification */
     ///     var verifyTemporaryPinCommand = new VerifyTemporaryPin(temporaryPin);
     ///     var verifyResponse = connection.SendCommand(verifyTemporaryPinCommand);
     ///     if (verifyResponse == ResponseStatus.Success) 
     ///     {
-    ///         // session is authenticated
+    ///         /* session is authenticated */
     ///     }
     ///   }
     /// </code>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
@@ -1,0 +1,168 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Yubico.Core.Iso7816;
+using Yubico.Core.Tlv;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// Verify the PIV PIN.
+    /// </summary>
+    /// <remarks>
+    /// The partner Response class is <see cref="VerifyPinResponse"/>.
+    /// <para>
+    /// Some operations require the user enter a PIN. Use this class to build a
+    /// command to verify the PIN. This will generally be used in conjunction
+    /// with other commands that require the PIN. But it is possible to simply
+    /// use this command to verify the PIN only.
+    /// </para>
+    /// <para>
+    /// The PIN starts out as a default value: "123456", which in ASCII is the
+    /// 6-byte sequence <c>0x31 32 33 34 35 36</c>. Generally, the first thing
+    /// done when a YubiKey is initialized for PIV is to change the PIN (along
+    /// with the PUK and management key). The PIN must be 6 to 8 bytes.
+    /// Ultimately the bytes that make up the PIN can be any binary value, but
+    /// are generally input from a keyboard, so are usually made up of ASCII
+    /// characters.
+    /// </para>
+    /// <para>
+    /// The PIN you pass in must be 6 to 8 bytes long. If the actual PIN
+    /// collected is less than 6  or more than 8 bytes long, it will be invalid.
+    /// </para>
+    /// <para>
+    /// Note that with PIV there is also a PUK (PIN Unblocking Key). This command
+    /// cannot verify a PUK.
+    /// </para>
+    /// <para>
+    /// When you pass a PIN to this class (the PIN to verify), the class will
+    /// copy a reference to the object passed in, it will not copy the value.
+    /// Because of this, you cannot overwrite the PIN until this object is done
+    /// with it. It will be safe to overwrite the PIN after calling
+    /// <c>connection.SendCommand</c>. See the User's Manual
+    /// <xref href="UsersManualSensitive"> entry on sensitive data</xref> for
+    /// more information on this topic.
+    /// </para>
+    /// <para>
+    /// Example:
+    /// </para>
+    /// <code language="csharp">
+    ///   /* This example assumes the application has a method to collect a PIN.
+    ///    */
+    ///   byte[] pin;<br/>
+    ///
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   pin = CollectPin();
+    ///   var verifyPinCommand = new VerifyPinCommand(pin);
+    ///   VerifyPinResponse verifyPinResponse = connection.SendCommand(verifyPinCommand);<br/>
+    ///   if (resetRetryResponse.Status == ResponseStatus.AuthenticationRequired)
+    ///   {
+    ///     int retryCount = resetRetryResponse.GetData();
+    ///     /* report the retry count */
+    ///   }
+    ///   else if (verifyPinResponse.Status != ResponseStatus.Success)
+    ///   {
+    ///     // Handle error
+    ///   }
+    ///
+    ///   CryptographicOperations.ZeroMemory(pin)
+    /// </code>
+    /// </remarks>
+    public sealed class VerifyTemporaryPinCommand : IYubiKeyCommand<VerifyTemporaryPinResponse>
+    {
+        private const byte PivVerifyInstruction = 0x20;
+        private const byte SlotOccAuth = 0x96;
+        private const int TemporaryPinLength = 16;
+
+        private readonly ReadOnlyMemory<byte> _temporaryPin;
+
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs. For this
+        /// command it's PIV.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.Piv
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Piv;
+
+        // The default constructor explicitly defined. We don't want it to be
+        // used.
+        // Note that there is no object-initializer constructor. the only
+        // constructor input is a secret byte arrays.
+        private VerifyTemporaryPinCommand()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the VerifyPinCommand class which will
+        /// use the given PIN.
+        /// </summary>
+        /// <remarks>
+        /// In order to verify a PIN, the caller must supply the PIN. In this
+        /// class, the PIN is supplied as <c>ReadOnlyMemory&lt;byte&gt;</c>. It
+        /// is possible to pass a <c>byte[]</c>, because it will be automatically
+        /// cast.
+        /// <para>
+        /// This class will copy references to the PIN (not the values. This
+        /// means that you can overwrite the PIN in your byte array only after
+        /// this class is done with it. It will no longer need the PIN after
+        /// calling <c>connection.SendCommand</c>.
+        /// </para>
+        /// <para>
+        /// A PIN is 6 to 8 bytes long.
+        /// </para>
+        /// </remarks>
+        /// <param name="temporaryPin">
+        /// The temporary Pin.
+        /// </param>
+        /// <exception cref="ArgumentException">
+        /// The PIN is an invalid length.
+        /// </exception>
+        public VerifyTemporaryPinCommand(ReadOnlyMemory<byte> temporaryPin)
+        {
+            if (temporaryPin.Length != TemporaryPinLength)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.InvalidTemporaryPinLength));
+            }
+
+            _temporaryPin = temporaryPin;
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu()
+        {
+            const byte VerifyTemporaryPinTag = 0x01;
+            var tlvWriter = new TlvWriter();
+            tlvWriter.WriteValue(VerifyTemporaryPinTag, _temporaryPin.Span);
+            return new CommandApdu
+            {
+                Ins = PivVerifyInstruction,
+                P2 = SlotOccAuth,
+                Data = tlvWriter.Encode()
+            };
+        }
+
+        /// <inheritdoc />
+        public VerifyTemporaryPinResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+          new VerifyTemporaryPinResponse(responseApdu);
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinCommand.cs
@@ -21,65 +21,41 @@ using Yubico.Core.Tlv;
 namespace Yubico.YubiKey.Piv.Commands
 {
     /// <summary>
-    /// Verify the PIV PIN.
+    /// Verify the PIV Bio temporary PIN.
     /// </summary>
     /// <remarks>
-    /// The partner Response class is <see cref="VerifyPinResponse"/>.
+    /// The partner Response class is <see cref="VerifyTemporaryPinResponse"/>.
     /// <para>
-    /// Some operations require the user enter a PIN. Use this class to build a
-    /// command to verify the PIN. This will generally be used in conjunction
-    /// with other commands that require the PIN. But it is possible to simply
-    /// use this command to verify the PIN only.
-    /// </para>
-    /// <para>
-    /// The PIN starts out as a default value: "123456", which in ASCII is the
-    /// 6-byte sequence <c>0x31 32 33 34 35 36</c>. Generally, the first thing
-    /// done when a YubiKey is initialized for PIV is to change the PIN (along
-    /// with the PUK and management key). The PIN must be 6 to 8 bytes.
-    /// Ultimately the bytes that make up the PIN can be any binary value, but
-    /// are generally input from a keyboard, so are usually made up of ASCII
-    /// characters.
-    /// </para>
-    /// <para>
-    /// The PIN you pass in must be 6 to 8 bytes long. If the actual PIN
-    /// collected is less than 6  or more than 8 bytes long, it will be invalid.
-    /// </para>
-    /// <para>
-    /// Note that with PIV there is also a PUK (PIN Unblocking Key). This command
-    /// cannot verify a PUK.
-    /// </para>
-    /// <para>
-    /// When you pass a PIN to this class (the PIN to verify), the class will
-    /// copy a reference to the object passed in, it will not copy the value.
-    /// Because of this, you cannot overwrite the PIN until this object is done
-    /// with it. It will be safe to overwrite the PIN after calling
-    /// <c>connection.SendCommand</c>. See the User's Manual
-    /// <xref href="UsersManualSensitive"> entry on sensitive data</xref> for
-    /// more information on this topic.
+    /// When using biometric verification, clients can request a temporary PIN
+    /// by calling <see cref="VerifyUvCommand"/> with requestTemporaryPin=true.
     /// </para>
     /// <para>
     /// Example:
     /// </para>
     /// <code language="csharp">
     ///   /* This example assumes the application has a method to collect a PIN.
-    ///    */
-    ///   byte[] pin;<br/>
-    ///
-    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
-    ///   pin = CollectPin();
-    ///   var verifyPinCommand = new VerifyPinCommand(pin);
-    ///   VerifyPinResponse verifyPinResponse = connection.SendCommand(verifyPinCommand);<br/>
-    ///   if (resetRetryResponse.Status == ResponseStatus.AuthenticationRequired)
+    ///   */
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);
+    ///   
+    ///   // request temporary PIN
+    ///   var verifyUvCommand = new VerifyUvCommand(true, false);
+    ///   
+    ///   // a biometric verification will be performed
+    ///   var verifyUvResponse = connection.SendCommand(verifyUvCommand);
+    ///   
+    ///   if (verifyUvResponse.Status == ResponseStatus.Success) 
     ///   {
-    ///     int retryCount = resetRetryResponse.GetData();
-    ///     /* report the retry count */
+    ///     var temporaryPin = verifyUvResponse.GetData();
+    ///     
+    ///     // using temporary PIN will not request biometric verification
+    ///     
+    ///     var verifyTemporaryPinCommand = new VerifyTemporaryPin(temporaryPin);
+    ///     var verifyResponse = connection.SendCommand(verifyTemporaryPinCommand);
+    ///     if (verifyResponse == ResponseStatus.Success) 
+    ///     {
+    ///         // session is authenticated
+    ///     }
     ///   }
-    ///   else if (verifyPinResponse.Status != ResponseStatus.Success)
-    ///   {
-    ///     // Handle error
-    ///   }
-    ///
-    ///   CryptographicOperations.ZeroMemory(pin)
     /// </code>
     /// </remarks>
     public sealed class VerifyTemporaryPinCommand : IYubiKeyCommand<VerifyTemporaryPinResponse>
@@ -89,7 +65,6 @@ namespace Yubico.YubiKey.Piv.Commands
         private const int TemporaryPinLength = 16;
 
         private readonly ReadOnlyMemory<byte> _temporaryPin;
-
 
         /// <summary>
         /// Gets the YubiKeyApplication to which this command belongs. For this
@@ -110,22 +85,21 @@ namespace Yubico.YubiKey.Piv.Commands
         }
 
         /// <summary>
-        /// Initializes a new instance of the VerifyPinCommand class which will
-        /// use the given PIN.
+        /// Initializes a new instance of the VerifyTemporaryPinCommand class which will
+        /// use the given temporary PIN.
         /// </summary>
         /// <remarks>
-        /// In order to verify a PIN, the caller must supply the PIN. In this
-        /// class, the PIN is supplied as <c>ReadOnlyMemory&lt;byte&gt;</c>. It
-        /// is possible to pass a <c>byte[]</c>, because it will be automatically
-        /// cast.
+        /// In order to verify a temporary PIN, the caller must supply the temporary PIN.
+        /// In this class, the temporary PIN is supplied as <c>ReadOnlyMemory&lt;byte&gt;</c>.
+        /// It is possible to pass a <c>byte[]</c>, because it will be automatically cast.
         /// <para>
-        /// This class will copy references to the PIN (not the values. This
-        /// means that you can overwrite the PIN in your byte array only after
-        /// this class is done with it. It will no longer need the PIN after
+        /// This class will copy references to the temporary PIN (not the values. This
+        /// means that you can overwrite the temporary PIN in your byte array only after
+        /// this class is done with it. It will no longer need the temporary PIN after
         /// calling <c>connection.SendCommand</c>.
         /// </para>
         /// <para>
-        /// A PIN is 6 to 8 bytes long.
+        /// A temporary PIN is 16 bytes long.
         /// </para>
         /// </remarks>
         /// <param name="temporaryPin">

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
@@ -52,9 +52,9 @@ namespace Yubico.YubiKey.Piv.Commands
     ///    */
     ///   byte[] temporaryPin = ...;<br/>
     ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
-    ///   var verifyTemporaryPinCommand = new VerifyTemporaryPinCommand(temporaryPin);
-    ///   VerifyTemporaryPinResponse verifyResponse = connection.SendCommand(verifyTemporaryPinCommand);<br/>
-    ///   if (verifyResponse.Status == ResponseStatus.Success)
+    ///   var command = new VerifyTemporaryPinCommand(temporaryPin);
+    ///   VerifyTemporaryPinResponse response = connection.SendCommand(command);<br/>
+    ///   if (response.Status == ResponseStatus.Success)
     ///   {
     ///     /* session is authenticated */
     ///   }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
@@ -51,7 +51,6 @@ namespace Yubico.YubiKey.Piv.Commands
     ///    * VerifyUvCommand(true, false).
     ///    */
     ///   byte[] temporaryPin = ...;<br/>
-    ///
     ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
     ///   var verifyTemporaryPinCommand = new VerifyTemporaryPinCommand(temporaryPin);
     ///   VerifyTemporaryPinResponse verifyResponse = connection.SendCommand(verifyTemporaryPinCommand);<br/>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyTemporaryPinResponse.cs
@@ -1,0 +1,175 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// The response to verifying the PIN.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the partner Response class to <see cref="VerifyPinCommand"/>.
+    /// </para>
+    /// <para>
+    /// To determine the result of the command, first look at the
+    /// <see cref="YubiKeyResponse.Status"/>. If <c>Status</c> is not one of
+    /// the following values then an error has occurred and <see cref="GetData"/>
+    /// will throw an exception.
+    /// </para>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Status</term>
+    /// <description>Description</description>
+    /// </listheader>
+    ///
+    /// <item>
+    /// <term><see cref="ResponseStatus.Success"/></term>
+    /// <description>The PIN verified. GetData returns <c>null</c>.</description>
+    /// </item>
+    ///
+    /// <item>
+    /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
+    /// <description>The PIN did not verify. GetData returns the number
+    /// of retries remaining. If the number of retries is 0, the PIN
+    /// is blocked.</description>
+    /// </item>
+    /// </list>
+    ///
+    /// <para>
+    /// Example:
+    /// </para>
+    /// <code language="csharp">
+    ///   /* This example assumes the application has a method to collect a PIN.
+    ///    */
+    ///   byte[] pin;<br/>
+    ///
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   pin = CollectPin();
+    ///   var verifyPinCommand = new VerifyPinCommand(pin);
+    ///   VerifyPinResponse verifyPinResponse = connection.SendCommand(verifyPinCommand);<br/>
+    ///   if (resetRetryResponse.Status == ResponseStatus.AuthenticationRequired)
+    ///   {
+    ///     int retryCount = resetRetryResponse.GetData();
+    ///     /* report the retry count */
+    ///   }
+    ///   else if (verifyPinResponse.Status != ResponseStatus.Success)
+    ///   {
+    ///     // Handle error
+    ///   }
+    ///
+    ///   CryptographicOperations.ZeroMemory(pin)
+    /// </code>
+    /// </remarks>
+    public sealed class VerifyTemporaryPinResponse : PivResponse, IYubiKeyResponseWithData<int?>
+    {
+        /// <inheritdoc />
+        protected override ResponseStatusPair StatusCodeMap
+        {
+            get
+            {
+                switch (StatusWord)
+                {
+                    case short statusWord when PivPinUtilities.HasRetryCount(statusWord):
+                        int remainingRetries = PivPinUtilities.GetRetriesRemaining(statusWord);
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, string.Format(CultureInfo.CurrentCulture, ResponseStatusMessages.PivPinPukFailedWithRetries, remainingRetries));
+
+                    case SWConstants.AuthenticationMethodBlocked:
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, ResponseStatusMessages.PivPinPukBlocked);
+
+                    case SWConstants.SecurityStatusNotSatisfied:
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, ResponseStatusMessages.PivSecurityStatusNotSatisfied);
+
+                    default:
+                        return base.StatusCodeMap;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a VerifyPinResponse based on a ResponseApdu received from
+        /// the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The object containing the response APDU<br/>returned by the YubiKey.
+        /// </param>
+        public VerifyTemporaryPinResponse(ResponseApdu responseApdu) :
+            base(responseApdu)
+        {
+        }
+
+        /// <summary>
+        /// Gets the number of PIN retries remaining, if applicable.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// First look at the
+        /// <see cref="YubiKeyResponse.Status"/>. If <c>Status</c> is not one of
+        /// the following values then an error has occurred and <see cref="GetData"/>
+        /// will throw an exception.
+        /// </para>
+        ///
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        ///
+        /// <item>
+        /// <term><see cref="ResponseStatus.Success"/></term>
+        /// <description>The PIN verified. GetData returns <c>null</c>.</description>
+        /// </item>
+        ///
+        /// <item>
+        /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
+        /// <description>The PIN did not verify. GetData returns the number
+        /// of retries remaining. If the number of retries is 0, the PIN
+        /// is blocked.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// <c>null</c> if the PIN verifies, or the number of retries remaining if
+        /// the PIN does not verify.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if <see cref="YubiKeyResponse.Status"/> is not <see cref="ResponseStatus.Success"/>
+        /// or <see cref="ResponseStatus.AuthenticationRequired"/>.
+        /// </exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability, avoiding nested conditionals.")]
+        public int? GetData()
+        {
+            if (Status != ResponseStatus.Success && Status != ResponseStatus.AuthenticationRequired)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (PivPinUtilities.HasRetryCount(StatusWord))
+            {
+                return PivPinUtilities.GetRetriesRemaining(StatusWord);
+            }
+            else if (StatusWord == SWConstants.AuthenticationMethodBlocked)
+            {
+                return 0;
+            }
+            else
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
@@ -61,7 +61,10 @@ namespace Yubico.YubiKey.Piv.Commands
         /// Initializes a new instance of the VerifyUvCommand class.
         /// </summary>
         /// <param name="requestTemporaryPin">
-        /// After successful match generate a temporary PIN.
+        /// After successful match generate a temporary PIN. Certain conditions may 
+        /// lead to the clearing of the temporary PIN, such as fingerprint mismatch, 
+        /// PIV PIN failed verification, timeout, power loss, failed attempt to verify 
+        /// against the set value.
         /// </param>
         /// <param name="checkOnly">
         /// Check verification state of biometrics, don't perform UV.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
@@ -90,14 +90,18 @@ namespace Yubico.YubiKey.Piv.Commands
         public CommandApdu CreateCommandApdu()
         {
             ReadOnlyMemory<byte> data = ReadOnlyMemory<byte>.Empty;
-            if (!_checkOnly) {
+            if (!_checkOnly)
+            {
                 const byte GetTemporaryPinTag = 0x02;
                 const byte VerifyUvTag = 0x03;
 
                 var tlvWriter = new TlvWriter();
-                if (_requestTemporaryPin) {
+                if (_requestTemporaryPin)
+                {
                     tlvWriter.WriteValue(GetTemporaryPinTag, null);
-                } else {
+                }
+                else
+                {
                     tlvWriter.WriteValue(VerifyUvTag, null);
                 }
                 data = tlvWriter.Encode();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
@@ -1,0 +1,114 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Yubico.Core.Iso7816;
+using Yubico.Core.Tlv;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// Authenticate with YubiKey Bio multi-protocol capabilities.
+    /// </summary>
+    /// <remarks>
+    /// The partner Response class is <see cref="VerifyUvResponse"/>.
+    /// <para>
+    /// Before calling this method, clients must verify that the authenticator is bio-capable and
+    /// not blocked for bio matching.
+    /// </para>
+    /// </remarks>
+    public sealed class VerifyUvCommand : IYubiKeyCommand<VerifyUvResponse>
+    {
+        private const byte PivVerifyInstruction = 0x20;
+        private const byte SlotOccAuth = 0x96;
+
+        private readonly bool _requestTemporaryPin;
+        private readonly bool _checkOnly;
+
+
+        /// <summary>
+        /// Gets the YubiKeyApplication to which this command belongs. For this
+        /// command it's PIV.
+        /// </summary>
+        /// <value>
+        /// YubiKeyApplication.Piv
+        /// </value>
+        public YubiKeyApplication Application => YubiKeyApplication.Piv;
+
+        // The default constructor explicitly defined. We don't want it to be
+        // used.
+        // Note that there is no object-initializer constructor. the only
+        // constructor input is a secret byte arrays.
+        private VerifyUvCommand()
+        {
+            throw new NotImplementedException();
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the VerifyUvCommand class.
+        /// </summary>
+        /// <param name="requestTemporaryPin">
+        /// After successful match generate a temporary PIN.
+        /// </param>
+        /// <param name="checkOnly">
+        /// Check verification state of biometrics, don't perform UV.
+        /// </param>        
+        /// <exception cref="ArgumentException">
+        /// The PIN is an invalid length.
+        /// </exception>
+        public VerifyUvCommand(bool requestTemporaryPin, bool checkOnly)
+        {
+            if (requestTemporaryPin && checkOnly)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.InvalidVerifyUvArguments
+                        ));
+            }
+            _requestTemporaryPin = requestTemporaryPin;
+            _checkOnly = checkOnly;
+        }
+
+        /// <inheritdoc />
+        public CommandApdu CreateCommandApdu()
+        {
+            ReadOnlyMemory<byte> data = ReadOnlyMemory<byte>.Empty;
+            if (!_checkOnly) {
+                const byte GetTemporaryPinTag = 0x02;
+                const byte VerifyUvTag = 0x03;
+
+                var tlvWriter = new TlvWriter();
+                if (_requestTemporaryPin) {
+                    tlvWriter.WriteValue(GetTemporaryPinTag, null);
+                } else {
+                    tlvWriter.WriteValue(VerifyUvTag, null);
+                }
+                data = tlvWriter.Encode();
+            }
+            return new CommandApdu
+            {
+                Ins = PivVerifyInstruction,
+                P2 = SlotOccAuth,
+                Data = data,
+            };
+        }
+
+        /// <inheritdoc />
+        public VerifyUvResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
+          new VerifyUvResponse(responseApdu, _requestTemporaryPin);
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvCommand.cs
@@ -105,10 +105,10 @@ namespace Yubico.YubiKey.Piv.Commands
             }
 
             var tlvWriter = new TlvWriter();
+            const byte getTemporaryPinTag = 0x02;
             if (RequestTemporaryPin)
             {
-                const byte GetTemporaryPinTag = 0x02;
-                tlvWriter.WriteValue(GetTemporaryPinTag, null);
+                tlvWriter.WriteValue(getTemporaryPinTag, null);
             }
             else
             {
@@ -125,8 +125,7 @@ namespace Yubico.YubiKey.Piv.Commands
             };
         }
 
-        /// <inheritdoc />
-        public void ValidateParameters(bool requestTemporaryPin, bool checkOnly)
+        private static void ValidateParameters(bool requestTemporaryPin, bool checkOnly)
         {
             if (requestTemporaryPin && checkOnly)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
@@ -1,0 +1,177 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Globalization;
+using Yubico.Core.Iso7816;
+
+namespace Yubico.YubiKey.Piv.Commands
+{
+    /// <summary>
+    /// The response to verifying the PIN.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the partner Response class to <see cref="VerifyPinCommand"/>.
+    /// </para>
+    /// <para>
+    /// To determine the result of the command, first look at the
+    /// <see cref="YubiKeyResponse.Status"/>. If <c>Status</c> is not one of
+    /// the following values then an error has occurred and <see cref="GetData"/>
+    /// will throw an exception.
+    /// </para>
+    /// <list type="table">
+    /// <listheader>
+    /// <term>Status</term>
+    /// <description>Description</description>
+    /// </listheader>
+    ///
+    /// <item>
+    /// <term><see cref="ResponseStatus.Success"/></term>
+    /// <description>The PIN verified. GetData returns <c>null</c>.</description>
+    /// </item>
+    ///
+    /// <item>
+    /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
+    /// <description>The PIN did not verify. GetData returns the number
+    /// of retries remaining. If the number of retries is 0, the PIN
+    /// is blocked.</description>
+    /// </item>
+    /// </list>
+    ///
+    /// <para>
+    /// Example:
+    /// </para>
+    /// <code language="csharp">
+    ///   /* This example assumes the application has a method to collect a PIN.
+    ///    */
+    ///   byte[] pin;<br/>
+    ///
+    ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
+    ///   pin = CollectPin();
+    ///   var verifyPinCommand = new VerifyPinCommand(pin);
+    ///   VerifyPinResponse verifyPinResponse = connection.SendCommand(verifyPinCommand);<br/>
+    ///   if (resetRetryResponse.Status == ResponseStatus.AuthenticationRequired)
+    ///   {
+    ///     int retryCount = resetRetryResponse.GetData();
+    ///     /* report the retry count */
+    ///   }
+    ///   else if (verifyPinResponse.Status != ResponseStatus.Success)
+    ///   {
+    ///     // Handle error
+    ///   }
+    ///
+    ///   CryptographicOperations.ZeroMemory(pin)
+    /// </code>
+    /// </remarks>
+    public sealed class VerifyUvResponse : PivResponse, IYubiKeyResponseWithData<ReadOnlyMemory<byte>>
+    {
+        private readonly bool _requestTemporaryPin;
+
+        /// <inheritdoc />
+        protected override ResponseStatusPair StatusCodeMap
+        {
+            get
+            {
+                switch (StatusWord)
+                {
+                    case short statusWord when PivPinUtilities.HasRetryCount(statusWord):
+                        int remainingRetries = PivPinUtilities.GetRetriesRemaining(statusWord);
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, string.Format(CultureInfo.CurrentCulture, ResponseStatusMessages.PivPinPukFailedWithRetries, remainingRetries));
+
+                    case SWConstants.AuthenticationMethodBlocked:
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, ResponseStatusMessages.PivPinPukBlocked);
+
+                    case SWConstants.SecurityStatusNotSatisfied:
+                        return new ResponseStatusPair(ResponseStatus.AuthenticationRequired, ResponseStatusMessages.PivSecurityStatusNotSatisfied);
+
+                    default:
+                        return base.StatusCodeMap;
+                }
+            }
+        }
+
+        /// <summary>
+        /// Constructs a VerifyPinResponse based on a ResponseApdu received from
+        /// the YubiKey.
+        /// </summary>
+        /// <param name="responseApdu">
+        /// The object containing the response APDU<br/>returned by the YubiKey.
+        /// </param>
+        /// <param name="requestTemporaryPin">
+        /// True means that a temporary PIN was requested.
+        /// </param>
+        public VerifyUvResponse(ResponseApdu responseApdu, bool requestTemporaryPin) :
+            base(responseApdu)
+        {
+            _requestTemporaryPin = requestTemporaryPin;
+        }
+
+        /// <summary>
+        /// Gets the number of PIN retries remaining, if applicable.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// First look at the
+        /// <see cref="YubiKeyResponse.Status"/>. If <c>Status</c> is not one of
+        /// the following values then an error has occurred and <see cref="GetData"/>
+        /// will throw an exception.
+        /// </para>
+        ///
+        /// <list type="table">
+        /// <listheader>
+        /// <term>Status</term>
+        /// <description>Description</description>
+        /// </listheader>
+        ///
+        /// <item>
+        /// <term><see cref="ResponseStatus.Success"/></term>
+        /// <description>The PIN verified. GetData returns <c>null</c>.</description>
+        /// </item>
+        ///
+        /// <item>
+        /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
+        /// <description>The PIN did not verify. GetData returns the number
+        /// of retries remaining. If the number of retries is 0, the PIN
+        /// is blocked.</description>
+        /// </item>
+        /// </list>
+        /// </remarks>
+        /// <returns>
+        /// <c>null</c> if the PIN verifies, or the number of retries remaining if
+        /// the PIN does not verify.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">
+        /// Thrown if <see cref="YubiKeyResponse.Status"/> is not <see cref="ResponseStatus.Success"/>
+        /// or <see cref="ResponseStatus.AuthenticationRequired"/>.
+        /// </exception>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability, avoiding nested conditionals.")]
+        public ReadOnlyMemory<byte> GetData()
+        {
+            if (Status != ResponseStatus.Success && Status != ResponseStatus.AuthenticationRequired)
+            {
+                throw new InvalidOperationException(StatusMessage);
+            }
+
+            if (!_requestTemporaryPin)
+            {
+                return ReadOnlyMemory<byte>.Empty;
+            }
+            else 
+            {
+                return ResponseApdu.Data;
+            }
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
@@ -56,14 +56,14 @@ namespace Yubico.YubiKey.Piv.Commands
     /// </para>
     /// <code language="csharp">
     ///   IYubiKeyConnection connection = key.Connect(YubiKeyApplication.Piv);<br/>
-    ///   var verifyUvCommand = new VerifyUvCommand(false, false);
-    ///   VerifyUvResponse verifyUvResponse = connection.SendCommand(verifyUvCommand);<br/>
-    ///   if (verifyUvResponse.Status == ResponseStatus.AuthenticationRequired)
+    ///   var command = new VerifyUvCommand(false, false);
+    ///   VerifyUvResponse response = connection.SendCommand(command);<br/>
+    ///   if (response.Status == ResponseStatus.AuthenticationRequired)
     ///   {
-    ///     int retryCount = verifyUvResponse.AttemptsRemaining;
+    ///     int retryCount = response.AttemptsRemaining;
     ///     /* report the retry count */
     ///   }
-    ///   else if (verifyUvResponse.Status != ResponseStatus.Success)
+    ///   else if (response.Status != ResponseStatus.Success)
     ///   {
     ///     /* handle error */
     ///   }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
@@ -65,7 +65,7 @@ namespace Yubico.YubiKey.Piv.Commands
     ///   }
     ///   else if (verifyUvResponse.Status != ResponseStatus.Success)
     ///   {
-    ///     // Handle error
+    ///     /* handle error */
     ///   }
     /// </code>
     /// </remarks>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
@@ -45,7 +45,7 @@ namespace Yubico.YubiKey.Piv.Commands
     ///
     /// <item>
     /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
-    /// <description>The biometric authentication failed. GetData returns null. <see cref="RetriesRemaining"/> 
+    /// <description>The biometric authentication failed. GetData returns null. <see cref="AttemptsRemaining"/> 
     /// returns the number of retries remaining. If the number of retries is 0, the biometric authentication is 
     /// blocked and the client should use PIN authentication <see cref="VerifyPinCommand"/>.</description>
     /// </item>
@@ -81,7 +81,7 @@ namespace Yubico.YubiKey.Piv.Commands
         /// The value is returned only if a authentication failed. To get remaining biometric attempts when not
         /// performing authentication, use <see cref="PivBioMetadata.AttemptsRemaining"/>.
         /// </remarks>
-        public int? RetriesRemaining
+        public int? AttemptsRemaining
         {
             get
             {
@@ -163,7 +163,7 @@ namespace Yubico.YubiKey.Piv.Commands
         ///
         /// <item>
         /// <term><see cref="ResponseStatus.AuthenticationRequired"/></term>
-        /// <description>The biometric authentication did not succeed. <see cref="RetriesRemaining"/> contains number of
+        /// <description>The biometric authentication did not succeed. <see cref="AttemptsRemaining"/> contains number of
         /// of retries remaining. If the number of retries is 0 the biometric authentication is blocked and the 
         /// client should use PIN authentication (<see cref="VerifyPinCommand"/>).</description>
         /// </item>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VerifyUvResponse.cs
@@ -60,7 +60,7 @@ namespace Yubico.YubiKey.Piv.Commands
     ///   VerifyUvResponse verifyUvResponse = connection.SendCommand(verifyUvCommand);<br/>
     ///   if (verifyUvResponse.Status == ResponseStatus.AuthenticationRequired)
     ///   {
-    ///     int retryCount = verifyUvResponse.UVAttemptsRemaining;
+    ///     int retryCount = verifyUvResponse.AttemptsRemaining;
     ///     /* report the retry count */
     ///   }
     ///   else if (verifyUvResponse.Status != ResponseStatus.Success)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
@@ -40,7 +40,7 @@ namespace Yubico.YubiKey.Piv
 
         /// <summary>
         /// The constructor that takes in the bio metadata encoding returned by the
-        /// YubiKey in response to the Get bio metadata command.
+        /// YubiKey in response to the get bio metadata command.
         /// </summary>
         /// <param name="responseData">
         /// The data portion of the response APDU, this is the encoded bio metadata.
@@ -104,8 +104,8 @@ namespace Yubico.YubiKey.Piv
         /// Indicates whether biometrics are configured or not (fingerprints enrolled or not).
         /// A false return value indicates a YubiKey Bio without biometrics configured and hence the
         /// client should fallback to a PIN based authentication.
-        /// @return true if biometrics are configured or not.
         /// </summary>
+        /// <returns>true if biometrics are configured or not.</returns>
         public bool IsConfigured { get; private set; }
 
         /// <summary>
@@ -118,11 +118,10 @@ namespace Yubico.YubiKey.Piv
         public int AttemptsRemaining { get; private set; }
 
         /// <summary>
-        /// Indicates whether biometrics are configured or not (fingerprints enrolled or not).
-        /// A false return value indicates a YubiKey Bio without biometrics configured and hence the
-        /// client should fallback to a PIN based authentication.
-        /// @return true if biometrics are configured or not.
+        /// Indicates whether a temporary PIN has been generated in the YubiKey in relation to a 
+        /// successful biometric match.
         /// </summary>
+        /// <returns>true if a temporary PIN has been generated.</returns>
         public bool HasTemporaryPin { get; private set; }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
@@ -65,12 +65,6 @@ namespace Yubico.YubiKey.Piv
 
                 switch (tag)
                 {
-                    default:
-                        throw new InvalidOperationException(
-                            string.Format(
-                                CultureInfo.CurrentCulture,
-                                ExceptionMessages.InvalidApduResponseData));
-
                     case BioConfiguredTag:
                         isConfigured = value.Span[0] == 1;
                         break;
@@ -82,19 +76,27 @@ namespace Yubico.YubiKey.Piv
                     case TemporaryPinTag:
                         hasTemporaryPin = value.Span[0] == 1;
                         break;
-                }
 
-                if (isConfigured == null  || attemptsRemaining == null || hasTemporaryPin == null) {
-                    throw new InvalidOperationException(
+                    default:
+                        throw new InvalidOperationException(
                             string.Format(
                                 CultureInfo.CurrentCulture,
                                 ExceptionMessages.InvalidApduResponseData));
                 }
-
-                IsConfigured = (bool) isConfigured;
-                AttemptsRemaining = (int) attemptsRemaining;
-                HasTemporaryPin = (bool) hasTemporaryPin;
             }
+
+
+            if (isConfigured == null || attemptsRemaining == null || hasTemporaryPin == null)
+            {
+                throw new InvalidOperationException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            ExceptionMessages.InvalidApduResponseData));
+            }
+
+            IsConfigured = (bool)isConfigured;
+            AttemptsRemaining = (int)attemptsRemaining;
+            HasTemporaryPin = (bool)hasTemporaryPin;
         }
 
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
@@ -16,6 +16,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using Yubico.Core.Tlv;
+using Yubico.YubiKey.Piv.Commands;
 
 namespace Yubico.YubiKey.Piv
 {
@@ -40,7 +41,7 @@ namespace Yubico.YubiKey.Piv
 
         /// <summary>
         /// The constructor that takes in the bio metadata encoding returned by the
-        /// YubiKey in response to the get bio metadata command.
+        /// YubiKey in response to the <see cref="GetBioMetadataCommand"/>.
         /// </summary>
         /// <param name="responseData">
         /// The data portion of the response APDU, this is the encoded bio metadata.
@@ -94,9 +95,9 @@ namespace Yubico.YubiKey.Piv
                             ExceptionMessages.InvalidApduResponseData));
             }
 
-            IsConfigured = (bool)isConfigured;
-            AttemptsRemaining = (int)attemptsRemaining;
-            HasTemporaryPin = (bool)hasTemporaryPin;
+            IsConfigured = isConfigured.Value;
+            AttemptsRemaining = attemptsRemaining.Value;
+            HasTemporaryPin = hasTemporaryPin.Value;
         }
 
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
@@ -1,0 +1,126 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using Yubico.Core.Tlv;
+
+namespace Yubico.YubiKey.Piv
+{
+    /// <summary>
+    /// This class parses the response data from the PIV Get Bio Metadata command. It
+    /// holds data about Bio multi-protocol key.
+    /// </summary>
+    /// <remarks>
+    /// The response to the
+    /// <see cref="Commands.GetBioMetadataCommand"/> is
+    /// <see cref="Commands.GetBioMetadataResponse"/>.
+    /// Call the <c>GetData</c> method in the response object to get the
+    /// metadata. An instance of this class will be returned.
+    /// </remarks>
+    public class PivBioMetadata
+    {
+        private const int AttemptsRemainingTag = 0x06;
+
+        private const int BioConfiguredTag = 0x07;
+
+        private const int TemporaryPinTag = 0x08;
+
+        /// <summary>
+        /// The constructor that takes in the bio metadata encoding returned by the
+        /// YubiKey in response to the Get bio metadata command.
+        /// </summary>
+        /// <param name="responseData">
+        /// The data portion of the response APDU, this is the encoded bio metadata.
+        /// </param>
+        /// <exception cref="InvalidOperationException">
+        /// The data supplied is not valid PIV bio metadata.
+        /// </exception>
+        public PivBioMetadata(ReadOnlyMemory<byte> responseData)
+        {
+
+            var tlvReader = new TlvReader(responseData);
+
+            bool? isConfigured = null;
+            int? attemptsRemaining = null;
+            bool? hasTemporaryPin = null;
+
+
+            while (tlvReader.HasData)
+            {
+                int tag = tlvReader.PeekTag();
+                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+
+                switch (tag)
+                {
+                    default:
+                        throw new InvalidOperationException(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                ExceptionMessages.InvalidApduResponseData));
+
+                    case BioConfiguredTag:
+                        isConfigured = value.Span[0] == 1;
+                        break;
+
+                    case AttemptsRemainingTag:
+                        attemptsRemaining = value.Span[0];
+                        break;
+
+                    case TemporaryPinTag:
+                        hasTemporaryPin = value.Span[0] == 1;
+                        break;
+                }
+
+                if (isConfigured == null  || attemptsRemaining == null || hasTemporaryPin == null) {
+                    throw new InvalidOperationException(
+                            string.Format(
+                                CultureInfo.CurrentCulture,
+                                ExceptionMessages.InvalidApduResponseData));
+                }
+
+                IsConfigured = (bool) isConfigured;
+                AttemptsRemaining = (int) attemptsRemaining;
+                HasTemporaryPin = (bool) hasTemporaryPin;
+            }
+        }
+
+
+        /// <summary>
+        /// Indicates whether biometrics are configured or not (fingerprints enrolled or not).
+        /// A false return value indicates a YubiKey Bio without biometrics configured and hence the
+        /// client should fallback to a PIN based authentication.
+        /// @return true if biometrics are configured or not.
+        /// </summary>
+        public bool IsConfigured { get; private set; }
+
+        /// <summary>
+        /// Returns value of biometric match retry counter which states how many biometric match retries
+        /// are left until a YubiKey Bio is blocked.
+        /// If this method returns 0 and {@link #isConfigured()} returns true, the device is blocked for
+        /// biometric match and the client should invoke PIN based authentication to reset the biometric
+        /// match retry counter.
+        /// </summary>
+        public int AttemptsRemaining { get; private set; }
+
+        /// <summary>
+        /// Indicates whether biometrics are configured or not (fingerprints enrolled or not).
+        /// A false return value indicates a YubiKey Bio without biometrics configured and hence the
+        /// client should fallback to a PIN based authentication.
+        /// @return true if biometrics are configured or not.
+        /// </summary>
+        public bool HasTemporaryPin { get; private set; }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPinPolicy.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPinPolicy.cs
@@ -45,6 +45,18 @@ namespace Yubico.YubiKey.Piv
         Always = 3,
 
         /// <summary>
+        /// Biometric verification succeeds or the PIN is checked for only
+        /// the first operation in a session using the key in the given slot.
+        /// </summary>
+        MatchOnce = 4,
+
+        /// <summary>
+        /// Biometric verification succeeds or the PIN is verified before every
+        /// operation that uses the key in the given slot.
+        /// </summary>
+        MatchAlways = 5,
+
+        /// <summary>
         /// The PIN policy is the default for the YubiKey.
         /// </summary>
         Default = 32,

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -374,7 +374,7 @@ namespace Yubico.YubiKey.Piv
         /// Get information about YubiKey Bio multi-protocol.
         /// </summary>
         /// <remarks>
-        /// This feature is available only on YubiKeys Bio multi-protocol 6.6 and later. If you call
+        /// This feature is available only on YubiKeys Bio multi-protocol (FW 5.6 and later). If you call
         /// this method on an incompatible YubiKey, it will throw a <c>NotSupportedException</c>.
         /// <code language="csharp">
         ///     IEnumerable&lt;IYubiKeyDevice&gt; list = YubiKey.FindByTransport(Transport.UsbSmartCard);
@@ -399,8 +399,7 @@ namespace Yubico.YubiKey.Piv
         /// </para>
         /// </remarks>
         /// <returns>
-        /// A new instance of a <c>PivBioMetadata</c> object containing information
-        /// about the given slot.
+        /// A new instance of a <c>PivBioMetadata</c> object.
         /// </returns>
         /// <exception cref="NotSupportedException">
         /// The queried YubiKey does not support bio metadata.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -378,17 +378,16 @@ namespace Yubico.YubiKey.Piv
         /// this method on an incompatible YubiKey, it will throw a <c>NotSupportedException</c>.
         /// <code language="csharp">
         ///     IEnumerable&lt;IYubiKeyDevice&gt; list = YubiKey.FindByTransport(Transport.UsbSmartCard);
-        ///     IYubiKeyDevice yubiKey = list.First();
-        ///
+        ///     IYubiKeyDevice yubiKey = list.First();<br/>
         ///     using (var pivSession = new PivSession(yubiKey))
         ///     {
         ///         try
         ///         {
         ///             var bioMetaData = PivSession.GetBioMetadata();
-        ///             // use bioMetaData
+        ///             /* use bioMetaData */
         ///         }
         ///         catch (NotSupportedException e) {
-        ///             // this device does not support Bio multi-protocol metadata
+        ///             /* this device does not support Bio multi-protocol metadata */
         ///         }
         ///     }
         /// </code>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -411,25 +411,7 @@ namespace Yubico.YubiKey.Piv
         public PivBioMetadata GetBioMetadata()
         {
             _log.LogInformation("GetBioMetadata");
-
-            try
-            {
-                var getBioMetadataCommand = new GetBioMetadataCommand();
-                GetBioMetadataResponse getBioMetadataResponse = Connection.SendCommand(getBioMetadataCommand);
-
-                return getBioMetadataResponse.GetData();
-            }
-            catch (ApduException e)
-            {
-                if (e.SW == SWConstants.DataNotFound)
-                {
-                    throw new NotSupportedException(
-                       string.Format(
-                    CultureInfo.CurrentCulture,
-                    ExceptionMessages.BiometricVerificationNotSupported));
-                }
-                throw e;
-            }
+            return Connection.SendCommand(new GetBioMetadataCommand()).GetData();
         }
 
         /// <summary>

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/BioMultiProtocolTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/BioMultiProtocolTests.cs
@@ -22,7 +22,7 @@ using Yubico.YubiKey.TestUtilities;
 
 namespace Yubico.YubiKey.Piv
 {
-    public class PivBioMultiProtocolTests
+    public class BioMultiProtocolTests
     {
         /// <summary>
         /// Verify authentication with YubiKey Bio Multi-protocol
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey.Piv
         /// <param name="testDeviceType"></param>
         [SkippableTheory(typeof(NotSupportedException))]
         [InlineData(StandardTestDevice.Fw5)]
-        public void PivBioMultiProtocol_Authenticate(StandardTestDevice testDeviceType)
+        public void BioMultiProtocol_Authenticate(StandardTestDevice testDeviceType)
         {
             IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(testDeviceType);
             using (var pivSession = new PivSession(testDevice))

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/BioMultiProtocolTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/BioMultiProtocolTests.cs
@@ -76,13 +76,12 @@ namespace Yubico.YubiKey.Piv
             using (var pivSession = new PivSession(testDevice))
             {
                 var connection = pivSession.Connection;
-                int? attemptsRemaining;
 
                 var response = VerifyUv(connection, false, false);
 
                 Assert.Equal(3, pivSession.GetBioMetadata().AttemptsRemaining);
 
-                response = VerifyUv(connection, false, false, out attemptsRemaining);
+                response = VerifyUv(connection, false, false, out int? attemptsRemaining);
                 Assert.True(response.IsEmpty);
                 Assert.Equal(2, attemptsRemaining);
 
@@ -124,7 +123,7 @@ namespace Yubico.YubiKey.Piv
                 Assert.True(pivSession.GetBioMetadata().HasTemporaryPin);
 
                 // use invalid temporary pin
-                Assert.False(VerifyTemporaryPin(connection, 
+                Assert.False(VerifyTemporaryPin(connection,
                     Encoding.ASCII.GetBytes("0102030405060708")));
                 Assert.False(pivSession.GetBioMetadata().HasTemporaryPin);
 
@@ -132,7 +131,7 @@ namespace Yubico.YubiKey.Piv
                 temporaryPin = VerifyUv(connection, true, false);
                 Assert.False(temporaryPin.IsEmpty);
                 Assert.True(pivSession.GetBioMetadata().HasTemporaryPin);
-                
+
                 Assert.True(VerifyTemporaryPin(connection, temporaryPin));
                 Assert.True(pivSession.GetBioMetadata().HasTemporaryPin);
             }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/PinBioMultiProtocolTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/PinBioMultiProtocolTests.cs
@@ -24,7 +24,6 @@ namespace Yubico.YubiKey.Piv
 {
     public class PivBioMultiProtocolTests
     {
-
         /// <summary>
         /// Verify authentication with YubiKey Bio Multi-protocol
         /// </summary>

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/PinBioMultiProtocolTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/PinBioMultiProtocolTests.cs
@@ -1,0 +1,78 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Yubico.PlatformInterop;
+using Yubico.YubiKey.Piv.Commands;
+using Yubico.YubiKey.TestUtilities;
+
+namespace Yubico.YubiKey.Piv
+{
+    public class PivBioMultiProtocolTests
+    {
+
+        /// <summary>
+        /// Verify authentication with YubiKey Bio Multi-protocol
+        /// </summary>
+        /// <remarks>
+        /// To run the test, create a PIN and enroll at least one fingerprint. The test will ask twice
+        /// for fingerprint authentication.
+        /// <para>
+        /// Tests with devices without Bio Metadata are skipped.
+        /// </remarks>
+        /// <param name="testDeviceType"></param>
+        [SkippableTheory(typeof(NotSupportedException))]
+        [InlineData(StandardTestDevice.Fw5)]
+        public void PivBioMultiProtocol_Authenticate(StandardTestDevice testDeviceType)
+        {
+            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(testDeviceType);
+            using (var pivSession = new PivSession(testDevice))
+            {
+                var bioMetadata = pivSession.GetBioMetadata();
+                var connection = pivSession.Connection;
+
+                Assert.True(VerifyUv(connection, false, false).IsEmpty);
+                Assert.False(pivSession.GetBioMetadata().HasTemporaryPin);                
+
+                // check verified state
+                Assert.True(VerifyUv(connection, false, true).IsEmpty);
+
+                var temporaryPin = VerifyUv(connection, true, false);
+                Assert.False(temporaryPin.IsEmpty);
+                Assert.True(pivSession.GetBioMetadata().HasTemporaryPin);
+
+                // check verified state
+                Assert.True(VerifyUv(connection, false, true).IsEmpty);
+
+                VerifyTemporaryPin(connection, temporaryPin);
+            }
+        }
+
+        private ReadOnlyMemory<byte> VerifyUv(IYubiKeyConnection connection, bool requestTemporaryPin, bool checkOnly)
+        {
+            var command = new VerifyUvCommand(requestTemporaryPin, checkOnly);
+            var response = connection.SendCommand(command);
+            return response.GetData();
+        }
+
+        private void VerifyTemporaryPin(IYubiKeyConnection connection, ReadOnlyMemory<byte> temporaryPin)
+        {
+            var command = new VerifyTemporaryPinCommand(temporaryPin);
+            _ = connection.SendCommand(command).GetData();
+        }
+    }
+}


### PR DESCRIPTION
# Description

Adds Metadata and Verify extensions for YubiKey Bio MPE.

Adds new slot verification policies (PIN_OR_MATCH_ONCE and PIN_OR_MATCH_ALWAYS).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How has this been tested?

There are new integration tests for verifying that we receive expected data.

**Test configuration**:
* Firmware version: 5.6+
* Yubikey model: YK Bio MPE

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
