### PR TITLE
Additions for PIN complexity violation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -35,8 +35,7 @@ indent_size = 4
 indent_style = space
 tab_width = 4
 guidelines = 100, 120
-guidelines_style =
-2.5px solid 40ff0000
+guidelines_style = 2.5px solid 40ff0000
 
 # New line preferences
 end_of_line = crlf

--- a/Yubico.YubiKey/docs/users-manual/sdk-programming-guide/pin-complexity-policy.md
+++ b/Yubico.YubiKey/docs/users-manual/sdk-programming-guide/pin-complexity-policy.md
@@ -1,0 +1,57 @@
+---
+uid: UsersManualPinComplexityPolicy
+---
+
+<!-- Copyright 2024 Yubico AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+# PIN Complexity policy
+
+Since firmware 5.7, the YubiKey can enforce usage of non-trivial PINs in its applications, this feature has been named _PIN complexity policy_ and is derived from the current Revision 3 of SP 800-63 (specifically SP 800-63B-3) with additional consideration of Revision 4 of SP 800-63 (specifically SP 800-63B-4).
+
+If PIN complexity has been enforced, the YubiKey will refuse to set or change values of following, if they violate the policy:
+- PIV PIN and PUK
+- FIDO2 PIN
+
+That means that simple values such as `11111111`, `password` or `12345678` will be refused. The YubiKey can also be programmed during the pre-registration to refuse other specific values. More information can be found in our <a href="https://docs.yubico.com/hardware/yubikey/yk-tech-manual/5.7-firmware-specifics.html#pin-complexity">online documentation</a> for the firmware version 5.7 additions.
+
+The SDK has support for getting information about the feature and also a way how to let the client know that an error is related to PIN complexity.
+
+## Read current PIN complexity status
+The PIN complexity enforcement status is part of the `IYubiKeyDeviceInfo` through `bool IsPinComplexityEnabled` property.
+
+## Handle PIN complexity errors
+The SDK can be used to create a variety of applications. If those support setting or changing PINs, they should handle the situation when a YubiKey refuses the user value because it is violating the PIN complexity.
+
+The SDK communicates this by throwing specific Exceptions.
+
+### PIV Session
+In PIV session the exception thrown during PIN complexity violations is `SecurityException` with a specific message: `ExceptionMessages.PinComplexityViolation`.
+
+If the application uses `KeyCollectors`, the violation is reported through `KeyEntryData.IsViolatingPinComplexity`.
+
+The violations are reported for following operations:
+- `PivSession.ChangePin()`
+- `PivSession.ChangePuk()`
+- `PivSession.ResetPin()`
+
+### FIDO2 Session
+In the FIDO2 application, `Fido2Exception` with `Status` of `CtapStatus.PinPolicyViolation` is thrown after a PIN complexity was violated. For `KeyCollectors`, `KeyEntryData.IsViolatingPinComplexity` will be set to `true` for these situations.
+
+This applies to following `Fido2Session` operations:
+- `Fido2Session.SetPin()`
+- `Fido2Session.ChangePin()`
+
+## Example code
+You can find examples of code in the `PivSampleCode` and `Fido2SampleCode` examples as well in `PinComplexityTests` integration tests.

--- a/Yubico.YubiKey/docs/users-manual/toc.yml
+++ b/Yubico.YubiKey/docs/users-manual/toc.yml
@@ -54,6 +54,8 @@
     href: sdk-programming-guide/commands.md
   - name: Device notifications
     href: sdk-programming-guide/device-notifications.md
+  - name: PIN Complexity policy
+    href: sdk-programming-guide/pin-complexity-policy.md
 
 - name: "Application: OTP"
   homepage: application-otp/otp-overview.md

--- a/Yubico.YubiKey/examples/Fido2SampleCode/KeyCollector/Fido2SampleKeyCollector.cs
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/KeyCollector/Fido2SampleKeyCollector.cs
@@ -41,6 +41,18 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 return false;
             }
 
