### PR TITLE
Add name of property to exception

### DIFF
--- a/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs
@@ -109,7 +109,7 @@ namespace Yubico.PlatformInterop
             {
                 return (T)value!;
             }
-            throw new KeyNotFoundException();
+            throw new KeyNotFoundException(property.ToString());
         }
 
         public SafeFileHandle OpenDevice()


### PR DESCRIPTION
# Description
Adds the name of the key that was missing in the dictionary to the thrown exception 
