### PR TITLE
Adding TemporaryTouchThreshold to the copy constructor

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/SetDeviceInfoBaseCommand.cs
@@ -138,6 +138,7 @@ namespace Yubico.YubiKey.Management.Commands
             DeviceFlags = baseCommand.DeviceFlags;
             ResetAfterConfig = baseCommand.ResetAfterConfig;
             RestrictNfc = baseCommand.RestrictNfc;
+            TemporaryTouchThreshold = baseCommand.TemporaryTouchThreshold;
 
             _lockCode = baseCommand._lockCode;
             _unlockCode = baseCommand._unlockCode;


### PR DESCRIPTION
# Description

Apparently, when this property was added, it wasn't added to the copy constructor.

Fixes # [YESDK-1344](https://yubico.atlassian.net/browse/YESDK-1344)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Currently testing by PFS QA team running PCS for FIDO Prereg testing

**Test configuration**:
* Firmware version: 5.7.1
* Yubikey model: ANFC/CNFC