+            if (keyEntryData.IsViolatingPinComplexity)
+            {
+                SampleMenu.WriteMessage(MessageType.Special, 0, "The provided value violates PIN complexity.");
+
+                SampleMenu.WriteMessage(MessageType.Title, 0, "Try again? y/n");
+                char[] answer = SampleMenu.ReadResponse(out int _);
+                if (answer.Length == 0 || (answer[0] != 'y' && answer[0] != 'Y'))
+                {
+                    return false;
+                }
+            }
+
             if (keyEntryData.IsRetry)
             {
                 SampleMenu.WriteMessage(MessageType.Title, 0, "A previous entry was incorrect, do you want to retry?");
@@ -49,7 +61,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                     string retryString =
                         ((int)keyEntryData.RetriesRemaining).ToString("D", CultureInfo.InvariantCulture);
                     SampleMenu.WriteMessage(MessageType.Title, 0,
-                        "(retries remainin until blocked: " + retryString + ")");
+                        "(retries remaining until blocked: " + retryString + ")");
                 }
 
                 SampleMenu.WriteMessage(MessageType.Title, 0, "y/n");

--- a/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
@@ -48,14 +48,6 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return false;
             }
 
-            if (keyEntryData.IsViolatingPinComplexity)
-            {
-                if (GetUserInputOnPinComplexityViolation(keyEntryData) == false)
-                {
-                    return false;
-                }
-            }
-
             if (keyEntryData.IsRetry)
             {
                 if (!(keyEntryData.RetriesRemaining is null))
@@ -141,20 +133,6 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             }
 
             string title = keyEntryData.RetriesRemaining + " tries remaining, continue?";
-            string[] menuItems = new string[]
-            {
-                "Yes, try again",
-                "No, cancel operation"
-            };
-            int response = _menuObject.RunMenu(title, menuItems);
-            return response == 0;
-        }
-
-        private bool GetUserInputOnPinComplexityViolation(KeyEntryData keyEntryData)
-        {
-            SampleMenu.WriteMessage(MessageType.Special, 0, "The provided value violates PIN complexity.");
-
-            string title = "Try again?";
             string[] menuItems = new string[]
             {
                 "Yes, try again",

--- a/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
@@ -48,6 +48,14 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return false;
             }
 
+            if (keyEntryData.IsViolatingPinComplexity)
+            {
+                if (GetUserInputOnPinComplexityViolation(keyEntryData) == false)
+                {
+                    return false;
+                }
+            }
+
             if (keyEntryData.IsRetry)
             {
                 if (!(keyEntryData.RetriesRemaining is null))
@@ -133,6 +141,20 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             }
 
             string title = keyEntryData.RetriesRemaining + " tries remaining, continue?";
+            string[] menuItems = new string[]
+            {
+                "Yes, try again",
+                "No, cancel operation"
+            };
+            int response = _menuObject.RunMenu(title, menuItems);
+            return response == 0;
+        }
+
+        private bool GetUserInputOnPinComplexityViolation(KeyEntryData keyEntryData)
+        {
+            SampleMenu.WriteMessage(MessageType.Special, 0, "The provided value violates PIN complexity.");
+
+            string title = "Try again?";
             string[] menuItems = new string[]
             {
                 "Yes, try again",

--- a/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs
@@ -48,23 +48,17 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return false;
             }
 
-            if (keyEntryData.IsViolatingPinComplexity)
+            if (keyEntryData.IsViolatingPinComplexity &&
+                !GetUserInputOnPinComplexityViolation(keyEntryData))
             {
-                if (GetUserInputOnPinComplexityViolation(keyEntryData) == false)
-                {
-                    return false;
-                }
+                return false;
             }
 
-            if (keyEntryData.IsRetry)
+            if (keyEntryData.IsRetry &&
+                keyEntryData.RetriesRemaining.HasValue &&
+                !GetUserInputOnRetries(keyEntryData))
             {
-                if (!(keyEntryData.RetriesRemaining is null))
-                {
-                    if (GetUserInputOnRetries(keyEntryData) == false)
-                    {
-                        return false;
-                    }
-                }
+                return false;
             }
 
             byte[] currentValue;

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -333,6 +333,12 @@ namespace Yubico.YubiKey {
             }
         }
         
