### PR TITLE
Add support for enforceCredProtectPolicy in AddCredProtectExtension

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
@@ -645,8 +645,8 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public void AddCredProtectExtension(
             CredProtectPolicy credProtectPolicy,
-            AuthenticatorInfo authenticatorInfo,
-            bool enforceCredProtectPolicy = true)
+            bool enforceCredProtectPolicy,
+            AuthenticatorInfo authenticatorInfo)
         {
             if (credProtectPolicy == CredProtectPolicy.None)
             {
@@ -671,6 +671,11 @@ namespace Yubico.YubiKey.Fido2
             // values are 1, 2, or 3, so the encoding is simply 0x01, 02,or 03.
             AddExtension(KeyCredProtect, new byte[] { (byte)credProtectPolicy });
         }
+
+        /// <inheritdoc cref="AddCredProtectExtension(CredProtectPolicy,bool,AuthenticatorInfo)"/>
+        public void AddCredProtectExtension(CredProtectPolicy credProtectPolicy,
+                                            AuthenticatorInfo authenticatorInfo) =>
+            AddCredProtectExtension(credProtectPolicy, true, authenticatorInfo);
 
         /// <summary>
         /// Add an entry to the list of options.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
@@ -631,16 +631,22 @@ namespace Yubico.YubiKey.Fido2
         /// <param name="authenticatorInfo">
         /// The FIDO2 <c>AuthenticatorInfo</c> for the YubiKey being used.
         /// </param>
+        /// <param name="enforceCredProtectPolicy">
+        /// Determines the behavior taken when the authenticator does not support the
+        /// requested credProtect extension. Throws NotSupportedException when true, returns
+        /// silently without adding the extension when false.
+        /// </param>
         /// <exception cref="ArgumentNullException">
         /// The <c>authenticatorInfo</c> arg is null.
         /// </exception>
-        /// <exception cref="ArgumentException">
+        /// <exception cref="NotSupportedException">
         /// The YubiKey does not support this extension, or the input values were
         /// not correct.
         /// </exception>
         public void AddCredProtectExtension(
             CredProtectPolicy credProtectPolicy,
-            AuthenticatorInfo authenticatorInfo)
+            AuthenticatorInfo authenticatorInfo,
+            bool enforceCredProtectPolicy = true)
         {
             if (credProtectPolicy == CredProtectPolicy.None)
             {
@@ -652,7 +658,12 @@ namespace Yubico.YubiKey.Fido2
             }
             if (!authenticatorInfo.Extensions.Contains<string>(KeyCredProtect))
             {
-                throw new NotSupportedException(ExceptionMessages.NotSupportedByYubiKeyVersion);
+                if (enforceCredProtectPolicy)
+                {
+                    throw new NotSupportedException(ExceptionMessages.NotSupportedByYubiKeyVersion);
+                }
+
+                return;
             }
 
             // The encoding is key/value where the key is "credProtect" and the

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/MakeCredentialParameters.cs
@@ -658,7 +658,7 @@ namespace Yubico.YubiKey.Fido2
             }
             if (!authenticatorInfo.Extensions.Contains<string>(KeyCredProtect))
             {
-                if (enforceCredProtectPolicy)
+                if (enforceCredProtectPolicy && credProtectPolicy != CredProtectPolicy.UserVerificationOptional)
                 {
                     throw new NotSupportedException(ExceptionMessages.NotSupportedByYubiKeyVersion);
                 }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/MakeCredentialGetAssertionTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/MakeCredentialGetAssertionTests.cs
@@ -138,8 +138,9 @@ namespace Yubico.YubiKey.Fido2
                 fido2.KeyCollector = KeyCollector;
                 int startCount = (int)fido2.AuthenticatorInfo.RemainingDiscoverableCredentials!; //RemainingDiscoverableCredentials is NULL on my two keys I tried with (USBA 5.4.3 Keychain and Nano)
 
-                // Verify the PIN
-                fido2.VerifyPin(); //Never completes on my 5.7 
+                // Fido app was reset above, so set and confirm a pin (hardcoded in KeyCollector)
+                fido2.SetPin();
+                fido2.VerifyPin();
 
                 // Call MakeCredential
                 var user1 = new UserEntity(new byte[] { 1, 2, 3, 4 })
@@ -200,6 +201,112 @@ namespace Yubico.YubiKey.Fido2
             }
         }
 
