### PR TITLE
Ensure IsSkySeries property is carried forward for 'merged' devices

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -299,6 +299,7 @@ namespace Yubico.YubiKey
                 ResetBlocked = ResetBlocked | second.ResetBlocked,
                 SerialNumber = SerialNumber ?? second.SerialNumber,
                 IsFipsSeries = IsFipsSeries || second.IsFipsSeries,
+                IsSkySeries = IsSkySeries || second.IsSkySeries,
 
                 FormFactor = FormFactor != FormFactor.Unknown
                     ? FormFactor

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiKeyDeviceListenerTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/YubiKeyDeviceListenerTests.cs
@@ -1,0 +1,58 @@
+﻿// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Threading;
+using Xunit;
+using Yubico.PlatformInterop;
+using Yubico.YubiKey.TestUtilities;
+
+namespace Yubico.YubiKey
+{
+    [Trait(TraitTypes.Category, TestCategories.Elevated)]
+    public class YubiKeyDeviceListenerTests
+    {
+        private IYubiKeyDevice WaitForDevice()
+        {
+            IYubiKeyDevice? device = null;
+
+            AutoResetEvent reset = new AutoResetEvent(false);
+            EventHandler<YubiKeyDeviceEventArgs> handler = (sender, args) =>
+            {
+                device = args.Device;
+                reset.Set();
+            };
+
+            YubiKeyDeviceListener.Instance.Arrived += handler;
+            reset.WaitOne();
+            YubiKeyDeviceListener.Instance.Arrived -= handler;
+
+            Assert.NotNull(device);
+            return device;
+        }
+
+        [Fact]
+        public void KeyArrived_SkyEe_IsSkySeriesIsTrue()
+        {
+            // Needs to run elevated so the listener finds and enumerates any hidFido
+            // devices else no Merge will happen, and it won't be a valid test
+            // See https://github.com/Yubico/Yubico.NET.SDK/issues/156
+            Assert.True(SdkPlatformInfo.IsElevated);
+
+            IYubiKeyDevice device = WaitForDevice();
+
+            Assert.True(device.IsSkySeries);
+        }
+    }
+}


### PR DESCRIPTION
# Description
Ensures that 'merged' devices carry forward the IsSkySeries property during device discovery in YubiKeyDeviceListener

Fixes: #156 

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Added a new integration test: YubiKeyDeviceListenerTests.KeyArrived_SkyEe_IsSkySeriesIsTrue

**Test configuration**:
* Firmware version: 5.7.1
* Yubikey model: A NFC SKY EE 

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/043119ad1d19e0e6e66556c970a81d0c1aba36c8/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