+        internal static string PinComplexityViolation {
+            get {
+                return ResourceManager.GetString("PinComplexityViolation", resourceCulture);
+            }
+        }
+        
         internal static string YubiKeyNotAuthenticatedInPiv {
             get {
                 return ResourceManager.GetString("YubiKeyNotAuthenticatedInPiv", resourceCulture);

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -264,6 +264,9 @@
   <data name="NoMoreRetriesRemaining" xml:space="preserve">
     <value>There are no retries remaining for a PIN, PUK, or other authentication element.</value>
   </data>
+  <data name="PinComplexityViolation" xml:space="preserve">
+    <value>The provided PIN or PUK value violates current complexity conditions.</value>
+  </data>  
   <data name="YubiKeyNotAuthenticatedInPiv" xml:space="preserve">
     <value>PIV management key mutual authentication failed because the YubiKey did not authenticate.</value>
   </data>

--- a/Yubico.YubiKey/src/Resources/ResponseStatusMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ResponseStatusMessages.Designer.cs
@@ -538,6 +538,15 @@ namespace Yubico.YubiKey {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The request was rejected because the PIN and/or UV was not verified..
+        /// </summary>
+        internal static string Fido2PinComplexityViolation {
+            get {
+                return ResourceManager.GetString("Fido2PinComplexityViolation", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The FIDO2 reset command must be sent within 10 seconds of the YubiKey being removed and reinserted..
         /// </summary>
         internal static string Fido2ResetProcess {

--- a/Yubico.YubiKey/src/Resources/ResponseStatusMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ResponseStatusMessages.resx
@@ -288,6 +288,9 @@
   <data name="Fido2PinNotVerified" xml:space="preserve">
     <value>The request was rejected because the PIN and/or UV was not verified.</value>
   </data>
+  <data name="Fido2PinComplexityViolation" xml:space="preserve">
+    <value>The request was rejected because the PIN violates PIN complexity setting.</value>
+  </data>
   <data name="Fido2PinBlocked" xml:space="preserve">
     <value>The request was rejected because the PIN and/or the UV was blocked.</value>
   </data>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/Fido2Response.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/Fido2Response.cs
@@ -41,6 +41,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             CtapStatus.NoCredentials => new ResponseStatusPair(ResponseStatus.NoData, ResponseStatusMessages.Fido2NoCredentials),
             CtapStatus.NotAllowed => new ResponseStatusPair(ResponseStatus.Failed, ResponseStatusMessages.Fido2NotAllowed),
             CtapStatus.PinRequired => new ResponseStatusPair(ResponseStatus.Failed, ResponseStatusMessages.Fido2PinNotVerified),
+            CtapStatus.PinPolicyViolation => new ResponseStatusPair(ResponseStatus.ConditionsNotSatisfied, ResponseStatusMessages.Fido2PinComplexityViolation),
             CtapStatus.PinNotSet => new ResponseStatusPair(ResponseStatus.Failed, ResponseStatusMessages.Fido2PinNotSet),
             CtapStatus.PinInvalid => new ResponseStatusPair(ResponseStatus.ConditionsNotSatisfied, ResponseStatusMessages.Fido2PinNotVerified),
             CtapStatus.PinBlocked => new ResponseStatusPair(ResponseStatus.Failed, ResponseStatusMessages.Fido2PinBlocked),

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Exception.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Exception.cs
@@ -49,6 +49,16 @@ namespace Yubico.YubiKey.Fido2
         /// <summary>
         /// Initializes a new instance of the <see cref="Fido2Exception"/> class.
         /// </summary>
+        /// <param name="status">The CTAP error.</param>
+        /// <param name="message">The message that describes the error.</param>
+        public Fido2Exception(CtapStatus status, string message) : base(message)
+        {
+            Status = status;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Fido2Exception"/> class.
+        /// </summary>
         /// <param name="message">The error message that explains the reason for the exception.</param>
         /// <param name="innerException">The exception that is the cause of the current exception.</param>
         public Fido2Exception(string message, Exception innerException) : base(message, innerException)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
@@ -538,10 +538,8 @@ namespace Yubico.YubiKey.Fido2
                             keyEntryData.IsViolatingPinComplexity = true;
                             continue;
                         }
-                        else
-                        {
-                            throw e;
-                        }
+
+                        throw;
                     }
                     throw new SecurityException(ExceptionMessages.PinAlreadySet);
                 }
@@ -701,10 +699,8 @@ namespace Yubico.YubiKey.Fido2
                             keyEntryData.IsViolatingPinComplexity = true;
                             continue;
                         }
-                        else
-                        {
-                            throw e;
-                        }
+
+                        throw;
                     }
 
                     keyEntryData.IsRetry = true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
@@ -565,6 +565,9 @@ namespace Yubico.YubiKey.Fido2
         /// <c>True</c> on success, <c>False</c> if the YubiKey has a PIN already set, and an exception for all
         /// other kinds of failures.
         /// </returns>
+        /// <exception cref="ArgumentException">
+        /// The provided PIN violates PIN complexity.
+        /// </exception>
         public bool TrySetPin(ReadOnlyMemory<byte> newPin)
         {
             _log.LogInformation("Try to set PIN (use supplied PIN).");
@@ -587,6 +590,17 @@ namespace Yubico.YubiKey.Fido2
                 GetCtapError(result) == CtapStatus.NotAllowed)
             {
                 return false; // PIN is already set.
+            }
+
+            if (GetCtapError(result) == CtapStatus.PinPolicyViolation)
+            {
+                // PIN complexity violation
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.PinComplexityViolation
+                    )
+                );
             }
 
             throw new Fido2Exception(result.StatusMessage);
@@ -720,6 +734,9 @@ namespace Yubico.YubiKey.Fido2
         /// <exception cref="Fido2Exception">
         /// The YubiKey returned an error indicating that the change PIN request could not be completed.
         /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The provided new PIN violates PIN complexity.
+        /// </exception>
         public bool TryChangePin(ReadOnlyMemory<byte> currentPin, ReadOnlyMemory<byte> newPin)
         {
             _log.LogInformation("Try to change PIN (use supplied PIN values).");
@@ -740,6 +757,17 @@ namespace Yubico.YubiKey.Fido2
                 // re-initialize everything so we can obtain the new shared secret.
                 AuthProtocol.Initialize();
                 return false; // PIN is invalid
+            }
+
+            if (GetCtapError(result) == CtapStatus.PinPolicyViolation)
+            {
+                // PIN complexity violation
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.PinComplexityViolation
+                    )
+                );
             }
 
             throw new Fido2Exception(result.StatusMessage);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
