### PR TITLE
Fix: Update vcpkg schema

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Build Yubico.NativeShims Package
+name: Build Yubico.NativeShims
 
 on:
   workflow_dispatch:

--- a/Yubico.NativeShims/vcpkg.json
+++ b/Yubico.NativeShims/vcpkg.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "yubico-nativeshims",
   "version": "1.11.0",
   "dependencies": [


### PR DESCRIPTION
The schema has not been updated for a while and its url has been moved.
See following links:

1. https://github.com/microsoft/vcpkg/issues/28366
2. https://learn.microsoft.com/en-us/vcpkg/reference/vcpkg-json