### PR TITLE
ci: added github attestation to build assets

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -108,6 +108,13 @@ jobs:
 
   pack:
     name: Package artifacts
+    permissions:
+      pull-requests: write
+      checks: write
+      id-token: write
+      contents: read
+      packages: read
+      attestations: write
     runs-on: windows-2019
     needs: [build-windows, build-linux-amd64, build-linux-arm64, build-macos]
     steps:
@@ -128,6 +135,13 @@ jobs:
         with:
           name: Yubico.NativeShims.nupkg
           path: Yubico.NativeShims.*.nupkg
+      
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            '${{ github.workspace }}/**/*.nupkg'
+            '${{ github.workspace }}/**/*.dll'
 
   publish-internal:
     name: Publish to internal NuGet

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,8 +58,12 @@ jobs:
     runs-on: windows-2019
     needs: run-tests
     permissions:
+      pull-requests: write
+      checks: write
+      id-token: write
       contents: read
       packages: read
+      attestations: write
     steps:
       # Checkout the local repository
       - uses: actions/checkout@v4
@@ -117,6 +121,14 @@ jobs:
             Yubico.DotNetPolyfills/src/bin/ReleaseWithDocs/**/*.dll
             Yubico.Core/src/bin/ReleaseWithDocs/**/*.dll
             Yubico.YubiKey/src/bin/ReleaseWithDocs/**/*.dll
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: |
+            '${{ github.workspace }}/**/*.nupkg'
+            '${{ github.workspace }}/**/*.snupkg'
+            '${{ github.workspace }}/**/*.dll'
 
       # Package the OATH sample code source
       - name: Save build artifacts


### PR DESCRIPTION
added github attestation to build assets, 

users will be able to prove that the assets were downloaded from github using 

gh attestation verify PATH/TO/YOUR/BUILD/ARTIFACT-BINARY -R Yubico/Yubico.NET.SDK