@@ -565,9 +565,6 @@ namespace Yubico.YubiKey.Fido2
         /// <c>True</c> on success, <c>False</c> if the YubiKey has a PIN already set, and an exception for all
         /// other kinds of failures.
         /// </returns>
-        /// <exception cref="ArgumentException">
-        /// The provided PIN violates PIN complexity.
-        /// </exception>
         public bool TrySetPin(ReadOnlyMemory<byte> newPin)
         {
             _log.LogInformation("Try to set PIN (use supplied PIN).");
@@ -592,18 +589,7 @@ namespace Yubico.YubiKey.Fido2
                 return false; // PIN is already set.
             }
 
-            if (GetCtapError(result) == CtapStatus.PinPolicyViolation)
-            {
-                // PIN complexity violation
-                throw new ArgumentException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        ExceptionMessages.PinComplexityViolation
-                    )
-                );
-            }
-
-            throw new Fido2Exception(result.StatusMessage);
+            throw new Fido2Exception(GetCtapError(result), result.StatusMessage);
         }
 
         /// <summary>
@@ -734,9 +720,6 @@ namespace Yubico.YubiKey.Fido2
         /// <exception cref="Fido2Exception">
         /// The YubiKey returned an error indicating that the change PIN request could not be completed.
         /// </exception>
-        /// <exception cref="ArgumentException">
-        /// The provided new PIN violates PIN complexity.
-        /// </exception>
         public bool TryChangePin(ReadOnlyMemory<byte> currentPin, ReadOnlyMemory<byte> newPin)
         {
             _log.LogInformation("Try to change PIN (use supplied PIN values).");
@@ -759,18 +742,7 @@ namespace Yubico.YubiKey.Fido2
                 return false; // PIN is invalid
             }
 
-            if (GetCtapError(result) == CtapStatus.PinPolicyViolation)
-            {
-                // PIN complexity violation
-                throw new ArgumentException(
-                    string.Format(
-                        CultureInfo.CurrentCulture,
-                        ExceptionMessages.PinComplexityViolation
-                    )
-                );
-            }
-
-            throw new Fido2Exception(result.StatusMessage);
+            throw new Fido2Exception(GetCtapError(result), result.StatusMessage);
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyEntryData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyEntryData.cs
@@ -137,6 +137,11 @@ namespace Yubico.YubiKey
         public bool IsRetry { get; set; }
 
         /// <summary>
+        /// Indicates if the current request for an item has violated PIN complexity.
+        /// </summary>
+        public bool IsViolatingPinComplexity { get; set; }
+
+        /// <summary>
         /// This is the result of the last fingerprint sample. This will be null
         /// if the <c>Request</c> is for something other than
         /// <see cref="KeyEntryRequest.EnrollFingerprint"/> or if it is the first
@@ -221,6 +226,7 @@ namespace Yubico.YubiKey
             _currentValue = Memory<byte>.Empty;
             _newValue = Memory<byte>.Empty;
             IsRetry = false;