+
+        // This test requires user to touch the device.
+        [Theory, Trait("Category", "RequiresTouch")]
+        [InlineData(CredProtectPolicy.UserVerificationOptional, true)]
+        [InlineData(CredProtectPolicy.UserVerificationOptional, false)]
+        [InlineData(CredProtectPolicy.UserVerificationRequired, true)]
+        [InlineData(CredProtectPolicy.UserVerificationRequired, false)]
+        public void AddCredProtectExtension_KeySupportsCredProtectExtension(
+            CredProtectPolicy credProtectPolicy,
+            bool enforceCredProtectPolicy)
+        {
+            // Could have combined expectExtensionSupported cases under a single Theory, but
+            // expectExtensionSupported true vs false requires using YubiKeys with different
+            // firmware, and using separate Theory methods makes it somewhat easier to run them
+            // as separate, grouped sets
+            TestAddCredProtectExtension(expectExtensionSupported: true, credProtectPolicy, enforceCredProtectPolicy);
+        }
+
+        [Theory, Trait("Category", "RequiresTouch")]
+        [InlineData(CredProtectPolicy.UserVerificationOptional, true)]
+        [InlineData(CredProtectPolicy.UserVerificationOptional, false)]
+        [InlineData(CredProtectPolicy.UserVerificationRequired, true)]
+        [InlineData(CredProtectPolicy.UserVerificationRequired, false)]
+        [InlineData(CredProtectPolicy.UserVerificationOptionalWithCredentialIDList, true)]
+        public void AddCredProtectExtension_KeyDoesNotSupportCredProtectExtension(
+            CredProtectPolicy credProtectPolicy,
+            bool enforceCredProtectPolicy)
+        {
+            // Could have combined expectExtensionSupported cases under a single Theory, but
+            // expectExtensionSupported true vs false requires using YubiKeys with different
+            // firmware, and using separate Theory methods makes it somewhat easier to run them
+            // as distinct, grouped sets
+            TestAddCredProtectExtension(expectExtensionSupported: false, credProtectPolicy, enforceCredProtectPolicy);
+        }
+
+        private void TestAddCredProtectExtension(
+            bool expectExtensionSupported,
+            CredProtectPolicy credProtectPolicy,
+            bool enforceCredProtectPolicy)
+        {
+            IYubiKeyDevice yubiKeyDevice = YubiKeyDevice.FindByTransport(Transport.HidFido).First();
+
+            bool isValid = Fido2ResetForTest.DoReset(yubiKeyDevice.SerialNumber);
+            Assert.True(isValid);
+
+            using (var fido2Session = new Fido2Session(yubiKeyDevice))
+            {
+                // Set up a key collector
+                fido2Session.KeyCollector = KeyCollector;
+
+                // Fido app was reset above, so set and confirm a pin (hardcoded in KeyCollector)
+                fido2Session.SetPin();
+                fido2Session.VerifyPin();
+
+                // Note that Name is a required value
+                var user = new UserEntity(new byte[] { 1, 2, 3, 4 })
+                {
+                    Name = "Name",
+                    DisplayName = "DisplayName",
+                };
+
+                var mcParams = new MakeCredentialParameters(_rp, user)
+                {
+                    ClientDataHash = _clientDataHash
+                };
+
+                var isExtensionSupported = fido2Session.AuthenticatorInfo.Extensions?.Contains("credProtect") ?? false;
+
+                // If this fails, the yubikey used doesn't have the proper support level expected for the test
+                // For expectExtensionSupported==true, the key must have FW 5.2.0 or later
+                // For expectExtensionSupported==false, the key must have FW before 5.2.0
+                Assert.Equal(expectExtensionSupported, isExtensionSupported);
+
+                // Act
+                try
+                {
+                    mcParams.AddCredProtectExtension(
+                        credProtectPolicy,
+                        fido2Session.AuthenticatorInfo!,
+                        enforceCredProtectPolicy);
+                }
+                catch (NotSupportedException)
+                {
+                    // This shouldn't fail for Optional, even if the key doesn't support the
+                    // extension, so ensure that's not what was set
+                    Assert.NotEqual(CredProtectPolicy.UserVerificationOptional, credProtectPolicy);
+                    Assert.False(isExtensionSupported);
+                    return;
+                }
+
+                // Verify
+                // The call to set the extension should always succeed under any of these conditions
+                Assert.True(
+                    !enforceCredProtectPolicy
+                    || isExtensionSupported
+                    || credProtectPolicy == CredProtectPolicy.UserVerificationOptional);
+
+                Assert.Equal(expectExtensionSupported, mcParams.Extensions?.ContainsKey("credProtect") ?? false);
+
+                MakeCredentialData mcData = fido2Session.MakeCredential(mcParams);
+
+                CredProtectPolicy cpPolicy = mcData.AuthenticatorData.GetCredProtectExtension();
+                Assert.Equal(expectExtensionSupported ? credProtectPolicy : CredProtectPolicy.None, cpPolicy);
+            }
+        }
+
         private bool KeyCollector(KeyEntryData arg)
         {
             switch (arg.Request)
@@ -208,6 +315,7 @@ namespace Yubico.YubiKey.Fido2
                     Console.WriteLine("YubiKey requires touch");
                     break;
                 case KeyEntryRequest.VerifyFido2Pin:
+                case KeyEntryRequest.SetFido2Pin:
                     arg.SubmitValue(Encoding.UTF8.GetBytes("123456"));
                     break;
                 case KeyEntryRequest.VerifyFido2Uv:

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/MakeCredentialGetAssertionTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/MakeCredentialGetAssertionTests.cs
@@ -279,8 +279,8 @@ namespace Yubico.YubiKey.Fido2
                 {
                     mcParams.AddCredProtectExtension(
                         credProtectPolicy,
-                        fido2Session.AuthenticatorInfo!,
-                        enforceCredProtectPolicy);
+                        enforceCredProtectPolicy,
+                        fido2Session.AuthenticatorInfo!);
                 }
                 catch (NotSupportedException)
                 {


### PR DESCRIPTION
[The CTAP spec](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-20210615.html#sctn-credProtect-extension) defines two input parameters for the client-side part of the credProtect extension, credentialProtectionPolicy and enforceCredentialProtectionPolicy. MakeCredentialParameters.AddCredProtectExtension already supports handling the credentialProtectionPolicy parameter, but it does not support the enforceCredentialProtectionPolicy parameter. This means that callers who want to properly support enforceCredentialProtectionPolicy would need to do their own checks against the keys' support levels and the requested policy so as not to return an error when enforceCredProtectPolicy is false, and in doing so would end up duplicating most of what's in AddCredProtectExtension already.

This change add support for silently ignoring credentialProtectionPolicy when the YK does not support the extension if enforceCredentialProtectionPolicy is false.

Fixes # https://yubico.atlassian.net/browse/PROD-2309

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

I deliberately added enforceCredentialProtectionPolicy as an optional parameter with a default of true so as not to make this a breaking API change. That said, it does make the parameter order a little weird. If anyone feels strongly about it, another option would be to create an explicit function overload with a 'better' parameter order and have the old API call the new one (passing true for enforceCredentialProtectionPolicy to maintain the current behavior).

# How has this been tested?
These changes were tested both with manual testing and new integration tests that run through all of the following combination of values.

Test cases 
YK FW 5.4.3
Policy=optional, Enforce=true
Policy=required, Enforce=true
Policy=optional, Enforce=false
Policy=required, Enforce=false
In all four combinations, programming was successful, and extension data was present in the response's AuthenticationData

YK FW 5.1.2
Policy=optional, Enforce=true*
Policy=required, Enforce=true - Exception thrown from AddCredProtectExtension (as expected)
Policy=optional, Enforce=false*
Policy=required, Enforce=false*
In all but case two, programming was successful, and extension data was NOT present in the response's AuthenticationData (as expected)

**Test configuration**:
* Firmware versions: 5.4.3 and 5.1.2
* Yubikey models: NFC A 

# Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

