### PR TITLE
Adopt inferred variable types (var) to enhance code readability and maintainability

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -86,9 +86,9 @@ dotnet_style_readonly_field = true:warning
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = false:warning
-csharp_style_var_for_built_in_types = false:warning
-csharp_style_var_when_type_is_apparent = true:suggestion
+csharp_style_var_elsewhere = true:warning
+csharp_style_var_for_built_in_types = false:suggestion
+csharp_style_var_when_type_is_apparent = true:warning
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
@@ -351,3 +351,10 @@ dotnet_diagnostic.ca1707.severity = none
 
 # CA1014: Mark assemblies with CLSCompliant
 dotnet_diagnostic.ca1014.severity = none
+
+
+[Yubico.Core/src/**/*.cs]
+# var preferences
+csharp_style_var_elsewhere = false:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = true:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -86,9 +86,9 @@ dotnet_style_readonly_field = true:warning
 #### C# Coding Conventions ####
 
 # var preferences
-csharp_style_var_elsewhere = true:warning
+csharp_style_var_elsewhere = true:suggestion
 csharp_style_var_for_built_in_types = false:suggestion
-csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_when_type_is_apparent = true:suggestion
 
 # Pattern matching preferences
 csharp_style_pattern_matching_over_as_with_null_check = true:suggestion

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDevice.cs
@@ -17,9 +17,8 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using Yubico.PlatformInterop;
 using Yubico.Core.Logging;
-
+using Yubico.PlatformInterop;
 using static Yubico.PlatformInterop.NativeMethods;
 
 namespace Yubico.Core.Devices.Hid

--- a/Yubico.DotNetPolyfills/src/Contrib.Bcl.Ranges/Range.cs
+++ b/Yubico.DotNetPolyfills/src/Contrib.Bcl.Ranges/Range.cs
@@ -77,7 +77,7 @@ namespace System
         public (int Offset, int Length) GetOffsetAndLength(int length)
         {
             int start;
-            Index startIndex = Start;
+            var startIndex = Start;
             if (startIndex.IsFromEnd)
             {
                 start = length - startIndex.Value;
@@ -88,7 +88,7 @@ namespace System
             }
 
             int end;
-            Index endIndex = End;
+            var endIndex = End;
             if (endIndex.IsFromEnd)
             {
                 end = length - endIndex.Value;

--- a/Yubico.YubiKey/examples/Fido2SampleCode/Run/Fido2SampleGui.cs
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/Run/Fido2SampleGui.cs
@@ -231,7 +231,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 return false;
             }
 
-            DialogResult dResult = DialogResult.OK;
+            var dResult = DialogResult.OK;
             do
             {
                 _pinPopupForm.UpdateMessage(dResult, keyEntryData);

--- a/Yubico.YubiKey/examples/Fido2SampleCode/Run/Fido2SampleRun.Operations.cs
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/Run/Fido2SampleRun.Operations.cs
@@ -142,7 +142,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             // EventHandler delegates must have access to the serial number.
             // So we're going to use a separate class to handle this.
             var fido2Reset = new Fido2Reset(_yubiKeyChosen.SerialNumber);
-            ResponseStatus status = fido2Reset.RunFido2Reset(_keyCollector.Fido2SampleKeyCollectorDelegate);
+            var status = fido2Reset.RunFido2Reset(_keyCollector.Fido2SampleKeyCollectorDelegate);
             if (status == ResponseStatus.Success)
             {
                 SampleMenu.WriteMessage(MessageType.Title, 0, "\nFIDO2 application successfully reset.\n");
@@ -175,11 +175,11 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
         public bool RunVerifyPin()
         {
-            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo);
+            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo);
             if (isValid)
             {
                 isValid = GetVerifyArguments(
-                    true, authenticatorInfo, out PinUvAuthTokenPermissions? permissions, out string relyingPartyId);
+                    true, authenticatorInfo, out var permissions, out string relyingPartyId);
 
                 if (isValid)
                 {
@@ -203,12 +203,12 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
         public bool RunVerifyUv()
         {
-            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo);
+            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo);
 
             if (isValid)
             {
                 isValid = GetVerifyArguments(
-                    false, authenticatorInfo, out PinUvAuthTokenPermissions? permissions, out string relyingPartyId);
+                    false, authenticatorInfo, out var permissions, out string relyingPartyId);
 
                 if (isValid && !(permissions is null))
                 {
@@ -258,19 +258,19 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter the user DisplayName");
             _ = SampleMenu.ReadResponse(out string userDisplayName);
 
-            RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
+            var randomObject = CryptographyProviders.RngCreator();
             byte[] randomBytes = new byte[16];
             randomObject.GetBytes(randomBytes);
             var userId = new ReadOnlyMemory<byte>(randomBytes);
 
-            ReadOnlyMemory<byte> clientDataHash = BuildFakeClientDataHash(relyingPartyId);
+            var clientDataHash = BuildFakeClientDataHash(relyingPartyId);
 
-            if (!Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo))
+            if (!Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo))
             {
                 return false;
             }
 
-            CredProtectPolicy credProtectPolicy = CredProtectPolicy.None;
+            var credProtectPolicy = CredProtectPolicy.None;
             if (authenticatorInfo.Extensions.Contains("credProtect"))
             {
                 string[] menuItems = new string[] {
@@ -325,7 +325,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 userName, userDisplayName, userId,
                 credProtectPolicy,
                 credBlobData,
-                out MakeCredentialData makeCredentialData);
+                out var makeCredentialData);
 
             if (!isValid)
             {
@@ -360,10 +360,10 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter the relyingPartyId");
             _ = SampleMenu.ReadResponse(out string relyingPartyId);
 
-            ReadOnlyMemory<byte> clientDataHash = BuildFakeClientDataHash(relyingPartyId);
+            var clientDataHash = BuildFakeClientDataHash(relyingPartyId);
 
-            ReadOnlyMemory<byte> salt = ReadOnlyMemory<byte>.Empty;
-            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo);
+            var salt = ReadOnlyMemory<byte>.Empty;
+            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo);
             if (isValid)
             {
                 if (authenticatorInfo.Extensions.Contains("hmac-secret"))
@@ -378,7 +378,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                         "digest to the YubiKey as the salt.\n");
                     _ = SampleMenu.ReadResponse(out string dataToDigest);
                     byte[] dataBytes = System.Text.Encoding.Unicode.GetBytes(dataToDigest);
-                    SHA256 digester = CryptographyProviders.Sha256Creator();
+                    var digester = CryptographyProviders.Sha256Creator();
                     _ = digester.TransformFinalBlock(dataBytes, 0, dataBytes.Length);
 
                     salt = new ReadOnlyMemory<byte>(digester.Hash);
@@ -393,8 +393,8 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 clientDataHash,
                 relyingPartyId,
                 salt,
-                out IReadOnlyList<GetAssertionData> assertions,
-                out IReadOnlyList<byte[]> hmacSecrets))
+                out var assertions,
+                out var hmacSecrets))
             {
                 return false;
             }
@@ -421,7 +421,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
@@ -436,21 +436,21 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
 
             ReportCredentials(credentialData, false, false, out int credentialCount);
 
-            CredentialUserInfo userInfo = SelectCredential(credentialData, credentialCount);
+            var userInfo = SelectCredential(credentialData, credentialCount);
 
             if (userInfo is null)
             {
                 return false;
             }
 
-            UserEntity updatedInfo = GetUpdatedInfo(userInfo.User);
+            var updatedInfo = GetUpdatedInfo(userInfo.User);
 
             return Fido2Protocol.RunUpdateUserInfo(
                 _yubiKeyChosen,
@@ -464,14 +464,14 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
 
             ReportCredentials(credentialData, false, false, out int credentialCount);
 
-            CredentialUserInfo userInfo = SelectCredential(credentialData, credentialCount);
+            var userInfo = SelectCredential(credentialData, credentialCount);
 
             if (userInfo is null)
             {
@@ -497,7 +497,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
             if (!Fido2Protocol.RunGetLargeBlobArray(
                 _yubiKeyChosen,
-                out SerializedLargeBlobArray blobArray))
+                out var blobArray))
             {
                 return true;
             }
@@ -524,7 +524,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
         {
             if (!Fido2Protocol.RunGetLargeBlobArray(
                 _yubiKeyChosen,
-                out SerializedLargeBlobArray blobArray))
+                out var blobArray))
             {
                 return false;
             }
@@ -565,7 +565,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
@@ -577,7 +577,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 "LargeBlob data is stored against a credential. Select a credential for which\n" +
                 "you want to see the largeBlob data. It is possible to retrieve data only for\n" +
                 "credentials that have an available Large Blob Key.\n");
-            CredentialUserInfo userInfo = SelectCredential(credentialData, credentialCount);
+            var userInfo = SelectCredential(credentialData, credentialCount);
 
             if (userInfo is null)
             {
@@ -620,7 +620,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             // data and "edit" it.
             if (!Fido2Protocol.RunGetLargeBlobArray(
                 _yubiKeyChosen,
-                out SerializedLargeBlobArray blobArray))
+                out var blobArray))
             {
                 return false;
             }
@@ -628,7 +628,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
@@ -642,7 +642,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 "with the largeBlob option. Hence, you must choose a credential against which the\n" +
                 "data will be stored, and that credential must have an available Large Blob Key.\n" +
                 "Note that this sample code will store only one entry per credential.\n");
-            CredentialUserInfo userInfo = SelectCredential(credentialData, credentialCount);
+            var userInfo = SelectCredential(credentialData, credentialCount);
 
             if (userInfo is null)
             {
@@ -696,7 +696,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
         {
             if (!Fido2Protocol.RunGetLargeBlobArray(
                 _yubiKeyChosen,
-                out SerializedLargeBlobArray blobArray))
+                out var blobArray))
             {
                 return false;
             }
@@ -704,7 +704,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetCredentialData(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out IReadOnlyList<object> credentialData))
+                out var credentialData))
             {
                 return false;
             }
@@ -718,7 +718,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 "YubiKey, or if there is no largeBlob data stored, or nothing stored against\n" +
                 "the selected credential, this sample code will do nothing.\n");
 
-            CredentialUserInfo userInfo = SelectCredential(credentialData, credentialCount);
+            var userInfo = SelectCredential(credentialData, credentialCount);
 
             if (userInfo is null || userInfo.LargeBlobKey is null)
             {
@@ -759,9 +759,9 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetBioInfo(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out BioModality modality,
-                out FingerprintSensorInfo sensorInfo,
-                out IReadOnlyList<TemplateInfo> templates))
+                out var modality,
+                out var sensorInfo,
+                out var templates))
             {
                 return false;
             }
@@ -807,7 +807,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
             try
             {
-                TemplateInfo templateInfo = Fido2Protocol.RunEnrollFingerprint(
+                var templateInfo = Fido2Protocol.RunEnrollFingerprint(
                     _yubiKeyChosen,
                     _keyCollector.Fido2SampleKeyCollectorDelegate,
                     friendlyName,
@@ -834,9 +834,9 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetBioInfo(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out BioModality modality,
-                out FingerprintSensorInfo sensorInfo,
-                out IReadOnlyList<TemplateInfo> templates))
+                out var modality,
+                out var sensorInfo,
+                out var templates))
             {
                 return false;
             }
@@ -867,9 +867,9 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             if (!Fido2Protocol.RunGetBioInfo(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out BioModality modality,
-                out FingerprintSensorInfo sensorInfo,
-                out IReadOnlyList<TemplateInfo> templates))
+                out var modality,
+                out var sensorInfo,
+                out var templates))
             {
                 return false;
             }
@@ -915,13 +915,13 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
         public bool RunToggleAlwaysUv()
         {
-            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo);
+            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo);
             if (!isValid)
             {
                 return false;
             }
 