+            IsViolatingPinComplexity = false;
         }
 
         /// <summary>
@@ -340,6 +346,7 @@ namespace Yubico.YubiKey
             LastBioEnrollSampleResult = null;
             SignalUserCancel = null;
             IsRetry = false;
+            IsViolatingPinComplexity = false;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ChangeReferenceDataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ChangeReferenceDataResponse.cs
@@ -164,7 +164,9 @@ namespace Yubico.YubiKey.Piv.Commands
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability, avoiding nested conditionals.")]
         public int? GetData()
         {
-            if (Status != ResponseStatus.Success && Status != ResponseStatus.AuthenticationRequired)
+            if (Status != ResponseStatus.Success &&
+                Status != ResponseStatus.AuthenticationRequired &&
+                Status != ResponseStatus.ConditionsNotSatisfied)
             {
                 throw new InvalidOperationException(StatusMessage);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ResetRetryResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ResetRetryResponse.cs
@@ -162,7 +162,9 @@ namespace Yubico.YubiKey.Piv.Commands
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0046:Convert to conditional expression", Justification = "Readability, avoiding nested conditionals.")]
         public int? GetData()
         {
-            if (Status != ResponseStatus.Success && Status != ResponseStatus.AuthenticationRequired)
+            if (Status != ResponseStatus.Success &&
+                Status != ResponseStatus.AuthenticationRequired &&
+                Status != ResponseStatus.ConditionsNotSatisfied)
             {
                 throw new InvalidOperationException(StatusMessage);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
@@ -1302,10 +1302,6 @@ namespace Yubico.YubiKey.Piv
 
                         return true;
                     }
-                    else if (status == ResponseStatus.ConditionsNotSatisfied)
-                    {
-                        _log.LogInformation("PIN complexity violated.");
-                    }
 
                     if ((keyEntryData.RetriesRemaining ?? 1) == 0)
                     {
@@ -1315,7 +1311,14 @@ namespace Yubico.YubiKey.Piv
                                 ExceptionMessages.NoMoreRetriesRemaining));
                     }
 
-                    keyEntryData.IsRetry = true;
+                    if (status == ResponseStatus.ConditionsNotSatisfied)
+                    {
+                        keyEntryData.IsViolatingPinComplexity = true;
+                    }
+                    else
+                    {
+                        keyEntryData.IsRetry = true;
+                    }
                 }
             }
             finally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
