### PR TITLE
Remove crlf from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -38,7 +38,6 @@ guidelines = 100, 120
 guidelines_style = 2.5px solid 40ff0000
 
 # New line preferences
-end_of_line = crlf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
# Description

Removing crlf from .editorconfig, this will make it so that dotnet format doesn't attempt to fix line endings when this is being handled by Git (with Windows: autocrlf=true, Linux/Mac: input)