-            OptionValue optionValue = authenticatorInfo.GetOptionValue("alwaysUv");
+            var optionValue = authenticatorInfo.GetOptionValue("alwaysUv");
 
             string[] menuItems = new string[] {
                 "Yes",
@@ -961,7 +961,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             isValid = Fido2Protocol.RunToggleAlwaysUv(
                 _yubiKeyChosen,
                 _keyCollector.Fido2SampleKeyCollectorDelegate,
-                out OptionValue newValue);
+                out var newValue);
 
             if (isValid)
             {
@@ -975,13 +975,13 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
         public bool RunSetPinConfig()
         {
-            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out AuthenticatorInfo authenticatorInfo);
+            bool isValid = Fido2Protocol.RunGetAuthenticatorInfo(_yubiKeyChosen, out var authenticatorInfo);
             if (!isValid)
             {
                 return false;
             }
 
-            OptionValue setMinPinValue = authenticatorInfo.GetOptionValue(AuthenticatorOptions.setMinPINLength);
+            var setMinPinValue = authenticatorInfo.GetOptionValue(AuthenticatorOptions.setMinPINLength);
             if (setMinPinValue != OptionValue.True)
             {
                 SampleMenu.WriteMessage(
@@ -1207,11 +1207,11 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             byte[] idBytes = System.Text.Encoding.Unicode.GetBytes(relyingPartyId);
 
             // Generate a random value to represent the challenge.
-            RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
+            var randomObject = CryptographyProviders.RngCreator();
             byte[] randomBytes = new byte[16];
             randomObject.GetBytes(randomBytes);
 
-            SHA256 digester = CryptographyProviders.Sha256Creator();
+            var digester = CryptographyProviders.Sha256Creator();
             _ = digester.TransformBlock(randomBytes, 0, randomBytes.Length, null, 0);
             _ = digester.TransformFinalBlock(idBytes, 0, idBytes.Length);
 
@@ -1302,7 +1302,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
         private bool CollectPermissions(out PinUvAuthTokenPermissions? permissions)
         {
             permissions = null;
-            PinUvAuthTokenPermissions current = PinUvAuthTokenPermissions.None;
+            var current = PinUvAuthTokenPermissions.None;
 
             SampleMenu.WriteMessage(
                 MessageType.Title, 0,
@@ -1368,7 +1368,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
         private bool CollectRelyingPartyId(PinUvAuthTokenPermissions? permissions, out string relyingPartyId)
         {
             relyingPartyId = "";
-            PinUvAuthTokenPermissions current = PinUvAuthTokenPermissions.None;
+            var current = PinUvAuthTokenPermissions.None;
             if (!(permissions is null))
             {
                 current = permissions.Value;

--- a/Yubico.YubiKey/examples/Fido2SampleCode/YubiKeyOperations/Fido2Protocol.cs
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/YubiKeyOperations/Fido2Protocol.cs
@@ -147,7 +147,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 // verification needed.
                 assertions = fido2Session.GetAssertions(getAssertionParameters);
 
-                foreach (GetAssertionData assertionData in assertions)
+                foreach (var assertionData in assertions)
                 {
                     byte[] hmacSecret = assertionData.AuthenticatorData.GetHmacSecretExtension(fido2Session.AuthProtocol);
                     hmacSecretList.Add(hmacSecret);
@@ -201,15 +201,15 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
 
                 returnValue.Add(new Tuple<int, int>(credCount, remainingCount));
 
-                IReadOnlyList<RelyingParty> rpList = fido2Session.EnumerateRelyingParties();
-                foreach (RelyingParty currentRp in rpList)
+                var rpList = fido2Session.EnumerateRelyingParties();
+                foreach (var currentRp in rpList)
                 {
                     returnValue.Add(currentRp);
 
-                    IReadOnlyList<CredentialUserInfo> credentialList =
+                    var credentialList =
                         fido2Session.EnumerateCredentialsForRelyingParty(currentRp);
 
-                    foreach (CredentialUserInfo currentCredential in credentialList)
+                    foreach (var currentCredential in credentialList)
                     {
                         returnValue.Add(currentCredential);
                     }
@@ -288,7 +288,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 throw new ArgumentNullException(nameof(blobArray));
             }
 
-            Memory<byte> plaintext = Memory<byte>.Empty;
+            var plaintext = Memory<byte>.Empty;
             byte[] plainArray = Array.Empty<byte>();
             entryIndex = -1;
             try

--- a/Yubico.YubiKey/examples/Fido2SampleCode/YubiKeyOperations/Fido2Reset.cs
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/YubiKeyOperations/Fido2Reset.cs
@@ -70,7 +70,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
             {
                 // The SDK comes with a listener that can tell when a YubiKey has
                 // been removed or inserted.
-                YubiKeyDeviceListener yubiKeyDeviceListener = YubiKeyDeviceListener.Instance;
+                var yubiKeyDeviceListener = YubiKeyDeviceListener.Instance;
 
                 yubiKeyDeviceListener.Arrived += YubiKeyInserted;
                 yubiKeyDeviceListener.Removed += YubiKeyRemoved;
@@ -153,7 +153,7 @@ namespace Yubico.YubiKey.Sample.Fido2SampleCode
                 touchMessageTask.Start();
 
                 var resetCmd = new ResetCommand();
-                ResetResponse resetRsp = fido2Session.Connection.SendCommand(resetCmd);
+                var resetRsp = fido2Session.Connection.SendCommand(resetCmd);
 
                 return resetRsp.Status;
             }

--- a/Yubico.YubiKey/examples/OathSampleCode/Run/OathSampleRun.Operations.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/Run/OathSampleRun.Operations.cs
@@ -121,13 +121,13 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter account name");
             _ = SampleMenu.ReadResponse(out string account);
 
-            _ = ChooseCredentialProperties.RunChooseTypeOption(_menuObject, out CredentialType? type);
+            _ = ChooseCredentialProperties.RunChooseTypeOption(_menuObject, out var type);
 
-            CredentialPeriod period = CredentialPeriod.Undefined;
+            var period = CredentialPeriod.Undefined;
 
             if (type == CredentialType.Totp)
             {
-                _ = ChooseCredentialProperties.RunChoosePeriodOption(_menuObject, out CredentialPeriod? credentialPeriod);
+                _ = ChooseCredentialProperties.RunChoosePeriodOption(_menuObject, out var credentialPeriod);
                 period = (CredentialPeriod)credentialPeriod;
             }
 
@@ -230,7 +230,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             else
             {
                 RunCollectCredential(_menuObject,
-                    out Credential credential,
+                    out var credential,
                     out string newIssuer,
                     out string newAccount);
 
@@ -256,13 +256,13 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter current account name");
             _ = SampleMenu.ReadResponse(out string currentAccount);
 
-            _ = ChooseCredentialProperties.RunChooseTypeOption(menuObject, out CredentialType? type);
+            _ = ChooseCredentialProperties.RunChooseTypeOption(menuObject, out var type);
 
-            CredentialPeriod period = CredentialPeriod.Undefined;
+            var period = CredentialPeriod.Undefined;
 
             if (type == CredentialType.Totp)
             {
-                _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out CredentialPeriod? credentialPeriod);
+                _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out var credentialPeriod);
                 period = credentialPeriod.Value;
             }
 

--- a/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/AddCredential.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/AddCredential.cs
@@ -52,7 +52,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
                 }
                 else
                 {
-                    Credential credential = CollectTotpCredential(menuObject);
+                    var credential = CollectTotpCredential(menuObject);
                     oathSession.AddCredential(credential);
                     ReportResult(credential);
                 }
@@ -93,7 +93,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
                 }
                 else
                 {
-                    Credential credential = CollectHotpCredential(menuObject);
+                    var credential = CollectHotpCredential(menuObject);
                     oathSession.AddCredential(credential);
                     ReportResult(credential);
                 }
@@ -116,12 +116,12 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
 
                 if (menuObject is null)
                 {
-                    Credential credential = oathSession.AddCredential("Yubico", "testDefaultTotp@example.com");
+                    var credential = oathSession.AddCredential("Yubico", "testDefaultTotp@example.com");
                     ReportResult(credential);
                 }
                 else
                 {
-                    Credential credential = CollectDefaultTotpCredential();
+                    var credential = CollectDefaultTotpCredential();
                     oathSession.AddCredential(credential);
                     ReportResult(credential);
                 }
@@ -144,7 +144,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
 
                 if (menuObject is null)
                 {
-                    Credential credential = oathSession.AddCredential(
+                    var credential = oathSession.AddCredential(
                         "Yubico",
                         "testDefaultHotp@example.com",
                         CredentialType.Hotp,
@@ -153,7 +153,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
                 }
                 else
                 {
-                    Credential credential = CollectDefaultHotpCredential();
+                    var credential = CollectDefaultHotpCredential();
                     oathSession.AddCredential(credential);
                     ReportResult(credential);
                 }
@@ -176,14 +176,14 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
 
                 if (menuObject is null)
                 {
-                    Credential credential = oathSession.AddCredential(
+                    var credential = oathSession.AddCredential(
                         "otpauth://totp/Yubico:testUri@example.com?secret=YY4KVNOUQ5IIUBAOGIDRYZ7FGY54VW54&issuer=Yubico&algorithm=SHA1&digits=6&period=30");
                     ReportResult(credential);
                 }
                 else
                 {
                     string stringFromUri = CollectStringFromUri();
-                    Credential credential = oathSession.AddCredential(stringFromUri);
+                    var credential = oathSession.AddCredential(stringFromUri);
                     ReportResult(credential);
                 }
             }
@@ -254,9 +254,9 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter account name");
             _ = SampleMenu.ReadResponse(out string account);
 
-            _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out CredentialPeriod? period);
+            _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out var period);
 
-            _ = ChooseCredentialProperties.RunChooseAlgorithmOption(menuObject, out HashAlgorithm? algorithm);
+            _ = ChooseCredentialProperties.RunChooseAlgorithmOption(menuObject, out var algorithm);
 
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter secret");
             _ = SampleMenu.ReadResponse(out string secret);
@@ -290,7 +290,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter account name");
             _ = SampleMenu.ReadResponse(out string account);
 
-            _ = ChooseCredentialProperties.RunChooseAlgorithmOption(menuObject, out HashAlgorithm? algorithm);
+            _ = ChooseCredentialProperties.RunChooseAlgorithmOption(menuObject, out var algorithm);
 
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter secret");
             _ = SampleMenu.ReadResponse(out string secret);

--- a/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/CalculateCredentials.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/CalculateCredentials.cs
@@ -28,8 +28,8 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             using var oathSession = new OathSession(yubiKey);
             {
                 oathSession.KeyCollector = KeyCollectorDelegate;
-                IDictionary<Credential, Code> result = oathSession.CalculateAllCredentials();
-                ReportAllResults(result);
+                var results = oathSession.CalculateAllCredentials();
+                ReportAllResults(results);
             }
 
             return true;
@@ -49,7 +49,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             using var oathSession = new OathSession(yubiKey);
             {
                 oathSession.KeyCollector = KeyCollectorDelegate;
-                Code code = oathSession.CalculateCredential(credential);
+                var code = oathSession.CalculateCredential(credential);
                 ReportOneResult(credential, code);
             }
 
@@ -64,18 +64,18 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             {
                 _ = outputList.AppendLine($"Number of credentials: {credentials.Count}");
                 _ = outputList.AppendLine();
-                foreach (KeyValuePair<Credential, Code> pair in credentials)
+                foreach (var (credential, code) in credentials)
                 {
-                    _ = outputList.AppendLine($"Issuer    : {pair.Key.Issuer}");
-                    _ = outputList.AppendLine($"Account   : {pair.Key.AccountName}");
-                    _ = outputList.AppendLine($"Type      : {pair.Key.Type}");
-                    _ = outputList.AppendLine($"Period    : {(int?)pair.Key.Period}sec");
-                    _ = outputList.AppendLine($"Digits    : {pair.Key.Digits}");
-                    _ = outputList.AppendLine($"Touch     : {pair.Key.RequiresTouch}");
-                    _ = outputList.AppendLine($"OTP code  : {pair.Value.Value}");
-                    _ = outputList.AppendLine($"ValidFrom : {pair.Value.ValidFrom}");
-                    _ = outputList.AppendLine($"ValidUntil: {pair.Value.ValidUntil}");
-                    _ = outputList.AppendLine($"Name      : {pair.Key.Name}");
+                    _ = outputList.AppendLine($"Issuer    : {credential.Issuer}");
+                    _ = outputList.AppendLine($"Account   : {credential.AccountName}");
+                    _ = outputList.AppendLine($"Type      : {credential.Type}");
+                    _ = outputList.AppendLine($"Period    : {(int?)credential.Period}sec");
+                    _ = outputList.AppendLine($"Digits    : {credential.Digits}");
+                    _ = outputList.AppendLine($"Touch     : {credential.RequiresTouch}");
+                    _ = outputList.AppendLine($"OTP code  : {code.Value}");
+                    _ = outputList.AppendLine($"ValidFrom : {code.ValidFrom}");
+                    _ = outputList.AppendLine($"ValidUntil: {code.ValidUntil}");
+                    _ = outputList.AppendLine($"Name      : {credential.Name}");
                     _ = outputList.AppendLine();
                 }
             }

--- a/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/ChooseCredential.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/ChooseCredential.cs
@@ -44,7 +44,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
 
             using var oathSession = new OathSession(yubiKey);
             {
-                IList<Credential> credentials = oathSession.GetCredentials();
+                var credentials = oathSession.GetCredentials();
 
                 // Are there any?
                 if (credentials.Count == 0)

--- a/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/GetCredentials.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/GetCredentials.cs
@@ -28,7 +28,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             using var oathSession = new OathSession(yubiKey);
             {
                 oathSession.KeyCollector = KeyCollectorDelegate;
-                IList<Credential> result = oathSession.GetCredentials();
+                var result = oathSession.GetCredentials();
                 ReportResult(result);
             }
 
@@ -42,7 +42,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             {
                 _ = outputList.AppendLine($"Number of credentials: {credentials.Count}");
                 _ = outputList.AppendLine();
-                foreach (Credential currentCredential in credentials)
+                foreach (var currentCredential in credentials)
                 {
                     _ = outputList.AppendLine($"Issuer    : {currentCredential.Issuer}");
                     _ = outputList.AppendLine($"Account   : {currentCredential.AccountName}");

--- a/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/RenameCredential.cs
+++ b/Yubico.YubiKey/examples/OathSampleCode/YubiKeyOperations/RenameCredential.cs
@@ -41,7 +41,7 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             {
                 oathSession.KeyCollector = KeyCollectorDelegate;
 
-                Credential renamedCredential = oathSession.RenameCredential(
+                var renamedCredential = oathSession.RenameCredential(
                     credential.Issuer,
                     credential.AccountName,
                     newIssuer,
@@ -85,13 +85,13 @@ namespace Yubico.YubiKey.Sample.OathSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "Enter current account name");
             _ = SampleMenu.ReadResponse(out string currentAccount);
 
-            _ = ChooseCredentialProperties.RunChooseTypeOption(menuObject, out CredentialType? type);
+            _ = ChooseCredentialProperties.RunChooseTypeOption(menuObject, out var type);
 
-            CredentialPeriod period = CredentialPeriod.Undefined;
+            var period = CredentialPeriod.Undefined;
 
             if (type == CredentialType.Totp)
             {
-                _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out CredentialPeriod? credentialPeriod);
+                _ = ChooseCredentialProperties.RunChoosePeriodOption(menuObject, out var credentialPeriod);
                 period = credentialPeriod.Value;
             }
 

--- a/Yubico.YubiKey/examples/PivSampleCode/CertificateOperations/X500NameBuilder.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/CertificateOperations/X500NameBuilder.cs
@@ -91,7 +91,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
         // If no elements had been added, this method will throw an exception.
         public byte[] GetEncodedName()
         {
-            Array enumValues = Enum.GetValues(typeof(X500NameElement));
+            var enumValues = Enum.GetValues(typeof(X500NameElement));
 
             // The DER encoding is simply the SEQUENCE of each element.
             // Get each encoding in order. That is, no matter what order they

--- a/Yubico.YubiKey/examples/PivSampleCode/CertificateOperations/YubiKeySignatureGenerator.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/CertificateOperations/YubiKeySignatureGenerator.cs
@@ -74,11 +74,11 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             _algorithm = pivPublicKey.Algorithm;
             _rsaPaddingMode = rsaPaddingMode;
 
-            using AsymmetricAlgorithm dotNetPublicKey = KeyConverter.GetDotNetFromPivPublicKey(pivPublicKey);
+            using var dotNetPublicKey = KeyConverter.GetDotNetFromPivPublicKey(pivPublicKey);
 
             if (_algorithm.IsRsa())
             {
-                RSASignaturePadding paddingScheme = rsaPaddingMode == RSASignaturePaddingMode.Pss ?
+                var paddingScheme = rsaPaddingMode == RSASignaturePaddingMode.Pss ?
                     RSASignaturePadding.Pss : RSASignaturePadding.Pkcs1;
                 _defaultGenerator = X509SignatureGenerator.CreateForRSA((RSA)dotNetPublicKey, paddingScheme);
             }

--- a/Yubico.YubiKey/examples/PivSampleCode/Converters/DsaSignatureConverter.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/Converters/DsaSignatureConverter.cs
@@ -90,7 +90,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             int offsetR = 0;
             int offsetS = 0;
             bool isValid = false;
-            if (tlvReader.TryReadNestedTlv(out TlvReader seqReader, 0x30))
+            if (tlvReader.TryReadNestedTlv(out var seqReader, 0x30))
             {
                 if (seqReader.TryReadValue(out rValue, 0x02))
                 {

--- a/Yubico.YubiKey/examples/PivSampleCode/Converters/KeyConverter.Asymmetric.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/Converters/KeyConverter.Asymmetric.cs
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             // cast the input to RSA.
             if (string.Equals(dotNetObject.SignatureAlgorithm, AlgorithmRsa, StringComparison.Ordinal))
             {
-                RSAParameters rsaParams = ((RSA)dotNetObject).ExportParameters(false);
+                var rsaParams = ((RSA)dotNetObject).ExportParameters(false);
                 // This constructor will validate the modulus and exponent.
                 var rsaPubKey = new PivRsaPublicKey(rsaParams.Modulus, rsaParams.Exponent);
                 return (PivPublicKey)rsaPubKey;

--- a/Yubico.YubiKey/examples/PivSampleCode/Converters/KeyConverter.Pem.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/Converters/KeyConverter.Pem.cs
@@ -35,7 +35,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
         //    -----END PRIVATE KEY-----
         public static PivPublicKey GetPivPublicKeyFromPem(char[] pemKeyString)
         {
-            using AsymmetricAlgorithm dotNetObject = GetDotNetFromPem(pemKeyString, false);
+            using var dotNetObject = GetDotNetFromPem(pemKeyString, false);
             return GetPivPublicKeyFromDotNet(dotNetObject);
         }
 
@@ -46,7 +46,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
         //    -----END PUBLIC KEY-----
         public static char[] GetPemFromPivPublicKey(PivPublicKey pivPublicKey)
         {
-            using AsymmetricAlgorithm dotNetObject = GetDotNetFromPivPublicKey(pivPublicKey);
+            using var dotNetObject = GetDotNetFromPivPublicKey(pivPublicKey);
             return GetPemFromDotNet(dotNetObject, false);
         }
 
@@ -57,7 +57,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
         //    -----END PRIVATE KEY-----
         public static PivPrivateKey GetPivPrivateKeyFromPem(char[] pemKeyString)
         {
-            using AsymmetricAlgorithm dotNetObject = GetDotNetFromPem(pemKeyString, true);
+            using var dotNetObject = GetDotNetFromPem(pemKeyString, true);
             return GetPivPrivateKeyFromDotNet(dotNetObject);
         }
 

--- a/Yubico.YubiKey/examples/PivSampleCode/Converters/SignatureAlgIdConverter.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/Converters/SignatureAlgIdConverter.cs
@@ -99,8 +99,8 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             PssSaltLength = 0;
             PssTrailerField = 0;
             var tlvReader = new TlvReader(algIdDer);
-            TlvReader seqReader = tlvReader.ReadNestedTlv(0x30);
-            ReadOnlyMemory<byte> oid = seqReader.ReadValue(0x06);
+            var seqReader = tlvReader.ReadNestedTlv(0x30);
+            var oid = seqReader.ReadValue(0x06);
 
             if (SetFromOid(oid))
             {

--- a/Yubico.YubiKey/examples/PivSampleCode/DotNetOperations/PublicKeyOperations.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/DotNetOperations/PublicKeyOperations.cs
@@ -48,7 +48,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 throw new ArgumentNullException(nameof(publicKey));
             }
 
-            using AsymmetricAlgorithm asymObject = KeyConverter.GetDotNetFromPivPublicKey(publicKey);
+            using var asymObject = KeyConverter.GetDotNetFromPivPublicKey(publicKey);
 
             // The algorithm is either RSA or ECC, otherwise the KeyConverter
             // call would have thrown an exception.
@@ -139,7 +139,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             // ECDH object from the EC parameters. So get the ECDsa object, then
             // get the parameters.
             using var ecDsaObject = (ECDsa)KeyConverter.GetDotNetFromPivPublicKey(publicKey);
-            ECParameters ecParams = ecDsaObject.ExportParameters(false);
+            var ecParams = ecDsaObject.ExportParameters(false);
 
             // This is the .NET version of the public key associated with the
             // private key on the YubiKey. The correspondent will combine this

--- a/Yubico.YubiKey/examples/PivSampleCode/Run/PivSampleRun.Operations.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/Run/PivSampleRun.Operations.cs
@@ -104,7 +104,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
         public bool RunGetPinOnlyMode()
         {
-            if (PinOnlyMode.RunGetPivPinOnlyMode(_yubiKeyChosen, out PivPinOnlyMode mode))
+            if (PinOnlyMode.RunGetPivPinOnlyMode(_yubiKeyChosen, out var mode))
             {
                 SampleMenu.WriteMessage(MessageType.Title, 0, "PIN-only mode: " + mode.ToString() + "\n");
                 return true;
@@ -115,7 +115,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
         public bool RunSetPinOnlyMode()
         {
-            if (!GetRequestedPinOnlyMode(out PivPinOnlyMode mode))
+            if (!GetRequestedPinOnlyMode(out var mode))
             {
                 return RunInvalidEntry();
             }
@@ -178,7 +178,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "overwritten. The result is the PivPinOnly mode of the YubiKey");
             SampleMenu.WriteMessage(MessageType.Title, 0, "after recovery.\n");
             if (PinOnlyMode.RunRecoverPivPinOnlyMode(
-                _yubiKeyChosen, _keyCollector.SampleKeyCollectorDelegate, out PivPinOnlyMode mode))
+                _yubiKeyChosen, _keyCollector.SampleKeyCollectorDelegate, out var mode))
             {
                 SampleMenu.WriteMessage(MessageType.Title, 0, "PIN-only mode: " + mode.ToString() + "\n");
                 return true;
@@ -194,17 +194,17 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            if (!GetAsymmetricAlgorithm(out PivAlgorithm algorithm))
+            if (!GetAsymmetricAlgorithm(out var algorithm))
             {
                 return RunInvalidEntry();
             }
 
-            if (!GetPinPolicy(out PivPinPolicy pinPolicy))
+            if (!GetPinPolicy(out var pinPolicy))
             {
                 return RunInvalidEntry();
             }
 
-            if (!GetTouchPolicy(out PivTouchPolicy touchPolicy))
+            if (!GetTouchPolicy(out var touchPolicy))
             {
                 return RunInvalidEntry();
             }
@@ -216,7 +216,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 algorithm,
                 pinPolicy,
                 touchPolicy,
-                out SamplePivSlotContents newSlotContents))
+                out var newSlotContents))
             {
                 newSlotContents.PrintPublicKeyPem();
                 AddSlotContents(newSlotContents);
@@ -233,17 +233,17 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            if (!GetAsymmetricAlgorithm(out PivAlgorithm algorithm))
+            if (!GetAsymmetricAlgorithm(out var algorithm))
             {
                 return RunInvalidEntry();
             }
 
-            if (!GetPinPolicy(out PivPinPolicy pinPolicy))
+            if (!GetPinPolicy(out var pinPolicy))
             {
                 return RunInvalidEntry();
             }
 
-            if (!GetTouchPolicy(out PivTouchPolicy touchPolicy))
+            if (!GetTouchPolicy(out var touchPolicy))
             {
                 return RunInvalidEntry();
             }
@@ -253,8 +253,8 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return false;
             }
 
-            PivPrivateKey pivPrivateKey = KeyConverter.GetPivPrivateKeyFromPem(pemKey.ToCharArray());
-            PivPublicKey pivPublicKey = KeyConverter.GetPivPublicKeyFromPem(pemKey.ToCharArray());
+            var pivPrivateKey = KeyConverter.GetPivPrivateKeyFromPem(pemKey.ToCharArray());
+            var pivPublicKey = KeyConverter.GetPivPublicKeyFromPem(pemKey.ToCharArray());
 
             if (KeyPairs.RunImportPrivateKey(
                 _yubiKeyChosen,
@@ -264,7 +264,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 slotNumber,
                 pinPolicy,
                 touchPolicy,
-                out SamplePivSlotContents newSlotContents))
+                out var newSlotContents))
             {
                 newSlotContents.PrintPublicKeyPem();
                 AddSlotContents(newSlotContents);
@@ -294,7 +294,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             // the code needs to know if the key's algorithm is RSA. If
             // so, it will need to pad the digest.
             // Hence, get the algorithm.
-            SamplePivSlotContents signSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
+            var signSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
             if (signSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -302,7 +302,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
             // This sample code will use SHA-384 for EccP384, and SHA-256
             // for all other algorithms.
-            HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA384;
+            var hashAlgorithm = HashAlgorithmName.SHA384;
             if (signSlotContents.Algorithm != PivAlgorithm.EccP384)
             {
                 hashAlgorithm = HashAlgorithmName.SHA256;
@@ -312,7 +312,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
             // This sample code will always use PSS for the RSA padding
             // scheme.
-            RSASignaturePadding signPaddingScheme = RSASignaturePadding.Pss;
+            var signPaddingScheme = RSASignaturePadding.Pss;
 
             if (!PrivateKeyOperations.RunSignData(
                 _yubiKeyChosen,
@@ -359,7 +359,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             }
 
             // It is possible to decrypt only if the key is RSA.
-            SamplePivSlotContents decryptSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
+            var decryptSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
             if (decryptSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -380,7 +380,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
             // This sample uses OAEP with SHA-256 as the padding scheme
             // for all RSA key sizes.
-            RSAEncryptionPadding encryptPaddingScheme = RSAEncryptionPadding.OaepSHA256;
+            var encryptPaddingScheme = RSAEncryptionPadding.OaepSHA256;
 
             if (!PublicKeyOperations.SampleEncryptRsa(
                 decryptSlotContents.PublicKey,
@@ -424,7 +424,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             }
 
             // It is possible to perform Key Agreement only if the key is ECC.
-            SamplePivSlotContents keyAgreeSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
+            var keyAgreeSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
             if (keyAgreeSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -447,7 +447,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             // send the shared secret, but for this sample, we're
             // returning it as well so that we can compare the two
             // results to make sure they match.
-            HashAlgorithmName hashAlgorithm = HashAlgorithmName.SHA256;
+            var hashAlgorithm = HashAlgorithmName.SHA256;
             if (keyAgreeSlotContents.Algorithm == PivAlgorithm.EccP384)
             {
                 hashAlgorithm = HashAlgorithmName.SHA384;
@@ -462,7 +462,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return false;
             }
 
-            PivPublicKey correspondentKey = KeyConverter.GetPivPublicKeyFromPem(correspondentPublicKey);
+            var correspondentKey = KeyConverter.GetPivPublicKeyFromPem(correspondentPublicKey);
 
             if (!PrivateKeyOperations.RunKeyAgree(
                 _yubiKeyChosen,
@@ -499,7 +499,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            SamplePivSlotContents requestSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
+            var requestSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
             if (requestSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -511,7 +511,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             nameBuilder.AddNameElement(X500NameElement.Locality, "Palo Alto");
             nameBuilder.AddNameElement(X500NameElement.Organization, "Fake");
             nameBuilder.AddNameElement(X500NameElement.CommonName, "Fake Cert");
-            X500DistinguishedName sampleCertName = nameBuilder.GetDistinguishedName();
+            var sampleCertName = nameBuilder.GetDistinguishedName();
             SampleCertificateOperations.GetCertRequest(
                 _yubiKeyChosen,
                 _keyCollector.SampleKeyCollectorDelegate,
@@ -531,7 +531,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            SamplePivSlotContents selfSignedSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
+            var selfSignedSlotContents = _slotContentsList.Find(x => x.SlotNumber == slotNumber);
             if (selfSignedSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -557,7 +557,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            SamplePivSlotContents requestorSlotContents = _slotContentsList.Find(x => x.SlotNumber == requestorSlotNumber);
+            var requestorSlotContents = _slotContentsList.Find(x => x.SlotNumber == requestorSlotNumber);
             if (requestorSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -569,7 +569,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 return RunInvalidEntry();
             }
 
-            SamplePivSlotContents signerSlotContents = _slotContentsList.Find(x => x.SlotNumber == signerSlotNumber);
+            var signerSlotContents = _slotContentsList.Find(x => x.SlotNumber == signerSlotNumber);
             if (signerSlotContents is null)
             {
                 return RunInvalidEntry();
@@ -602,7 +602,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
                 _yubiKeyChosen,
                 _keyCollector.SampleKeyCollectorDelegate,
                 slotNumber,
-                out X509Certificate2 certificate);
+                out var certificate);
 
             byte[] certDer = certificate.Export(X509ContentType.Cert);
             char[] certPem = PemOperations.BuildPem("CERTIFICATE", certDer);
@@ -620,7 +620,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             KeyPairs.RunCreateAttestationStatement(
                 _yubiKeyChosen,
                 slotNumber,
-                out X509Certificate2 certificate);
+                out var certificate);
 
             byte[] certDer = certificate.Export(X509ContentType.Cert);
             char[] certPem = PemOperations.BuildPem("CERTIFICATE", certDer);
@@ -630,7 +630,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
 
         public bool RunGetAttestationCert()
         {
-            KeyPairs.RunGetAttestationCert(_yubiKeyChosen, out X509Certificate2 certificate);
+            KeyPairs.RunGetAttestationCert(_yubiKeyChosen, out var certificate);
 
             byte[] certDer = certificate.Export(X509ContentType.Cert);
             char[] certPem = PemOperations.BuildPem("CERTIFICATE", certDer);

--- a/Yubico.YubiKey/examples/PivSampleCode/YubiKeyOperations/KeyPairs.cs
+++ b/Yubico.YubiKey/examples/PivSampleCode/YubiKeyOperations/KeyPairs.cs
@@ -33,7 +33,7 @@ namespace Yubico.YubiKey.Sample.PivSampleCode
             {
                 pivSession.KeyCollector = KeyCollectorDelegate;
 
-                PivPublicKey pivPublicKey = pivSession.GenerateKeyPair(slotNumber, algorithm, pinPolicy, touchPolicy);
+                var pivPublicKey = pivSession.GenerateKeyPair(slotNumber, algorithm, pinPolicy, touchPolicy);
 
                 // At this point you will likely want to save the public key and
                 // other information. For this sample, we're simply going to

--- a/Yubico.YubiKey/examples/SharedSampleCode/YubiKeyOperations/ChooseYubiKey.cs
+++ b/Yubico.YubiKey/examples/SharedSampleCode/YubiKeyOperations/ChooseYubiKey.cs
@@ -56,8 +56,7 @@ namespace Yubico.YubiKey.Sample.SharedCode
             }
 
             // Find all currently connected YubiKeys.
-            IEnumerable<IYubiKeyDevice> yubiKeyEnumerable = YubiKeyDevice.FindByTransport(transport);
-            IYubiKeyDevice[] yubiKeyArray = yubiKeyEnumerable.ToArray();
+            var yubiKeyArray = YubiKeyDevice.FindByTransport(transport).ToArray();
 
             // Are there any?
             if (yubiKeyArray.Length == 0)

--- a/Yubico.YubiKey/examples/SharedSampleCode/YubiKeyOperations/ListYubiKeys.cs
+++ b/Yubico.YubiKey/examples/SharedSampleCode/YubiKeyOperations/ListYubiKeys.cs
@@ -26,7 +26,7 @@ namespace Yubico.YubiKey.Sample.SharedCode
         // none available is a successful completion of its task.
         public static bool RunListYubiKeys(Transport transport)
         {
-            IEnumerable<IYubiKeyDevice> yubiKeyEnumerable = YubiKeyDevice.FindByTransport(transport);
+            var yubiKeyEnumerable = YubiKeyDevice.FindByTransport(transport);
 
             ReportResult(yubiKeyEnumerable);
 
@@ -42,7 +42,7 @@ namespace Yubico.YubiKey.Sample.SharedCode
             if (yubiKeyDevices.Any())
             {
                 outputList = "\n   YubiKeys:";
-                foreach (IYubiKeyDevice current in yubiKeyDevices)
+                foreach (var current in yubiKeyDevices)
                 {
                     int serial = 0;
                     if (!(current.SerialNumber is null))

--- a/Yubico.YubiKey/examples/U2fSampleCode/Run/U2fSampleRun.Operations.cs
+++ b/Yubico.YubiKey/examples/U2fSampleCode/Run/U2fSampleRun.Operations.cs
@@ -184,7 +184,7 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             _keyCollector.Operation = U2fKeyCollectorOperation.Register;
             if (!U2fProtocol.Register(
                 _yubiKeyChosen, _keyCollector.U2fSampleKeyCollectorDelegate,
-                applicationId, clientDataHash, out RegistrationData registrationData))
+                applicationId, clientDataHash, out var registrationData))
             {
                 return false;
             }
@@ -226,7 +226,7 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             }
 
             int response = _menuObject.RunMenu("Which credential is to be authenticated?", nameList);
-            RegistrationData regData = _credentials[nameList[response]];
+            var regData = _credentials[nameList[response]];
 
             // There are a number of ways a credential can be unauthenticated.
             // One way is if the keyHandle is invalid. If that is the case, we
@@ -259,7 +259,7 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             if (!U2fProtocol.Authenticate(
                 _yubiKeyChosen, _keyCollector.U2fSampleKeyCollectorDelegate,
                 regData.ApplicationId, regData.ClientDataHash, regData.KeyHandle,
-                out AuthenticationData authenticationData))
+                out var authenticationData))
             {
                 return false;
             }
@@ -395,7 +395,7 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             SampleMenu.WriteMessage(MessageType.Title, 0, "For this sample code, the challenge is a random value base-64 encoded\n");
 
             byte[] randomBytes = new byte[9];
-            using RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
+            using var randomObject = CryptographyProviders.RngCreator();
             randomObject.GetBytes(randomBytes, 0, randomBytes.Length);
             string challenge = Convert.ToBase64String(randomBytes);
             SampleMenu.WriteMessage(MessageType.Title, 0, "challenge = " + challenge);

--- a/Yubico.YubiKey/examples/U2fSampleCode/YubiKeyOperations/U2fFips.cs
+++ b/Yubico.YubiKey/examples/U2fSampleCode/YubiKeyOperations/U2fFips.cs
@@ -34,7 +34,7 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             using (var u2fSession = new U2fSession(yubiKey))
             {
                 var fipsModeCommand = new VerifyFipsModeCommand();
-                VerifyFipsModeResponse fipsModeResponse = u2fSession.Connection.SendCommand(fipsModeCommand);
+                var fipsModeResponse = u2fSession.Connection.SendCommand(fipsModeCommand);
                 isFipsMode = fipsModeResponse.GetData();
 
                 return true;

--- a/Yubico.YubiKey/examples/U2fSampleCode/YubiKeyOperations/U2fReset.cs
+++ b/Yubico.YubiKey/examples/U2fSampleCode/YubiKeyOperations/U2fReset.cs
@@ -61,10 +61,10 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
 
             _yubiKeyDevice = null;
             var keyEntryData = new KeyEntryData();
-            KeyEntryRequest keyEntryRequest = KeyEntryRequest.TouchRequest;
+            var keyEntryRequest = KeyEntryRequest.TouchRequest;
             Task? touchMessageTask = null;
 
-            YubiKeyDeviceListener yubiKeyDeviceListener = YubiKeyDeviceListener.Instance;
+            var yubiKeyDeviceListener = YubiKeyDeviceListener.Instance;
 
             yubiKeyDeviceListener.Arrived += YubiKeyInserted;
             yubiKeyDeviceListener.Removed += YubiKeyRemoved;
@@ -87,9 +87,9 @@ namespace Yubico.YubiKey.Sample.U2fSampleCode
             // The YubiKey has been rebooted, so we need to quickly reset.
             try
             {
-                using IYubiKeyConnection connection = reinsert.Result.Connect(YubiKeyApplication.FidoU2f);
+                using var connection = reinsert.Result.Connect(YubiKeyApplication.FidoU2f);
                 var resetCmd = new ResetCommand();
-                ResetResponse resetRsp = connection.SendCommand(resetCmd);
+                var resetRsp = connection.SendCommand(resetCmd);
 
                 while (resetRsp.Status == ResponseStatus.ConditionsNotSatisfied)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AesUtilities.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AesUtilities.cs
@@ -51,7 +51,7 @@ namespace Yubico.YubiKey.Cryptography
 
             byte[] ciphertext;
 
-            using (Aes aesObj = CryptographyProviders.AesCreator())
+            using (var aesObj = CryptographyProviders.AesCreator())
             {
 #pragma warning disable CA5358 // Allow the usage of cipher mode 'ECB'
                 aesObj.Mode = CipherMode.ECB;
@@ -63,7 +63,7 @@ namespace Yubico.YubiKey.Cryptography
                 aesObj.Padding = PaddingMode.None;
 #pragma warning disable CA5401 // Justification: Allow the symmetric encryption to use
                 // a non-default initialization vector
-                ICryptoTransform encryptor = aesObj.CreateEncryptor();
+                var encryptor = aesObj.CreateEncryptor();
 #pragma warning restore CA5401
                 using (var msEncrypt = new MemoryStream())
                 {
@@ -117,7 +117,7 @@ namespace Yubico.YubiKey.Cryptography
 
             byte[] ciphertext;
 
-            using (Aes aesObj = CryptographyProviders.AesCreator())
+            using (var aesObj = CryptographyProviders.AesCreator())
             {
                 aesObj.Mode = CipherMode.CBC;
                 aesObj.KeySize = BlockSizeBits;
@@ -127,7 +127,7 @@ namespace Yubico.YubiKey.Cryptography
                 aesObj.Padding = PaddingMode.None;
 #pragma warning disable CA5401 // Justification: Allow the symmetric encryption to use
                 // a non-default initialization vector
-                ICryptoTransform encryptor = aesObj.CreateEncryptor();
+                var encryptor = aesObj.CreateEncryptor();
 #pragma warning restore CA5401
                 using (var msEncrypt = new MemoryStream())
                 {
@@ -181,7 +181,7 @@ namespace Yubico.YubiKey.Cryptography
 
             byte[] plaintext;
 
-            using (Aes aesObj = CryptographyProviders.AesCreator())
+            using (var aesObj = CryptographyProviders.AesCreator())
             {
                 aesObj.Mode = CipherMode.CBC;
                 aesObj.KeySize = BlockSizeBits;
@@ -190,7 +190,7 @@ namespace Yubico.YubiKey.Cryptography
                 aesObj.IV = iv;
                 aesObj.Padding = PaddingMode.None;
 
-                ICryptoTransform decryptor = aesObj.CreateDecryptor();
+                var decryptor = aesObj.CreateDecryptor();
 
                 using (var msDecrypt = new MemoryStream())
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorInfo.cs
@@ -333,13 +333,13 @@ namespace Yubico.YubiKey.Fido2
                 }
                 if (cborMap.Contains(KeyOptions))
                 {
-                    CborMap<string> optionsMap = cborMap.ReadMap<string>(KeyOptions);
-                    Options = optionsMap.AsDictionary<bool>();
+                    var optionsCborMap = cborMap.ReadMap<string>(KeyOptions);
+                    Options = optionsCborMap.AsDictionary<bool>();
                 }
                 MaximumMessageSize = (int?)cborMap.ReadOptional<int>(KeyMaxMsgSize);
                 if (cborMap.Contains(KeyPinUvAuthProtocols))
                 {
-                    IReadOnlyList<int> temp = cborMap.ReadArray<int>(KeyPinUvAuthProtocols);
+                    var temp = cborMap.ReadArray<int>(KeyPinUvAuthProtocols);
                     var translator = new List<PinUvAuthProtocol>(temp.Count);
                     for (int index = 0; index < temp.Count; index++)
                     {
@@ -367,13 +367,13 @@ namespace Yubico.YubiKey.Fido2
                 UvModality = (int?)cborMap.ReadOptional<int>(KeyUvModality);
                 if (cborMap.Contains(KeyCertifications))
                 {
-                    CborMap<string> certMap = cborMap.ReadMap<string>(KeyCertifications);
-                    Certifications = certMap.AsDictionary<int>();
+                    var certCborMap = cborMap.ReadMap<string>(KeyCertifications);
+                    Certifications = certCborMap.AsDictionary<int>();
                 }
                 RemainingDiscoverableCredentials = (int?)cborMap.ReadOptional<int>(KeyRemainingDiscoverableCredentials);
                 if (cborMap.Contains(KeyVendorPrototypeConfigCommands))
                 {
-                    IReadOnlyList<object> intList = cborMap.ReadArray<object>(KeyVendorPrototypeConfigCommands);
+                    var intList = cborMap.ReadArray<object>(KeyVendorPrototypeConfigCommands);
                     var int64List = new List<long>(intList.Count);
                     for (int index = 0; index < intList.Count; index++)
                     {
@@ -486,7 +486,7 @@ namespace Yubico.YubiKey.Fido2
         {
             var algorithms = new List<Tuple<string, CoseAlgorithmIdentifier>>();
 
-            IReadOnlyList<CborMap<string>> entries = cborMap.ReadArray<CborMap<string>>(KeyAlgorithms);
+            var entries = cborMap.ReadArray<CborMap<string>>(KeyAlgorithms);
             for (int index = 0; index < entries.Count; index++)
             {
                 string currentType = entries[index].ReadTextString(ParameterHelpers.TagType);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cbor/CborHelpers.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cbor/CborHelpers.cs
@@ -74,16 +74,16 @@ namespace Yubico.YubiKey.Fido2.Cbor
             int? entries = cbor.ReadStartArray();
             int count = entries ?? 0;
 
-            List<string> dest = destination ?? new List<string>(count);
+            var allDestinationsList = destination ?? new List<string>(count);
 
             for (int index = 0; index < count; index++)
             {
-                dest.Add(cbor.ReadTextString());
+                allDestinationsList.Add(cbor.ReadTextString());
             }
 
             cbor.ReadEndArray();
 
-            return dest;
+            return allDestinationsList;
         }
 
         /// <summary>
@@ -149,7 +149,7 @@ namespace Yubico.YubiKey.Fido2.Cbor
             var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
 
             cbor.WriteStartArray(localData.Count);
-            foreach (ICborEncode cborEncode in localData)
+            foreach (var cborEncode in localData)
             {
                 cbor.WriteEncodedValue(cborEncode.CborEncode());
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cbor/CborMap.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cbor/CborMap.cs
@@ -66,7 +66,7 @@ namespace Yubico.YubiKey.Fido2.Cbor
 
             while (count > 0)
             {
-                TKey currentKey = ReadKey<TKey>(cbor);
+                var currentKey = ReadKey<TKey>(cbor);
                 object? currentValue = ProcessSingleElement(cbor);
                 _dict.Add(currentKey, currentValue);
 
@@ -101,7 +101,7 @@ namespace Yubico.YubiKey.Fido2.Cbor
         public IReadOnlyDictionary<TKey, TValue> AsDictionary<TValue>()
         {
             var returnValue = new Dictionary<TKey, TValue>(_dict.Count);
-            foreach (KeyValuePair<TKey, object?> entry in _dict)
+            foreach (var entry in _dict)
             {
                 object? currentValue = ConvertValue<TValue>(entry.Value);
                 if (!(currentValue is TValue targetValue))
@@ -434,18 +434,18 @@ namespace Yubico.YubiKey.Fido2.Cbor
 
         private static object? ProcessSubMap(CborReader cbor)
         {
-            ReadOnlyMemory<byte> encodedMap = cbor.ReadEncodedValue();
-            var subCbor = new CborReader(encodedMap, CborConformanceMode.Ctap2Canonical);
+            var encodedMapBytes = cbor.ReadEncodedValue();
+            var subCbor = new CborReader(encodedMapBytes, CborConformanceMode.Ctap2Canonical);
             _ = subCbor.ReadStartMap();
 
-            CborReaderState cborType = subCbor.PeekState();
+            var cborType = subCbor.PeekState();
             switch (cborType)
             {
                 case CborReaderState.UnsignedInteger:
                 case CborReaderState.NegativeInteger:
-                    return new CborMap<int>(encodedMap);
+                    return new CborMap<int>(encodedMapBytes);
                 case CborReaderState.TextString:
-                    return new CborMap<string>(encodedMap);
+                    return new CborMap<string>(encodedMapBytes);
                 default:
                     throw new InvalidOperationException(ExceptionMessages.TypeNotSupported);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollBeginResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollBeginResponse.cs
@@ -42,16 +42,16 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <inheritdoc/>
         public BioEnrollSampleResult GetData()
         {
-            BioEnrollmentData enrollData = _response.GetData();
+            var bioEnrollmentData = _response.GetData();
 
-            if (!(enrollData.TemplateId is null)
-                && !(enrollData.LastEnrollSampleStatus is null)
-                && !(enrollData.RemainingSampleCount is null))
+            if (!(bioEnrollmentData.TemplateId is null)
+                && !(bioEnrollmentData.LastEnrollSampleStatus is null)
+                && !(bioEnrollmentData.RemainingSampleCount is null))
             {
                 return new BioEnrollSampleResult(
-                    enrollData.TemplateId.Value,
-                    enrollData.LastEnrollSampleStatus.Value,
-                    enrollData.RemainingSampleCount.Value);
+                    bioEnrollmentData.TemplateId.Value,
+                    bioEnrollmentData.LastEnrollSampleStatus.Value,
+                    bioEnrollmentData.RemainingSampleCount.Value);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollEnumerateResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollEnumerateResponse.cs
@@ -55,11 +55,10 @@ namespace Yubico.YubiKey.Fido2.Commands
                 return new List<TemplateInfo>();
             }
 
-            BioEnrollmentData enrollData = _response.GetData();
-
-            if (!(enrollData.TemplateInfos is null))
+            var bioEnrollmentData = _response.GetData();
+            if (!(bioEnrollmentData.TemplateInfos is null))
             {
-                return enrollData.TemplateInfos;
+                return bioEnrollmentData.TemplateInfos;
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollNextSampleResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollNextSampleResponse.cs
@@ -53,15 +53,14 @@ namespace Yubico.YubiKey.Fido2.Commands
                 throw new InvalidOperationException(StatusMessage);
             }
 
-            BioEnrollmentData enrollData = _response.GetData();
-
-            if (!(enrollData.LastEnrollSampleStatus is null)
-                && !(enrollData.RemainingSampleCount is null))
+            var bioEnrollmentData = _response.GetData();
+            if (!(bioEnrollmentData.LastEnrollSampleStatus is null)
+                && !(bioEnrollmentData.RemainingSampleCount is null))
             {
                 return new BioEnrollSampleResult(
                     _templateId,
-                    enrollData.LastEnrollSampleStatus.Value,
-                    enrollData.RemainingSampleCount.Value);
+                    bioEnrollmentData.LastEnrollSampleStatus.Value,
+                    bioEnrollmentData.RemainingSampleCount.Value);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollmentData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollmentData.cs
@@ -175,9 +175,9 @@ namespace Yubico.YubiKey.Fido2.Commands
 
             if (cborMap.Contains(KeyTemplateInfos))
             {
-                IReadOnlyList<CborMap<int>> templateList = cborMap.ReadArray<CborMap<int>>(KeyTemplateInfos);
-                var templateInfos = new List<TemplateInfo>(templateList.Count);
-                foreach (CborMap<int> currentMap in templateList)
+                var cborTemplateList = cborMap.ReadArray<CborMap<int>>(KeyTemplateInfos);
+                var templateInfos = new List<TemplateInfo>(cborTemplateList.Count);
+                foreach (var currentMap in cborTemplateList)
                 {
                     byte[] currentId = currentMap.ReadByteString(KeyTemplateInfoId).ToArray();
                     string friendlyName = currentMap.Contains(KeyFriendlyName) ?

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/ChangePinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/ChangePinCommand.cs
@@ -155,7 +155,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         ExceptionMessages.InvalidFido2Pin));
             }
 
-            using SHA256 sha256Object = CryptographyProviders.Sha256Creator();
+            using var sha256Object = CryptographyProviders.Sha256Creator();
             byte[] pin = currentPin.ToArray();
             byte[] digest = sha256Object.ComputeHash(pin);
             CryptographicOperations.ZeroMemory(pin);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsBeginResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsBeginResponse.cs
@@ -71,22 +71,22 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </exception>
         public (int credentialCount, CredentialUserInfo credentialUserInfo) GetData()
         {
-            CredentialManagementData mgmtData = _response.GetData();
+            var credentialManagementData = _response.GetData();
 
-            if (!(mgmtData.TotalCredentialsForRelyingParty is null)
-                && !(mgmtData.User is null)
-                && !(mgmtData.CredentialId is null)
-                && !(mgmtData.CredentialPublicKey is null)
-                && !(mgmtData.CredProtectPolicy is null))
+            if (!(credentialManagementData.TotalCredentialsForRelyingParty is null)
+                && !(credentialManagementData.User is null)
+                && !(credentialManagementData.CredentialId is null)
+                && !(credentialManagementData.CredentialPublicKey is null)
+                && !(credentialManagementData.CredProtectPolicy is null))
             {
                 var userInfo = new CredentialUserInfo(
-                    mgmtData.User,
-                    mgmtData.CredentialId,
-                    mgmtData.CredentialPublicKey,
-                    mgmtData.CredProtectPolicy.Value,
-                    mgmtData.LargeBlobKey);
+                    credentialManagementData.User,
+                    credentialManagementData.CredentialId,
+                    credentialManagementData.CredentialPublicKey,
+                    credentialManagementData.CredProtectPolicy.Value,
+                    credentialManagementData.LargeBlobKey);
 
-                return (mgmtData.TotalCredentialsForRelyingParty.Value, userInfo);
+                return (credentialManagementData.TotalCredentialsForRelyingParty.Value, userInfo);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextResponse.cs
@@ -42,19 +42,19 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <inheritdoc/>
         public CredentialUserInfo GetData()
         {
-            CredentialManagementData mgmtData = _response.GetData();
+            var credentialManagementData = _response.GetData();
 
-            if (!(mgmtData.User is null)
-                && !(mgmtData.CredentialId is null)
-                && !(mgmtData.CredentialPublicKey is null)
-                && !(mgmtData.CredProtectPolicy is null))
+            if (!(credentialManagementData.User is null)
+                && !(credentialManagementData.CredentialId is null)
+                && !(credentialManagementData.CredentialPublicKey is null)
+                && !(credentialManagementData.CredProtectPolicy is null))
             {
                 return new CredentialUserInfo(
-                    mgmtData.User,
-                    mgmtData.CredentialId,
-                    mgmtData.CredentialPublicKey,
-                    mgmtData.CredProtectPolicy.Value,
-                    mgmtData.LargeBlobKey);
+                    credentialManagementData.User,
+                    credentialManagementData.CredentialId,
+                    credentialManagementData.CredentialPublicKey,
+                    credentialManagementData.CredProtectPolicy.Value,
+                    credentialManagementData.LargeBlobKey);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginResponse.cs
@@ -70,15 +70,15 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </exception>
         public (int totalRelyingPartyCount, RelyingParty relyingParty) GetData()
         {
-            CredentialManagementData mgmtData = _response.GetData();
+            var credentialManagementData = _response.GetData();
 
-            if (!(mgmtData.RelyingParty is null)
-                && !(mgmtData.RelyingPartyIdHash is null)
-                && !(mgmtData.TotalRelyingPartyCount is null))
+            if (!(credentialManagementData.RelyingParty is null)
+                && !(credentialManagementData.RelyingPartyIdHash is null)
+                && !(credentialManagementData.TotalRelyingPartyCount is null))
             {
-                if (mgmtData.RelyingParty.IsMatchingRelyingPartyId(mgmtData.RelyingPartyIdHash.Value))
+                if (credentialManagementData.RelyingParty.IsMatchingRelyingPartyId(credentialManagementData.RelyingPartyIdHash.Value))
                 {
-                    return (mgmtData.TotalRelyingPartyCount.Value, mgmtData.RelyingParty);
+                    return (credentialManagementData.TotalRelyingPartyCount.Value, credentialManagementData.RelyingParty);
                 }
             }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsGetNextResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsGetNextResponse.cs
@@ -42,14 +42,13 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <inheritdoc/>
         public RelyingParty GetData()
         {
-            CredentialManagementData mgmtData = _response.GetData();
-
-            if (!(mgmtData.RelyingParty is null)
-                && !(mgmtData.RelyingPartyIdHash is null))
+            var credentialManagementData = _response.GetData();
+            if (!(credentialManagementData.RelyingParty is null) &&
+                !(credentialManagementData.RelyingPartyIdHash is null))
             {
-                if (mgmtData.RelyingParty.IsMatchingRelyingPartyId(mgmtData.RelyingPartyIdHash.Value))
+                if (credentialManagementData.RelyingParty.IsMatchingRelyingPartyId(credentialManagementData.RelyingPartyIdHash.Value))
                 {
-                    return mgmtData.RelyingParty;
+                    return credentialManagementData.RelyingParty;
                 }
             }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetBioModalityResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetBioModalityResponse.cs
@@ -47,11 +47,10 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </returns>
         public int GetData()
         {
-            BioEnrollmentData enrollData = _response.GetData();
-
-            if (!(enrollData.Modality is null))
+            var bioEnrollmentData = _response.GetData();
+            if (!(bioEnrollmentData.Modality is null))
             {
-                return enrollData.Modality.Value;
+                return bioEnrollmentData.Modality.Value;
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetCredentialMetadataResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetCredentialMetadataResponse.cs
@@ -57,11 +57,11 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </exception>
         public (int discoverableCredentialCount, int remainingCredentialCount) GetData()
         {
-            CredentialManagementData mgmtData = _response.GetData();
-
-            if (!(mgmtData.NumberOfDiscoverableCredentials is null) && !(mgmtData.RemainingCredentialCount is null))
+            var credentialManagementData = _response.GetData();
+            if (!(credentialManagementData.NumberOfDiscoverableCredentials is null) && 
+                !(credentialManagementData.RemainingCredentialCount is null))
             {
-                return (mgmtData.NumberOfDiscoverableCredentials.Value, mgmtData.RemainingCredentialCount.Value);
+                return (credentialManagementData.NumberOfDiscoverableCredentials.Value, credentialManagementData.RemainingCredentialCount.Value);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetFingerprintSensorInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetFingerprintSensorInfoResponse.cs
@@ -42,16 +42,16 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <inheritdoc/>
         public FingerprintSensorInfo GetData()
         {
-            BioEnrollmentData enrollData = _response.GetData();
+            var bioEnrollmentData = _response.GetData();
 
-            if (!(enrollData.FingerprintKind is null)
-                && !(enrollData.MaxCaptureCount is null)
-                && !(enrollData.MaxFriendlyNameBytes is null))
+            if (!(bioEnrollmentData.FingerprintKind is null) &&
+                !(bioEnrollmentData.MaxCaptureCount is null) &&
+                !(bioEnrollmentData.MaxFriendlyNameBytes is null))
             {
                 return new FingerprintSensorInfo(
-                    enrollData.FingerprintKind.Value,
-                    enrollData.MaxCaptureCount.Value,
-                    enrollData.MaxFriendlyNameBytes.Value);
+                    bioEnrollmentData.FingerprintKind.Value,
+                    bioEnrollmentData.MaxCaptureCount.Value,
+                    bioEnrollmentData.MaxFriendlyNameBytes.Value);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetKeyAgreementResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetKeyAgreementResponse.cs
@@ -49,9 +49,8 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </remarks>
         public CoseEcPublicKey GetData()
         {
-            ClientPinData data = _response.GetData();
-
-            if (data.KeyAgreement is CoseEcPublicKey ecPublicKey)
+            var clientPinData = _response.GetData();
+            if (clientPinData.KeyAgreement is CoseEcPublicKey ecPublicKey)
             {
                 return ecPublicKey;
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinRetriesResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinRetriesResponse.cs
@@ -53,14 +53,13 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </returns>
         public (int retriesRemaining, bool? powerCycleRequired) GetData()
         {
-            ClientPinData data = _response.GetData();
-
-            if (data.PinRetries is null)
+            var clientPinData = _response.GetData();
+            if (clientPinData.PinRetries is null)
             {
                 throw new Ctap2DataException(ExceptionMessages.Ctap2MissingRequiredField);
             }
 
-            return (data.PinRetries.Value, data.PowerCycleState);
+            return (clientPinData.PinRetries.Value, clientPinData.PowerCycleState);
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinTokenCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinTokenCommand.cs
@@ -92,6 +92,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             {
                 throw new ArgumentNullException(nameof(pinProtocol));
             }
+
             if (pinProtocol.PlatformPublicKey is null)
             {
                 throw new InvalidOperationException(
@@ -99,6 +100,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         CultureInfo.CurrentCulture,
                         ExceptionMessages.InvalidCallOrder));
             }
+
             if (currentPin.Length > MaximumPinLength)
             {
                 throw new ArgumentException(
@@ -107,7 +109,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         ExceptionMessages.InvalidFido2Pin));
             }
 
-            using SHA256 sha256Object = CryptographyProviders.Sha256Creator();
+            using var sha256Object = CryptographyProviders.Sha256Creator();
             byte[] pin = currentPin.ToArray();
             byte[] digest = sha256Object.ComputeHash(pin);
             CryptographicOperations.ZeroMemory(pin);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinUvAuthTokenResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinUvAuthTokenResponse.cs
@@ -56,9 +56,8 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </returns>
         public ReadOnlyMemory<byte> GetData()
         {
-            ClientPinData data = _response.GetData();
-
-            if (data.PinUvAuthToken is null)
+            var clientPinData = _response.GetData();
+            if (clientPinData.PinUvAuthToken is null)
             {
                 throw new Ctap2DataException(
                     string.Format(
@@ -66,7 +65,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         ExceptionMessages.Ctap2MissingRequiredField));
             }
 
-            return (ReadOnlyMemory<byte>)data.PinUvAuthToken;
+            return (ReadOnlyMemory<byte>)clientPinData.PinUvAuthToken;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinUvAuthTokenUsingPinCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetPinUvAuthTokenUsingPinCommand.cs
@@ -137,7 +137,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         ExceptionMessages.InvalidFido2Pin));
             }
 
-            using SHA256 sha256Object = CryptographyProviders.Sha256Creator();
+            using var sha256Object = CryptographyProviders.Sha256Creator();
             byte[] pin = currentPin.ToArray();
             byte[] digest = sha256Object.ComputeHash(pin);
             CryptographicOperations.ZeroMemory(pin);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetUvRetriesResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetUvRetriesResponse.cs
@@ -61,14 +61,13 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </remarks>
         public int GetData()
         {
-            ClientPinData data = _response.GetData();
-
-            if (data.UvRetries is null)
+            var clientPinData = _response.GetData();
+            if (clientPinData.UvRetries is null)
             {
                 throw new Ctap2DataException(ExceptionMessages.Ctap2MissingRequiredField);
             }
 
-            return data.UvRetries.Value;
+            return clientPinData.UvRetries.Value;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/VersionResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/VersionResponse.cs
@@ -51,13 +51,13 @@ namespace Yubico.YubiKey.Fido2.Commands
                 throw new MalformedYubiKeyResponseException(ExceptionMessages.UnknownFidoError);
             }
 
-            ReadOnlySpan<byte> responseApduData = ResponseApdu.Data.Span;
+            var responseApduDataSpan = ResponseApdu.Data.Span;
 
-            return new FirmwareVersion()
+            return new FirmwareVersion
             {
-                Major = responseApduData[13],
-                Minor = responseApduData[14],
-                Patch = responseApduData[15]
+                Major = responseApduDataSpan[13],
+                Minor = responseApduDataSpan[14],
+                Patch = responseApduDataSpan[15]
             };
         }
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialId.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialId.cs
@@ -151,8 +151,8 @@ namespace Yubico.YubiKey.Fido2
             Id = cborMap.ReadByteString(TagId);
             if (cborMap.Contains(TagTransports))
             {
-                IReadOnlyList<string> transportArray = cborMap.ReadArray<string>(TagTransports);
-                foreach (string entry in transportArray)
+                var transports = cborMap.ReadArray<string>(TagTransports);
+                foreach (string entry in transports)
                 {
                     AddTransport(entry);
                 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Config.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Config.cs
@@ -72,7 +72,7 @@ namespace Yubico.YubiKey.Fido2
         {
             _log.LogInformation("Try to EnableEnterpriseAttestation.");
 
-            OptionValue epValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.ep);
+            var epValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.ep);
 
             if (epValue == OptionValue.True)
             {
@@ -84,21 +84,21 @@ namespace Yubico.YubiKey.Fido2
                 return false;
             }
 
-            ReadOnlyMemory<byte> currentToken = GetAuthToken(
+            var currentToken = GetAuthToken(
                 false,
                 PinUvAuthTokenPermissions.AuthenticatorConfiguration,
                 null);
 
-            var enableCmd = new EnableEnterpriseAttestationCommand(currentToken, AuthProtocol);
-            Fido2Response enableRsp = Connection.SendCommand(enableCmd);
-            if (enableRsp.CtapStatus == CtapStatus.PinAuthInvalid)
+            var command = new EnableEnterpriseAttestationCommand(currentToken, AuthProtocol);
+            var response = Connection.SendCommand(command);
+            if (response.CtapStatus == CtapStatus.PinAuthInvalid)
             {
                 currentToken = GetAuthToken(true, PinUvAuthTokenPermissions.AuthenticatorConfiguration, null);
-                enableCmd = new EnableEnterpriseAttestationCommand(currentToken, AuthProtocol);
-                enableRsp = Connection.SendCommand(enableCmd);
+                command = new EnableEnterpriseAttestationCommand(currentToken, AuthProtocol);
+                response = Connection.SendCommand(command);
             }
 
-            if (enableRsp.Status == ResponseStatus.Success)
+            if (response.Status == ResponseStatus.Success)
             {
                 // This operation can change the AuthenticatorInfo, so make sure
                 // if someone gets it, they get a new one.
@@ -106,7 +106,7 @@ namespace Yubico.YubiKey.Fido2
                 return true;
             }
 
-            throw new Ctap2DataException(enableRsp.StatusMessage);
+            throw new Ctap2DataException(response.StatusMessage);
         }
 
         /// <summary>
@@ -164,27 +164,27 @@ namespace Yubico.YubiKey.Fido2
         {
             _log.LogInformation("Try to ToggleAlwaysUv.");
 
-            OptionValue alwaysUvValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.alwaysUv);
+            var alwaysUvValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.alwaysUv);
             if (alwaysUvValue != OptionValue.True && alwaysUvValue != OptionValue.False)
             {
                 return false;
             }
 
-            ReadOnlyMemory<byte> currentToken = GetAuthToken(
+            var currentToken = GetAuthToken(
                 false,
                 PinUvAuthTokenPermissions.AuthenticatorConfiguration,
                 null);
 
-            var toggleCmd = new ToggleAlwaysUvCommand(currentToken, AuthProtocol);
-            Fido2Response toggleRsp = Connection.SendCommand(toggleCmd);
-            if (toggleRsp.CtapStatus == CtapStatus.PinAuthInvalid)
+            var command = new ToggleAlwaysUvCommand(currentToken, AuthProtocol);
+            var response = Connection.SendCommand(command);
+            if (response.CtapStatus == CtapStatus.PinAuthInvalid)
             {
                 currentToken = GetAuthToken(true, PinUvAuthTokenPermissions.AuthenticatorConfiguration, null);
-                toggleCmd = new ToggleAlwaysUvCommand(currentToken, AuthProtocol);
-                toggleRsp = Connection.SendCommand(toggleCmd);
+                command = new ToggleAlwaysUvCommand(currentToken, AuthProtocol);
+                response = Connection.SendCommand(command);
             }
 
-            if (toggleRsp.Status == ResponseStatus.Success)
+            if (response.Status == ResponseStatus.Success)
             {
                 // This operation can change the AuthenticatorInfo, so make sure
                 // if someone gets it, they get a new one.
@@ -192,7 +192,7 @@ namespace Yubico.YubiKey.Fido2
                 return true;
             }
 
-            throw new Ctap2DataException(toggleRsp.StatusMessage);
+            throw new Ctap2DataException(response.StatusMessage);
         }
 
         /// <summary>
@@ -324,14 +324,14 @@ namespace Yubico.YubiKey.Fido2
         {
             _log.LogInformation("Try to set the PIN config (setMinPINLength).");
 
-            OptionValue setMinPinValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.setMinPINLength);
+            var setMinPinValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.setMinPINLength);
 
             if (setMinPinValue != OptionValue.True)
             {
                 return false;
             }
 
-            ReadOnlyMemory<byte> currentToken = GetAuthToken(
+            var currentToken = GetAuthToken(
                 false,
                 PinUvAuthTokenPermissions.AuthenticatorConfiguration,
                 null);
@@ -342,7 +342,7 @@ namespace Yubico.YubiKey.Fido2
                 forceChangePin,
                 currentToken,
                 AuthProtocol);
-            Fido2Response setRsp = Connection.SendCommand(setCmd);
+            var setRsp = Connection.SendCommand(setCmd);
             if (setRsp.CtapStatus == CtapStatus.PinAuthInvalid)
             {
                 currentToken = GetAuthToken(true, PinUvAuthTokenPermissions.AuthenticatorConfiguration, null);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.GetAssertion.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.GetAssertion.cs
@@ -98,7 +98,8 @@ namespace Yubico.YubiKey.Fido2
             {
                 throw new ArgumentNullException(nameof(parameters));
             }
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
+            
+            var keyCollector = EnsureKeyCollector();
 
             byte[] token = new byte[MaximumAuthTokenLength];
             byte[] clientDataHash = parameters.ClientDataHash.ToArray();
@@ -109,7 +110,7 @@ namespace Yubico.YubiKey.Fido2
             {
                 // The first time through, forceToken will be false.
                 // If there is a second time, it will be true.
-                ReadOnlyMemory<byte> currentToken = GetAuthToken(
+                var currentToken = GetAuthToken(
                     forceToken, PinUvAuthTokenPermissions.GetAssertion, parameters.RelyingParty.Id);
 
                 try
@@ -128,12 +129,12 @@ namespace Yubico.YubiKey.Fido2
                 // do nothing.
                 parameters.EncodeHmacSecretExtension(AuthProtocol);
 
-                GetAssertionResponse rsp = RunGetAssertion(parameters, keyCollector, out CtapStatus ctapStatus);
+                var response = RunGetAssertion(parameters, keyCollector, out var ctapStatus);
 
                 switch (ctapStatus)
                 {
                     case CtapStatus.Ok:
-                        return CompleteGetAssertions(rsp.GetData());
+                        return CompleteGetAssertions(response.GetData());
 
                     case CtapStatus.PinAuthInvalid:
                         // If forceToken is false (its initial value), this
@@ -163,7 +164,7 @@ namespace Yubico.YubiKey.Fido2
                         break;
                 }
 
-                message = rsp.StatusMessage;
+                message = response.StatusMessage;
             } while (forceToken);
 
             throw new Fido2Exception(message);
@@ -186,9 +187,9 @@ namespace Yubico.YubiKey.Fido2
 
             try
             {
-                GetAssertionResponse rsp = Connection.SendCommand(new GetAssertionCommand(parameters));
-                ctapStatus = touchTask.IsUserCanceled ? CtapStatus.KeepAliveCancel : rsp.CtapStatus;
-                return rsp;
+                var response = Connection.SendCommand(new GetAssertionCommand(parameters));
+                ctapStatus = touchTask.IsUserCanceled ? CtapStatus.KeepAliveCancel : response.CtapStatus;
+                return response;
             }
             finally
             {
@@ -205,7 +206,7 @@ namespace Yubico.YubiKey.Fido2
 
             for (int index = 1; index < numberOfCredentials; index++)
             {
-                GetAssertionResponse response = Connection.SendCommand(new GetNextAssertionCommand());
+                var response = Connection.SendCommand(new GetNextAssertionCommand());
                 assertions.Add(response.GetData());
             }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.LargeBlobs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.LargeBlobs.cs
@@ -125,7 +125,7 @@ namespace Yubico.YubiKey.Fido2
             do
             {
                 var command = new GetLargeBlobCommand(offset, maxFragmentLength);
-                GetLargeBlobResponse response = Connection.SendCommand(command);
+                var response = Connection.SendCommand(command);
                 currentData = response.GetData();
 
                 fullEncoding.Write(currentData.ToArray(), 0, currentData.Length);
@@ -143,7 +143,7 @@ namespace Yubico.YubiKey.Fido2
             //      01 byte string
             var cborMap = new CborMap<int>(
                 fullEncoding.GetBuffer().AsMemory<byte>(0, (int)fullEncoding.Length));
-            ReadOnlyMemory<byte> encodedArray = cborMap.ReadByteString(KeyEncodedArray);
+            var encodedArray = cborMap.ReadByteString(KeyEncodedArray);
 
             var returnValue = new SerializedLargeBlobArray(encodedArray);
 
@@ -242,7 +242,7 @@ namespace Yubico.YubiKey.Fido2
 
                 do
                 {
-                    ReadOnlyMemory<byte> currentToken = GetAuthToken(
+                    var currentToken = GetAuthToken(
                         forceToken, PinUvAuthTokenPermissions.LargeBlobWrite, null);
                     currentToken.CopyTo(token.AsMemory());
 
@@ -257,7 +257,8 @@ namespace Yubico.YubiKey.Fido2
                         encodedArray.Length,
                         pinUvAuthParam,
                         (int)AuthProtocol.Protocol);
-                    SetLargeBlobResponse response = Connection.SendCommand(command);
+                    
+                    var response = Connection.SendCommand(command);
                     if (response.Status == ResponseStatus.Success)
                     {
                         remaining -= currentLength;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
@@ -283,8 +283,8 @@ namespace Yubico.YubiKey.Fido2
         {
             _log.LogInformation("Add permissions (get new AuthToken with more permissions).");
 
-            PinUvAuthTokenPermissions current = AuthTokenPermissions ?? PinUvAuthTokenPermissions.None;
-            PinUvAuthTokenPermissions allPermissions = permissions | current;
+            var currentPermissions = AuthTokenPermissions ?? PinUvAuthTokenPermissions.None;
+            var allPermissions = permissions | currentPermissions;
 
             // If the caller supplies an RpId, replace the one in the
             // AuthTokenRelyingPartyId property.
@@ -513,9 +513,9 @@ namespace Yubico.YubiKey.Fido2
         public bool TrySetPin()
         {
             _log.LogInformation("Try to set PIN (use KeyCollector).");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
-
-            var keyEntryData = new KeyEntryData()
+            
+            var keyCollector = EnsureKeyCollector();
+            var keyEntryData = new KeyEntryData
             {
                 Request = KeyEntryRequest.SetFido2Pin,
             };
@@ -584,9 +584,8 @@ namespace Yubico.YubiKey.Fido2
 
             ObtainSharedSecret();
 
-            SetPinResponse result = Connection.SendCommand(new SetPinCommand(AuthProtocol, newPin));
-
-            if (result.Status == ResponseStatus.Success)
+            var response = Connection.SendCommand(new SetPinCommand(AuthProtocol, newPin));
+            if (response.Status == ResponseStatus.Success)
             {
                 // Setting the PIN changes the AuthenticatorInfo, so set this to
                 // null so the next reference initiates a new GetInfo command.
@@ -595,13 +594,13 @@ namespace Yubico.YubiKey.Fido2
             }
 
             // Spec says "PinAuthInvalid" for PIN already set. YubiKey says "NotAllowed".
-            if (GetCtapError(result) == CtapStatus.PinAuthInvalid ||
-                GetCtapError(result) == CtapStatus.NotAllowed)
+            if (GetCtapError(response) == CtapStatus.PinAuthInvalid ||
+                GetCtapError(response) == CtapStatus.NotAllowed)
             {
                 return false; // PIN is already set.
             }
 
-            throw new Fido2Exception(GetCtapError(result), result.StatusMessage);
+            throw new Fido2Exception(GetCtapError(response), response.StatusMessage);
         }
 
         /// <summary>
@@ -674,8 +673,8 @@ namespace Yubico.YubiKey.Fido2
         public bool TryChangePin()
         {
             _log.LogInformation("Try to change PIN (use KeyCollector).");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
-
+            
+            var keyCollector = EnsureKeyCollector();
             var keyEntryData = new KeyEntryData()
             {
                 Request = KeyEntryRequest.ChangeFido2Pin
@@ -752,14 +751,13 @@ namespace Yubico.YubiKey.Fido2
 
             ObtainSharedSecret();
 
-            ChangePinResponse result = Connection.SendCommand(new ChangePinCommand(AuthProtocol, currentPin, newPin));
-
-            if (result.Status == ResponseStatus.Success)
+            var response = Connection.SendCommand(new ChangePinCommand(AuthProtocol, currentPin, newPin));
+            if (response.Status == ResponseStatus.Success)
             {
                 return true;
             }
 
-            if (GetCtapError(result) == CtapStatus.PinInvalid)
+            if (GetCtapError(response) == CtapStatus.PinInvalid)
             {
                 // FIDO authenticators regenerate the public key used for the auth protocol. We need to
                 // re-initialize everything so we can obtain the new shared secret.
@@ -767,7 +765,7 @@ namespace Yubico.YubiKey.Fido2
                 return false; // PIN is invalid
             }
 
-            throw new Fido2Exception(GetCtapError(result), result.StatusMessage);
+            throw new Fido2Exception(GetCtapError(response), response.StatusMessage);
         }
 
         /// <summary>
@@ -914,9 +912,9 @@ namespace Yubico.YubiKey.Fido2
         public bool TryVerifyPin(PinUvAuthTokenPermissions? permissions = null, string? relyingPartyId = null)
         {
             _log.LogInformation("Try to verify PIN (use KeyCollector).");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
-
-            var keyEntryData = new KeyEntryData()
+            
+            var keyCollector = EnsureKeyCollector();
+            var keyEntryData = new KeyEntryData
             {
                 Request = KeyEntryRequest.VerifyFido2Pin
             };
@@ -1056,8 +1054,7 @@ namespace Yubico.YubiKey.Fido2
                     relyingPartyId);
             }
 
-            GetPinUvAuthTokenResponse response = Connection.SendCommand(command);
-
+            var response = Connection.SendCommand(command);
             if (response.Status == ResponseStatus.Success)
             {
                 AuthToken = response.GetData();
@@ -1211,9 +1208,9 @@ namespace Yubico.YubiKey.Fido2
         public bool TryVerifyUv(PinUvAuthTokenPermissions permissions, string? relyingPartyId = null)
         {
             _log.LogInformation("Try to verify UV (use KeyCollector).");
-            CtapStatus status = DoVerifyUv(permissions, relyingPartyId, out string statusMessage);
-
-            switch (status)
+            
+            var ctapStatus = DoVerifyUv(permissions, relyingPartyId, out string statusMessage);
+            switch (ctapStatus)
             {
                 case CtapStatus.Ok:
                     return true;
@@ -1252,9 +1249,8 @@ namespace Yubico.YubiKey.Fido2
                 return CtapStatus.InvalidParameter;
             }
 
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
+            var keyCollector = EnsureKeyCollector();
 
-            CtapStatus status;
             ObtainSharedSecret();
             var command = new GetPinUvAuthTokenUsingUvCommand(AuthProtocol, permissions, relyingPartyId);
 
@@ -1270,12 +1266,13 @@ namespace Yubico.YubiKey.Fido2
 
             try
             {
+                CtapStatus status;
                 do
                 {
-                    GetPinUvAuthTokenResponse response = Connection.SendCommand(command);
-                    status = touchTask.IsUserCanceled ? CtapStatus.KeepAliveCancel : response.CtapStatus;
+                    var response = Connection.SendCommand(command);
+                    
                     statusMessage = response.StatusMessage;
-
+                    status = touchTask.IsUserCanceled ? CtapStatus.KeepAliveCancel : response.CtapStatus;
                     if (status == CtapStatus.Ok)
                     {
                         AuthToken = response.GetData();
@@ -1375,8 +1372,7 @@ namespace Yubico.YubiKey.Fido2
 
         private PinUvAuthProtocolBase GetPreferredPinProtocol()
         {
-            PinUvAuthProtocol protocol = AuthenticatorInfo.PinUvAuthProtocols?[0] ?? PinUvAuthProtocol.ProtocolOne;
-
+            var protocol = AuthenticatorInfo.PinUvAuthProtocols?[0] ?? PinUvAuthProtocol.ProtocolOne;
             return protocol switch
             {
                 PinUvAuthProtocol.ProtocolOne => new PinUvAuthProtocolOne(),
@@ -1391,10 +1387,9 @@ namespace Yubico.YubiKey.Fido2
 
         private CoseEcPublicKey GetPeerCoseKey()
         {
-            GetKeyAgreementResponse keyAgreementResponse =
-                Connection.SendCommand(new GetKeyAgreementCommand(AuthProtocol.Protocol));
-
-            CoseEcPublicKey peerCoseKey = keyAgreementResponse.GetData();
+            var response = Connection.SendCommand(new GetKeyAgreementCommand(AuthProtocol.Protocol));
+            var peerCoseKey = response.GetData();
+            
             return peerCoseKey;
         }
 
@@ -1403,7 +1398,7 @@ namespace Yubico.YubiKey.Fido2
             if (AuthProtocol.PlatformPublicKey is null)
             {
                 AuthProtocol.Initialize();
-                CoseEcPublicKey peerCoseKey = GetPeerCoseKey();
+                var peerCoseKey = GetPeerCoseKey();
                 AuthProtocol.Encapsulate(peerCoseKey);
             }
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
@@ -215,8 +215,8 @@ namespace Yubico.YubiKey.Fido2
         // necessary to call the command.
         private AuthenticatorInfo SetAndReturnAuthenticatorInfoField()
         {
-            GetInfoResponse info = Connection.SendCommand(new GetInfoCommand());
-            _authenticatorInfo = info.GetData();
+            var response = Connection.SendCommand(new GetInfoCommand());
+            _authenticatorInfo = response.GetData();
 
             return _authenticatorInfo;
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/GetAssertionData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/GetAssertionData.cs
@@ -130,32 +130,35 @@ namespace Yubico.YubiKey.Fido2
             try
             {
                 var map = new CborMap<int>(cborEncoding);
+                var stringCborMap = map.ReadMap<string>(KeyCredential);
 
-                CborMap<string> stringMap = map.ReadMap<string>(KeyCredential);
-                CredentialId = new CredentialId()
+                CredentialId = new CredentialId
                 {
-                    Type = stringMap.ReadTextString(KeyCredentialType),
-                    Id = stringMap.ReadByteString(KeyCredentialId),
+                    Type = stringCborMap.ReadTextString(KeyCredentialType),
+                    Id = stringCborMap.ReadByteString(KeyCredentialId),
                 };
-                if (stringMap.Contains(KeyCredentialTransports))
+
+                if (stringCborMap.Contains(KeyCredentialTransports))
                 {
-                    IReadOnlyList<string> transports = stringMap.ReadArray<string>(KeyCredentialTransports);
+                    var transports = stringCborMap.ReadArray<string>(KeyCredentialTransports);
                     foreach (string current in transports)
                     {
                         CredentialId.AddTransport(current);
                     }
                 }
+
                 AuthenticatorData = new AuthenticatorData(map.ReadByteString(KeyAuthData));
                 Signature = map.ReadByteString(KeySignature);
                 if (map.Contains(KeyUser))
                 {
-                    stringMap = map.ReadMap<string>(KeyUser);
-                    User = new UserEntity(stringMap.ReadByteString(KeyUserId))
+                    stringCborMap = map.ReadMap<string>(KeyUser);
+                    User = new UserEntity(stringCborMap.ReadByteString(KeyUserId))
                     {
-                        Name = (string?)stringMap.ReadOptional<string>(KeyUserName),
-                        DisplayName = (string?)stringMap.ReadOptional<string>(KeyUserDisplayName)
+                        Name = (string?)stringCborMap.ReadOptional<string>(KeyUserName),
+                        DisplayName = (string?)stringCborMap.ReadOptional<string>(KeyUserDisplayName)
                     };
                 }
+
                 NumberOfCredentials = (int?)map.ReadOptional<int>(KeyNumberCredentials);
                 UserSelected = (bool?)map.ReadOptional<bool>(KeyUserSelected);
                 _keyData = (byte[]?)map.ReadOptional<byte[]>(KeyLargeBlobKey);
@@ -197,14 +200,15 @@ namespace Yubico.YubiKey.Fido2
         /// </returns>
         public bool VerifyAssertion(CoseKey publicKey, ReadOnlyMemory<byte> clientDataHash)
         {
-            using SHA256 digester = CryptographyProviders.Sha256Creator();
-            _ = digester.TransformBlock(
+            using var digesterHashAlgorithm = CryptographyProviders.Sha256Creator();
+            _ = digesterHashAlgorithm.TransformBlock(
                 AuthenticatorData.EncodedAuthenticatorData.ToArray(), 0,
                 AuthenticatorData.EncodedAuthenticatorData.Length, null, 0);
-            _ = digester.TransformFinalBlock(clientDataHash.ToArray(), 0, clientDataHash.Length);
+
+            _ = digesterHashAlgorithm.TransformFinalBlock(clientDataHash.ToArray(), 0, clientDataHash.Length);
 
             using var ecdsaVfy = new EcdsaVerify(publicKey);
-            return ecdsaVfy.VerifyDigestedData(digester.Hash, Signature.ToArray());
+            return ecdsaVfy.VerifyDigestedData(digesterHashAlgorithm.Hash, Signature.ToArray());
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/ParameterHelpers.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/ParameterHelpers.cs
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey.Fido2
                 throw new ArgumentNullException();
             }
 
-            List<T> returnList = currentList is null ? new List<T>() : currentList;
+            var returnList = currentList ?? new List<T>();
             returnList.Add(itemToAdd);
 
             return returnList;
@@ -69,7 +69,7 @@ namespace Yubico.YubiKey.Fido2
                 throw new ArgumentNullException(nameof(theValue));
             }
 
-            Dictionary<string, TValue> returnDictionary =
+            var returnDictionary =
                 currentDictionary is null ? new Dictionary<string, TValue>() : currentDictionary;
 
             // If the key already exists, replace the current value in the
@@ -112,7 +112,7 @@ namespace Yubico.YubiKey.Fido2
             var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
 
             cbor.WriteStartMap(null);
-            foreach (KeyValuePair<string, TValue> entry in localData)
+            foreach (var entry in localData)
             {
                 cbor.WriteTextString(entry.Key);
                 if (entry.Value is byte[] encodedValue)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolBase.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolBase.cs
@@ -136,7 +136,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
         /// exception.
         /// </para>
         /// </remarks>
-        /// <param new="authenticatorPublicKey">
+        /// <param name="authenticatorPublicKey">
         /// The YubiKey's public key obtained by calling the
         /// <see cref="Yubico.YubiKey.Fido2.Commands.GetKeyAgreementCommand"/>.
         /// </param>
@@ -191,7 +191,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
 
             try
             {
-                IEcdhPrimitives ecdh = CryptographyProviders.EcdhPrimitivesCreator();
+                var ecdh = CryptographyProviders.EcdhPrimitivesCreator();
                 platformKeyPair = ecdh.GenerateKeyPair(ECCurve.NamedCurves.nistP256);
 
                 PlatformPublicKey = new CoseEcPublicKey(platformKeyPair.Value);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolOne.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolOne.cs
@@ -63,13 +63,13 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
                         ExceptionMessages.IncorrectPlaintextLength));
             }
 
-            using Aes aes = CryptographyProviders.AesCreator();
+            using var aes = CryptographyProviders.AesCreator();
             aes.Mode = CipherMode.CBC;
             aes.Padding = PaddingMode.None;
             aes.IV = new byte[BlockSize];
             aes.Key = _keyData;
-            using ICryptoTransform aesTransform = aes.CreateEncryptor();
-
+            
+            using var aesTransform = aes.CreateEncryptor();
             byte[] encryptedData = new byte[length];
             _ = aesTransform.TransformBlock(plaintext, offset, length, encryptedData, 0);
 
@@ -99,13 +99,13 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
                         ExceptionMessages.IncorrectCiphertextLength));
             }
 
-            using Aes aes = CryptographyProviders.AesCreator();
+            using var aes = CryptographyProviders.AesCreator();
             aes.Mode = CipherMode.CBC;
             aes.Padding = PaddingMode.None;
             aes.IV = new byte[BlockSize];
             aes.Key = _keyData;
-            using ICryptoTransform aesTransform = aes.CreateDecryptor();
-
+            
+            using var aesTransform = aes.CreateDecryptor();
             byte[] decryptedData = new byte[length];
             _ = aesTransform.TransformBlock(ciphertext, offset, length, decryptedData, 0);
 
@@ -134,7 +134,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
         /// <inheritdoc />
         protected override byte[] Authenticate(byte[] keyData, byte[] message)
         {
-            using HMAC hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
+            using var hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
             hmacSha256.Key = keyData;
             return hmacSha256.ComputeHash(message).AsMemory(0, 16).ToArray();
         }
@@ -147,7 +147,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
                 throw new ArgumentNullException(nameof(buffer));
             }
 
-            using SHA256 sha256 = CryptographyProviders.Sha256Creator();
+            using var sha256 = CryptographyProviders.Sha256Creator();
             _ = sha256.TransformFinalBlock(buffer, 0, buffer.Length);
             if (sha256.Hash.Length != KeyLength)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolTwo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/PinProtocols/PinUvAuthProtocolTwo.cs
@@ -73,17 +73,17 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
             // For protocol 2, generate a 16-byte, random IV, encrypt, then
             // return a buffer containing IV || ciphertext.
 
+            using var randomObject = CryptographyProviders.RngCreator();
             byte[] initVector = new byte[BlockSize];
-            using RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
             randomObject.GetBytes(initVector);
 
-            using Aes aes = CryptographyProviders.AesCreator();
+            using var aes = CryptographyProviders.AesCreator();
             aes.Mode = CipherMode.CBC;
             aes.Padding = PaddingMode.None;
             aes.IV = initVector;
             aes.Key = _aesKey;
-            using ICryptoTransform aesTransform = aes.CreateEncryptor();
-
+            
+            using var aesTransform = aes.CreateEncryptor();
             byte[] encryptedData = new byte[BlockSize + length];
             Array.Copy(initVector, 0, encryptedData, 0, BlockSize);
             _ = aesTransform.TransformBlock(plaintext, offset, length, encryptedData, BlockSize);
@@ -120,13 +120,13 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
             byte[] initVector = new byte[BlockSize];
             Array.Copy(ciphertext, offset, initVector, 0, BlockSize);
 
-            using Aes aes = CryptographyProviders.AesCreator();
+            using var aes = CryptographyProviders.AesCreator();
             aes.Mode = CipherMode.CBC;
             aes.Padding = PaddingMode.None;
             aes.IV = initVector;
             aes.Key = _aesKey;
-            using ICryptoTransform aesTransform = aes.CreateDecryptor();
-
+            
+            using var aesTransform = aes.CreateDecryptor();
             byte[] decryptedData = new byte[length - BlockSize];
             _ = aesTransform.TransformBlock(ciphertext, BlockSize + offset, length - BlockSize, decryptedData, 0);
 
@@ -155,7 +155,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
         /// <inheritdoc />
         protected override byte[] Authenticate(byte[] keyData, byte[] message)
         {
-            using HMAC hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
+            using var hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
             hmacSha256.Key = keyData;
             return hmacSha256.ComputeHash(message);
         }
@@ -194,7 +194,7 @@ namespace Yubico.YubiKey.Fido2.PinProtocols
             {
                 // Extract.
                 byte[] salt = new byte[SaltLength];
-                using HMAC hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
+                using var hmacSha256 = CryptographyProviders.HmacCreator("HMACSHA256");
                 hmacSha256.Key = salt;
                 prk = hmacSha256.ComputeHash(buffer);
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/RelyingParty.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/RelyingParty.cs
@@ -179,10 +179,10 @@ namespace Yubico.YubiKey.Fido2
         // Perform the appropriate digest operation to generate the correct value.
         private void ComputeRelyingPartyIdHash()
         {
-            using SHA256 digester = CryptographyProviders.Sha256Creator();
-            digester.Initialize();
+            using var digestHashAlgorihm = CryptographyProviders.Sha256Creator();
+            digestHashAlgorihm.Initialize();
             byte[] utf = Encoding.UTF8.GetBytes(Id);
-            byte[] digest = digester.ComputeHash(utf);
+            byte[] digest = digestHashAlgorihm.ComputeHash(utf);
             RelyingPartyIdHash = new ReadOnlyMemory<byte>(digest);
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoConnection.cs
@@ -49,8 +49,8 @@ namespace Yubico.YubiKey
         public TResponse SendCommand<TResponse>(IYubiKeyCommand<TResponse> yubiKeyCommand)
             where TResponse : IYubiKeyResponse
         {
-            CommandApdu commandApdu = yubiKeyCommand.CreateCommandApdu();
-            ResponseApdu responseApdu = _apduPipeline.Invoke(commandApdu, yubiKeyCommand.GetType(), typeof(TResponse));
+            var commandApdu = yubiKeyCommand.CreateCommandApdu();
+            var responseApdu = _apduPipeline.Invoke(commandApdu, yubiKeyCommand.GetType(), typeof(TResponse));
 
             return yubiKeyCommand.CreateResponseForApdu(responseApdu);
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FidoDeviceInfoFactory.cs
@@ -39,29 +39,29 @@ namespace Yubico.YubiKey
 
             Log.LogInformation("Getting device info for FIDO device {Device}", device);
 
-            if (!TryGetDeviceInfoFromFido(device, out YubiKeyDeviceInfo? ykDeviceInfo))
+            if (!TryGetDeviceInfoFromFido(device, out var deviceInfo))
             {
-                ykDeviceInfo = new YubiKeyDeviceInfo();
+                deviceInfo = new YubiKeyDeviceInfo();
             }
 
-            ykDeviceInfo.IsSkySeries |= device.ProductId == ProductIdentifiers.SecurityKey;
+            deviceInfo.IsSkySeries |= device.ProductId == ProductIdentifiers.SecurityKey;
 
             // Manually fill in gaps, if necessary
             var defaultDeviceInfo = new YubiKeyDeviceInfo();
 
-            if (ykDeviceInfo.FirmwareVersion == defaultDeviceInfo.FirmwareVersion
-                && TryGetFirmwareVersionFromFido(device, out FirmwareVersion? firmwareVersion))
+            if (deviceInfo.FirmwareVersion == defaultDeviceInfo.FirmwareVersion && 
+                TryGetFirmwareVersionFromFido(device, out var firmwareVersion))
             {
-                ykDeviceInfo.FirmwareVersion = firmwareVersion;
+                deviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
-                ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (deviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 &&
+                deviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
-                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.FidoU2f;
+                deviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.FidoU2f;
             }
 
-            return ykDeviceInfo;
+            return deviceInfo;
         }
 
         private static bool TryGetDeviceInfoFromFido(
@@ -112,8 +112,7 @@ namespace Yubico.YubiKey
                 Log.LogInformation("Attempting to read firmware version through FIDO.");
                 using var connection = new FidoConnection(device);
 
-                VersionResponse response = connection.SendCommand(new VersionCommand());
-
+                var response = connection.SendCommand(new VersionCommand());
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoHelper.cs
@@ -31,8 +31,7 @@ namespace Yubico.YubiKey
         /// <typeparam name="TCommand">The specific type of IGetPagedDeviceInfoCommand, e.g. GetPagedDeviceInfoCommand, which will then allow for returning the appropriate response.</typeparam>
         /// <param name="connection">The connection interface to communicate with a YubiKey.</param>
         /// <returns>A YubiKeyDeviceInfo? object containing all relevant device information if successful, otherwise null.</returns>
-        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(
-            IYubiKeyConnection connection)
+        public static YubiKeyDeviceInfo? GetDeviceInfo<TCommand>(IYubiKeyConnection connection)
             where TCommand
             : IGetPagedDeviceInfoCommand<IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>>>,
             new()
@@ -43,21 +42,18 @@ namespace Yubico.YubiKey
             bool hasMoreData = true;
             while (hasMoreData)
             {
-                IYubiKeyResponseWithData<Dictionary<int, ReadOnlyMemory<byte>>> response =
-                    connection.SendCommand(new TCommand { Page = (byte)page++ });
-
+                var response = connection.SendCommand(new TCommand { Page = (byte)page++ });
                 if (response.Status == ResponseStatus.Success)
                 {
-                    Dictionary<int, ReadOnlyMemory<byte>> tlvData = response.GetData();
-
-                    foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tlv in tlvData)
+                    var tlvData = response.GetData();
+                    foreach (var tlv in tlvData)
                     {
                         combinedPages.Add(tlv.Key, tlv.Value);
                     }
 
                     const int moreDataTag = 0x10;
 
-                    hasMoreData = tlvData.TryGetValue(moreDataTag, out ReadOnlyMemory<byte> hasMoreDataByte)
+                    hasMoreData = tlvData.TryGetValue(moreDataTag, out var hasMoreDataByte)
                         && hasMoreDataByte.Span.Length == 1
                         && hasMoreDataByte.Span[0] == 1;
                 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoResponseHelper.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/GetDeviceInfoResponseHelper.cs
@@ -54,7 +54,7 @@ namespace Yubico.YubiKey
             while (tlvReader.HasData)
             {
                 int tag = tlvReader.PeekTag();
-                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                var value = tlvReader.ReadValue(tag);
                 result.Add(tag, value);
             }
 
@@ -81,7 +81,7 @@ namespace Yubico.YubiKey
                 };
             }
 
-            Dictionary<int, ReadOnlyMemory<byte>>? result = CreateApduDictionaryFromResponseData(responseApdu.Data);
+            var result = CreateApduDictionaryFromResponseData(responseApdu.Data);
             return result ?? throw new MalformedYubiKeyResponseException
             {
                 ResponseClass = responseClass,

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardConnection.cs
@@ -39,9 +39,8 @@ namespace Yubico.YubiKey
         public TResponse SendCommand<TResponse>(IYubiKeyCommand<TResponse> yubiKeyCommand)
             where TResponse : IYubiKeyResponse
         {
-            CommandApdu apdu = yubiKeyCommand.CreateCommandApdu();
-
-            ResponseApdu responseApdu = _apduPipeline.Invoke(apdu, yubiKeyCommand.GetType(), typeof(TResponse));
+            var commandApdu = yubiKeyCommand.CreateCommandApdu();
+            var responseApdu = _apduPipeline.Invoke(commandApdu, yubiKeyCommand.GetType(), typeof(TResponse));
 
             return yubiKeyCommand.CreateResponseForApdu(responseApdu);
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/KeyboardDeviceInfoFactory.cs
@@ -40,32 +40,32 @@ namespace Yubico.YubiKey
                 throw new ArgumentException(ExceptionMessages.InvalidDeviceNotKeyboard, nameof(device));
             }
 
-            if (!TryGetDeviceInfoFromKeyboard(device, out YubiKeyDeviceInfo? ykDeviceInfo))
+            if (!TryGetDeviceInfoFromKeyboard(device, out var deviceInfo))
             {
-                ykDeviceInfo = new YubiKeyDeviceInfo();
+                deviceInfo = new YubiKeyDeviceInfo();
             }
 
             // Manually fill in gaps, if necessary
             var defaultDeviceInfo = new YubiKeyDeviceInfo();
 
-            if (ykDeviceInfo.SerialNumber == defaultDeviceInfo.SerialNumber
+            if (deviceInfo.SerialNumber == defaultDeviceInfo.SerialNumber
                 && TryGetSerialNumberFromKeyboard(device, out int? serialNumber))
             {
-                ykDeviceInfo.SerialNumber = serialNumber;
+                deviceInfo.SerialNumber = serialNumber;
             }
 
-            if (ykDeviceInfo.FirmwareVersion == defaultDeviceInfo.FirmwareVersion
-                && TryGetFirmwareVersionFromKeyboard(device, out FirmwareVersion? firmwareVersion))
+            if (deviceInfo.FirmwareVersion == defaultDeviceInfo.FirmwareVersion && 
+                TryGetFirmwareVersionFromKeyboard(device, out var firmwareVersion))
             {
-                ykDeviceInfo.FirmwareVersion = firmwareVersion;
+                deviceInfo.FirmwareVersion = firmwareVersion;
             }
 
-            if (ykDeviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && ykDeviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
+            if (deviceInfo.FirmwareVersion < FirmwareVersion.V4_0_0 && deviceInfo.AvailableUsbCapabilities == YubiKeyCapabilities.None)
             {
-                ykDeviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Otp;
+                deviceInfo.AvailableUsbCapabilities = YubiKeyCapabilities.Otp;
             }
 
-            return ykDeviceInfo;
+            return deviceInfo;
         }
 
         private static bool TryGetDeviceInfoFromKeyboard(IHidDevice device, [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo yubiKeyDeviceInfo)
@@ -109,8 +109,7 @@ namespace Yubico.YubiKey
                 Logger.LogInformation("Attempting to read serial number through the keybaord interface.");
                 using var keyboardConnection = new KeyboardConnection(device);
 
-                Otp.Commands.GetSerialNumberResponse response = keyboardConnection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
-
+                var response = keyboardConnection.SendCommand(new GetSerialNumberCommand());
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
@@ -145,8 +144,7 @@ namespace Yubico.YubiKey
                 Logger.LogInformation("Attempting to read firmware version through the keyboard interface.");
                 using var keyboardConnection = new KeyboardConnection(device);
 
-                Otp.Commands.ReadStatusResponse response = keyboardConnection.SendCommand(new Otp.Commands.ReadStatusCommand());
-
+                var response = keyboardConnection.SendCommand(new ReadStatusCommand());
                 if (response.Status == ResponseStatus.Success)
                 {
                     firmwareVersion = response.GetData().FirmwareVersion;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Management/Commands/GetDeviceInfoResponse.cs
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.Management.Commands
                 };
             }
 
-            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
+            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out var deviceInfo))
             {
                 throw new MalformedYubiKeyResponseException
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Code.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Code.cs
@@ -79,7 +79,7 @@ namespace Yubico.YubiKey.Oath
             {
                 Value = value;
 
-                DateTimeOffset timestamp = DateTimeOffset.UtcNow;
+                var timestamp = DateTimeOffset.UtcNow;
 
                 if (period != CredentialPeriod.Undefined)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/CalculateAllCredentialsResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/CalculateAllCredentialsResponse.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.Oath.Commands
             while (tlvReader.HasData)
             {
                 (string? OtpString, int? Digits) response = (null, null);
-                CredentialType type = CredentialType.Totp;
+                var credentialType = CredentialType.Totp;
                 bool requiresTouch = false;
 
                 string label = tlvReader.PeekTag() switch
@@ -94,7 +94,7 @@ namespace Yubico.YubiKey.Oath.Commands
                 {
                     case HotpTag:
                         _ = tlvReader.ReadByte(HotpTag);
-                        type = CredentialType.Hotp;
+                        credentialType = CredentialType.Hotp;
                         break;
 
                     case TouchTag:
@@ -103,12 +103,12 @@ namespace Yubico.YubiKey.Oath.Commands
                         break;
 
                     case FullResponseTag:
-                        ReadOnlyMemory<byte> fullValue = tlvReader.ReadValue(FullResponseTag);
+                        var fullValue = tlvReader.ReadValue(FullResponseTag);
                         response = GetOtpValue(fullValue);
                         break;
 
                     case TruncatedResponseTag:
-                        ReadOnlyMemory<byte> truncatedValue = tlvReader.ReadValue(TruncatedResponseTag);
+                        var truncatedValue = tlvReader.ReadValue(TruncatedResponseTag);
                         response = GetOtpValue(truncatedValue);
                         break;
 
@@ -120,7 +120,7 @@ namespace Yubico.YubiKey.Oath.Commands
                         };
                 }
 
-                Credential credential = FromLabelAndType(label, type);
+                var credential = FromLabelAndType(label, credentialType);
                 credential.RequiresTouch = requiresTouch;
                 credential.Digits = response.Digits;
 
@@ -163,8 +163,8 @@ namespace Yubico.YubiKey.Oath.Commands
                 throw new ArgumentNullException(nameof(label));
             }
 
-            (CredentialPeriod period, string? issuer, string account) = Credential.ParseLabel(label, type);
-            return new Credential(issuer, account, type, period);
+            (var credentialPeriod, string? issuer, string account) = Credential.ParseLabel(label, type);
+            return new Credential(issuer, account, type, credentialPeriod);
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/CalculateCredentialResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/CalculateCredentialResponse.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.Oath.Commands
 
             var tlvReader = new TlvReader(ResponseApdu.Data);
 
-            ReadOnlyMemory<byte> bytes = tlvReader.PeekTag() switch
+            var tlvBytes = tlvReader.PeekTag() switch
             {
                 FullResponseTag => tlvReader.ReadValue(FullResponseTag),
                 TruncatedResponseTag => tlvReader.ReadValue(TruncatedResponseTag),
@@ -88,7 +88,7 @@ namespace Yubico.YubiKey.Oath.Commands
                 }
             };
 
-            if (bytes.Length < 5)
+            if (tlvBytes.Length < 5)
             {
                 throw new MalformedYubiKeyResponseException()
                 {
@@ -97,10 +97,10 @@ namespace Yubico.YubiKey.Oath.Commands
                 };
             }
 
-            int digits = bytes.Span[0];
+            int digits = tlvBytes.Span[0];
             Credential.Digits = digits;
 
-            uint otpValue = BinaryPrimitives.ReadUInt32BigEndian(bytes.Slice(1).Span);
+            uint otpValue = BinaryPrimitives.ReadUInt32BigEndian(tlvBytes.Slice(1).Span);
             otpValue %= (uint)Math.Pow(10, digits);
             string response = otpValue.ToString(CultureInfo.InvariantCulture).PadLeft(digits, '0');
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/ListResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/ListResponse.cs
@@ -92,18 +92,18 @@ namespace Yubico.YubiKey.Oath.Commands
         /// </returns>
         private static Credential _GetCredential(ReadOnlyMemory<byte> value)
         {
-            _ThrowIfNotLength(value, 2);
+            ThrowIfNotLength(value, 2);
 
             byte algorithmType = value.Span[0];
             var algorithm = (HashAlgorithm)(algorithmType & 0x0F);
             var type = (CredentialType)(algorithmType & 0xF0);
             string label = Encoding.UTF8.GetString(value.Slice(1).ToArray());
-            (CredentialPeriod period, string? issuer, string account) = Credential.ParseLabel(label, type);
+            (var credentialPeriod, string? issuer, string account) = Credential.ParseLabel(label, type);
 
-            return new Credential(issuer, account, period, type, algorithm);
+            return new Credential(issuer, account, credentialPeriod, type, algorithm);
         }
 
-        private static void _ThrowIfNotLength(ReadOnlyMemory<byte> value, int minLength)
+        private static void ThrowIfNotLength(ReadOnlyMemory<byte> value, int minLength)
         {
             if (value.Length < minLength)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/OathChallengeResponseBaseCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/OathChallengeResponseBaseCommand.cs
@@ -53,7 +53,7 @@ namespace Yubico.YubiKey.Oath.Commands
         /// </returns>
         protected static byte[] GenerateRandomChallenge()
         {
-            using RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
+            using var randomObject = CryptographyProviders.RngCreator();
 
             byte[] randomBytes = new byte[8];
             randomObject.GetBytes(randomBytes);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/SelectOathResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/SelectOathResponse.cs
@@ -59,9 +59,9 @@ namespace Yubico.YubiKey.Oath.Commands
             }
 
             FirmwareVersion? version = null;
-            ReadOnlyMemory<byte> salt = ReadOnlyMemory<byte>.Empty;
-            ReadOnlyMemory<byte> challenge = ReadOnlyMemory<byte>.Empty;
-            HashAlgorithm algorithm = HashAlgorithm.Sha1;
+            var salt = ReadOnlyMemory<byte>.Empty;
+            var challenge = ReadOnlyMemory<byte>.Empty;
+            var algorithm = HashAlgorithm.Sha1;
 
             var tlvReader = new TlvReader(ResponseApdu.Data);
             while (tlvReader.HasData)
@@ -69,7 +69,7 @@ namespace Yubico.YubiKey.Oath.Commands
                 switch (tlvReader.PeekTag())
                 {
                     case VersionTag:
-                        ReadOnlySpan<byte> firmwareValue = tlvReader.ReadValue(VersionTag).Span;
+                        var firmwareValue = tlvReader.ReadValue(VersionTag).Span;
                         version = new FirmwareVersion
                         {
                             Major = firmwareValue[0],

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/ValidateResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Commands/ValidateResponse.cs
@@ -72,7 +72,7 @@ namespace Yubico.YubiKey.Oath.Commands
             }
 
             var tlvReader = new TlvReader(ResponseApdu.Data);
-            ReadOnlyMemory<byte> value = tlvReader.ReadValue(ResponseTag);
+            var value = tlvReader.ReadValue(ResponseTag);
 
             return value.Span.SequenceEqual(Response.Span);
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Credential.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/Credential.cs
@@ -420,7 +420,7 @@ namespace Yubico.YubiKey.Oath
         /// </returns>
         internal static (CredentialPeriod period, string? issuer, string account) ParseLabel(string label, CredentialType type)
         {
-            CredentialPeriod period = CredentialPeriod.Period30;
+            var credentialPeriod = CredentialPeriod.Period30;
             string? issuer = null;
             string issuerAccount;
 
@@ -430,7 +430,7 @@ namespace Yubico.YubiKey.Oath
 
                 if (parsedLabel.Length > 1)
                 {
-                    period = (CredentialPeriod)ToInt32(parsedLabel[0], NumberFormatInfo.InvariantInfo);
+                    credentialPeriod = (CredentialPeriod)ToInt32(parsedLabel[0], NumberFormatInfo.InvariantInfo);
                     issuerAccount = parsedLabel[1];
                 }
                 else
@@ -441,7 +441,7 @@ namespace Yubico.YubiKey.Oath
             else
             {
                 issuerAccount = label;
-                period = CredentialPeriod.Undefined;
+                credentialPeriod = CredentialPeriod.Undefined;
             }
 
             string[]? parsedAccount = issuerAccount.Split(':');
@@ -458,7 +458,7 @@ namespace Yubico.YubiKey.Oath
 
             string account = parsedAccount.Last();
 
-            return (period, issuer, account);
+            return (credentialPeriod, issuer, account);
         }
 
         /// <summary>
@@ -502,16 +502,16 @@ namespace Yubico.YubiKey.Oath
                 throw new InvalidOperationException(ExceptionMessages.InvalidUriQuery);
             }
 
-            NameValueCollection? parsedUri = HttpUtility.ParseQueryString(uriQuery);
+            var parsedUri = HttpUtility.ParseQueryString(uriQuery);
 
             string? defaultIssuer = parsedUri["issuer"];
             (string? issuer, string account) = ParseUriPath(uriPath, defaultIssuer);
 
             string secret = parsedUri["secret"];
 
-            CredentialType type = uri.Host == "totp" ? CredentialType.Totp : CredentialType.Hotp;
+            var type = uri.Host == "totp" ? CredentialType.Totp : CredentialType.Hotp;
 
-            HashAlgorithm algorithm = HashAlgorithm.Sha1;
+            var algorithm = HashAlgorithm.Sha1;
             string algorithmString = parsedUri["algorithm"];
 
             if (!string.IsNullOrWhiteSpace(algorithmString))
@@ -550,14 +550,14 @@ namespace Yubico.YubiKey.Oath
                 digits = DefaultDigits;
             }
 
-            CredentialPeriod period = CredentialPeriod.Period30;
+            var credentialPeriod = CredentialPeriod.Period30;
             string periodString = parsedUri["period"];
 
             if (!string.IsNullOrWhiteSpace(periodString))
             {
                 if (int.TryParse(periodString, NumberStyles.Any, CultureInfo.InvariantCulture, out int periodInt))
                 {
-                    period = (CredentialPeriod)periodInt;
+                    credentialPeriod = (CredentialPeriod)periodInt;
                 }
                 else
                 {
@@ -578,7 +578,7 @@ namespace Yubico.YubiKey.Oath
                 issuer = Uri.UnescapeDataString(issuer);
             }
 
-            return new Credential(issuer, Uri.UnescapeDataString(account), type, algorithm, secret, period, digits, counter, false);
+            return new Credential(issuer, Uri.UnescapeDataString(account), type, algorithm, secret, credentialPeriod, digits, counter, false);
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.Credential.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.Credential.cs
@@ -38,21 +38,21 @@ namespace Yubico.YubiKey.Oath
         /// </exception>
         public IList<Credential> GetCredentials()
         {
-            var listCommand = new ListCommand();
-            ListResponse listResponse = Connection.SendCommand(listCommand);
+            var command = new ListCommand();
+            var response = Connection.SendCommand(command);
 
-            if (listResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPassword();
-                listResponse = Connection.SendCommand(listCommand);
+                response = Connection.SendCommand(command);
             }
 
-            if (listResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(listResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
 
-            IList<Credential> result = listResponse.GetData();
+            IList<Credential> result = response.GetData();
 
             return result;
         }
@@ -83,21 +83,21 @@ namespace Yubico.YubiKey.Oath
         public IDictionary<Credential, Code> CalculateAllCredentials(
             ResponseFormat responseFormat = ResponseFormat.Truncated)
         {
-            var calculateAllCommand = new CalculateAllCredentialsCommand(responseFormat);
-            CalculateAllCredentialsResponse calculateAllResponse = Connection.SendCommand(calculateAllCommand);
+            var command = new CalculateAllCredentialsCommand(responseFormat);
+            var response = Connection.SendCommand(command);
 
-            if (calculateAllResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPassword();
-                calculateAllResponse = Connection.SendCommand(calculateAllCommand);
+                response = Connection.SendCommand(command);
             }
 
-            if (calculateAllResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(calculateAllResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
 
-            IDictionary<Credential, Code> result = calculateAllResponse.GetData();
+            var result = response.GetData();
 
             return result;
         }
@@ -129,21 +129,21 @@ namespace Yubico.YubiKey.Oath
             Credential credential,
             ResponseFormat responseFormat = ResponseFormat.Truncated)
         {
-            var calculateCommand = new CalculateCredentialCommand(credential, responseFormat);
-            CalculateCredentialResponse calculateResponse = Connection.SendCommand(calculateCommand);
+            var command = new CalculateCredentialCommand(credential, responseFormat);
+            var response = Connection.SendCommand(command);
 
-            if (calculateResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPassword();
-                calculateResponse = Connection.SendCommand(calculateCommand);
+                response = Connection.SendCommand(command);
             }
 
-            if (calculateResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(calculateResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
 
-            Code otpCode = calculateResponse.GetData();
+            var otpCode = response.GetData();
 
             return otpCode;
         }
@@ -187,7 +187,7 @@ namespace Yubico.YubiKey.Oath
             ResponseFormat responseFormat = ResponseFormat.Truncated)
         {
             var credential = new Credential(issuer, account, type, period);
-            Code otpCode = CalculateCredential(credential, responseFormat);
+            var otpCode = CalculateCredential(credential, responseFormat);
 
             return otpCode;
         }
@@ -228,18 +228,18 @@ namespace Yubico.YubiKey.Oath
                 throw new InvalidOperationException(ExceptionMessages.SHA512NotSupported);
             }
 
-            var putCommand = new PutCommand(credential);
-            OathResponse putResponse = Connection.SendCommand(putCommand);
+            var command = new PutCommand(credential);
+            var response = Connection.SendCommand(command);
 
-            if (putResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPassword();
-                putResponse = Connection.SendCommand(putCommand);
+                response = Connection.SendCommand(command);
             }
 
-            if (putResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(putResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -451,18 +451,18 @@ namespace Yubico.YubiKey.Oath
                 throw new InvalidOperationException(ExceptionMessages.RenameCommandNotSupported);
             }
 
-            var renameCommand = new RenameCommand(credential, newIssuer, newAccount);
-            RenameResponse renameResponse = Connection.SendCommand(renameCommand);
+            var command = new RenameCommand(credential, newIssuer, newAccount);
+            var response = Connection.SendCommand(command);
 
-            if (renameResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPassword();
-                renameResponse = Connection.SendCommand(renameCommand);
+                response = Connection.SendCommand(command);
             }
 
-            if (renameResponse.Status != ResponseStatus.Success)
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(renameResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.Password.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.Password.cs
@@ -50,13 +50,13 @@ namespace Yubico.YubiKey.Oath
             {
                 if (KeyCollector!(keyEntryData))
                 {
-                    ReadOnlyMemory<byte> password = keyEntryData.GetCurrentValue();
-                    var validateCommand = new ValidateCommand(password, _oathData);
-                    ValidateResponse verifyResponse = Connection.SendCommand(validateCommand);
-
-                    if (verifyResponse.Status == ResponseStatus.Success)
+                    var password = keyEntryData.GetCurrentValue();
+                    var command = new ValidateCommand(password, _oathData);
+                    
+                    var response = Connection.SendCommand(command);
+                    if (response.Status == ResponseStatus.Success)
                     {
-                        passwordVerified = verifyResponse.GetData();
+                        passwordVerified = response.GetData();
                     }
                 }
             }
@@ -132,22 +132,22 @@ namespace Yubico.YubiKey.Oath
         /// </exception>
         public bool TryVerifyPassword(ReadOnlyMemory<byte> password)
         {
-            var validateCommand = new ValidateCommand(password, _oathData);
-            ValidateResponse verifyResponse = Connection.SendCommand(validateCommand);
+            var command = new ValidateCommand(password, _oathData);
+            var response = Connection.SendCommand(command);
 
-            if (verifyResponse.Status == ResponseStatus.Success)
+            if (response.Status == ResponseStatus.Success)
             {
-                return verifyResponse.GetData();
+                return response.GetData();
             }
 
-            if (verifyResponse.StatusWord == SWConstants.InvalidCommandDataParameter
-                || verifyResponse.StatusWord == SWConstants.ReferenceDataUnusable)
+            if (response.StatusWord == SWConstants.InvalidCommandDataParameter ||
+                response.StatusWord == SWConstants.ReferenceDataUnusable)
             {
                 return false;
             }
 
             // If the response was anything else, that is an error.
-            throw new InvalidOperationException(verifyResponse.StatusMessage);
+            throw new InvalidOperationException(response.StatusMessage);
         }
 
         /// <summary>
@@ -186,8 +186,8 @@ namespace Yubico.YubiKey.Oath
             {
                 if (KeyCollector!(keyEntryData))
                 {
-                    ReadOnlyMemory<byte> currentPassword = keyEntryData.GetCurrentValue();
-                    ReadOnlyMemory<byte> newPassword = keyEntryData.GetNewValue();
+                    var currentPassword = keyEntryData.GetCurrentValue();
+                    var newPassword = keyEntryData.GetNewValue();
 
                     if (currentPassword.Span.SequenceEqual(newPassword.Span))
                     {
@@ -323,12 +323,11 @@ namespace Yubico.YubiKey.Oath
             }
 
             var setPasswordCommand = new SetPasswordCommand(newPassword, _oathData);
-            SetPasswordResponse setPasswordResponse = Connection.SendCommand(setPasswordCommand);
-
+            var setPasswordResponse = Connection.SendCommand(setPasswordCommand);
             if (setPasswordResponse.Status == ResponseStatus.Success)
             {
-                SelectOathResponse response = Connection.SendCommand(new SelectOathCommand());
-                _oathData = response.GetData();
+                var selectOathResponse = Connection.SendCommand(new SelectOathCommand());
+                _oathData = selectOathResponse.GetData();
 
                 return true;
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
@@ -120,15 +120,14 @@ namespace Yubico.YubiKey.Oath
         /// </exception>
         public void ResetApplication()
         {
-            OathResponse resetResponse = Connection.SendCommand(new ResetCommand());
-
-            if (resetResponse.Status != ResponseStatus.Success)
+            var resetOathResponse = Connection.SendCommand(new ResetCommand());
+            if (resetOathResponse.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(resetResponse.StatusMessage);
+                throw new InvalidOperationException(resetOathResponse.StatusMessage);
             }
 
-            SelectOathResponse response = Connection.SendCommand(new SelectOathCommand());
-            _oathData = response.GetData();
+            var selectOathResponse = Connection.SendCommand(new SelectOathCommand());
+            _oathData = selectOathResponse.GetData();
         }
 
         // Checks if the KeyCollector delegate is null

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/ConfigureSlotCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/ConfigureSlotCommand.cs
@@ -51,7 +51,7 @@ namespace Yubico.YubiKey.Otp.Commands
                         fixedData.Length));
             }
 
-            Span<byte> target = ConfigurationBuffer.Slice(FixedDataOffset, FixedDataLength);
+            var target = ConfigurationBuffer.Slice(FixedDataOffset, FixedDataLength);
             fixedData.CopyTo(target);
             // If the data is less than the buffer, make sure the rest is empty.
             if (fixedData.Length < FixedDataLength)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/GetDeviceInfoResponse.cs
@@ -66,7 +66,7 @@ namespace Yubico.YubiKey.Otp.Commands
                 };
             }
 
-            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
+            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out var deviceInfo))
             {
                 throw new MalformedYubiKeyResponseException
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/ReadStatusResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Commands/ReadStatusResponse.cs
@@ -65,23 +65,23 @@ namespace Yubico.YubiKey.Otp.Commands
                 };
             }
 
-            ReadOnlySpan<byte> responseApduData = ResponseApdu.Data.Span;
+            var responseApduSpan = ResponseApdu.Data.Span;
 
             return new OtpStatus
             {
                 FirmwareVersion = new FirmwareVersion
                 {
-                    Major = responseApduData[0],
-                    Minor = responseApduData[1],
-                    Patch = responseApduData[2]
+                    Major = responseApduSpan[0],
+                    Minor = responseApduSpan[1],
+                    Patch = responseApduSpan[2]
                 },
-                SequenceNumber = responseApduData[3],
-                ShortPressConfigured = (responseApduData[4] & ShortPressValidMask) != 0,
-                LongPressConfigured = (responseApduData[4] & LongPressValidMask) != 0,
-                ShortPressRequiresTouch = (responseApduData[4] & ShortPressTouchMask) != 0,
-                LongPressRequiresTouch = (responseApduData[4] & LongPressTouchMask) != 0,
-                LedBehaviorInverted = (responseApduData[4] & LedInvertedMask) != 0,
-                TouchLevel = responseApduData[5],
+                SequenceNumber = responseApduSpan[3],
+                ShortPressConfigured = (responseApduSpan[4] & ShortPressValidMask) != 0,
+                LongPressConfigured = (responseApduSpan[4] & LongPressValidMask) != 0,
+                ShortPressRequiresTouch = (responseApduSpan[4] & ShortPressTouchMask) != 0,
+                LongPressRequiresTouch = (responseApduSpan[4] & LongPressTouchMask) != 0,
+                LedBehaviorInverted = (responseApduSpan[4] & LedInvertedMask) != 0,
+                TouchLevel = responseApduSpan[5],
             };
         }
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/NdefConfig.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/NdefConfig.cs
@@ -111,7 +111,7 @@ namespace Yubico.YubiKey.Otp
                 throw new ArgumentNullException(nameof(languageCode));
             }
 
-            Encoding encoding = encodeAsUtf16 ? Encoding.BigEndianUnicode : Encoding.UTF8;
+            var encoding = encodeAsUtf16 ? Encoding.BigEndianUnicode : Encoding.UTF8;
 
             int languageLength = Encoding.ASCII.GetByteCount(languageCode);
             int valueLength = encoding.GetByteCount(value);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/NdefDataReader.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/NdefDataReader.cs
@@ -91,7 +91,7 @@ namespace Yubico.YubiKey.Otp
 
             Debug.Assert(responseData[2] == 0xD1); // Short Record, Well-known TypeName, Message Begin, Message End
 
-            ReadOnlySpan<byte> recordType = responseData.Slice(TypeOffset, typeLength);
+            var recordType = responseData.Slice(TypeOffset, typeLength);
 
             Type = recordType[0] switch
             {
@@ -131,7 +131,7 @@ namespace Yubico.YubiKey.Otp
             int languageCodeLength = header & languageCodeLengthMask;
             int textOffset = languageCodeLength + 1;
 
-            Encoding encoding = Encoding.UTF8;
+            var encoding = Encoding.UTF8;
             if (isUtf16)
             {
                 bool bomPresent;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/CalculateChallengeResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/CalculateChallengeResponse.cs
@@ -139,7 +139,8 @@ namespace Yubico.YubiKey.Otp.Operations
                         OtpSlot!.Value,
                         _algorithm,
                         _challenge);
-                    ChallengeResponseResponse response = Connection.SendCommand(cmd);
+                    
+                    var response = Connection.SendCommand(cmd);
                     if (response.Status != ResponseStatus.Success)
                     {
                         throw new InvalidOperationException(string.Format(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureChallengeResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureChallengeResponse.cs
@@ -71,11 +71,11 @@ namespace Yubico.YubiKey.Otp.Operations
         /// <inheritdoc/>
         protected override void ExecuteOperation()
         {
-            YubiKeyFlags ykFlags = Settings.YubiKeyFlags;
+            var yubiKeyFlags = Settings.YubiKeyFlags;
 
             var cmd = new ConfigureSlotCommand
             {
-                YubiKeyFlags = ykFlags,
+                YubiKeyFlags = yubiKeyFlags,
                 OtpSlot = OtpSlot!.Value
             };
 
@@ -104,7 +104,7 @@ namespace Yubico.YubiKey.Otp.Operations
                 cmd.ApplyCurrentAccessCode(CurrentAccessCode);
                 cmd.SetAccessCode(NewAccessCode);
 
-                ReadStatusResponse response = Connection.SendCommand(cmd);
+                var response = Connection.SendCommand(cmd);
                 if (response.Status != ResponseStatus.Success)
                 {
                     throw new InvalidOperationException(
@@ -268,7 +268,7 @@ namespace Yubico.YubiKey.Otp.Operations
                 // Handle generating.
                 if (_generateKey.Value)
                 {
-                    using RandomNumberGenerator rng = CryptographyProviders.RngCreator();
+                    using var rng = CryptographyProviders.RngCreator();
                     rng.Fill(_randomKey.Span);
                     _key = _randomKey;
                     // From here forward, we use _key, so we'll release this

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureHotp.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureHotp.cs
@@ -41,11 +41,11 @@ namespace Yubico.YubiKey.Otp.Operations
         /// <inheritdoc/>
         protected override void ExecuteOperation()
         {
-            YubiKeyFlags ykFlags = Settings.YubiKeyFlags;
+            var yubiKeyFlags = Settings.YubiKeyFlags;
 
             var cmd = new ConfigureSlotCommand
             {
-                YubiKeyFlags = ykFlags,
+                YubiKeyFlags = yubiKeyFlags,
                 OtpSlot = OtpSlot!.Value
             };
 
@@ -68,7 +68,8 @@ namespace Yubico.YubiKey.Otp.Operations
                 _key.Span.CopyTo(hotpKey[..HmacKeySize]);
 
                 // Get a span that points to the bytes for the IMF.
-                Span<byte> imf = hotpKey[HmacKeySize..];
+                var imf = hotpKey[HmacKeySize..];
+                
                 // Write it in network order (big endian).
                 BinaryPrimitives.WriteUInt16BigEndian(imf, _imf);
 
@@ -79,7 +80,7 @@ namespace Yubico.YubiKey.Otp.Operations
                 cmd.ApplyCurrentAccessCode(CurrentAccessCode);
                 cmd.SetAccessCode(NewAccessCode);
 
-                ReadStatusResponse response = Connection.SendCommand(cmd);
+                var response = Connection.SendCommand(cmd);
                 if (response.Status != ResponseStatus.Success)
                 {
                     throw new InvalidOperationException(string.Format(
@@ -196,7 +197,7 @@ namespace Yubico.YubiKey.Otp.Operations
             }
             _key = key;
 
-            using RandomNumberGenerator rng = CryptographyProviders.RngCreator();
+            using var rng = CryptographyProviders.RngCreator();
             rng.Fill(key.Span);
             return this;
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureNdef.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureNdef.cs
@@ -68,7 +68,7 @@ namespace Yubico.YubiKey.Otp.Operations
                 ? NdefConfig.CreateUriConfig(_uri!)
                 : NdefConfig.CreateTextConfig(_text!, _languageCode!, _useUtf16);
 
-            ReadStatusResponse response = Connection.SendCommand(new ConfigureNdefCommand(OtpSlot!.Value, configBuffer.Span));
+            var response = Connection.SendCommand(new ConfigureNdefCommand(OtpSlot!.Value, configBuffer.Span));
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(string.Format(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureStaticPassword.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureStaticPassword.cs
@@ -59,11 +59,11 @@ namespace Yubico.YubiKey.Otp.Operations
                 _passwordHidCodes = _passwordHidCodes
                     .Concat(new byte[SlotConfigureBase.MaxPasswordLength - _passwordHidCodes.Length])
                     .ToArray();
-                YubiKeyFlags ykFlags = Settings.YubiKeyFlags;
-
+                
+                var yubiKeyFlags = Settings.YubiKeyFlags;
                 var cmd = new ConfigureSlotCommand
                 {
-                    YubiKeyFlags = ykFlags,
+                    YubiKeyFlags = yubiKeyFlags,
                     OtpSlot = OtpSlot!.Value
                 };
                 cmd.SetFixedData(_passwordHidCodes.AsSpan(0, SlotConfigureBase.FixedDataLength));
@@ -74,7 +74,7 @@ namespace Yubico.YubiKey.Otp.Operations
 
                 try
                 {
-                    ReadStatusResponse response = Connection.SendCommand(cmd);
+                    var response = Connection.SendCommand(cmd);
                     if (response.Status != ResponseStatus.Success)
                     {
                         throw new InvalidOperationException(
@@ -343,7 +343,8 @@ namespace Yubico.YubiKey.Otp.Operations
                     && _generatePassword.HasValue)
                 {
                     var translator = HidCodeTranslator.GetInstance(_keyboardLayout!.Value);
-                    ReadOnlySpan<char> password = _password.Span;
+                    var password = _password.Span;
+                    
                     if (_generatePassword.Value)
                     {
                         GenerateRandomPassword(translator);
@@ -376,8 +377,8 @@ namespace Yubico.YubiKey.Otp.Operations
             // here.
             void GenerateRandomPassword(HidCodeTranslator translator)
             {
-                Span<char> password = _generatedPassword.Span;
-                using RandomNumberGenerator rng = CryptographyProviders.RngCreator();
+                var password = _generatedPassword.Span;
+                using var rng = CryptographyProviders.RngCreator();
                 // Build the table of possible random characters.
                 byte[] hidTable = translator
                     .SupportedHidCodes

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureYubicoOtp.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/ConfigureYubicoOtp.cs
@@ -82,11 +82,10 @@ namespace Yubico.YubiKey.Otp.Operations
         /// <inheritdoc/>
         protected override void ExecuteOperation()
         {
-            YubiKeyFlags ykFlags = Settings.YubiKeyFlags;
-
+            var yubiKeyFlags = Settings.YubiKeyFlags;
             var cmd = new ConfigureSlotCommand
             {
-                YubiKeyFlags = ykFlags,
+                YubiKeyFlags = yubiKeyFlags,
                 OtpSlot = OtpSlot!.Value
             };
             try
@@ -97,7 +96,7 @@ namespace Yubico.YubiKey.Otp.Operations
                 cmd.ApplyCurrentAccessCode(CurrentAccessCode);
                 cmd.SetAccessCode(NewAccessCode);
 
-                ReadStatusResponse response = Connection.SendCommand(cmd);
+                var response = Connection.SendCommand(cmd);
                 if (response.Status != ResponseStatus.Success)
                 {
                     throw new InvalidOperationException(string.Format(
@@ -218,7 +217,7 @@ namespace Yubico.YubiKey.Otp.Operations
         /// <returns>The current <see cref="ConfigureYubicoOtp"/> instance.</returns>
         public ConfigureYubicoOtp UseSerialNumberAsPublicId(Memory<byte>? publicId = null)
         {
-            Memory<byte> serialAsId = publicId ?? new byte[6];
+            var serialAsId = publicId ?? new byte[6];
             var exceptions = new List<Exception>();
             if (!(_useSerialAsPublicId ?? true))
             {
@@ -257,7 +256,7 @@ namespace Yubico.YubiKey.Otp.Operations
             // we won't bother with the MODHEX step.
             // When ykman builds the byte collection, it deals with the serial
             // number as big-endian before converting it, so that's what we'll do.
-            Span<byte> pidSpan = serialAsId.Span;
+            var pidSpan = serialAsId.Span;
             pidSpan[0] = 0xff;
             pidSpan[1] = 0x00;
             BinaryPrimitives.WriteInt32BigEndian(pidSpan[2..], serialNumber!.Value);
@@ -336,7 +335,7 @@ namespace Yubico.YubiKey.Otp.Operations
 
             _privateIdentifier = privateId;
 
-            using RandomNumberGenerator rng = CryptographyProviders.RngCreator();
+            using var rng = CryptographyProviders.RngCreator();
             rng.Fill(privateId.Span);
 
             return this;
@@ -397,7 +396,7 @@ namespace Yubico.YubiKey.Otp.Operations
             }
             _key = key;
 
-            using RandomNumberGenerator rng = CryptographyProviders.RngCreator();
+            using var rng = CryptographyProviders.RngCreator();
             rng.Fill(key.Span);
             return this;
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/DeleteSlotConfiguration.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/DeleteSlotConfiguration.cs
@@ -31,7 +31,7 @@ namespace Yubico.YubiKey.Otp.Operations
             };
             cmd.ApplyCurrentAccessCode(CurrentAccessCode);
 
-            ReadStatusResponse response = Connection.SendCommand(cmd);
+            var response = Connection.SendCommand(cmd);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(string.Format(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/UpdateSlot.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/Operations/UpdateSlot.cs
@@ -29,16 +29,17 @@ namespace Yubico.YubiKey.Otp.Operations
         /// <inheritdoc/>
         protected override void ExecuteOperation()
         {
-            YubiKeyFlags ykFlags = Settings.YubiKeyFlags;
-            var cmd = new UpdateSlotCommand
+            var yubiKeyFlags = Settings.YubiKeyFlags;
+            var command = new UpdateSlotCommand
             {
-                YubiKeyFlags = ykFlags,
+                YubiKeyFlags = yubiKeyFlags,
                 OtpSlot = OtpSlot!.Value
             };
-            cmd.ApplyCurrentAccessCode(CurrentAccessCode);
-            cmd.SetAccessCode(NewAccessCode);
+            
+            command.ApplyCurrentAccessCode(CurrentAccessCode);
+            command.SetAccessCode(NewAccessCode);
 
-            ReadStatusResponse response = Connection.SendCommand(cmd);
+            var response = Connection.SendCommand(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(string.Format(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
@@ -180,8 +180,7 @@ namespace Yubico.YubiKey.Otp
                 throw new InvalidOperationException(ExceptionMessages.OtpSlotsNotConfigured);
             }
 
-            ReadStatusResponse swapResponse = _connection.SendCommand(new SwapSlotsCommand());
-
+            var swapResponse = _connection.SendCommand(new SwapSlotsCommand());
             if (swapResponse.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(swapResponse.StatusMessage);
@@ -245,7 +244,7 @@ namespace Yubico.YubiKey.Otp
             ReadNdefDataResponse response;
             using (_connection = YubiKey.Connect(YubiKeyApplication.OtpNdef))
             {
-                OtpResponse selectResponse = _connection.SendCommand(new SelectNdefDataCommand() { FileID = NdefFileId.Ndef });
+                var selectResponse = _connection.SendCommand(new SelectNdefDataCommand() { FileID = NdefFileId.Ndef });
                 if (selectResponse.Status != ResponseStatus.Success)
                 {
                     throw new InvalidOperationException(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSettings.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSettings.cs
@@ -63,11 +63,12 @@ namespace Yubico.YubiKey.Otp
                 int bitmask = 0;
                 try
                 {
-                    foreach (Flag flag in FlagsSet.Where(k => k != Flag.None))
+                    foreach (var flag in FlagsSet.Where(k => k != Flag.None))
                     {
-                        OtpFlagItem flagItem = _flagDefinitions[flag];
+                        var flagItem = _flagDefinitions[flag];
+                        
                         // Doing this here makes the RequiredOr check easier.
-                        Flag requiredOr =
+                        var requiredOr =
                             flagItem.RequiredOrFlags == Flag.None
                             ? flag
                             : flagItem.RequiredOrFlags;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
@@ -46,13 +46,13 @@ namespace Yubico.YubiKey.Pipelines
                 return _pipeline.Invoke(command, commandType, responseType);
             }
 
-            ReadOnlyMemory<byte> sourceData = command.Data;
+            var sourceData = command.Data;
             ResponseApdu? responseApdu = null;
 
             while (!sourceData.IsEmpty)
             {
                 int length = Math.Min(MaxSize, sourceData.Length);
-                ReadOnlyMemory<byte> data = sourceData.Slice(0, length);
+                var data = sourceData.Slice(0, length);
                 sourceData = sourceData.Slice(length);
 
                 var partialApdu = new CommandApdu

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/FidoErrorTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/FidoErrorTransform.cs
@@ -33,7 +33,7 @@ namespace Yubico.YubiKey.Pipelines
         /// <inheritdoc />
         public ResponseApdu Invoke(CommandApdu command, Type commandType, Type responseType)
         {
-            ResponseApdu fidoResponse = _nextTransform.Invoke(
+            var fidoResponse = _nextTransform.Invoke(
                 command,
                 commandType,
                 responseType);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/FidoTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/FidoTransform.cs
@@ -85,15 +85,13 @@ namespace Yubico.YubiKey.Pipelines
             }
 
             byte[] responseData = TransmitCommand(_channelId!.Value, ctapCmd, ctapData, out byte responseByte);
-
-            ResponseApdu responseApdu =
-                responseByte switch
-                {
-                    Ctap1Message => new ResponseApdu(responseData),
-                    CtapHidCbor => CtapToApduResponse.ToCtap2ResponseApdu(responseData),
-                    CtapError => CtapToApduResponse.ToCtap1ResponseApdu(responseData),
-                    _ => new ResponseApdu(responseData, SWConstants.Success),
-                };
+            var responseApdu = responseByte switch
+            {
+                Ctap1Message => new ResponseApdu(responseData),
+                CtapHidCbor => CtapToApduResponse.ToCtap2ResponseApdu(responseData),
+                CtapError => CtapToApduResponse.ToCtap1ResponseApdu(responseData),
+                _ => new ResponseApdu(responseData, SWConstants.Success),
+            };
 
             return responseApdu;
         }
@@ -132,11 +130,9 @@ namespace Yubico.YubiKey.Pipelines
         }
 
         // This function applies a mask to remove the initial frame identifier (0x80)
-        private static byte GetPacketCmd(byte[] packet) =>
-            (byte)(packet[4] & ~0x80);
+        private static byte GetPacketCmd(byte[] packet) => (byte)(packet[4] & ~0x80);
 
-        private static int GetPacketBcnt(byte[] packet) =>
-            (packet[5] << 8) | packet[6];
+        private static int GetPacketBcnt(byte[] packet) => (packet[5] << 8) | packet[6];
 
         private byte[] TransmitCommand(uint channelId, byte commandByte, byte[] data, out byte responseByte)
         {
@@ -157,7 +153,10 @@ namespace Yubico.YubiKey.Pipelines
         {
             // send init request packet
             bool requestFitsInInit = data.Length <= InitDataSize;
-            ReadOnlySpan<byte> dataInInitPacket = requestFitsInInit ? data : data.Slice(0, InitDataSize);
+            var dataInInitPacket = requestFitsInInit
+                ? data
+                : data.Slice(0, InitDataSize);
+
             _hidConnection.SetReport(ConstructInitPacket(channelId, commandByte, dataInInitPacket, data.Length));
 
             if (!requestFitsInInit)
@@ -172,6 +171,7 @@ namespace Yubico.YubiKey.Pipelines
                     data = data[ContinuationDataSize..];
                     seq++;
                 }
+
                 _hidConnection.SetReport(ConstructContinuationPacket(channelId, seq, data));
             }
         }
@@ -213,11 +213,15 @@ namespace Yubico.YubiKey.Pipelines
             {
                 if (!(QueryCancel is null) && QueryCancel(commandByte))
                 {
-                    _hidConnection.SetReport(ConstructInitPacket(channelId, CtapHidCancelCmd, ReadOnlySpan<byte>.Empty, 0));
+                    _hidConnection.SetReport(
+                        ConstructInitPacket(channelId, CtapHidCancelCmd, ReadOnlySpan<byte>.Empty, 0));
+
                     QueryCancel = null;
                 }
+
                 responseInitPacket = _hidConnection.GetReport();
             }
+
             int responseDataLength = GetPacketBcnt(responseInitPacket);
 
             if (responseDataLength > MaxPayloadSize)
@@ -242,6 +246,7 @@ namespace Yubico.YubiKey.Pipelines
                     continuationPacket.AsSpan(ContinuationHeaderSize).CopyTo(responseData.AsSpan(bytesRead));
                     bytesRead += ContinuationDataSize;
                 }
+
                 byte[] lastContinuationPacket = _hidConnection.GetReport();
                 lastContinuationPacket.AsSpan(ContinuationHeaderSize).CopyTo(responseData.AsSpan(bytesRead));
             }
@@ -261,7 +266,7 @@ namespace Yubico.YubiKey.Pipelines
             rng.GetBytes(nonce);
             byte[] response = TransmitCommand(CtapHidBroadcastChannelId, CtapHidInitCmd, nonce, out _);
 
-            Span<byte> receivedNonce = response.AsSpan(0, 8);
+            var receivedNonce = response.AsSpan(0, 8);
 
             if (!nonce.AsSpan().SequenceEqual(receivedNonce))
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/KeyboardTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/KeyboardTransform.cs
@@ -119,7 +119,7 @@ namespace Yubico.YubiKey.Pipelines
         private void HandleSlotRequestInstruction(CommandApdu apdu, KeyboardFrameReader frameReader, bool configInstruction)
         {
             KeyboardReport? report = null;
-            foreach (KeyboardReport featureReport in apdu.GetHidReports())
+            foreach (var featureReport in apdu.GetHidReports())
             {
                 _log.LogInformation("Wait for write pending...");
 
@@ -215,7 +215,7 @@ namespace Yubico.YubiKey.Pipelines
             int timeLimitMs = shortTimeout ? 1023 : 14000;
             int sleepDurationMs = shortTimeout ? 1 : 250;
             int growthFactor = shortTimeout ? 2 : 1;
-            Stopwatch stopwatch = Stopwatch.StartNew();
+            var stopwatch = Stopwatch.StartNew();
 
             while (stopwatch.ElapsedMilliseconds < timeLimitMs)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/OtpErrorTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/OtpErrorTransform.cs
@@ -56,15 +56,15 @@ namespace Yubico.YubiKey.Pipelines
 
             try
             {
-                ResponseApdu response = _nextTransform.Invoke(command, commandType, responseType);
-                int afterSequence = new ReadStatusResponse(response).GetData().SequenceNumber;
+                var responseApdu = _nextTransform.Invoke(command, commandType, responseType);
+                int afterSequence = new ReadStatusResponse(responseApdu).GetData().SequenceNumber;
                 int expectedSequence = (beforeSequence + 1) % 0x100;
 
                 // If we see the sequence number change, we can assume that the configuration was applied successfully. Otherwise
                 // we just invent an error in the response.
                 return afterSequence != expectedSequence
-                    ? new ResponseApdu(response.Data.ToArray(), SWConstants.WarningNvmUnchanged)
-                    : response;
+                    ? new ResponseApdu(responseApdu.Data.ToArray(), SWConstants.WarningNvmUnchanged)
+                    : responseApdu;
             }
             catch (KeyboardConnectionException e)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/ResponseChainingTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/ResponseChainingTransform.cs
@@ -44,38 +44,38 @@ namespace Yubico.YubiKey.Pipelines
                 throw new ArgumentNullException(nameof(command));
             }
 
-            ResponseApdu response = _pipeline.Invoke(command, commandType, responseType);
+            var responseApdu = _pipeline.Invoke(command, commandType, responseType);
 
             // Unless we see that bytes are available, there's nothing for this transform to do.
-            if (response.SW1 != SW1Constants.BytesAvailable)
+            if (responseApdu.SW1 != SW1Constants.BytesAvailable)
             {
-                return response;
+                return responseApdu;
             }
 
             var tempBuffer = new List<byte>();
 
             do
             {
-                tempBuffer.AddRange(response.Data.ToArray());
+                tempBuffer.AddRange(responseApdu.Data.ToArray());
 
                 // Note that OATH uses its own "get response" command.
                 // See OathResponseChainingTransform
-                IYubiKeyCommand<YubiKeyResponse> getResponseCommand =
-                    CreateGetResponseCommand(command, response.SW2);
+                var getResponseCommand =
+                    CreateGetResponseCommand(command, responseApdu.SW2);
 
-                response = _pipeline.Invoke(
+                responseApdu = _pipeline.Invoke(
                     getResponseCommand.CreateCommandApdu(),
                     commandType,
                     responseType);
             }
-            while (response.SW1 == SW1Constants.BytesAvailable);
+            while (responseApdu.SW1 == SW1Constants.BytesAvailable);
 
-            if (response.SW == SWConstants.Success)
+            if (responseApdu.SW == SWConstants.Success)
             {
-                tempBuffer.AddRange(response.Data.ToArray());
+                tempBuffer.AddRange(responseApdu.Data.ToArray());
             }
 
-            return new ResponseApdu(tempBuffer.ToArray(), response.SW);
+            return new ResponseApdu(tempBuffer.ToArray(), responseApdu.SW);
         }
 
         protected virtual IYubiKeyCommand<YubiKeyResponse> CreateGetResponseCommand(CommandApdu originatingCommand, short SW2) =>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/AesForManagementKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/AesForManagementKey.cs
@@ -79,7 +79,7 @@ namespace Yubico.YubiKey.Piv.Commands
                         ExceptionMessages.IncorrectAesKeyLength));
             }
 
-            using Aes aesObject = CryptographyProviders.AesCreator();
+            using var aesObject = CryptographyProviders.AesCreator();
 #pragma warning disable CA5358 // Allow the usage of cipher mode 'ECB' per the standard
             aesObject.Mode = CipherMode.ECB;
 #pragma warning restore CA5358

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/AuthenticateResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/AuthenticateResponse.cs
@@ -128,8 +128,8 @@ namespace Yubico.YubiKey.Piv.Commands
         private byte[] ExtractGeneralAuthenticateResponseData()
         {
             var tlvReader = new TlvReader(ResponseApdu.Data);
-            TlvReader dataReader = tlvReader.ReadNestedTlv(NestedTag);
-            ReadOnlyMemory<byte> value = dataReader.ReadValue(ResponseTag);
+            var dataReader = tlvReader.ReadNestedTlv(NestedTag);
+            var value = dataReader.ReadValue(ResponseTag);
 
             return value.ToArray();
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/CompleteAuthenticateManagementKeyCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/CompleteAuthenticateManagementKeyCommand.cs
@@ -169,7 +169,7 @@ namespace Yubico.YubiKey.Piv.Commands
 
             Algorithm = initializeAuthenticationResponse.Algorithm;
 
-            (bool isMutual, ReadOnlyMemory<byte> clientAuthenticationChallenge) = initializeAuthenticationResponse.GetData();
+            (bool isMutual, var clientAuthenticationChallenge) = initializeAuthenticationResponse.GetData();
             _isMutual = isMutual;
 
             // With single auth, encrypt the challenge. Mutual decrypts.
@@ -209,7 +209,7 @@ namespace Yubico.YubiKey.Piv.Commands
             if (_isMutual)
             {
                 // For mutual auth, we will decrypt the witness
-                using RandomNumberGenerator randomObject = CryptographyProviders.RngCreator();
+                using var randomObject = CryptographyProviders.RngCreator();
                 randomObject.GetBytes(_buffer, ExpectedResponseOffset * _blockSize, _blockSize);
 
                 // The app will send the YubiKey a challenge in the clear. The

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/CompleteAuthenticateManagementKeyResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/CompleteAuthenticateManagementKeyResponse.cs
@@ -152,9 +152,9 @@ namespace Yubico.YubiKey.Piv.Commands
                     var tlvReader = new TlvReader(ResponseApdu.Data);
                     if (tlvReader.TryReadNestedTlv(out tlvReader, EncodingTag))
                     {
-                        if (tlvReader.TryReadValue(out ReadOnlyMemory<byte> responseValue, ResponseTag))
+                        if (tlvReader.TryReadValue(out var tlvBytes, ResponseTag))
                         {
-                            return MemoryExtensions.SequenceEqual(responseValue.Span, YubiKeyAuthenticationExpectedResponse.Span)
+                            return tlvBytes.Span.SequenceEqual(YubiKeyAuthenticationExpectedResponse.Span)
                                 ? AuthenticateManagementKeyResult.MutualFullyAuthenticated
                                 : AuthenticateManagementKeyResult.MutualYubiKeyAuthenticationFailed;
                         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairCommand.cs
@@ -306,8 +306,9 @@ namespace Yubico.YubiKey.Piv.Commands
             }
 
             data[IndexValueLength] = (byte)valueLength;
-            Span<byte> returnValue = data.AsSpan(0, length);
-            return returnValue.ToArray();
+            var apduData = data.AsSpan(0, length);
+            
+            return apduData.ToArray();
         }
 
         /// <inheritdoc />

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/InitializeAuthenticateManagementKeyResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/InitializeAuthenticateManagementKeyResponse.cs
@@ -113,9 +113,9 @@ namespace Yubico.YubiKey.Piv.Commands
             // just ignore any extra bytes.
             var tlvReader = new TlvReader(ResponseApdu.Data);
             int nestedTag = tlvReader.PeekTag();
-            TlvReader authReader = tlvReader.ReadNestedTlv(nestedTag);
+            var authReader = tlvReader.ReadNestedTlv(nestedTag);
             int authTag = authReader.PeekTag();
-            ReadOnlyMemory<byte> value = authReader.ReadValue(authTag);
+            var value = authReader.ReadValue(authTag);
 
             if (nestedTag != NestedTag || (authTag != MutualAuthTag && authTag != SingleAuthTag))
             {
@@ -124,6 +124,7 @@ namespace Yubico.YubiKey.Piv.Commands
                     ResponseClass = nameof(InitializeAuthenticateManagementKeyResponse),
                 };
             }
+            
             if (value.Length < TDesDataLength)
             {
                 throw new MalformedYubiKeyResponseException()

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/TripleDesForManagementKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/TripleDesForManagementKey.cs
@@ -239,7 +239,7 @@ namespace Yubico.YubiKey.Piv.Commands
         // Build this object to use TripleDES with the given key.
         private ICryptoTransform BuildTripleDes(byte[] keyData)
         {
-            using TripleDES tripleDesObject = CryptographyProviders.TripleDesCreator();
+            using var tripleDesObject = CryptographyProviders.TripleDesCreator();
 #pragma warning disable CA5358 // Allow the usage of cipher mode 'ECB'
             tripleDesObject.Mode = CipherMode.ECB;
 #pragma warning restore CA5358
@@ -268,7 +268,7 @@ namespace Yubico.YubiKey.Piv.Commands
                     return BuildDesWithWeakKey(keyData);
                 }
 #pragma warning restore CA5351
-                using DES desObject = CryptographyProviders.DesCreator();
+                using var desObject = CryptographyProviders.DesCreator();
 #pragma warning disable CA5358 // Allow the usage of cipher mode 'ECB'
                 desObject.Mode = CipherMode.ECB;
 #pragma warning restore CA5358
@@ -322,11 +322,11 @@ namespace Yubico.YubiKey.Piv.Commands
             try
             {
 #pragma warning disable CA5358 // Allow the usage of cipher mode 'ECB'
-                using TripleDES tripleDesObject = CryptographyProviders.TripleDesCreator();
+                using var tripleDesObject = CryptographyProviders.TripleDesCreator();
                 tripleDesObject.Mode = CipherMode.ECB;
                 tripleDesObject.Padding = PaddingMode.None;
 
-                using DES desObject = CryptographyProviders.DesCreator();
+                using var desObject = CryptographyProviders.DesCreator();
                 desObject.Mode = CipherMode.ECB;
                 desObject.Padding = PaddingMode.None;
 #pragma warning restore CA5358

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VersionResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/VersionResponse.cs
@@ -93,12 +93,12 @@ namespace Yubico.YubiKey.Piv.Commands
                 };
             }
 
-            ReadOnlySpan<byte> responseApduData = ResponseApdu.Data.Span;
+            var responseApduDataSpan = ResponseApdu.Data.Span;
             return new FirmwareVersion
             {
-                Major = responseApduData[0],
-                Minor = responseApduData[1],
-                Patch = responseApduData[2]
+                Major = responseApduDataSpan[0],
+                Minor = responseApduDataSpan[1],
+                Patch = responseApduDataSpan[2]
             };
         }
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/AdminData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/AdminData.cs
@@ -426,21 +426,21 @@ namespace Yubico.YubiKey.Piv.Objects
             // If we have read this before, the XOR will clear the bit.
             elementsRead ^= SaltRead;
 
-            bool isValid = tlvReader.TryReadValue(out ReadOnlyMemory<byte> salt, SaltTag);
+            bool isValid = tlvReader.TryReadValue(out var saltBytes, SaltTag);
             if (isValid)
             {
-                if (salt.Length == 0)
+                if (saltBytes.Length == 0)
                 {
                     Salt = null;
                     return true;
                 }
 
-                if (salt.Length != SaltLength)
+                if (saltBytes.Length != SaltLength)
                 {
                     return false;
                 }
 
-                salt.CopyTo(_salt);
+                saltBytes.CopyTo(_salt);
                 Salt = _salt;
                 isValid = (elementsRead & SaltRead) != 0;
             }
@@ -464,13 +464,13 @@ namespace Yubico.YubiKey.Piv.Objects
             // Also, if the length is 0, there is no date, we'll want the
             // property to be null. It was set to null when we called Clear
             // before decoding.
-            bool isValid = tlvReader.TryReadValue(out ReadOnlyMemory<byte> theTime, DateTag);
-            isValid = isValid && theTime.Length <= 8;
+            bool isValid = tlvReader.TryReadValue(out var theTimeAsBytes, DateTag);
+            isValid = isValid && theTimeAsBytes.Length <= 8;
 
-            if (isValid && theTime.Length > 0)
+            if (isValid && theTimeAsBytes.Length > 0)
             {
                 var cpyObj = new Memory<byte>(new byte[8]);
-                theTime.CopyTo(cpyObj);
+                theTimeAsBytes.CopyTo(cpyObj);
                 long unixTimeSeconds = BinaryPrimitives.ReadInt64LittleEndian(cpyObj.Span);
                 PinLastUpdated = DateTimeOffset.FromUnixTimeSeconds(unixTimeSeconds).UtcDateTime;
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/CardCapabilityContainer.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/CardCapabilityContainer.cs
@@ -213,7 +213,7 @@ namespace Yubico.YubiKey.Piv.Objects
             _log.LogInformation("Set the CardId of CardCapabilityContainer with a random value.");
             Clear();
 
-            using (RandomNumberGenerator randomObject = CryptographyProviders.RngCreator())
+            using (var randomObject = CryptographyProviders.RngCreator())
             {
                 randomObject.GetBytes(_uniqueCardIdentifier, CardIdOffset, CardIdLength);
             }
@@ -351,7 +351,7 @@ namespace Yubico.YubiKey.Piv.Objects
             if (isValid)
             {
                 _log.LogInformation("Decode data into CardCapabilityContainer: UniqueId.");
-                if (tlvReader.TryReadValue(out ReadOnlyMemory<byte> encodedUniqueId, UniqueCardIdTag))
+                if (tlvReader.TryReadValue(out var encodedUniqueId, UniqueCardIdTag))
                 {
                     if (encodedUniqueId.Length == UniqueCardIdLength &&
                         MemoryExtensions.SequenceEqual<byte>(encodedUniqueId.Slice(AidOffset, AidLength).Span, ApplicationIdentifier.Span))
@@ -380,34 +380,34 @@ namespace Yubico.YubiKey.Piv.Objects
             }
 
             _log.LogInformation("Decode data into CardCapabilityContainer: FixedValues.");
-            bool returnValue = isValid;
+            bool readSuccessful = isValid;
 
-            Tuple<int, int, byte>[] elementList = GetFixedTupleArray();
+            var elementList = GetFixedTupleArray();
 
             int index = 0;
-            while (returnValue && index < elementList.Length)
+            while (readSuccessful && index < elementList.Length)
             {
                 if (elementList[index].Item2 == 0)
                 {
-                    returnValue = tlvReader.TryReadValue(out ReadOnlyMemory<byte> currentValue, elementList[index].Item1) &&
+                    readSuccessful = tlvReader.TryReadValue(out var currentValue, elementList[index].Item1) &&
                               currentValue.Length == elementList[index].Item2;
                 }
                 else
                 {
-                    returnValue = tlvReader.TryReadByte(out byte currentValue, elementList[index].Item1) &&
+                    readSuccessful = tlvReader.TryReadByte(out byte currentValue, elementList[index].Item1) &&
                         currentValue == elementList[index].Item3;
                 }
 
                 index++;
             }
 
-            return returnValue;
+            return readSuccessful;
         }
 
         private void WriteFixedValues(TlvWriter tlvWriter)
         {
-            Tuple<int, int, byte>[] elementList = GetFixedTupleArray();
-            ReadOnlySpan<byte> emptySpan = ReadOnlySpan<byte>.Empty;
+            var elementList = GetFixedTupleArray();
+            var emptySpan = ReadOnlySpan<byte>.Empty;
 
             int index = 0;
             do

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/CardholderUniqueId.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/CardholderUniqueId.cs
@@ -155,7 +155,7 @@ namespace Yubico.YubiKey.Piv.Objects
             _log.LogInformation("Set the GUID of CardholderUniqueId with a random value.");
             Clear();
 
-            using (RandomNumberGenerator randomObject = CryptographyProviders.RngCreator())
+            using (var randomObject = CryptographyProviders.RngCreator())
             {
                 randomObject.GetBytes(_guidValue, 0, GuidLength);
             }
@@ -217,7 +217,7 @@ namespace Yubico.YubiKey.Piv.Objects
             //      3e 00
             //      fe 00
             var tlvWriter = new TlvWriter();
-            ReadOnlySpan<byte> emptySpan = ReadOnlySpan<byte>.Empty;
+            var emptySpan = ReadOnlySpan<byte>.Empty;
             using (tlvWriter.WriteNestedTlv(EncodingTag))
             {
                 tlvWriter.WriteValue(FascNumberTag, FascNumber.Span);
@@ -278,7 +278,7 @@ namespace Yubico.YubiKey.Piv.Objects
             if (isValid)
             {
                 _log.LogInformation("Decode data into CardholderUniqueId: FascNumber.");
-                if (tlvReader.TryReadValue(out ReadOnlyMemory<byte> encodedFascn, FascNumberTag))
+                if (tlvReader.TryReadValue(out var encodedFascn, FascNumberTag))
                 {
                     if (MemoryExtensions.SequenceEqual<byte>(encodedFascn.Span, FascNumber.Span))
                     {
@@ -302,12 +302,12 @@ namespace Yubico.YubiKey.Piv.Objects
             if (isValid)
             {
                 _log.LogInformation("Decode data into CardholderUniqueId: Guid.");
-                if (tlvReader.TryReadValue(out ReadOnlyMemory<byte> encodedGuid, GuidTag))
+                if (tlvReader.TryReadValue(out var encodedGuidBytes, GuidTag))
                 {
-                    if (encodedGuid.Length == GuidLength)
+                    if (encodedGuidBytes.Length == GuidLength)
                     {
                         var dest = new Memory<byte>(_guidValue);
-                        encodedGuid.CopyTo(dest);
+                        encodedGuidBytes.CopyTo(dest);
                         return true;
                     }
                 }
@@ -339,9 +339,9 @@ namespace Yubico.YubiKey.Piv.Objects
             if (isValid)
             {
                 _log.LogInformation("Decode data into CardholderUniqueId: TrailingElements.");
-                if (tlvReader.TryReadValue(out ReadOnlyMemory<byte> signature, SignatureTag))
+                if (tlvReader.TryReadValue(out var signatureBytes, SignatureTag))
                 {
-                    if (signature.Length == 0 && tlvReader.TryReadValue(out ReadOnlyMemory<byte> lrc, LrcTag))
+                    if (signatureBytes.Length == 0 && tlvReader.TryReadValue(out var lrc, LrcTag))
                     {
                         if (lrc.Length == 0 && !tlvReader.HasData)
                         {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/KeyHistory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/KeyHistory.cs
@@ -250,7 +250,7 @@ namespace Yubico.YubiKey.Piv.Objects
             //      FE 00
             byte onCard = 0;
             byte offCard = 0;
-            ReadOnlyMemory<byte> offCardUrl = ReadOnlyMemory<byte>.Empty;
+            var offCardUrl = ReadOnlyMemory<byte>.Empty;
             var tlvReader = new TlvReader(encodedData);
             bool isValid = tlvReader.TryReadNestedTlv(out tlvReader, EncodingTag);
             if (isValid)
@@ -267,7 +267,7 @@ namespace Yubico.YubiKey.Piv.Objects
             }
             if (isValid)
             {
-                isValid = tlvReader.TryReadValue(out ReadOnlyMemory<byte> unusedData, UnusedTag);
+                isValid = tlvReader.TryReadValue(out var unusedData, UnusedTag);
                 if (isValid)
                 {
                     isValid = unusedData.Length == 0;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PinProtectedData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Objects/PinProtectedData.cs
@@ -221,7 +221,7 @@ namespace Yubico.YubiKey.Piv.Objects
             //      88 1A                       (or 12 or 22)
             //         89 18                    (or 10 or 20)
             //            --management key--
-            ReadOnlyMemory<byte> mgmtKey = ReadOnlyMemory<byte>.Empty;
+            var managementKey = ReadOnlyMemory<byte>.Empty;
             var tlvReader = new TlvReader(encodedData);
 
             bool isValid = true;
@@ -232,21 +232,21 @@ namespace Yubico.YubiKey.Piv.Objects
                 {
                     0 => tlvReader.TryReadNestedTlv(out tlvReader, EncodingTag),
                     1 => tlvReader.TryReadNestedTlv(out tlvReader, PinProtectedTag),
-                    2 => tlvReader.TryReadValue(out mgmtKey, MgmtKeyTag),
+                    2 => tlvReader.TryReadValue(out managementKey, MgmtKeyTag),
                     _ => false,
                 };
 
                 count++;
             }
 
-            if (IsValidKeyLength(mgmtKey.Length))
+            if (IsValidKeyLength(managementKey.Length))
             {
-                mgmtKey.CopyTo(_mgmtKey);
-                ManagementKey = _mgmtKey.Slice(0, mgmtKey.Length);
+                managementKey.CopyTo(_mgmtKey);
+                ManagementKey = _mgmtKey.Slice(0, managementKey.Length);
             }
             else
             {
-                if (mgmtKey.Length != 0)
+                if (managementKey.Length != 0)
                 {
                     isValid = false;
                 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivBioMetadata.cs
@@ -61,7 +61,7 @@ namespace Yubico.YubiKey.Piv
             while (tlvReader.HasData)
             {
                 int tag = tlvReader.PeekTag();
-                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                var value = tlvReader.ReadValue(tag);
 
                 switch (tag)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivDataTagExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivDataTagExtensions.cs
@@ -63,8 +63,7 @@ namespace Yubico.YubiKey.Piv
         /// </returns>
         public static bool IsValidEncodingForPut(this PivDataTag tag, ReadOnlyMemory<byte> encoding)
         {
-            TlvReader? tlvReader = GetTlvReader(tag, encoding);
-
+            var tlvReader = GetTlvReader(tag, encoding);
             if (tlvReader is null)
             {
                 return false;
@@ -334,7 +333,7 @@ namespace Yubico.YubiKey.Piv
             try
             {
                 var tlvReader = new TlvReader(encoding);
-                TlvReader nestedReader = tlvReader.ReadNestedTlv(expectedTag);
+                var nestedReader = tlvReader.ReadNestedTlv(expectedTag);
 
                 if (tlvReader.HasData == false)
                 {
@@ -364,10 +363,10 @@ namespace Yubico.YubiKey.Piv
         // will need to update this code.
         private static bool VerifyTagLength(TlvReader tlvReader, int[] expectedFormat, int optionalIndex)
         {
-            bool returnValue = true;
+            bool verifySuccess = true;
             int index = 0;
 
-            while (returnValue && index < expectedFormat.Length)
+            while (verifySuccess && index < expectedFormat.Length)
             {
                 try
                 {
@@ -389,9 +388,9 @@ namespace Yubico.YubiKey.Piv
                         }
                     }
 
-                    ReadOnlyMemory<byte> value = tlvReader.ReadValue(expectedFormat[index]);
+                    var value = tlvReader.ReadValue(expectedFormat[index]);
 
-                    returnValue = expectedFormat[index + 1] != 0
+                    verifySuccess = expectedFormat[index + 1] != 0
                         ? value.Length <= expectedFormat[index + 1]
                         : value.Length == expectedFormat[index + 2];
 
@@ -399,11 +398,11 @@ namespace Yubico.YubiKey.Piv
                 }
                 catch (TlvException)
                 {
-                    returnValue = false;
+                    verifySuccess = false;
                 }
             }
 
-            return returnValue;
+            return verifySuccess;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
@@ -109,7 +109,7 @@ namespace Yubico.YubiKey.Piv
                         ExceptionMessages.InvalidPrivateKeyData));
             }
 
-            ReadOnlyMemory<byte> value = tlvReader.ReadValue(EccTag);
+            var value = tlvReader.ReadValue(EccTag);
 
             return new PivEccPrivateKey(value.Span);
         }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivMetadata.cs
@@ -175,7 +175,7 @@ namespace Yubico.YubiKey.Piv
             while (tlvReader.HasData)
             {
                 int tag = tlvReader.PeekTag();
-                ReadOnlyMemory<byte> value = tlvReader.ReadValue(tag);
+                var value = tlvReader.ReadValue(tag);
 
                 switch (tag)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPublicKey.cs
@@ -125,9 +125,8 @@ namespace Yubico.YubiKey.Piv
         {
             // Try to decode as an RSA public key. If that works, we're done. If
             // not, try ECC. If that doesn't work, exception.
-            bool isCreated = PivRsaPublicKey.TryCreate(out PivPublicKey publicKeyObject, encodedPublicKey);
-
-            if (isCreated == false)
+            bool isCreated = PivRsaPublicKey.TryCreate(out var publicKeyObject, encodedPublicKey);
+            if (!isCreated)
             {
                 if (PivEccPublicKey.TryCreate(out publicKeyObject, encodedPublicKey) == false)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPrivateKey.cs
@@ -202,7 +202,7 @@ namespace Yubico.YubiKey.Piv
                 }
 
                 int tag = tlvReader.PeekTag();
-                ReadOnlyMemory<byte> temp = tlvReader.ReadValue(tag);
+                var temp = tlvReader.ReadValue(tag);
                 if (tag <= 0 || tag > CrtComponentCount)
                 {
                     continue;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Crypto.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Crypto.cs
@@ -393,10 +393,9 @@ namespace Yubico.YubiKey.Piv
         // Common code, this performs either Signing, Decryption, or Key
         // Agreement. Just pass in the actual command to run, along with some
         // other information.
-        private byte[] PerformPrivateKeyOperation(byte slotNumber,
-                                                  IYubiKeyCommand<IYubiKeyResponseWithData<byte[]>> command,
-                                                  PivAlgorithm algorithm,
-                                                  string algorithmExceptionMessage)
+        private byte[] PerformPrivateKeyOperation(
+            byte slotNumber, IYubiKeyCommand<IYubiKeyResponseWithData<byte[]>> commandToPerform,
+            PivAlgorithm algorithm,string algorithmExceptionMessage)
         {
             bool pinRequired = true;
 
@@ -412,10 +411,10 @@ namespace Yubico.YubiKey.Piv
             if (_yubiKeyDevice.HasFeature(YubiKeyFeature.PivMetadata))
             {
                 var metadataCommand = new GetMetadataCommand(slotNumber);
-                GetMetadataResponse metadataResponse = Connection.SendCommand(metadataCommand);
+                var metadataResponse = Connection.SendCommand(metadataCommand);
 
                 // If there is no key in the slot, this will throw an exception.
-                PivMetadata metadata = metadataResponse.GetData();
+                var metadata = metadataResponse.GetData();
 
                 // We know the algorithm based on the input data. Is it the
                 // algorithm of the key in the slot?
@@ -442,7 +441,7 @@ namespace Yubico.YubiKey.Piv
                 // Metadata is not available on this YubiKey.
                 // Try to perform the operation. If it works, we're done. If not,
                 // we can get limited information on why not.
-                IYubiKeyResponseWithData<byte[]> initialResponse = Connection.SendCommand(command);
+                var initialResponse = Connection.SendCommand(commandToPerform);
 
                 // If the response is AuthRequired, either the PIN is required or
                 // touch is. The response does not tell us which.
@@ -476,11 +475,10 @@ namespace Yubico.YubiKey.Piv
                 VerifyPin();
             }
 
-            IYubiKeyResponseWithData<byte[]> response = Connection.SendCommand(command);
-
-            if (response.Status != ResponseStatus.AuthenticationRequired)
+            var commandToPerformResponse = Connection.SendCommand(commandToPerform);
+            if (commandToPerformResponse.Status != ResponseStatus.AuthenticationRequired)
             {
-                return response.GetData();
+                return commandToPerformResponse.GetData();
             }
 
             // If we reach this code, the Status is AuthRequired and the problem is touch.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Objects.cs
@@ -313,15 +313,15 @@ namespace Yubico.YubiKey.Piv
         // instantiation.
         private bool TryReadObject(PivDataObject pivDataObject)
         {
-            var getDataCommand = new GetDataCommand(pivDataObject.DataTag);
-            GetDataResponse getDataResponse = Connection.SendCommand(getDataCommand);
+            var command = new GetDataCommand(pivDataObject.DataTag);
+            var response = Connection.SendCommand(command);
 
             // If GetDataCommand requires the PIN and it had not been verified,
             // verify it now and run it again.
-            if (getDataResponse.Status == ResponseStatus.AuthenticationRequired)
+            if (response.Status == ResponseStatus.AuthenticationRequired)
             {
                 VerifyPin();
-                getDataResponse = Connection.SendCommand(getDataCommand);
+                response = Connection.SendCommand(command);
             }
 
             // If there is no data, simply return the object created, the IsEmpty
@@ -330,9 +330,9 @@ namespace Yubico.YubiKey.Piv
             // the data or we will get an exception because of an error in the
             // GetData, which is the kind of exception we want to throw, even
             // though this is a Try method.
-            if (getDataResponse.Status != ResponseStatus.NoData)
+            if (response.Status != ResponseStatus.NoData)
             {
-                ReadOnlyMemory<byte> encodedData = getDataResponse.GetData();
+                var encodedData = response.GetData();
                 return pivDataObject.TryDecode(encodedData);
             }
 
@@ -391,20 +391,20 @@ namespace Yubico.YubiKey.Piv
             try
             {
                 dataToStore = pivDataObject.Encode();
-                var putDataCommand = new PutDataCommand(pivDataObject.DataTag, dataToStore);
-                PutDataResponse putDataResponse = Connection.SendCommand(putDataCommand);
+                var command = new PutDataCommand(pivDataObject.DataTag, dataToStore);
+                var response = Connection.SendCommand(command);
 
                 // The PutDataCommand requires mgmt key auth, if it has not been
                 // authenticated, do so now and run it again.
-                if (putDataResponse.Status == ResponseStatus.AuthenticationRequired)
+                if (response.Status == ResponseStatus.AuthenticationRequired)
                 {
                     AuthenticateManagementKey(true);
-                    putDataResponse = Connection.SendCommand(putDataCommand);
+                    response = Connection.SendCommand(command);
                 }
 
-                if (putDataResponse.Status != ResponseStatus.Success)
+                if (response.Status != ResponseStatus.Success)
                 {
-                    throw new InvalidOperationException(putDataResponse.StatusMessage);
+                    throw new InvalidOperationException(response.StatusMessage);
                 }
             }
             finally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
@@ -380,10 +380,10 @@ namespace Yubico.YubiKey.Piv
                         ExceptionMessages.NotSupportedByYubiKeyVersion));
             }
 
-            var metadataCommand = new GetMetadataCommand(slotNumber);
-            GetMetadataResponse metadataResponse = Connection.SendCommand(metadataCommand);
+            var command = new GetMetadataCommand(slotNumber);
+            var response = Connection.SendCommand(command);
 
-            return metadataResponse.GetData();
+            return response.GetData();
         }
 
         /// <summary>
@@ -477,10 +477,9 @@ namespace Yubico.YubiKey.Piv
             TryBlock(PivSlot.Pin);
             TryBlock(PivSlot.Puk);
 
-            var resetCommand = new ResetPivCommand();
-            ResetPivResponse resetResponse = Connection.SendCommand(resetCommand);
-
-            if (resetResponse.Status != ResponseStatus.Success)
+            var command = new ResetPivCommand();
+            var response = Connection.SendCommand(command);
+            if (response.Status != ResponseStatus.Success)
             {
                 throw new SecurityException(
                     string.Format(
@@ -532,9 +531,9 @@ namespace Yubico.YubiKey.Piv
             }
 
             _log.LogDebug("Moving key from {SourceSlot} to {DestinationSlot}", sourceSlot, destinationSlot);
+            
             var command = new MoveKeyCommand(sourceSlot, destinationSlot);
-            MoveKeyResponse response = Connection.SendCommand(command);
-
+            var response = Connection.SendCommand(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
@@ -580,8 +579,9 @@ namespace Yubico.YubiKey.Piv
             }
 
             _log.LogDebug("Deleting key at slot {TargetSlot}", slotToClear);
+            
             var command = new DeleteKeyCommand(slotToClear);
-            DeleteKeyResponse response = Connection.SendCommand(command);
+            var response = Connection.SendCommand(command);
 
             bool unsuccessfulStatus =
                 response.Status != ResponseStatus.Success &&
@@ -627,15 +627,14 @@ namespace Yubico.YubiKey.Piv
                     0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22
                 };
 
-                var changeCommand = new ChangeReferenceDataCommand(slotNumber, currentValue, newValue);
-                ChangeReferenceDataResponse changeResponse = Connection.SendCommand(changeCommand);
-
-                if (changeResponse.Status == ResponseStatus.Failed)
+                var command = new ChangeReferenceDataCommand(slotNumber, currentValue, newValue);
+                var response = Connection.SendCommand(command);
+                if (response.Status == ResponseStatus.Failed)
                 {
                     return false;
                 }
 
-                retriesRemaining = changeResponse.GetData() ?? 1;
+                retriesRemaining = response.GetData() ?? 1;
             }
             while (retriesRemaining > 0);
 
@@ -662,13 +661,13 @@ namespace Yubico.YubiKey.Piv
 
         private PivAlgorithm GetManagementKeyAlgorithm()
         {
-            GetMetadataResponse response = Connection.SendCommand(new GetMetadataCommand(PivSlot.Management));
+            var response = Connection.SendCommand(new GetMetadataCommand(PivSlot.Management));
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
             }
 
-            PivMetadata metadata = response.GetData();
+            var metadata = response.GetData();
             return metadata.Algorithm;
         }
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/ChannelMac.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/ChannelMac.cs
@@ -31,14 +31,14 @@ namespace Yubico.YubiKey.Scp03
                 throw new ArgumentException(ExceptionMessages.UnknownScp03Error, nameof(macChainingValue));
             }
 
-            CommandApdu apduWithLongerLen = AddDataToApdu(apdu, new byte[8]);
+            var apduWithLongerLen = AddDataToApdu(apdu, new byte[8]);
             byte[] apduBytesWithZeroMac = ApduToBytes(apduWithLongerLen);
             byte[] apduBytes = apduBytesWithZeroMac.Take(apduBytesWithZeroMac.Length - 8).ToArray();
             byte[] macInp = new byte[16 + apduBytes.Length];
             macChainingValue.CopyTo(macInp, 0);
             apduBytes.CopyTo(macInp, 16);
 
-            using ICmacPrimitives cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
+            using var cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
             cmacObj.CmacInit(macKey);
             cmacObj.CmacUpdate(macInp);
             cmacObj.CmacFinal(macChainingValue);
@@ -68,13 +68,13 @@ namespace Yubico.YubiKey.Scp03
             macInp[16 + respDataLen] = SW1Constants.Success;
             macInp[16 + respDataLen + 1] = SWConstants.Success & 0xFF;
 
-            using ICmacPrimitives cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
+            using var cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
             byte[] cmac = new byte[16];
             cmacObj.CmacInit(rmacKey);
             cmacObj.CmacUpdate(macInp);
             cmacObj.CmacFinal(cmac);
-            Span<byte> calculatedRmac = cmac.AsSpan(0, 8);
-
+            
+            var calculatedRmac = cmac.AsSpan(0, 8);
             if (!CryptographicOperations.FixedTimeEquals(recvdRmac, calculatedRmac))
             {
                 throw new SecureChannelException(ExceptionMessages.IncorrectRmac);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Commands/InitializeUpdateResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Commands/InitializeUpdateResponse.cs
@@ -44,7 +44,7 @@ namespace Yubico.YubiKey.Scp03.Commands
                 throw new ArgumentException(ExceptionMessages.IncorrectInitializeUpdateResponseData, nameof(responseApdu));
             }
 
-            ReadOnlySpan<byte> responseData = responseApdu.Data.Span;
+            var responseData = responseApdu.Data.Span;
             DiversificationData = new ReadOnlyCollection<byte>(responseData[0..10].ToArray());
             KeyInfo = new ReadOnlyCollection<byte>(responseData[10..13].ToArray());
             CardChallenge = new ReadOnlyCollection<byte>(responseData[13..21].ToArray());

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Derivation.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Derivation.cs
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.Scp03
             cardChallenge.CopyTo(macInp, 24);
 
             byte[] cmac = new byte[16];
-            using ICmacPrimitives cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
+            using var cmacObj = CryptographyProviders.CmacPrimitivesCreator(CmacBlockCipherAlgorithm.Aes128);
             cmacObj.CmacInit(kdfKey);
             cmacObj.CmacUpdate(macInp);
             cmacObj.CmacFinal(cmac);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Connection.cs
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey
         public Scp03Connection(ISmartCardDevice smartCardDevice, byte[] applicationId, StaticKeys scp03Keys)
             : base(smartCardDevice, YubiKeyApplication.Unknown, applicationId)
         {
-            YubiKeyApplication setError = YubiKeyApplication.Unknown;
+            var setError = YubiKeyApplication.Unknown;
             if (applicationId.SequenceEqual(YubiKeyApplication.Fido2.GetIso7816ApplicationId()))
             {
                 setError = YubiKeyApplication.Fido2;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Session.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp03/Scp03Session.cs
@@ -250,19 +250,20 @@ namespace Yubico.YubiKey.Scp03
             {
                 throw new ArgumentNullException(nameof(newKeySet));
             }
-            var cmd = new PutKeyCommand(Connection.GetScp03Keys(), newKeySet);
-            PutKeyResponse rsp = Connection.SendCommand(cmd);
-            if (rsp.Status != ResponseStatus.Success)
+            
+            var command = new PutKeyCommand(Connection.GetScp03Keys(), newKeySet);
+            var response = Connection.SendCommand(command);
+            if (response.Status != ResponseStatus.Success)
             {
                 throw new SecureChannelException(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         ExceptionMessages.YubiKeyOperationFailed,
-                        rsp.StatusMessage));
+                        response.StatusMessage));
             }
 
-            ReadOnlyMemory<byte> checksum = rsp.GetData();
-            if (!CryptographicOperations.FixedTimeEquals(checksum.Span, cmd.ExpectedChecksum.Span))
+            var checksum = response.GetData();
+            if (!CryptographicOperations.FixedTimeEquals(checksum.Span, command.ExpectedChecksum.Span))
             {
                 throw new SecureChannelException(ExceptionMessages.ChecksumError);
             }
@@ -290,17 +291,17 @@ namespace Yubico.YubiKey.Scp03
         /// </param>
         public void DeleteKeySet(byte keyVersionNumber, bool isLastKey = false)
         {
-            _log.LogInformation("Delete an SCP03 key set from a YubiKey.");
+            _log.LogInformation("Deleting an SCP03 key set from a YubiKey.");
 
-            var cmd = new DeleteKeyCommand(keyVersionNumber, isLastKey);
-            Scp03Response rsp = Connection.SendCommand(cmd);
-            if (rsp.Status != ResponseStatus.Success)
+            var command = new DeleteKeyCommand(keyVersionNumber, isLastKey);
+            var response = Connection.SendCommand(command);
+            if (response.Status != ResponseStatus.Success)
             {
                 throw new SecureChannelException(
                     string.Format(
                         CultureInfo.CurrentCulture,
                         ExceptionMessages.YubiKeyOperationFailed,
-                        rsp.StatusMessage));
+                        response.StatusMessage));
             }
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
@@ -117,8 +117,8 @@ namespace Yubico.YubiKey
             };
 
             _log.LogInformation("Selecting smart card application [{AID}]", Hex.BytesToHex(_applicationId ?? _yubiKeyApplication.GetIso7816ApplicationId()));
-            ResponseApdu responseApdu = _smartCardConnection.Transmit(selectApplicationCommand.CreateCommandApdu());
-
+            
+            var responseApdu = _smartCardConnection.Transmit(selectApplicationCommand.CreateCommandApdu());
             if (responseApdu.SW != SWConstants.Success)
             {
                 throw new ApduException(
@@ -131,20 +131,20 @@ namespace Yubico.YubiKey
                 };
             }
 
-            ISelectApplicationResponse<ISelectApplicationData>? response = selectApplicationCommand.CreateResponseForApdu(responseApdu);
+            var response = selectApplicationCommand.CreateResponseForApdu(responseApdu);
             SelectApplicationData = response.GetData();
         }
 
         public TResponse SendCommand<TResponse>(IYubiKeyCommand<TResponse> yubiKeyCommand) where TResponse : IYubiKeyResponse
         {
-            using (IDisposable _ = _smartCardConnection.BeginTransaction(out bool cardWasReset))
+            using (var _ = _smartCardConnection.BeginTransaction(out bool cardWasReset))
             {
                 if (cardWasReset)
                 {
                     SelectApplication();
                 }
 
-                ResponseApdu responseApdu = _apduPipeline.Invoke(
+                var responseApdu = _apduPipeline.Invoke(
                     yubiKeyCommand.CreateCommandApdu(),
                     yubiKeyCommand.GetType(),
                     typeof(TResponse));

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardDeviceInfoFactory.cs
@@ -27,7 +27,7 @@ namespace Yubico.YubiKey
         public static YubiKeyDeviceInfo GetDeviceInfo(
             ISmartCardDevice device)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             if (!device.IsYubicoDevice())
             {
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey
 
             log.LogInformation("Getting device info for smart card {Device}.", device);
 
-            if (!TryGetDeviceInfoFromManagement(device, out YubiKeyDeviceInfo? deviceInfo))
+            if (!TryGetDeviceInfoFromManagement(device, out var deviceInfo))
             {
                 deviceInfo = new YubiKeyDeviceInfo();
             }
@@ -52,7 +52,7 @@ namespace Yubico.YubiKey
             }
 
             if (deviceInfo.FirmwareVersion == defaultDeviceInfo.FirmwareVersion
-                && TryGetFirmwareVersionFromOtp(device, out FirmwareVersion? firmwareVersion))
+                && TryGetFirmwareVersionFromOtp(device, out var firmwareVersion))
             {
                 deviceInfo.FirmwareVersion = firmwareVersion;
             }
@@ -86,7 +86,7 @@ namespace Yubico.YubiKey
             ISmartCardDevice device,
             [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo deviceInfo)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             try
             {
@@ -121,15 +121,14 @@ namespace Yubico.YubiKey
             ISmartCardDevice device,
             [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through OTP.");
                 using var connection = new SmartCardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.ReadStatusResponse response =
-                    connection.SendCommand(new Otp.Commands.ReadStatusCommand());
+                var response = connection.SendCommand(new Otp.Commands.ReadStatusCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
@@ -164,14 +163,14 @@ namespace Yubico.YubiKey
             ISmartCardDevice device,
             [MaybeNullWhen(returnValue: false)] out FirmwareVersion firmwareVersion)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             try
             {
                 log.LogInformation("Attempting to read firmware version through the PIV application.");
                 using var connection = new SmartCardConnection(device, YubiKeyApplication.Piv);
 
-                Piv.Commands.VersionResponse response = connection.SendCommand(new Piv.Commands.VersionCommand());
+                var response = connection.SendCommand(new Piv.Commands.VersionCommand());
 
                 if (response.Status == ResponseStatus.Success)
                 {
@@ -202,16 +201,14 @@ namespace Yubico.YubiKey
             ISmartCardDevice device,
             out int? serialNumber)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             try
             {
                 log.LogInformation("Attempting to read serial number through the OTP application.");
                 using var connection = new SmartCardConnection(device, YubiKeyApplication.Otp);
 
-                Otp.Commands.GetSerialNumberResponse response =
-                    connection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
-
+                var response = connection.SendCommand(new Otp.Commands.GetSerialNumberCommand());
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();
@@ -246,16 +243,14 @@ namespace Yubico.YubiKey
             ISmartCardDevice device,
             out int? serialNumber)
         {
-            ILogger log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
+            var log = Log.GetLogger(typeof(SmartCardDeviceInfoFactory).FullName!);
 
             try
             {
                 log.LogInformation("Attempting to read serial number through the PIV application.");
                 using var connection = new SmartCardConnection(device, YubiKeyApplication.Piv);
 
-                Piv.Commands.GetSerialNumberResponse response =
-                    connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
-
+                var response = connection.SendCommand(new Piv.Commands.GetSerialNumberCommand());
                 if (response.Status == ResponseStatus.Success)
                 {
                     serialNumber = response.GetData();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/TouchFingerprintTask.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/TouchFingerprintTask.cs
@@ -154,8 +154,9 @@ namespace Yubico.YubiKey
         // Any other value entered will be considered Release.
         public void SdkUpdate(KeyEntryData keyEntryData)
         {
-            KeyEntryRequest request = keyEntryData.Request == KeyEntryRequest.EnrollFingerprint
-                ? KeyEntryRequest.EnrollFingerprint : KeyEntryRequest.Release;
+            var request = keyEntryData.Request == KeyEntryRequest.EnrollFingerprint 
+                ? KeyEntryRequest.EnrollFingerprint 
+                : KeyEntryRequest.Release;
 
             lock (_updateLock)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetDeviceInfoResponse.cs
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.U2f.Commands
                 };
             }
 
-            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out YubiKeyDeviceInfo? deviceInfo))
+            if (!YubiKeyDeviceInfo.TryCreateFromResponseData(ResponseApdu.Data, out var deviceInfo))
             {
                 throw new MalformedYubiKeyResponseException
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetProtocolVersionResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/Commands/GetProtocolVersionResponse.cs
@@ -63,7 +63,7 @@ namespace Yubico.YubiKey.U2f.Commands
                 throw new InvalidOperationException(StatusMessage);
             }
 
-            ReadOnlySpan<byte> responseApduData = ResponseApdu.Data.Span;
+            var responseApduData = ResponseApdu.Data.Span;
             return Encoding.ASCII.GetString(responseApduData.ToArray());
         }
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/RegistrationData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/RegistrationData.cs
@@ -138,13 +138,13 @@ namespace Yubico.YubiKey.U2f
             int certLength = 1;
             if (encodedResponse.Length > MinEncodedLength)
             {
-                if (encodedResponse.Span[MsgReservedOffset] == MsgReservedValue
-                    && encodedResponse.Span[MsgKeyHandleOffset] == KeyHandleLength
-                    && encodedResponse.Span[MsgPublicKeyOffset] == PublicKeyTag)
+                if (encodedResponse.Span[MsgReservedOffset] == MsgReservedValue && 
+                    encodedResponse.Span[MsgKeyHandleOffset] == KeyHandleLength &&
+                    encodedResponse.Span[MsgPublicKeyOffset] == PublicKeyTag)
                 {
-                    ReadOnlyMemory<byte> certAndSig = encodedResponse.Slice(MsgCertOffset);
-                    var tlvReader = new TlvReader(certAndSig);
-                    if (tlvReader.TryReadEncoded(out ReadOnlyMemory<byte> cert, CertTag))
+                    var certAndSignatureBytes = encodedResponse.Slice(MsgCertOffset);
+                    var tlvReader = new TlvReader(certAndSignatureBytes);
+                    if (tlvReader.TryReadEncoded(out var cert, CertTag))
                     {
                         certLength = cert.Length;
                         isValid = true;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/U2fSession.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/U2fSession.Pin.cs
@@ -107,7 +107,7 @@ namespace Yubico.YubiKey.U2f
         public bool TrySetPin()
         {
             _log.LogInformation("Try to set the U2F PIN using the KeyCollector.");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
+            var keyCollectorFunc = EnsureKeyCollector();
 
             var keyEntryData = new KeyEntryData()
             {
@@ -116,7 +116,7 @@ namespace Yubico.YubiKey.U2f
 
             try
             {
-                while (keyCollector(keyEntryData))
+                while (keyCollectorFunc(keyEntryData))
                 {
                     if (TrySetPin(keyEntryData.GetCurrentValue()))
                     {
@@ -131,7 +131,7 @@ namespace Yubico.YubiKey.U2f
                 keyEntryData.Clear();
 
                 keyEntryData.Request = KeyEntryRequest.Release;
-                _ = keyCollector(keyEntryData);
+                _ = keyCollectorFunc(keyEntryData);
             }
 
             return false;
@@ -164,10 +164,10 @@ namespace Yubico.YubiKey.U2f
         public bool TrySetPin(ReadOnlyMemory<byte> pin)
         {
             _log.LogInformation("Try to set the U2F PIN using a provided value.");
-            var setCommand = new SetPinCommand(ReadOnlyMemory<byte>.Empty, pin);
-            SetPinResponse setResponse = Connection.SendCommand(setCommand);
-
-            return setResponse.StatusWord switch
+            
+            var command = new SetPinCommand(ReadOnlyMemory<byte>.Empty, pin);
+            var response = Connection.SendCommand(command);
+            return response.StatusWord switch
             {
                 SWConstants.Success => true,
                 SWConstants.VerifyFail => throw new SecurityException(
@@ -285,7 +285,7 @@ namespace Yubico.YubiKey.U2f
         public bool TryChangePin()
         {
             _log.LogInformation("Try to change the U2F PIN using the KeyCollector.");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
+            var keyCollectorFunc = EnsureKeyCollector();
 
             var keyEntryData = new KeyEntryData()
             {
@@ -294,7 +294,7 @@ namespace Yubico.YubiKey.U2f
 
             try
             {
-                while (keyCollector(keyEntryData))
+                while (keyCollectorFunc(keyEntryData))
                 {
                     if (TryChangePin(keyEntryData.GetCurrentValue(), keyEntryData.GetNewValue()))
                     {
@@ -309,7 +309,7 @@ namespace Yubico.YubiKey.U2f
                 keyEntryData.Clear();
 
                 keyEntryData.Request = KeyEntryRequest.Release;
-                _ = keyCollector(keyEntryData);
+                _ = keyCollectorFunc(keyEntryData);
             }
 
             return false;
@@ -337,10 +337,9 @@ namespace Yubico.YubiKey.U2f
         public bool TryChangePin(ReadOnlyMemory<byte> currentPin, ReadOnlyMemory<byte> newPin)
         {
             _log.LogInformation("Try to change the U2F PIN using provided values.");
-            var setCommand = new SetPinCommand(currentPin, newPin);
-            SetPinResponse setResponse = Connection.SendCommand(setCommand);
-
-            return setResponse.StatusWord switch
+            var command = new SetPinCommand(currentPin, newPin);
+            var response = Connection.SendCommand(command);
+            return response.StatusWord switch
             {
                 SWConstants.Success => true,
                 SWConstants.AuthenticationMethodBlocked => throw new SecurityException(
@@ -434,7 +433,7 @@ namespace Yubico.YubiKey.U2f
         private bool CommonVerifyPin(bool throwOnCancel)
         {
             _log.LogInformation("Verify the U2F PIN using the KeyCollector.");
-            Func<KeyEntryData, bool> keyCollector = EnsureKeyCollector();
+            var keyCollectorFunc = EnsureKeyCollector();
 
             var keyEntryData = new KeyEntryData()
             {
@@ -443,7 +442,7 @@ namespace Yubico.YubiKey.U2f
 
             try
             {
-                while (keyCollector(keyEntryData))
+                while (keyCollectorFunc(keyEntryData))
                 {
                     if (TryVerifyPin(keyEntryData.GetCurrentValue()))
                     {
@@ -458,7 +457,7 @@ namespace Yubico.YubiKey.U2f
                 keyEntryData.Clear();
 
                 keyEntryData.Request = KeyEntryRequest.Release;
-                _ = keyCollector(keyEntryData);
+                _ = keyCollectorFunc(keyEntryData);
             }
 
             if (throwOnCancel)
@@ -494,10 +493,10 @@ namespace Yubico.YubiKey.U2f
         public bool TryVerifyPin(ReadOnlyMemory<byte> pin)
         {
             _log.LogInformation("Try to verify the U2F PIN using a provided value.");
-            var verifyCommand = new VerifyPinCommand(pin);
-            VerifyPinResponse verifyResponse = Connection.SendCommand(verifyCommand);
-
-            return verifyResponse.StatusWord switch
+            
+            var command = new VerifyPinCommand(pin);
+            var response = Connection.SendCommand(command);
+            return response.StatusWord switch
             {
                 SWConstants.Success => true,
                 SWConstants.AuthenticationMethodBlocked => throw new SecurityException(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/U2f/U2fSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/U2f/U2fSession.cs
@@ -315,7 +315,7 @@ namespace Yubico.YubiKey.U2f
                                          TimeSpan timeout)
         {
             _log.LogInformation("Register a new U2F credential.");
-            RegisterResponse response = CommonRegister(applicationId, clientDataHash, timeout, true);
+            var response = CommonRegister(applicationId, clientDataHash, timeout, true);
 
             // If everything worked, this will return the correct result. If
             // there was an error, this will throw an exception.
@@ -423,7 +423,7 @@ namespace Yubico.YubiKey.U2f
                                 [MaybeNullWhen(returnValue: false)] out RegistrationData registrationData)
         {
             _log.LogInformation("Try to register a new U2F credential.");
-            RegisterResponse response = CommonRegister(applicationId, clientDataHash, timeout, false);
+            var response = CommonRegister(applicationId, clientDataHash, timeout, false);
 
             if (response.Status == ResponseStatus.Success)
             {
@@ -450,10 +450,10 @@ namespace Yubico.YubiKey.U2f
             Task? touchMessageTask = null;
             var keyEntryData = new KeyEntryData();
 
-            TimeSpan timeoutToUse = GetTimeoutToUse(timeout);
+            var timeoutToUseTimeSpan = GetTimeoutToUse(timeout);
 
             var command = new RegisterCommand(applicationId, clientDataHash);
-            RegisterResponse response = Connection.SendCommand(command);
+            var response = Connection.SendCommand(command);
 
             // This should only apply to FIPS series devices.
             // This response happens if the PIN is not verified.
@@ -491,8 +491,8 @@ namespace Yubico.YubiKey.U2f
                         Thread.Sleep(100);
                         response = Connection.SendCommand(command);
                     }
-                    while (response.Status == ResponseStatus.ConditionsNotSatisfied
-                           && timer.Elapsed < timeoutToUse);
+                    while (response.Status == ResponseStatus.ConditionsNotSatisfied &&
+                           timer.Elapsed < timeoutToUseTimeSpan);
 
                     // Did we break out because of timeout or because the
                     // response was something other than ConditionsNotSatisfied.
@@ -577,7 +577,7 @@ namespace Yubico.YubiKey.U2f
             var command = new AuthenticateCommand(U2fAuthenticationType.CheckOnly, applicationId, clientDataHash,
                 keyHandle);
 
-            AuthenticateResponse response = Connection.SendCommand(command);
+            var response = Connection.SendCommand(command);
 
             // The standard specifies that if the key handle matches, the token
             // must respond with the test-of-user-presence error. If the key
@@ -697,8 +697,7 @@ namespace Yubico.YubiKey.U2f
         {
             _log.LogInformation("Authenticate a U2F credential.");
 
-            AuthenticateResponse response = CommonAuthenticate(
-                applicationId, clientDataHash, keyHandle, timeout, requireProofOfPresence);
+            var response = CommonAuthenticate(applicationId, clientDataHash, keyHandle, timeout, requireProofOfPresence);
 
             // If everything worked, this will return the correct result. If
             // there was an error, this will throw an exception.
@@ -771,9 +770,7 @@ namespace Yubico.YubiKey.U2f
         {
             _log.LogInformation("Try to authenticate a U2F credential.");
 
-            AuthenticateResponse response = CommonAuthenticate(
-                applicationId, clientDataHash, keyHandle, timeout, requireProofOfPresence);
-
+            var response = CommonAuthenticate(applicationId, clientDataHash, keyHandle, timeout, requireProofOfPresence);
             if (response.Status == ResponseStatus.Success)
             {
                 authenticationData = response.GetData();
@@ -799,15 +796,14 @@ namespace Yubico.YubiKey.U2f
             Task? touchMessageTask = null;
             var keyEntryData = new KeyEntryData();
 
-            TimeSpan timeoutToUse = GetTimeoutToUse(timeout);
+            var timeoutToUseTimeSpan = GetTimeoutToUse(timeout);
 
-            U2fAuthenticationType authType = requireProofOfPresence
+            var authType = requireProofOfPresence
                 ? U2fAuthenticationType.EnforceUserPresence
                 : U2fAuthenticationType.DontEnforceUserPresence;
 
             var command = new AuthenticateCommand(authType, applicationId, clientDataHash, keyHandle);
-            AuthenticateResponse response = Connection.SendCommand(command);
-
+            var response = Connection.SendCommand(command);
             if (response.Status == ResponseStatus.ConditionsNotSatisfied)
             {
                 // On a separate thread, call the KeyCollector to announce we
@@ -829,8 +825,8 @@ namespace Yubico.YubiKey.U2f
                         Thread.Sleep(100);
                         response = Connection.SendCommand(command);
                     }
-                    while (response.Status == ResponseStatus.ConditionsNotSatisfied
-                           && timer.Elapsed < timeoutToUse);
+                    while (response.Status == ResponseStatus.ConditionsNotSatisfied &&
+                           timer.Elapsed < timeoutToUseTimeSpan);
 
                     // Did we break out because of timeout or because the
                     // response was something other than ConditionsNotSatisfied.
@@ -886,7 +882,7 @@ namespace Yubico.YubiKey.U2f
         /// </remarks>
         public static byte[] EncodeAndHashString(string data)
         {
-            using (SHA256 sha = CryptographyProviders.Sha256Creator())
+            using (var sha = CryptographyProviders.Sha256Creator())
             {
                 byte[] encodedString = Encoding.UTF8.GetBytes(data);
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialCommand.cs
@@ -127,7 +127,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         /// </returns>
         private byte[] BuildDataField()
         {
-            TlvWriter tlvWriter = new TlvWriter();
+            var tlvWriter = new TlvWriter();
             tlvWriter.WriteValue(DataTagConstants.ManagementKey, _managementKey.Span);
             tlvWriter.WriteString(DataTagConstants.Label,
                 _credentialWithSecrets.Label, Encoding.UTF8);
@@ -139,10 +139,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             tlvWriter.WriteByte(DataTagConstants.Touch,
                 _credentialWithSecrets.TouchRequired ? (byte)1 : (byte)0);
 
-            byte[] returnValue = tlvWriter.Encode();
+            byte[] tlvBytes = tlvWriter.Encode();
             tlvWriter.Clear();
 
-            return returnValue;
+            return tlvBytes;
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/ChangeManagementKeyCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/ChangeManagementKeyCommand.cs
@@ -128,14 +128,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         /// </returns>
         private byte[] BuildDataField()
         {
-            TlvWriter tlvWriter = new TlvWriter();
+            var tlvWriter = new TlvWriter();
             tlvWriter.WriteValue(DataTagConstants.ManagementKey, _currentManagementKey.Span);
             tlvWriter.WriteValue(DataTagConstants.ManagementKey, _newManagementKey.Span);
 
-            byte[] returnValue = tlvWriter.Encode();
+            byte[] tlvBytes = tlvWriter.Encode();
             tlvWriter.Clear();
 
-            return returnValue;
+            return tlvBytes;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/DeleteCredentialCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/DeleteCredentialCommand.cs
@@ -127,15 +127,15 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
 
         private byte[] BuildDataField()
         {
-            TlvWriter tlvWriter = new TlvWriter();
+            var tlvWriter = new TlvWriter();
             tlvWriter.WriteValue(DataTagConstants.ManagementKey, _managementKey.Span);
             tlvWriter.WriteString(DataTagConstants.Label,
                 Label, Encoding.UTF8);
 
-            byte[] returnValue = tlvWriter.Encode();
+            byte[] tlvBytes = tlvWriter.Encode();
             tlvWriter.Clear();
 
-            return returnValue;
+            return tlvBytes;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysCommand.cs
@@ -176,7 +176,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         /// </returns>
         private byte[] BuildDataField()
         {
-            TlvWriter tlvWriter = new TlvWriter();
+            var tlvWriter = new TlvWriter();
 
             tlvWriter.WriteString(DataTagConstants.Label, CredentialLabel, Encoding.UTF8);
 
@@ -187,10 +187,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
 
             tlvWriter.WriteValue(DataTagConstants.Password, _credentialPassword.Span);
 
-            byte[] returnValue = tlvWriter.Encode();
+            byte[] tlvBytes = tlvWriter.Encode();
             tlvWriter.Clear();
 
-            return returnValue;
+            return tlvBytes;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysResponse.cs
@@ -97,7 +97,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
                 throw new MalformedYubiKeyResponseException();
             }
 
-            SessionKeys keys = new SessionKeys(
+            var keys = new SessionKeys(
                 ResponseApdu.Data.Slice(encStart, keyLength),
                 ResponseApdu.Data.Slice(macStart, keyLength),
                 ResponseApdu.Data.Slice(rmacStart, keyLength));

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionResponse.cs
@@ -35,9 +35,8 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
                 throw new InvalidOperationException(StatusMessage);
             }
 
-            ReadOnlySpan<byte> versionData = ResponseApdu.Data.Span;
-
-            ApplicationVersion version = new ApplicationVersion()
+            var versionData = ResponseApdu.Data.Span;
+            var version = new ApplicationVersion
             {
                 Major = versionData[0],
                 Minor = versionData[1],

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsResponse.cs
@@ -69,8 +69,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
                 throw new InvalidOperationException(StatusMessage);
             }
 
-            List<CredentialRetryPair> credentialRetryPairs = new List<CredentialRetryPair>();
-
+            var credentialRetryPairs = new List<CredentialRetryPair>();
             var tlvReader = new TlvReader(ResponseApdu.Data);
 
             // Parse data by iterating over each LabelList element, parsing it into a
@@ -78,7 +77,6 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             while (tlvReader.HasData)
             {
                 int nextTagValue = tlvReader.PeekTag();
-
                 if (nextTagValue != DataTagConstants.LabelList)
                 {
                     throw new MalformedYubiKeyResponseException(
@@ -88,18 +86,17 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
                                 nextTagValue));
                 }
 
-                ReadOnlySpan<byte> credentialRetryElement =
-                    tlvReader.ReadValue(DataTagConstants.LabelList).Span;
+                var credentialRetryElement = tlvReader.ReadValue(DataTagConstants.LabelList).Span;
 
                 // Check that it's formatted correctly
-                if (credentialRetryElement.Length < MinElementSize
-                    || credentialRetryElement.Length > MaxElementSize)
+                if (credentialRetryElement.Length < MinElementSize || 
+                    credentialRetryElement.Length > MaxElementSize)
                 {
                     throw new MalformedYubiKeyResponseException(
                         ExceptionMessages.InvalidCredentialRetryDataLength);
                 }
 
-                Credential credential = new Credential(
+                var credential = new Credential(
                     (CryptographicKeyType)credentialRetryElement[CryptoKeyTypeIndex],
                     Encoding.UTF8.GetString(credentialRetryElement[LabelRange].ToArray()),
                     credentialRetryElement[TouchIndex] != 0);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.Credential.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.Credential.cs
@@ -109,28 +109,21 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             managementKeyRetries = null;
 
-            AddCredentialCommand addCredCmd =
-                new AddCredentialCommand(managementKey, credentialWithSecrets);
-
-            AddCredentialResponse addCredRsp = Connection.SendCommand(addCredCmd);
-
-            if (addCredRsp.Status != ResponseStatus.Success)
+            var command = new AddCredentialCommand(managementKey, credentialWithSecrets);
+            var response = Connection.SendCommand(command);
+            if (response.Status != ResponseStatus.Success)
             {
-                if (addCredRsp.Status == ResponseStatus.AuthenticationRequired)
+                if (response.Status == ResponseStatus.AuthenticationRequired)
                 {
-                    managementKeyRetries = addCredRsp.RetriesRemaining!;
+                    managementKeyRetries = response.RetriesRemaining!;
 
                     return false;
                 }
-                else
-                {
-                    throw new InvalidOperationException(addCredRsp.StatusMessage);
-                }
+
+                throw new InvalidOperationException(response.StatusMessage);
             }
-            else
-            {
-                return true;
-            }
+
+            return true;
         }
 
         /// <summary>
@@ -198,7 +191,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </returns>
         public bool TryAddCredential(CredentialWithSecrets credentialWithSecrets)
         {
-            Func<KeyEntryData, bool>? keyCollector = GetKeyCollector();
+            var keyCollector = GetKeyCollector();
 
             var keyEntryData = new KeyEntryData()
             {
@@ -320,7 +313,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public bool TryDeleteCredential(string label)
         {
-            Func<KeyEntryData, bool>? keyCollector = GetKeyCollector();
+            var keyCollector = GetKeyCollector();
 
             var keyEntryData = new KeyEntryData()
             {
@@ -446,10 +439,10 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             managementKeyRetries = null;
 
-            DeleteCredentialCommand deleteCredCmd =
+            var deleteCredCmd =
                 new DeleteCredentialCommand(managementKey, label);
 
-            DeleteCredentialResponse deleteCredRsp =
+            var deleteCredRsp =
                 Connection.SendCommand(deleteCredCmd);
 
             if (deleteCredRsp.Status != ResponseStatus.Success)
@@ -486,7 +479,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public IReadOnlyList<CredentialRetryPair> ListCredentials()
         {
-            ListCredentialsResponse listCredsRsp =
+            var listCredsRsp =
                 Connection.SendCommand(new ListCredentialsCommand());
 
             if (listCredsRsp.Status != ResponseStatus.Success)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.ManagementKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.ManagementKey.cs
@@ -45,15 +45,13 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public int GetManagementKeyRetries()
         {
-            GetManagementKeyRetriesResponse retryCountResponse =
-                Connection.SendCommand(new GetManagementKeyRetriesCommand());
-
-            if (retryCountResponse.Status != ResponseStatus.Success)
+            var response = Connection.SendCommand(new GetManagementKeyRetriesCommand());
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(retryCountResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
 
-            return retryCountResponse.GetData();
+            return response.GetData();
         }
 
         /// <summary>
@@ -131,7 +129,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public bool TryChangeManagementKey()
         {
-            Func<KeyEntryData, bool> keyCollector = GetKeyCollector();
+            var keyCollector = GetKeyCollector();
 
             var keyEntryData = new KeyEntryData
             {
@@ -237,7 +235,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
 
             var changeMgmtKeyCmd = new ChangeManagementKeyCommand(currentManagementKey, newManagementKey);
 
-            ChangeManagementKeyResponse changeMgmtKeyRsp =
+            var changeMgmtKeyRsp =
                 Connection.SendCommand(changeMgmtKeyCmd);
 
             if (changeMgmtKeyRsp.Status == ResponseStatus.Success)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.cs
@@ -118,11 +118,10 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public void ResetApplication()
         {
-            ResetApplicationResponse resetResponse = Connection.SendCommand(new ResetApplicationCommand());
-
-            if (resetResponse.Status != ResponseStatus.Success)
+            var response = Connection.SendCommand(new ResetApplicationCommand());
+            if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException(resetResponse.StatusMessage);
+                throw new InvalidOperationException(response.StatusMessage);
             }
         }
 
@@ -137,7 +136,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         /// </exception>
         public ApplicationVersion GetApplicationVersion()
         {
-            GetApplicationVersionResponse applicationVersionResponse = Connection.SendCommand(new GetApplicationVersionCommand());
+            var applicationVersionResponse = Connection.SendCommand(new GetApplicationVersionCommand());
 
             if (applicationVersionResponse.Status != ResponseStatus.Success)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyCapabilitiesExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyCapabilitiesExtensions.cs
@@ -17,26 +17,26 @@ namespace Yubico.YubiKey
     internal static class YubiKeyCapabilitiesExtensions
     {
         public static YubiKeyCapabilities ToDeviceInfoCapabilities(
-            this YubiKeyCapabilities yubiKeyCapabilities)
+            this YubiKeyCapabilities capabilities)
         {
-            if (yubiKeyCapabilities.HasFlag(YubiKeyCapabilities.All))
+            if (capabilities.HasFlag(YubiKeyCapabilities.All))
             {
-                return yubiKeyCapabilities;
+                return capabilities;
             }
 
-            YubiKeyCapabilities deviceInfoCapabilities = YubiKeyCapabilities.None;
+            var deviceInfoCapabilities = YubiKeyCapabilities.None;
 
-            if (yubiKeyCapabilities.HasFlag(YubiKeyCapabilities.Otp))
+            if (capabilities.HasFlag(YubiKeyCapabilities.Otp))
             {
                 deviceInfoCapabilities |= YubiKeyCapabilities.Otp;
             }
 
-            if (yubiKeyCapabilities.HasFlag(YubiKeyCapabilities.FidoU2f))
+            if (capabilities.HasFlag(YubiKeyCapabilities.FidoU2f))
             {
                 deviceInfoCapabilities |= YubiKeyCapabilities.FidoU2f | YubiKeyCapabilities.Fido2;
             }
 
-            if (yubiKeyCapabilities.HasFlag(YubiKeyCapabilities.Ccid))
+            if (capabilities.HasFlag(YubiKeyCapabilities.Ccid))
             {
                 deviceInfoCapabilities |=
                     YubiKeyCapabilities.Piv

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Instance.cs
@@ -118,7 +118,7 @@ namespace Yubico.YubiKey
         {
             get
             {
-                Transport transports = Transport.None;
+                var transports = Transport.None;
 
                 if (HasHidKeyboard)
                 {
@@ -275,28 +275,28 @@ namespace Yubico.YubiKey
         /// <inheritdoc />
         public IYubiKeyConnection Connect(YubiKeyApplication yubikeyApplication)
         {
-            _ = TryConnect(yubikeyApplication, null, true, out IYubiKeyConnection? returnValue);
+            _ = TryConnect(yubikeyApplication, null, true, out var returnValue);
             return returnValue!;
         }
 
         /// <inheritdoc />
         public IScp03YubiKeyConnection ConnectScp03(YubiKeyApplication yubikeyApplication, StaticKeys scp03Keys)
         {
-            _ = TryConnectScp03(yubikeyApplication, null, scp03Keys, true, out IScp03YubiKeyConnection? returnValue);
+            _ = TryConnectScp03(yubikeyApplication, null, scp03Keys, true, out var returnValue);
             return returnValue!;
         }
 
         /// <inheritdoc />
         public IYubiKeyConnection Connect(byte[] applicationId)
         {
-            _ = TryConnect(null, applicationId, true, out IYubiKeyConnection? returnValue);
+            _ = TryConnect(null, applicationId, true, out var returnValue);
             return returnValue!;
         }
 
         /// <inheritdoc />
         public IScp03YubiKeyConnection ConnectScp03(byte[] applicationId, StaticKeys scp03Keys)
         {
-            _ = TryConnectScp03(null, applicationId, scp03Keys, true, out IScp03YubiKeyConnection? returnValue);
+            _ = TryConnectScp03(null, applicationId, scp03Keys, true, out var returnValue);
             return returnValue!;
         }
 
@@ -339,7 +339,7 @@ namespace Yubico.YubiKey
             [MaybeNullWhen(returnValue: false)]
             out IYubiKeyConnection connection)
         {
-            IYubiKeyConnection? returnValue = Connect(application, applicationId, null);
+            var returnValue = Connect(application, applicationId, null);
             if (!(returnValue is null) || !throwOnFail)
             {
                 connection = returnValue;
@@ -357,7 +357,7 @@ namespace Yubico.YubiKey
             [MaybeNullWhen(returnValue: false)]
             out IScp03YubiKeyConnection connection)
         {
-            IYubiKeyConnection? returnValue = Connect(application, applicationId, scp03Keys);
+            var returnValue = Connect(application, applicationId, scp03Keys);
             if (!(returnValue is null) && returnValue is IScp03YubiKeyConnection scp03Connection)
             {
                 connection = scp03Connection;
@@ -458,7 +458,7 @@ namespace Yubico.YubiKey
                 ResetAfterConfig = true,
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
 
             if (response.Status != ResponseStatus.Success)
             {
@@ -480,7 +480,7 @@ namespace Yubico.YubiKey
                 ResetAfterConfig = true,
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
 
             if (response.Status != ResponseStatus.Success)
             {
@@ -501,7 +501,7 @@ namespace Yubico.YubiKey
                 ChallengeResponseTimeout = (byte)seconds,
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
 
             if (response.Status != ResponseStatus.Success)
             {
@@ -522,7 +522,7 @@ namespace Yubico.YubiKey
                 AutoEjectTimeout = seconds,
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
 
             if (response.Status != ResponseStatus.Success)
             {
@@ -540,7 +540,7 @@ namespace Yubico.YubiKey
                 RestrictNfc = enabled
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
@@ -555,7 +555,7 @@ namespace Yubico.YubiKey
                 DeviceFlags = deviceFlags,
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
@@ -586,7 +586,7 @@ namespace Yubico.YubiKey
             var command = new MgmtCmd.SetDeviceInfoCommand();
             command.SetLockCode(lockCode);
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
@@ -611,7 +611,7 @@ namespace Yubico.YubiKey
             command.ApplyLockCode(lockCode);
             command.SetLockCode(_lockCodeAllZeros.Span);
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
 
             if (response.Status != ResponseStatus.Success)
             {
@@ -672,7 +672,7 @@ namespace Yubico.YubiKey
             // Newer YubiKeys should use SetDeviceInfo
             if (FirmwareVersion.Major >= 5)
             {
-                DeviceFlags deviceFlags =
+                var deviceFlags =
                     touchEjectEnabled
                     ? DeviceFlags | DeviceFlags.TouchEject
                     : DeviceFlags & ~DeviceFlags.TouchEject;
@@ -735,7 +735,7 @@ namespace Yubico.YubiKey
                 TemporaryTouchThreshold = value
             };
 
-            IYubiKeyResponse response = SendConfiguration(command);
+            var response = SendConfiguration(command);
             if (response.Status != ResponseStatus.Success)
             {
                 throw new InvalidOperationException(response.StatusMessage);
@@ -1090,7 +1090,7 @@ namespace Yubico.YubiKey
             // should still probably wait a few milliseconds for things to stabilize. But definitely not the full
             // three seconds! For older keys, we use a value of 3.01 seconds to give us a little wiggle room as the
             // YubiKey's measurement for the reclaim timeout is likely not as accurate as our system clock.
-            TimeSpan reclaimTimeout = CanFastReclaim() ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromSeconds(3.01);
+            var reclaimTimeout = CanFastReclaim() ? TimeSpan.FromMilliseconds(100) : TimeSpan.FromSeconds(3.01);
 
             // We're only affected by the reclaim timeout if we're switching USB transports.
             if (_lastActiveTransport == newTransport)
@@ -1107,13 +1107,13 @@ namespace Yubico.YubiKey
                 _lastActiveTransport,
                 newTransport);
 
-            TimeSpan timeSinceLastActivation = DateTime.Now - GetLastActiveTime();
+            var timeSinceLastActivation = DateTime.Now - GetLastActiveTime();
 
             // If we haven't already waited the duration of the reclaim timeout, we need to do so.
             // Otherwise, we've already waited and can immediately switch the transport.
             if (timeSinceLastActivation < reclaimTimeout)
             {
-                TimeSpan waitNeeded = reclaimTimeout - timeSinceLastActivation;
+                var waitNeeded = reclaimTimeout - timeSinceLastActivation;
 
                 _log.LogInformation(
                     "Reclaim timeout still active. Need to wait {TimeMS} milliseconds.",

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
@@ -73,7 +73,7 @@ namespace Yubico.YubiKey
         /// </exception>
         public static IEnumerable<IYubiKeyDevice> FindByTransport(Transport transport = Transport.All)
         {
-            ILogger log = Log.GetLogger(typeof(YubiKeyDeviceListener).FullName!);
+            var log = Log.GetLogger(typeof(YubiKeyDeviceListener).FullName!);
 
             log.LogInformation("FindByTransport {Transport}", transport);
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -130,7 +130,7 @@ namespace Yubico.YubiKey
             ReadOnlyMemory<byte> responseApduData,
             [MaybeNullWhen(returnValue: false)] out YubiKeyDeviceInfo deviceInfo)
         {
-            Dictionary<int, ReadOnlyMemory<byte>>? data =
+            var data =
                 GetDeviceInfoResponseHelper.CreateApduDictionaryFromResponseData(responseApduData);
 
             if (data is null)
@@ -162,9 +162,9 @@ namespace Yubico.YubiKey
             bool skySeriesFlag = false;
             var deviceInfo = new YubiKeyDeviceInfo();
 
-            foreach (KeyValuePair<int, ReadOnlyMemory<byte>> tagValuePair in responseApduData)
+            foreach (var tagValuePair in responseApduData)
             {
-                ReadOnlySpan<byte> value = tagValuePair.Value.Span;
+                var value = tagValuePair.Value.Span;
                 switch (tagValuePair.Key)
                 {
                     case YubikeyDeviceManagementTags.UsbPrePersCapabilitiesTag:

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceListener.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceListener.cs
@@ -124,19 +124,18 @@ namespace Yubico.YubiKey
 
             ResetCacheMarkers();
 
-            List<IDevice> devicesToProcess = GetDevices();
+            var devicesToProcess = GetDevices();
 
             _log.LogInformation("Cache currently aware of {Count} YubiKeys.", _internalCache.Count);
 
             var addedYubiKeys = new List<IYubiKeyDevice>();
 
-            foreach (IDevice device in devicesToProcess)
+            foreach (var device in devicesToProcess)
             {
                 _log.LogInformation("Processing device {Device}", device);
 
                 // First check if we've already seen this device (very fast)
-                IYubiKeyDevice? existingEntry = _internalCache.Keys.FirstOrDefault(k => k.Contains(device));
-
+                var existingEntry = _internalCache.Keys.FirstOrDefault(k => k.Contains(device));
                 if (existingEntry != null)
                 {
                     MarkExistingYubiKey(existingEntry);
@@ -198,13 +197,13 @@ namespace Yubico.YubiKey
                 .Select(e => e.Key)
                 .ToList();
 
-            foreach (IYubiKeyDevice removedKey in removedYubiKeys)
+            foreach (var removedKey in removedYubiKeys)
             {
                 OnDeviceRemoved(new YubiKeyDeviceEventArgs(removedKey));
                 _ = _internalCache.Remove(removedKey);
             }
 
-            foreach (IYubiKeyDevice addedKey in addedYubiKeys)
+            foreach (var addedKey in addedYubiKeys)
             {
                 OnDeviceArrived(new YubiKeyDeviceEventArgs(addedKey));
             }
@@ -248,7 +247,7 @@ namespace Yubico.YubiKey
         private void ResetCacheMarkers()
         {
             // Copy the list of keys as changing a dictionary's value will invalidate any enumerators (i.e. the loop).
-            foreach (IYubiKeyDevice cacheDevice in _internalCache.Keys.ToList())
+            foreach (var cacheDevice in _internalCache.Keys.ToList())
             {
                 _internalCache[cacheDevice] = false;
             }

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Oath/GetLargeData.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Oath/GetLargeData.cs
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.Oath
 
         private IEnumerable<Credential> FillWithRandCreds(IYubiKeyDevice testDevice)
         {
-            List<Credential> creds = new List<Credential>();
+            var creds = new List<Credential>();
 
             using (var oathSession = new OathSession(testDevice))
             {

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionCredentialTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionCredentialTests.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
 
             using (var yubiHsmAuthSession = new YubiHsmAuthSession(testDevice))
             {
-                SimpleKeyCollector keyCollector = new SimpleKeyCollector
+                var keyCollector = new SimpleKeyCollector
                 {
                     // Start with the incorrect management key, forcing a retry
                     UseDefaultValue = false
@@ -222,7 +222,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
             // Preconditions
             IYubiKeyDevice testDevice = YhaTestUtilities.GetCleanDevice();
 
-            SimpleKeyCollector simpleKeyCollector = new SimpleKeyCollector
+            var simpleKeyCollector = new SimpleKeyCollector
             {
                 // Start with the incorrect management key, forcing a retry
                 UseDefaultValue = false,

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionGetAes128SessionKeysTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionGetAes128SessionKeysTests.cs
@@ -203,7 +203,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
 
             using (var yubiHsmAuthSession = new YubiHsmAuthSession(testDevice))
             {
-                SimpleKeyCollector keyCollector = new SimpleKeyCollector
+                var keyCollector = new SimpleKeyCollector
                 {
                     // Start with the incorrect cred password, forcing a retry
                     UseDefaultValue = false

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionManagementKeyTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiHsmAuth/SessionManagementKeyTests.cs
@@ -265,7 +265,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             // Preconditions
             IYubiKeyDevice testDevice = YhaTestUtilities.GetCleanDevice();
-            SimpleKeyCollector keyCollector = new SimpleKeyCollector();
+            var keyCollector = new SimpleKeyCollector();
 
             using (var yubiHsmAuthSession = new YubiHsmAuthSession(testDevice))
             {
@@ -285,7 +285,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             // Preconditions
             IYubiKeyDevice testDevice = YhaTestUtilities.GetCleanDevice();
-            SimpleKeyCollector keyCollector = new SimpleKeyCollector
+            var keyCollector = new SimpleKeyCollector
             {
                 UseDefaultValue = false,
             };

--- a/Yubico.YubiKey/tests/sandbox/Plugins/DavidPlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/DavidPlugin.cs
@@ -119,7 +119,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                     using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                     {
-                        ListCredentialsCommand cmd = new ListCredentialsCommand();
+                        var cmd = new ListCredentialsCommand();
                         ListCredentialsResponse response = hsmAuthConnection.SendCommand(cmd);
                         if (response.Status != ResponseStatus.Success)
                         {
@@ -178,7 +178,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                     bool touchRequired = false;
 
                     var aesCred = new Aes128CredentialWithSecrets(password, encKey, macKey, label, touchRequired);
-                    AddCredentialCommand cmd = new AddCredentialCommand(mgmtKey, aesCred);
+                    var cmd = new AddCredentialCommand(mgmtKey, aesCred);
                     AddCredentialResponse response = hsmAuthConnection.SendCommand(cmd);
 
                     if (response.Status != ResponseStatus.Success)
@@ -325,7 +325,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                 return;
             }
 
-            AddCredentialCommand addCmd = new AddCredentialCommand(mgmtKey, aesCred);
+            var addCmd = new AddCredentialCommand(mgmtKey, aesCred);
             AddCredentialResponse response = hsmAuthConnection.SendCommand(addCmd);
 
             if (response.Status != ResponseStatus.Success)
@@ -343,7 +343,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
         private bool HelperListCreds(IYubiKeyConnection hsmAuthConnection)
         {
-            ListCredentialsCommand listCmd = new ListCredentialsCommand();
+            var listCmd = new ListCredentialsCommand();
             ListCredentialsResponse listResponse = hsmAuthConnection.SendCommand(listCmd);
             if (listResponse.Status != ResponseStatus.Success)
             {
@@ -397,7 +397,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                 using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                 {
-                    ListCredentialsCommand listCmd = new ListCredentialsCommand();
+                    var listCmd = new ListCredentialsCommand();
                     ListCredentialsResponse listResponse = hsmAuthConnection.SendCommand(listCmd);
                     if (listResponse.Status != ResponseStatus.Success)
                     {
@@ -414,7 +414,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         Output.WriteLine($"Adding cred #{i}");
 
                         aesCred.Label = $"Test Cred {i}";
-                        AddCredentialCommand cmd = new AddCredentialCommand(mgmtKey, aesCred);
+                        var cmd = new AddCredentialCommand(mgmtKey, aesCred);
                         AddCredentialResponse response = hsmAuthConnection.SendCommand(cmd);
 
                         if (response.Status != ResponseStatus.Success)
@@ -476,7 +476,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                     CredentialRetryPair credRetryPair = credRetryPairs.First();
 
-                    DeleteCredentialCommand cmd =
+                    var cmd =
                         new DeleteCredentialCommand(mgmtKey, credRetryPair.Credential.Label);
 
                     Output.WriteLine($"\nAttempting to delete credential \"{cmd.Label}\"...");
@@ -529,7 +529,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
         private List<CredentialRetryPair>? HelperGetCreds(IYubiKeyConnection hsmAuthConnection)
         {
-            ListCredentialsCommand listCmd = new ListCredentialsCommand();
+            var listCmd = new ListCredentialsCommand();
             ListCredentialsResponse listResponse = hsmAuthConnection.SendCommand(listCmd);
             if (listResponse.Status != ResponseStatus.Success)
             {
@@ -560,7 +560,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                     using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                     {
-                        GetManagementKeyRetriesCommand cmd = new GetManagementKeyRetriesCommand();
+                        var cmd = new GetManagementKeyRetriesCommand();
                         GetManagementKeyRetriesResponse response = hsmAuthConnection.SendCommand(cmd);
                         if (response.Status != ResponseStatus.Success)
                         {
@@ -600,7 +600,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                 using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                 {
-                    GetApplicationVersionCommand cmd = new GetApplicationVersionCommand();
+                    var cmd = new GetApplicationVersionCommand();
                     GetApplicationVersionResponse response = hsmAuthConnection.SendCommand(cmd);
 
                     if (response.Status != ResponseStatus.Success)
@@ -648,7 +648,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                     byte[] currentManagementKey = new byte[16] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
                     byte[] newManagementKey = new byte[16] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
 
-                    ChangeManagementKeyCommand cmd = new ChangeManagementKeyCommand(currentManagementKey, newManagementKey);
+                    var cmd = new ChangeManagementKeyCommand(currentManagementKey, newManagementKey);
                     ChangeManagementKeyResponse response = hsmAuthConnection.SendCommand(cmd);
 
                     if (response.Status != ResponseStatus.Success)
@@ -703,7 +703,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                     using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                     {
                         // Get initial mgmt key retries remaining
-                        GetManagementKeyRetriesCommand cmdRetries = new GetManagementKeyRetriesCommand();
+                        var cmdRetries = new GetManagementKeyRetriesCommand();
                         GetManagementKeyRetriesResponse responseRetries = hsmAuthConnection.SendCommand(cmdRetries);
                         if (responseRetries.Status != ResponseStatus.Success)
                         {
@@ -719,7 +719,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         byte[] currentManagementKey = new byte[16] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
                         byte[] newManagementKey = new byte[16] { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4 };
 
-                        ChangeManagementKeyCommand cmdChangeMgmt = new ChangeManagementKeyCommand(newManagementKey, currentManagementKey);
+                        var cmdChangeMgmt = new ChangeManagementKeyCommand(newManagementKey, currentManagementKey);
                         ChangeManagementKeyResponse responseChangeMgmt = hsmAuthConnection.SendCommand(cmdChangeMgmt);
 
                         if (responseChangeMgmt.Status != ResponseStatus.Success)
@@ -795,11 +795,11 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                     Output.WriteLine($"\n{deviceCount++}) Using YubiKey v{device.FirmwareVersion} S/N {device.SerialNumber}...");
 
-                    using (YubiHsmAuthSession yhaSession = new YubiHsmAuthSession(device))
+                    using (var yhaSession = new YubiHsmAuthSession(device))
                     {
                         if (!HelperGetCreds(yhaSession.Connection)!.Any())
                         {
-                            AddCredentialCommand cmdAddCred = new AddCredentialCommand(mgmtKey, aesCred);
+                            var cmdAddCred = new AddCredentialCommand(mgmtKey, aesCred);
                             AddCredentialResponse responseAddCred = yhaSession.Connection.SendCommand(cmdAddCred);
 
                             if (responseAddCred.Status != ResponseStatus.Success)
@@ -865,7 +865,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                     using (IYubiKeyConnection hsmAuthConnection = device.Connect(YubiKeyApplication.YubiHsmAuth))
                     {
                         // Reset app
-                        ResetApplicationCommand cmd = new ResetApplicationCommand();
+                        var cmd = new ResetApplicationCommand();
                         ResetApplicationResponse response = hsmAuthConnection.SendCommand(cmd);
                         if (response.Status != ResponseStatus.Success)
                         {
@@ -878,7 +878,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         }
 
                         // Add cred
-                        AddCredentialCommand cmdAddCred = new AddCredentialCommand(mgmtKey, aesCred);
+                        var cmdAddCred = new AddCredentialCommand(mgmtKey, aesCred);
                         AddCredentialResponse responseAddCred = hsmAuthConnection.SendCommand(cmdAddCred);
 
                         if (responseAddCred.Status != ResponseStatus.Success)
@@ -892,7 +892,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         }
 
                         // Get session keys
-                        GetAes128SessionKeysCommand cmdGetSessionKeys = new GetAes128SessionKeysCommand(strLabel, password, hostChallenge, hsmDeviceChallenge);
+                        var cmdGetSessionKeys = new GetAes128SessionKeysCommand(strLabel, password, hostChallenge, hsmDeviceChallenge);
                         GetAes128SessionKeysResponse rspGetSessionKeys = hsmAuthConnection.SendCommand(cmdGetSessionKeys);
 
                         if (responseAddCred.Status != ResponseStatus.Success)
@@ -950,7 +950,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
 
                     Output.WriteLine($"\n{deviceCount++}) Using YubiKey v{device.FirmwareVersion} S/N {device.SerialNumber}...");
 
-                    using (YubiHsmAuthSession yhaSession = new YubiHsmAuthSession(device))
+                    using (var yhaSession = new YubiHsmAuthSession(device))
                     {
                         Output.WriteLine("Resetting YubiHSM Auth application...");
                         yhaSession.ResetApplication();
@@ -1055,7 +1055,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         string targetCredLabel = creds[0].Credential.Label;
                         Output.WriteLine($"Reducing {targetCredLabel} retries to 6...");
                         int? retriesRemaining = creds.First(cred => cred.Credential.Label == targetCredLabel).Retries;
-                        GetAes128SessionKeysCommand getSessionKeys = new GetAes128SessionKeysCommand(targetCredLabel, newMgmtKey, hostChallenge, hsmDeviceChallenge);
+                        var getSessionKeys = new GetAes128SessionKeysCommand(targetCredLabel, newMgmtKey, hostChallenge, hsmDeviceChallenge);
                         GetAes128SessionKeysResponse responseSessionKeys;
                         while (retriesRemaining > 6)
                         {
@@ -1085,7 +1085,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
                         //Output.WriteLine();
 
                         Output.WriteLine("Attempting to change mgmt key (correct current mgmt key)...");
-                        ChangeManagementKeyCommand cmdChangeMgmt = new ChangeManagementKeyCommand(currentMgmtKey, newMgmtKey);
+                        var cmdChangeMgmt = new ChangeManagementKeyCommand(currentMgmtKey, newMgmtKey);
                         ChangeManagementKeyResponse responseChangeMgmt = yhaSession.Connection.SendCommand(cmdChangeMgmt);
                         Output.WriteLine($"Response status: {responseChangeMgmt.Status}, {responseChangeMgmt.StatusMessage}; retries = {responseChangeMgmt.RetriesRemaining}");
                         Output.WriteLine();

--- a/Yubico.YubiKey/tests/sandbox/Plugins/HidCodeTablePlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/HidCodeTablePlugin.cs
@@ -83,7 +83,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
         public override void HandleParameters()
         {
             // If none were specified, print them all.
-            IEnumerable<string> keyboards = (IEnumerable<string>)(Parameters["keyboardids"].Value ?? Array.Empty<string>());
+            var keyboards = (IEnumerable<string>)(Parameters["keyboardids"].Value ?? Array.Empty<string>());
             _keyboards = keyboards.Any()
                 ? keyboards
                 : _keyboardLayouts.Keys;

--- a/Yubico.YubiKey/tests/sandbox/Plugins/YubiKeyFeaturePlugin.cs
+++ b/Yubico.YubiKey/tests/sandbox/Plugins/YubiKeyFeaturePlugin.cs
@@ -166,7 +166,7 @@ namespace Yubico.YubiKey.TestApp.Plugins
             Output.Write("Select an option and press ENTER. Press any other key to exit: ");
 
             ConsoleKeyInfo inputKey = Console.ReadKey(true);
-            StringBuilder inputStr = new StringBuilder(inputKey.KeyChar.ToString());
+            var inputStr = new StringBuilder(inputKey.KeyChar.ToString());
             Console.Write(inputStr);
 
             while (inputKey.Key != ConsoleKey.Enter)

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/LargeBlobArrayTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/LargeBlobArrayTests.cs
@@ -137,7 +137,7 @@ namespace Yubico.YubiKey.Fido2
 
             // The code will generate a random nonce. So to guarantee the nonce
             // we want, use the fixed byte RNG.
-            RandomObjectUtility nonceGenerator =
+            var nonceGenerator =
                 RandomObjectUtility.SetRandomProviderFixedBytes(nonceBytes);
 
             try

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/LargeBlobEntryTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/LargeBlobEntryTests.cs
@@ -71,7 +71,7 @@ namespace Yubico.YubiKey.Fido2
 
             // The code will generate a random nonce. So to guarantee the nonce
             // we want, use the fixed byte RNG.
-            RandomObjectUtility nonceGenerator =
+            var nonceGenerator =
                 RandomObjectUtility.SetRandomProviderFixedBytes(nonceBytes);
             bool isValid = false;
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/CalculateAllCredentialsCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/CalculateAllCredentialsCommandTests.cs
@@ -76,7 +76,7 @@ namespace Yubico.YubiKey.Oath.Commands
         [Fact]
         public void CreateCommandApdu_ReturnsCorrectLength()
         {
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -100,7 +100,7 @@ namespace Yubico.YubiKey.Oath.Commands
         [Fact]
         public void CreateCommandApdu_ReturnsCorrectData()
         {
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/CalculateCredentialCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/CalculateCredentialCommandTests.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.Oath.Commands
         [Fact]
         public void CreateCommandApdu_TotpCredential_ReturnsCorrectLength()
         {
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -105,7 +105,7 @@ namespace Yubico.YubiKey.Oath.Commands
         [Fact]
         public void CreateCommandApdu_TotpCredential_ReturnsCorrectData()
         {
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/SetPasswordCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/SetPasswordCommandTests.cs
@@ -82,7 +82,7 @@ namespace Yubico.YubiKey.Oath.Commands
         {
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -111,7 +111,7 @@ namespace Yubico.YubiKey.Oath.Commands
         {
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/ValidateCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/ValidateCommandTests.cs
@@ -81,8 +81,8 @@ namespace Yubico.YubiKey.Oath.Commands
         public void CreateCommandApdu_GetNcProperty_ReturnsCorrectLength()
         {
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
-            OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var oathData = selectOathResponse.GetData();
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -109,7 +109,7 @@ namespace Yubico.YubiKey.Oath.Commands
         {
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/ValidateResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/Commands/ValidateResponseTests.cs
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey.Oath.Commands
 
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -75,7 +75,7 @@ namespace Yubico.YubiKey.Oath.Commands
 
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {
@@ -104,7 +104,7 @@ namespace Yubico.YubiKey.Oath.Commands
         {
             var selectOathResponse = new SelectOathResponse(selectResponseApdu);
             OathApplicationData oathData = selectOathResponse.GetData();
-            RandomObjectUtility utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
+            var utility = RandomObjectUtility.SetRandomProviderFixedBytes(_fixedBytes);
 
             try
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/CredentialTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Oath/CredentialTests.cs
@@ -27,7 +27,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Issuer_GetDefaultValue_ReturnsNull()
         {
-            Credential cred = new Credential();
+            var cred = new Credential();
 
             Assert.Null(cred.Issuer);
         }
@@ -35,7 +35,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Issuer_SetToTestString_ReturnsTestString()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Issuer = DefaultTestIssuer
             };
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Issuer_SetToTestStringWithLeadingTrailingWhiteSpace_ReturnsTestString()
         {
-            Credential cred = new Credential();
+            var cred = new Credential();
 
             string? expectedIssuer = "  " + DefaultTestIssuer + " \t ";
             cred.Issuer = expectedIssuer;
@@ -59,7 +59,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Issuer_SetToNull_ReturnsNull()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Issuer = null
             };
@@ -71,7 +71,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Issuer_SetToEmptyString_ReturnsNull()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Issuer = string.Empty
             };
@@ -86,7 +86,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData("\u2000\u2000\u2000")]
         public void Issuer_SetToWhiteSpace_ReturnsNull(string? issuerValue)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Issuer = issuerValue
             };
@@ -102,7 +102,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_Totp15sIssuerAccount_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period15,
@@ -119,7 +119,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_Totp30sIssuerAccount_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period30,
@@ -136,7 +136,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_HotpIssuerAccount_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Hotp,
                 Issuer = DefaultTestIssuer,
@@ -155,7 +155,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData("      ")]
         public void Name_Totp15sAccount_ReturnsCorrectName(string? issuerValue)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period15,
@@ -172,7 +172,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_Totp15sAccountDefaultIssuer_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period15,
@@ -191,7 +191,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData("      ")]
         public void Name_Totp30sAccount_ReturnsCorrectName(string? issuerValue)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period30,
@@ -208,7 +208,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_Totp30sAccountDefaultIssuer_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period30,
@@ -227,7 +227,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData("      ")]
         public void Name_HotpAccount_ReturnsCorrectName(string? issuerValue)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Hotp,
                 Issuer = issuerValue,
@@ -243,7 +243,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_HotpAccountDefaultIssuer_ReturnsCorrectName()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Hotp,
                 AccountName = DefaultTestAccount
@@ -265,7 +265,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData(CredentialType.Hotp, CredentialPeriod.Undefined, null, "1234567890123456789012345678901234567890123456789012345678901234")]
         public void Name_64ByteNameLength_ReturnsCorrectName(CredentialType credType, CredentialPeriod credPeriod, string? issuer, string account)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = credType,
                 Period = credPeriod,
@@ -291,7 +291,7 @@ namespace Yubico.YubiKey.Oath
         [InlineData(CredentialType.Hotp, CredentialPeriod.Undefined, null, "12345678901234567890123456789012345678901234567890123456789012345")]
         public void Name_65ByteNameLength_ThrowsInvalidOperationException(CredentialType credType, CredentialPeriod credPeriod, string? issuer, string account)
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = credType,
                 Period = credPeriod,
@@ -305,7 +305,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_CredTypeDefault_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Issuer = DefaultTestIssuer,
                 AccountName = DefaultTestAccount
@@ -317,7 +317,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_CredTypeNone_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.None,
                 Issuer = DefaultTestIssuer,
@@ -330,7 +330,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_TotpCredPeriodDefault_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Issuer = DefaultTestIssuer,
@@ -343,7 +343,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_TotpCredPeriodUndefined_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Period = CredentialPeriod.Undefined,
                 Type = CredentialType.Totp,
@@ -357,7 +357,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_Totp30sAccountDefault_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Totp,
                 Period = CredentialPeriod.Period30,
@@ -370,7 +370,7 @@ namespace Yubico.YubiKey.Oath
         [Fact]
         public void Name_HotpAccountDefault_ThrowsInvalidOperationException()
         {
-            Credential cred = new Credential
+            var cred = new Credential
             {
                 Type = CredentialType.Hotp,
                 Issuer = DefaultTestIssuer

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/KeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/KeyTests.cs
@@ -76,7 +76,7 @@ namespace Yubico.YubiKey.Piv
             byte[] encryptedData = new byte[8];
             byte[] encryptCipher = new byte[8];
 
-            TripleDES desObject = TripleDES.Create();
+            var desObject = TripleDES.Create();
             desObject.Mode = CipherMode.ECB;
             desObject.Padding = PaddingMode.None;
             ICryptoTransform encryptor = desObject.CreateEncryptor(keyData, null);
@@ -122,7 +122,7 @@ namespace Yubico.YubiKey.Piv
             byte[] result3 = new byte[8];
             byte[] result4 = new byte[8];
 
-            TripleDES tDesObject = TripleDES.Create();
+            var tDesObject = TripleDES.Create();
             tDesObject.Mode = CipherMode.ECB;
             tDesObject.Padding = PaddingMode.None;
 
@@ -166,7 +166,7 @@ namespace Yubico.YubiKey.Piv
             byte[] result2 = new byte[8];
             byte[] result3 = new byte[8];
 
-            TripleDES tDesObject = TripleDES.Create();
+            var tDesObject = TripleDES.Create();
             tDesObject.Mode = CipherMode.ECB;
             tDesObject.Padding = PaddingMode.None;
             tDesObject.KeySize = 128;
@@ -212,7 +212,7 @@ namespace Yubico.YubiKey.Piv
             byte[] part1 = new byte[8];
             byte[] part2 = new byte[8];
 
-            TripleDES tDesObject = TripleDES.Create();
+            var tDesObject = TripleDES.Create();
             tDesObject.Mode = CipherMode.ECB;
             tDesObject.Padding = PaddingMode.None;
 
@@ -224,7 +224,7 @@ namespace Yubico.YubiKey.Piv
             eLen = encryptor1.TransformBlock(dataToEncrypt, 0, 8, part1, 0);
             Assert.Equal(8, eLen);
 
-            DES desObject = DES.Create();
+            var desObject = DES.Create();
             desObject.Mode = CipherMode.ECB;
             desObject.Padding = PaddingMode.None;
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Aes128CredentialWithSecretsTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Aes128CredentialWithSecretsTests.cs
@@ -78,7 +78,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         [Fact]
         public void Constructor_SetGetLabel()
         {
-            Aes128CredentialWithSecrets aes128Cred = new Aes128CredentialWithSecrets(
+            var aes128Cred = new Aes128CredentialWithSecrets(
                 _password,
                 _encKey,
                 _macKey,
@@ -91,7 +91,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         [Fact]
         public void Constructor_SetGetTouchRequired()
         {
-            Aes128CredentialWithSecrets aes128Cred = new Aes128CredentialWithSecrets(
+            var aes128Cred = new Aes128CredentialWithSecrets(
                 _password,
                 _encKey,
                 _macKey,

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialCommandTests.cs
@@ -44,7 +44,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
         }
@@ -52,7 +52,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Cla);
@@ -61,7 +61,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x01()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0x01, apdu.Ins);
@@ -70,7 +70,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P1);
@@ -79,7 +79,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P2);
@@ -88,10 +88,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsMgmtKeyTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7b)
             {
@@ -105,10 +105,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsMgmtKeyValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7b)
             {
@@ -124,10 +124,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {
@@ -141,10 +141,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {
@@ -160,10 +160,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsTouchRequiredTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7a)
             {
@@ -177,10 +177,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsTouchRequiredValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7a)
             {
@@ -196,10 +196,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsKeyTypeTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x74)
             {
@@ -213,10 +213,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsKeyTypeValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x74)
             {
@@ -232,10 +232,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsCredPasswordTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x73)
             {
@@ -249,10 +249,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsCredPasswordValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x73)
             {
@@ -268,10 +268,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_GivenAes128Credential_DataContainsEncKeyTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x75)
             {
@@ -285,10 +285,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_GivenAes128Credential_DataContainsEncKeyValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x75)
             {
@@ -304,10 +304,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_GivenAes128Credential_DataContainsMacKeyTag()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x76)
             {
@@ -321,10 +321,10 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_GivenAes128Credential_DataContainsMacKeyValue()
         {
-            AddCredentialCommand command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
+            var command = new AddCredentialCommand(_mgmtKey, _aes128Cred);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x76)
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/AddCredentialResponseTests.cs
@@ -22,9 +22,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.Success);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.Success);
 
-            AddCredentialResponse response = new AddCredentialResponse(apdu);
+            var response = new AddCredentialResponse(apdu);
 
             Assert.NotNull(response);
         }
@@ -32,9 +32,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void ResponseStatus_GivenStatusWord0x6983_ReturnsFailed()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            AddCredentialResponse response = new AddCredentialResponse(apdu);
+            var response = new AddCredentialResponse(apdu);
 
             Assert.Equal(ResponseStatus.Failed, response.Status);
         }
@@ -44,9 +44,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         {
             string expectedMessage = "A credential with that label already exists.";
 
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            AddCredentialResponse response = new AddCredentialResponse(apdu);
+            var response = new AddCredentialResponse(apdu);
 
             Assert.Equal(expectedMessage, response.StatusMessage);
         }
@@ -55,9 +55,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void ResponseStatus_GivenStatusWord0x63C0_ReturnsAuthenticationRequired()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.VerifyFail);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.VerifyFail);
 
-            AddCredentialResponse response = new AddCredentialResponse(apdu);
+            var response = new AddCredentialResponse(apdu);
 
             Assert.Equal(ResponseStatus.AuthenticationRequired, response.Status);
         }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/BaseYubiHsmAuthResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/BaseYubiHsmAuthResponseTests.cs
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         {
             short expectedSW = SWConstants.Success;
 
-            SampleYubiHsmAuthResponse response = new SampleYubiHsmAuthResponse(
+            var response = new SampleYubiHsmAuthResponse(
                 new ResponseApdu(new byte[] { }, expectedSW));
 
             Assert.Equal(expectedSW, response.StatusWord);
@@ -49,7 +49,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(SWConstants.Success, ResponseStatus.Success)]
         public void Status_GivenStatusWord_ReturnsCorrectResponseStatus(short responseSw, ResponseStatus expectedStatus)
         {
-            SampleYubiHsmAuthResponse response = new SampleYubiHsmAuthResponse(
+            var response = new SampleYubiHsmAuthResponse(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedStatus, response.Status);
@@ -62,7 +62,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(SWConstants.Success, SuccessStatusMessage)]
         public void Status_GivenStatusWord_ReturnsCorrectResponseMessage(short responseSw, string expectedMessage)
         {
-            SampleYubiHsmAuthResponse response = new SampleYubiHsmAuthResponse(
+            var response = new SampleYubiHsmAuthResponse(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedMessage, response.StatusMessage);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/BaseYubiHsmAuthResponseWithRetriesTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/BaseYubiHsmAuthResponseWithRetriesTests.cs
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(0x63cf, ResponseStatus.AuthenticationRequired)]
         public void Status_GivenStatusWord_ReturnsCorrectResponseStatus(short responseSw, ResponseStatus expectedStatus)
         {
-            SampleYubiHsmAuthResponseWithRetries response = new SampleYubiHsmAuthResponseWithRetries(
+            var response = new SampleYubiHsmAuthResponseWithRetries(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedStatus, response.Status);
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(0x63cf, AuthenticationRequired15RetriesStatusMessage)]
         public void Status_GivenStatusWord_ReturnsCorrectResponseMessage(short responseSw, string expectedMessage)
         {
-            SampleYubiHsmAuthResponseWithRetries response = new SampleYubiHsmAuthResponseWithRetries(
+            var response = new SampleYubiHsmAuthResponseWithRetries(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedMessage, response.StatusMessage);
@@ -60,7 +60,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(SWConstants.InvalidParameter, false)]
         public void SwContainsRetries_GivenSw_ReturnsTrueWhenRetriesPresent(short responseSw, bool expectedResponse)
         {
-            SampleYubiHsmAuthResponseWithRetries response = new SampleYubiHsmAuthResponseWithRetries(
+            var response = new SampleYubiHsmAuthResponseWithRetries(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedResponse, response.HasRetries);
@@ -71,7 +71,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(0x63cf, 15)]
         public void RetriesRemaining_GivenSwWithRetryCount_ReturnsCorrectRetryCount(short responseSw, int? expectedCount)
         {
-            SampleYubiHsmAuthResponseWithRetries response = new SampleYubiHsmAuthResponseWithRetries(
+            var response = new SampleYubiHsmAuthResponseWithRetries(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.Equal(expectedCount, response.RetriesRemaining);
@@ -82,7 +82,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(SWConstants.InvalidParameter)]
         public void RetriesRemaining_GivenSwNoRetryCount_ReturnsNull(short responseSw)
         {
-            SampleYubiHsmAuthResponseWithRetries response = new SampleYubiHsmAuthResponseWithRetries(
+            var response = new SampleYubiHsmAuthResponseWithRetries(
                 new ResponseApdu(new byte[] { }, responseSw));
 
             Assert.True(!response.RetriesRemaining.HasValue);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ChangeManagementKeyCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ChangeManagementKeyCommandTests.cs
@@ -80,7 +80,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             ChangeManagementKeyCommand command = _command;
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
 
             int mgmtKeyTagCount = 0;
 
@@ -104,7 +104,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             ChangeManagementKeyCommand command = _command;
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
 
             int mgmtKeyTagCount = 0;
             byte[] value = Array.Empty<byte>();
@@ -129,7 +129,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             ChangeManagementKeyCommand command = _command;
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
 
             int mgmtKeyTagCount = 0;
             byte[] value = Array.Empty<byte>();

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/DeleteCredentialCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/DeleteCredentialCommandTests.cs
@@ -46,7 +46,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void ConstructorMgmtKeyLabel_ValidInputs_LabelMatchesInput()
         {
-            DeleteCredentialCommand cmd =
+            var cmd =
                 new DeleteCredentialCommand(_mgmtKey, _label);
 
             Assert.Equal(_label, cmd.Label);
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Label_SetGetValidString_ReturnsMatchingString()
         {
-            DeleteCredentialCommand cmd = new DeleteCredentialCommand(_mgmtKey)
+            var cmd = new DeleteCredentialCommand(_mgmtKey)
             {
                 Label = _label
             };
@@ -92,7 +92,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         {
             string invalidLabel = new string('a', length);
 
-            DeleteCredentialCommand cmd = new DeleteCredentialCommand(_mgmtKey);
+            var cmd = new DeleteCredentialCommand(_mgmtKey);
 
             _ = Assert.ThrowsAny<ArgumentException>(() => cmd.Label = invalidLabel);
         }
@@ -100,7 +100,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey);
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
@@ -109,7 +109,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -119,7 +119,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x02()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -129,7 +129,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -139,7 +139,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -149,11 +149,11 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsMgmtKeyTag()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7b)
             {
@@ -167,11 +167,11 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsMgmtKeyValue()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x7b)
             {
@@ -187,11 +187,11 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelTag()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {
@@ -205,11 +205,11 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelValue()
         {
-            DeleteCredentialCommand command =
+            var command =
                 new DeleteCredentialCommand(_mgmtKey, _label);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysCommandTests.cs
@@ -33,7 +33,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
@@ -87,7 +87,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
@@ -101,7 +101,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x03()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
@@ -115,7 +115,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
@@ -129,7 +129,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
@@ -143,14 +143,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelTag()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {
@@ -164,14 +164,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsLabelValue()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x71)
             {
@@ -187,14 +187,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsContextTag()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x77)
             {
@@ -208,14 +208,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsContextLength16()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x77)
             {
@@ -231,14 +231,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsContextValue()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x77)
             {
@@ -257,14 +257,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsCredPasswordTag()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x73)
             {
@@ -278,14 +278,14 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataContainsCredPasswordValue()
         {
-            GetAes128SessionKeysCommand command = new GetAes128SessionKeysCommand(
+            var command = new GetAes128SessionKeysCommand(
                 _label,
                 _password,
                 _hostChallenge,
                 _hsmDeviceChallenge);
             CommandApdu apdu = command.CreateCommandApdu();
 
-            TlvReader reader = new TlvReader(apdu.Data);
+            var reader = new TlvReader(apdu.Data);
             int tag = reader.PeekTag();
             while (reader.HasData && tag != 0x73)
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetAes128SessionKeysResponseTests.cs
@@ -40,9 +40,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_NotSuccess_ThrowsInvalidOperationException()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            GetAes128SessionKeysResponse response = new GetAes128SessionKeysResponse(apdu);
+            var response = new GetAes128SessionKeysResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -54,9 +54,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [InlineData(48 + 1)]
         public void GetData_InvalidDataLength_ThrowsMalformedResponseException(int dataLength)
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[dataLength], SWConstants.Success);
+            var apdu = new ResponseApdu(new byte[dataLength], SWConstants.Success);
 
-            GetAes128SessionKeysResponse response = new GetAes128SessionKeysResponse(apdu);
+            var response = new GetAes128SessionKeysResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -66,9 +66,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_Success_ReturnsExpectedEncryptionSessionKey()
         {
-            ResponseApdu apdu = new ResponseApdu(_data(), SWConstants.Success);
+            var apdu = new ResponseApdu(_data(), SWConstants.Success);
 
-            GetAes128SessionKeysResponse response = new GetAes128SessionKeysResponse(apdu);
+            var response = new GetAes128SessionKeysResponse(apdu);
             SessionKeys sessionKeys = response.GetData();
 
             Assert.Equal(_encKey, sessionKeys.EncryptionKey.ToArray());
@@ -77,9 +77,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_Success_ReturnsExpectedMacSessionKey()
         {
-            ResponseApdu apdu = new ResponseApdu(_data(), SWConstants.Success);
+            var apdu = new ResponseApdu(_data(), SWConstants.Success);
 
-            GetAes128SessionKeysResponse response = new GetAes128SessionKeysResponse(apdu);
+            var response = new GetAes128SessionKeysResponse(apdu);
             SessionKeys sessionKeys = response.GetData();
 
             Assert.Equal(_macKey, sessionKeys.MacKey.ToArray());
@@ -88,9 +88,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_Success_ReturnsExpectedRmacSessionKey()
         {
-            ResponseApdu apdu = new ResponseApdu(_data(), SWConstants.Success);
+            var apdu = new ResponseApdu(_data(), SWConstants.Success);
 
-            GetAes128SessionKeysResponse response = new GetAes128SessionKeysResponse(apdu);
+            var response = new GetAes128SessionKeysResponse(apdu);
             SessionKeys sessionKeys = response.GetData();
 
             Assert.Equal(_rmacKey, sessionKeys.RmacKey.ToArray());

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionCommandTests.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
         }
@@ -30,7 +30,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Cla);
@@ -39,7 +39,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x07()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0x07, apdu.Ins);
@@ -48,7 +48,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P1);
@@ -57,7 +57,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P2);
@@ -66,7 +66,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataLength0()
         {
-            GetApplicationVersionCommand command = new GetApplicationVersionCommand();
+            var command = new GetApplicationVersionCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Data.Length);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetApplicationVersionResponseTests.cs
@@ -23,9 +23,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.Success);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.Success);
 
-            GetApplicationVersionResponse response = new GetApplicationVersionResponse(apdu);
+            var response = new GetApplicationVersionResponse(apdu);
 
             Assert.NotNull(response);
         }
@@ -33,9 +33,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ThrowsInvalidOperationException()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            GetApplicationVersionResponse response = new GetApplicationVersionResponse(apdu);
+            var response = new GetApplicationVersionResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -45,9 +45,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ExceptionMessageMatchesStatusMessage()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            GetApplicationVersionResponse response = new GetApplicationVersionResponse(apdu);
+            var response = new GetApplicationVersionResponse(apdu);
 
             try
             {
@@ -62,12 +62,12 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_Given1dot2dot3_ReturnsAppV1dot2dot3()
         {
-            ApplicationVersion expectedAppVersion = new ApplicationVersion(1, 2, 3);
+            var expectedAppVersion = new ApplicationVersion(1, 2, 3);
 
             byte[] dataWithoutSw = new byte[] { 1, 2, 3 };
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
 
-            GetApplicationVersionResponse response = new GetApplicationVersionResponse(apdu);
+            var response = new GetApplicationVersionResponse(apdu);
 
             ApplicationVersion appVersion = response.GetData();
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetManagementKeyRetriesCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetManagementKeyRetriesCommandTests.cs
@@ -25,7 +25,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            GetManagementKeyRetriesCommand command =
+            var command =
                 new GetManagementKeyRetriesCommand();
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
@@ -34,7 +34,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            GetManagementKeyRetriesCommand command =
+            var command =
                 new GetManagementKeyRetriesCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -44,7 +44,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x09()
         {
-            GetManagementKeyRetriesCommand command =
+            var command =
                 new GetManagementKeyRetriesCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -54,7 +54,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            GetManagementKeyRetriesCommand command =
+            var command =
                 new GetManagementKeyRetriesCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
@@ -64,7 +64,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            GetManagementKeyRetriesCommand command =
+            var command =
                 new GetManagementKeyRetriesCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetManagementKeyRetriesResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/GetManagementKeyRetriesResponseTests.cs
@@ -23,9 +23,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ThrowsInvalidOperationException()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            GetManagementKeyRetriesResponse response =
+            var response =
                 new GetManagementKeyRetriesResponse(apdu);
 
             Action action = () => response.GetData();
@@ -36,9 +36,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ExceptionMessageMatchesStatusMessage()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            GetManagementKeyRetriesResponse response =
+            var response =
                 new GetManagementKeyRetriesResponse(apdu);
 
             try
@@ -55,9 +55,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         public void GetData_SuccessApdu6Retries_Returns6Retries()
         {
             byte[] dataWithoutSw = new byte[] { 6 };
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
 
-            GetManagementKeyRetriesResponse response =
+            var response =
                 new GetManagementKeyRetriesResponse(apdu);
 
             int retries = response.GetData();

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsCommandTests.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
         }
@@ -30,7 +30,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
 
             Assert.NotNull(command);
         }
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Cla);
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x05()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0x05, apdu.Ins);
@@ -56,7 +56,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P1);
@@ -65,7 +65,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.P2);
@@ -74,7 +74,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataLength0()
         {
-            ListCredentialsCommand command = new ListCredentialsCommand();
+            var command = new ListCredentialsCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Data.Length);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ListCredentialsResponseTests.cs
@@ -25,9 +25,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.Success);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             Assert.NotNull(response);
         }
@@ -35,9 +35,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ThrowsInvalidOperationException()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -47,9 +47,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ResponseStatusFailed_ExceptionMessageMatchesStatusMessage()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.AuthenticationMethodBlocked);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             try
             {
@@ -65,9 +65,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         public void GetData_DataTagAlgorithm_ThrowsMalformedException()
         {
             byte[] dataWithoutSw = new byte[] { DataTagConstants.CryptographicKeyType, 1, 0 };
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -81,9 +81,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
                 $"a data tag supported by the YubiKey application.";
 
             byte[] dataWithoutSw = new byte[] { DataTagConstants.CryptographicKeyType, 1, 0 };
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw, SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             try
             {
@@ -104,7 +104,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             // Touch - false
             // Label - string of given size
             // Retries - 0
-            List<byte> credRetryData = new List<byte>
+            var credRetryData = new List<byte>
             {
                 (byte)CryptographicKeyType.None,
                 0
@@ -112,16 +112,16 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             credRetryData.AddRange(Encoding.UTF8.GetBytes(new char[labelLength]));
             credRetryData.Add(0);
 
-            List<byte> dataWithoutSw = new List<byte>
+            var dataWithoutSw = new List<byte>
             {
                 DataTagConstants.LabelList,
                 (byte)credRetryData.Count
             };
             dataWithoutSw.AddRange(credRetryData);
 
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             Action action = () => response.GetData();
 
@@ -137,7 +137,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             // Touch - false
             // Label - string of given size
             // Retries - 0
-            List<byte> credRetryData = new List<byte>
+            var credRetryData = new List<byte>
             {
                 (byte)CryptographicKeyType.None,
                 0
@@ -145,16 +145,16 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             credRetryData.AddRange(Encoding.UTF8.GetBytes(new char[0]));
             credRetryData.Add(0);
 
-            List<byte> dataWithoutSw = new List<byte>
+            var dataWithoutSw = new List<byte>
             {
                 DataTagConstants.LabelList,
                 (byte)credRetryData.Count
             };
             dataWithoutSw.AddRange(credRetryData);
 
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             string actualMessage = "";
             try
@@ -172,9 +172,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void GetData_ZeroElements_ReturnsEmptyList()
         {
-            ResponseApdu apdu = new ResponseApdu(new byte[0], SWConstants.Success);
+            var apdu = new ResponseApdu(new byte[0], SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             List<CredentialRetryPair> credentialRetryPairs = response.GetData();
 
@@ -195,7 +195,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             // Touch - false
             // Label - string of given size
             // Retries - 0
-            List<byte> credRetryData = new List<byte>
+            var credRetryData = new List<byte>
             {
                 (byte)expectedKeyType,
                 expectedTouch ? (byte)1 : (byte)0
@@ -203,16 +203,16 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             credRetryData.AddRange(Encoding.UTF8.GetBytes(expectedLabel));
             credRetryData.Add(expectedRetryCount);
 
-            List<byte> dataWithoutSw = new List<byte>
+            var dataWithoutSw = new List<byte>
             {
                 DataTagConstants.LabelList,
                 (byte)credRetryData.Count
             };
             dataWithoutSw.AddRange(credRetryData);
 
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             List<CredentialRetryPair> pairs = response.GetData();
 
@@ -240,7 +240,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             // Touch - false
             // Label - string of given size
             // Retries - 0
-            List<byte> credRetryData = new List<byte>
+            var credRetryData = new List<byte>
             {
                 (byte)expectedKeyType,
                 expectedTouch ? (byte)1 : (byte)0
@@ -248,7 +248,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             credRetryData.AddRange(Encoding.UTF8.GetBytes(expectedLabel));
             credRetryData.Add(expectedRetryCount);
 
-            List<byte> dataWithoutSw = new List<byte>
+            var dataWithoutSw = new List<byte>
             {
                 // First element
                 DataTagConstants.LabelList,
@@ -261,9 +261,9 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
             dataWithoutSw.Add((byte)credRetryData.Count);
             dataWithoutSw.AddRange(credRetryData);
 
-            ResponseApdu apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
+            var apdu = new ResponseApdu(dataWithoutSw.ToArray(), SWConstants.Success);
 
-            ListCredentialsResponse response = new ListCredentialsResponse(apdu);
+            var response = new ListCredentialsResponse(apdu);
 
             List<CredentialRetryPair> pairs = response.GetData();
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ResetApplicationCommandTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/Commands/ResetApplicationCommandTests.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Application_Get_ReturnsYubiHsmAuth()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
 
             Assert.Equal(YubiKeyApplication.YubiHsmAuth, command.Application);
         }
@@ -30,7 +30,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
 
             Assert.NotNull(command);
         }
@@ -38,7 +38,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Cla0()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Cla);
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_Ins0x06()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0x06, apdu.Ins);
@@ -56,7 +56,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P1Is0xde()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0xde, apdu.P1);
@@ -65,7 +65,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_P2Is0xad()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0xad, apdu.P2);
@@ -74,7 +74,7 @@ namespace Yubico.YubiKey.YubiHsmAuth.Commands
         [Fact]
         public void CreateCommandApdu_DataLength0()
         {
-            ResetApplicationCommand command = new ResetApplicationCommand();
+            var command = new ResetApplicationCommand();
             CommandApdu apdu = command.CreateCommandApdu();
 
             Assert.Equal(0, apdu.Data.Length);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/CredentialRetryPairTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/CredentialRetryPairTests.cs
@@ -29,14 +29,14 @@ namespace Yubico.YubiKey.YubiHsmAuth
         [Fact]
         public void Constructor_ReturnsObject()
         {
-            CredentialRetryPair pair = new CredentialRetryPair(cred, 0);
+            var pair = new CredentialRetryPair(cred, 0);
             Assert.NotNull(pair);
         }
 
         [Fact]
         public void Constructor_Given2Retries_SetsRetriesTo2()
         {
-            CredentialRetryPair pair = new CredentialRetryPair(cred, 2);
+            var pair = new CredentialRetryPair(cred, 2);
             Assert.Equal(2, pair.Retries);
         }
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/CredentialTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubiHsmAuth/CredentialTests.cs
@@ -25,7 +25,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             CryptographicKeyType expectedKeyType = CryptographicKeyType.Aes128;
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 expectedKeyType,
                 "test key",
                 false);
@@ -58,7 +58,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             string expectedLabel = "test key";
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 expectedLabel,
                 false);
@@ -84,7 +84,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             bool expectedTouchRequired = true;
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                     CryptographicKeyType.Aes128,
                     "test key",
                     expectedTouchRequired);
@@ -99,7 +99,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             CryptographicKeyType expectedKeyType = CryptographicKeyType.Aes128;
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "test key",
                 false)
@@ -113,9 +113,9 @@ namespace Yubico.YubiKey.YubiHsmAuth
         [Fact]
         public void KeyType_SetNegative1_ThrowsArgOutOfRange()
         {
-            CryptographicKeyType invalidKeyType = (CryptographicKeyType)(-1);
+            var invalidKeyType = (CryptographicKeyType)(-1);
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "test key",
                 false);
@@ -129,7 +129,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             CryptographicKeyType invalidKeyType = CryptographicKeyType.None;
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "test key",
                 false);
@@ -159,7 +159,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             string expectedLabel = new string('a', labelLength);
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "old label",
                 false)
@@ -175,7 +175,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             string expectedLabel = "abc\uD801\uD802d";
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "old label",
                 false);
@@ -191,7 +191,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             string expectedLabel = new string('a', labelLength);
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "old label",
                 false);
@@ -207,7 +207,7 @@ namespace Yubico.YubiKey.YubiHsmAuth
         {
             bool expectedTouch = true;
 
-            Credential cred = new Credential(
+            var cred = new Credential(
                 CryptographicKeyType.Aes128,
                 "test key",
                 false)


### PR DESCRIPTION
# Description
Now using inferred variable types (var) instead of explicit types in all projects except Yubico.Core. This change aims to improve code readability, reduce verbosity, and enhance developer productivity while maintaining type safety.

Key points:

- Improved readability: Using 'var' can make code more concise and easier to read, especially with long or complex type names.
- Reduced redundancy: 'var' eliminates the need to repeat type information that's already clear from the right-hand side of the assignment.
- Easier refactoring: When types change, using 'var' means fewer places in the code need to be updated.
- Consistency with modern C# practices: Many contemporary C# codebases and style guides recommend using 'var' where the type is obvious.
- Faster coding: Typing 'var' is quicker than writing out full type names, speeding up the development process.
- Encourages descriptive variable names: With type information inferred, developers are more likely to use clear, descriptive variable names.

**Exclusion of Yubico.Core:**
I excluded Yubico.Core from this change initially due to its extensive use of interop code and custom structs. This cautious approach allows us to implement the change gradually and assess its impact before applying it to more complex areas of the codebase.

By adopting 'var' in most of our projects, we aim to modernize our codebase, improve developer productivity, and enhance code maintainability while still maintaining the robustness and clarity of our type system.

## Type of change

- [x] Refactor (non-breaking change which improves code quality or performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?
Unit tests in Yubico.Yubikey passed locally.

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