@@ -1233,6 +1233,7 @@ namespace Yubico.YubiKey.Piv
 
             if (resetResponse.Status == ResponseStatus.ConditionsNotSatisfied)
             {
+                retriesRemaining = null;
                 throw new SecurityException(
                     string.Format(
                         CultureInfo.CurrentCulture,

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Pin.cs
@@ -1266,7 +1266,7 @@ namespace Yubico.YubiKey.Piv
         // Command/Response operations (Change or Reset).
         // If the mode is not None, then set the YubiKey to that mode.
         private bool TryChangeReference(KeyEntryRequest request,
-                                        Func<KeyEntryData, ResponseStatus> CommandResponse,
+                                        Func<KeyEntryData, ResponseStatus> commandResponse,
                                         PivPinOnlyMode mode)
         {
             if (KeyCollector is null)
@@ -1286,7 +1286,7 @@ namespace Yubico.YubiKey.Piv
             {
                 while (KeyCollector(keyEntryData))
                 {
-                    ResponseStatus status = CommandResponse(keyEntryData);
+                    ResponseStatus status = commandResponse(keyEntryData);
 
                     if (status == ResponseStatus.Success)
                     {
@@ -1336,12 +1336,9 @@ namespace Yubico.YubiKey.Piv
         // TryChangeReference. It executes the ChangeReference command and response.
         private ResponseStatus ChangePinOrPuk(KeyEntryData keyEntryData)
         {
-            byte slotNumber = PivSlot.Puk;
-
-            if (keyEntryData.Request == KeyEntryRequest.ChangePivPin)
-            {
-                slotNumber = PivSlot.Pin;
-            }
+            byte slotNumber = keyEntryData.Request == KeyEntryRequest.ChangePivPin
+                ? PivSlot.Pin
+                : PivSlot.Puk;
 
             var changeCommand = new ChangeReferenceDataCommand(
                 slotNumber, keyEntryData.GetCurrentValue(), keyEntryData.GetNewValue());
@@ -1388,25 +1385,28 @@ namespace Yubico.YubiKey.Piv
         // If the mgmt key is not authenticated, it will do nothing.
         private void UpdateAdminData()
         {
-            if (ManagementKeyAuthenticated)
+            if (!ManagementKeyAuthenticated)
             {
-                bool isValid = TryReadObject<AdminData>(out AdminData adminData);
+                _log.LogDebug("Unauthenticated attempt to update AdminData failed.");
+                return;
+            }
 
-                using (adminData)
+            bool isValid = TryReadObject(out AdminData adminData);
+
+            using (adminData)
+            {
+                if (!isValid || adminData.IsEmpty)
                 {
-                    if (!isValid || adminData.IsEmpty)
-                    {
-                        return;
-                    }
-
-                    if (!adminData.PinProtected && adminData.Salt is null)
-                    {
-                        return;
-                    }
-
-                    adminData.PinLastUpdated = DateTime.UtcNow;
-                    WriteObject(adminData);
+                    return;
                 }
+
+                if (!adminData.PinProtected && adminData.Salt is null)
+                {
+                    return;
+                }
+
+                adminData.PinLastUpdated = DateTime.UtcNow;
+                WriteObject(adminData);
             }
         }
     }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
@@ -45,7 +45,7 @@ namespace Yubico.YubiKey
         private readonly ReadOnlyMemory<byte> invalidPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
 
         [SkippableFact]
-        public void SettingInvalidPivPin_Throws()
+        public void ChangePivPinToInvalidValue_ThrowsSecurityException()
         {
             IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
@@ -61,7 +61,7 @@ namespace Yubico.YubiKey
         }
 
         [SkippableFact]
-        public void SettingInvalidPivPuk_Throws()
+        public void ChangePivPukToInvalidValue_ThrowsSecurityException()
         {
             IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
@@ -78,7 +78,23 @@ namespace Yubico.YubiKey
         }
 
         [SkippableFact]
-        public void SettingInvalidFido2Pin_Throws()
+        public void ResetPivPinToInvalidValue_ThrowsSecurityException()
+        {
+            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            Skip.IfNot(testDevice.IsPinComplexityEnabled);
+
+            using var pivSession = new PivSession(testDevice);
+            pivSession.ResetApplication();
+
+            Assert.True(pivSession.TryResetPin(defaultPuk, complexPin, out _));
+            int? retriesRemaining = 3;
+            var e = Assert.Throws<SecurityException>(() => pivSession.TryResetPin(defaultPuk, invalidPin, out retriesRemaining));
+            Assert.Equal(ExceptionMessages.PinComplexityViolation, e.Message);
+            Assert.Null(retriesRemaining);
+        }        
+
+        [SkippableFact]
+        public void SetFido2PinToInvalidValue_ThrowsFido2Exception()
         {
             IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
@@ -98,10 +98,10 @@ namespace Yubico.YubiKey
             // set violating PIN
             var fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TrySetPin(_invalidPin));
             Assert.Equal(CtapStatus.PinPolicyViolation, fido2Exception.Status);
-            
+
             // set complex PIN to be able to try to change it later
             Assert.True(fido2Session.TrySetPin(_complexPin));
-            
+
             // change to violating PIN
             fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TryChangePin(_complexPin, _invalidPin));
             Assert.Equal(CtapStatus.PinPolicyViolation, fido2Exception.Status);
@@ -119,7 +119,7 @@ namespace Yubico.YubiKey
                 NewPin = _invalidPin
             };
 
-            fido2Session.KeyCollector = pinComplexityKeyCollector.Fido2SampleKeyCollectorDelegate;
+            fido2Session.KeyCollector = pinComplexityKeyCollector.KeyCollectorDelegate;
 
             // set violating PIN
             var fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TrySetPin());
@@ -140,7 +140,7 @@ namespace Yubico.YubiKey
             public ReadOnlyMemory<byte> NewPin { get; set; }
             private ReadOnlyMemory<byte> _currentPin;
 
-            public bool Fido2SampleKeyCollectorDelegate(KeyEntryData keyEntryData)
+            public bool KeyCollectorDelegate(KeyEntryData keyEntryData)
             {
                 if (keyEntryData.IsViolatingPinComplexity)
                 {

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
@@ -14,18 +14,12 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics;
-using System.IO;
 using System.Security;
 using System.Text;
-using System.Threading;
-using Microsoft.Extensions.Logging;
 using Xunit;
 using Yubico.YubiKey.Fido2;
-using Yubico.YubiKey.Otp;
 using Yubico.YubiKey.Piv;
 using Yubico.YubiKey.TestUtilities;
-using Log = Yubico.Core.Logging.Log;
 
 namespace Yubico.YubiKey
 {
@@ -36,26 +30,26 @@ namespace Yubico.YubiKey
     public class PinComplexityTests
     {
 
-        private readonly ReadOnlyMemory<byte> defaultPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("123456"));
-        private readonly ReadOnlyMemory<byte> complexPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
-        private readonly ReadOnlyMemory<byte> invalidPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
+        private readonly ReadOnlyMemory<byte> _defaultPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("123456"));
+        private readonly ReadOnlyMemory<byte> _complexPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
+        private readonly ReadOnlyMemory<byte> _invalidPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
 
-        private readonly ReadOnlyMemory<byte> defaultPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("12345678"));
-        private readonly ReadOnlyMemory<byte> complexPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
-        private readonly ReadOnlyMemory<byte> invalidPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
+        private readonly ReadOnlyMemory<byte> _defaultPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("12345678"));
+        private readonly ReadOnlyMemory<byte> _complexPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
+        private readonly ReadOnlyMemory<byte> _invalidPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
 
         [SkippableFact]
         public void ChangePivPinToInvalidValue_ThrowsSecurityException()
         {
-            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            var testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
 
             using var pivSession = new PivSession(testDevice);
             pivSession.ResetApplication();
 
-            Assert.True(pivSession.TryChangePin(defaultPin, complexPin, out _));
+            Assert.True(pivSession.TryChangePin(_defaultPin, _complexPin, out _));
             int? retriesRemaining = 3;
-            var e = Assert.Throws<SecurityException>(() => pivSession.TryChangePin(complexPin, invalidPin, out retriesRemaining));
+            var e = Assert.Throws<SecurityException>(() => pivSession.TryChangePin(_complexPin, _invalidPin, out retriesRemaining));
             Assert.Equal(ExceptionMessages.PinComplexityViolation, e.Message);
             Assert.Null(retriesRemaining);
         }
@@ -63,16 +57,16 @@ namespace Yubico.YubiKey
         [SkippableFact]
         public void ChangePivPukToInvalidValue_ThrowsSecurityException()
         {
-            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            var testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
 
             using var pivSession = new PivSession(testDevice);
             pivSession.ResetApplication();
 
-            Assert.True(pivSession.TryChangePuk(defaultPuk, complexPuk, out _));
+            Assert.True(pivSession.TryChangePuk(_defaultPuk, _complexPuk, out _));
             int? retriesRemaining = 3;
 
-            var e = Assert.Throws<SecurityException>(() => pivSession.TryChangePuk(complexPuk, invalidPuk, out retriesRemaining));
+            var e = Assert.Throws<SecurityException>(() => pivSession.TryChangePuk(_complexPuk, _invalidPuk, out retriesRemaining));
             Assert.Equal(ExceptionMessages.PinComplexityViolation, e.Message);
             Assert.Null(retriesRemaining);
         }
@@ -80,15 +74,15 @@ namespace Yubico.YubiKey
         [SkippableFact]
         public void ResetPivPinToInvalidValue_ThrowsSecurityException()
         {
-            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            var testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
 
             using var pivSession = new PivSession(testDevice);
             pivSession.ResetApplication();
 
-            Assert.True(pivSession.TryResetPin(defaultPuk, complexPin, out _));
+            Assert.True(pivSession.TryResetPin(_defaultPuk, _complexPin, out _));
             int? retriesRemaining = 3;
-            var e = Assert.Throws<SecurityException>(() => pivSession.TryResetPin(defaultPuk, invalidPin, out retriesRemaining));
+            var e = Assert.Throws<SecurityException>(() => pivSession.TryResetPin(_defaultPuk, _invalidPin, out retriesRemaining));
             Assert.Equal(ExceptionMessages.PinComplexityViolation, e.Message);
             Assert.Null(retriesRemaining);
         }
@@ -96,18 +90,18 @@ namespace Yubico.YubiKey
         [SkippableFact]
         public void SetFido2PinToInvalidValue_ThrowsFido2Exception()
         {
-            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            var testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
             Skip.IfNot(testDevice.IsPinComplexityEnabled);
 
             using var fido2Session = new Fido2Session(testDevice);
 
             // set violating PIN
-            var fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TrySetPin(invalidPin));
+            var fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TrySetPin(_invalidPin));
             Assert.Equal(CtapStatus.PinPolicyViolation, fido2Exception.Status);
             // set complex PIN to be able to try to change it later
-            Assert.True(fido2Session.TrySetPin(complexPin));
+            Assert.True(fido2Session.TrySetPin(_complexPin));
             // change to violating PIN
-            fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TryChangePin(complexPin, invalidPin));
+            fido2Exception = Assert.Throws<Fido2Exception>(() => fido2Session.TryChangePin(_complexPin, _invalidPin));
             Assert.Equal(CtapStatus.PinPolicyViolation, fido2Exception.Status);
         }
     }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
@@ -1,0 +1,89 @@
+
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Text;
+using System.Threading;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Yubico.YubiKey.Fido2;
+using Yubico.YubiKey.Otp;
+using Yubico.YubiKey.Piv;
+using Yubico.YubiKey.TestUtilities;
+using Log = Yubico.Core.Logging.Log;
+
+namespace Yubico.YubiKey
+{
+    /// <summary>
+    /// Tests device that it will not accept PINs or PUKs which violate PIN complexity
+    /// Before running the tests reset the device
+    /// </summary>
+    public class PinComplexityTests
+    {
+
+        private readonly ReadOnlyMemory<byte> defaultPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("123456"));
+        private readonly ReadOnlyMemory<byte> complexPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
+        private readonly ReadOnlyMemory<byte> invalidPin = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
+
+        private readonly ReadOnlyMemory<byte> defaultPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("12345678"));
+        private readonly ReadOnlyMemory<byte> complexPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("11234567"));
+        private readonly ReadOnlyMemory<byte> invalidPuk = new ReadOnlyMemory<byte>(Encoding.ASCII.GetBytes("33333333"));
+
+        [SkippableFact]
+        public void SettingInvalidPivPin_Throws()
+        {
+            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            Skip.IfNot(testDevice.IsPinComplexityEnabled);
+
+            using var pivSession = new PivSession(testDevice);
+            pivSession.ResetApplication();
+
+            Assert.True(pivSession.TryChangePin(currentPin: defaultPin, newPin: complexPin, out _));
+            _ = Assert.Throws<ArgumentException>(() => pivSession.TryChangePin(currentPin: complexPin, newPin: invalidPin, out _));
+        }
+
+        [SkippableFact]
+        public void SettingInvalidPivPuk_Throws()
+        {
+            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+
+            Skip.IfNot(testDevice.IsPinComplexityEnabled);
+
+            using var pivSession = new PivSession(testDevice);
+            pivSession.ResetApplication();
+
+            Assert.True(pivSession.TryChangePuk(currentPuk: defaultPuk, newPuk: complexPuk, out _));
+            _ = Assert.Throws<ArgumentException>(() => pivSession.TryChangePuk(currentPuk: complexPuk, newPuk: invalidPuk, out _));
+        }
+
+        [SkippableFact]
+        public void SettingInvalidFido2Pin_Throws()
+        {
+            IYubiKeyDevice testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(StandardTestDevice.Fw5Fips);
+            Skip.IfNot(testDevice.IsPinComplexityEnabled);
+
+            using var fido2Session = new Fido2Session(testDevice);
+
+            // set violating PIN
+            _ = Assert.Throws<ArgumentException>(() => fido2Session.TrySetPin(invalidPin));
+            // set complex PIN to be able to try to change it later
+            Assert.True(fido2Session.TrySetPin(complexPin));
+            // change to violating PIN
+            _ = Assert.Throws<ArgumentException>(() => fido2Session.TryChangePin(complexPin, invalidPin));
+        }
+    }
+}

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs
@@ -91,7 +91,7 @@ namespace Yubico.YubiKey
             var e = Assert.Throws<SecurityException>(() => pivSession.TryResetPin(defaultPuk, invalidPin, out retriesRemaining));
             Assert.Equal(ExceptionMessages.PinComplexityViolation, e.Message);
             Assert.Null(retriesRemaining);
-        }        
+        }
 
         [SkippableFact]
         public void SetFido2PinToInvalidValue_ThrowsFido2Exception()


### PR DESCRIPTION
# Description

Fw 5.7 adds PIN complexity. With this change the clients can in unified way catch `SecurityException` from PIV ChangePin/Puk and FIDO2s Set/ChangePin methods.

Fixes # YESDK-1378

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How has this been tested?

Added integration tests, tested with device which have PIN complexity enabled. Updated PIV and Fido2 sample applications to handle PIN complexity policy violations.

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
