### PR TITLE
ci: improvements to sign output

### DIFF
--- a/build/sign.ps1
+++ b/build/sign.ps1
@@ -97,13 +97,13 @@ function Initialize-DirectoryStructure {
         Packages   = Join-Path $BaseDirectory "signed\packages"
     }
 
-    Write-Host "`nCreating directory structure..."
+    Write-Debug "`nCreating directory structure..."
     # Only create the directories we'll manage
     $directories.Keys | Where-Object { $_ -ne 'WorkingDir' } | ForEach-Object {
         $dir = $directories[$_]
         if (-not (Test-Path $dir)) {
             New-Item -ItemType Directory -Path $dir -Force | Out-Null
-            Write-Host "✓ Created: $dir"
+            Write-Debug "✓ Created: $dir"
         }
     }
 
@@ -157,6 +157,8 @@ How to use:
 3. Start a Powershell terminal, and load the script by running the following command:
    > . \.Yubico.NET.SDK\build\sign.ps1
 4. The script can be invoked by following the examples below.
+
+Set $DebugPreference = "Continue" for verbose output
 
 .PARAMETER Thumbprint
 The thumbprint of the signing certificate stored on the smart card.
@@ -307,7 +309,7 @@ function Invoke-NuGetPackageSigning {
             Write-Host "Extracting to: $extractPath"
             Expand-Archive -Path $package.FullName -DestinationPath $extractPath -Force
 
-            Write-Host "Cleaning package structure"
+            Write-Debug "Cleaning package structure"
             Get-ChildItem -Path $extractPath -Recurse -Include "_rels", "package" | Remove-Item -Force -Recurse
             Get-ChildItem -Path $extractPath -Recurse -Filter '[Content_Types].xml' | Remove-Item -Force
 
@@ -377,7 +379,9 @@ function Invoke-NuGetPackageSigning {
         }
 
         Write-Host "`n✨ Package signing process completed successfully! ✨" -ForegroundColor Green
-        return $directories.Packages
+        Write-Host "➡️ Locate your signed packages here: $($directories.Packages)" -ForegroundColor Yellow
+
+        return 
     }
     catch {
         Write-Host "`n❌ Error occurred:" -ForegroundColor Red


### PR DESCRIPTION
improvements to sign output:

╰─ $ Invoke-NuGetPackageSigning -WorkingDirectory 1.12 -Thumbprint $thumbprint

Initializing NuGet package signing process...

Verifying required tools...
✓ SignTool found at: signtool.exe
✓ NuGet found at: nuget.exe
✓ GitHub CLI  found at: nuget.exe

Certificate Details:
  Subject:      CN=Yubico AB, O=Yubico AB, L=STOCKHOLM, S=Stockholms län, C=SE
  Issuer:       CN=DigiCert Trusted G4 Code Signing RSA4096 SHA384 2021 CA1, O="DigiCert, Inc.", C=US
  Thumbprint:   A1614CD84976030D49209B56162D9EFA69B73698
  Valid From:   02/27/2024 01:00:00
  Valid To:     02/27/2027 00:59:59

Creating directory structure...

Validating required build assets...
  :white_check_mark: Found Symbol packages in: Symbols Packages.zip
  :white_check_mark: Found NuGet packages in: Nuget Packages.zip

:package: Processing ZIP files...

  :arrows_counterclockwise: Processing: Nuget Packages.zip
    :open_file_folder: Extracting to: 1.12\unsigned\Nuget Packages
    :clipboard: Copying packages to unsigned directory
  Copying: Yubico.Core.1.12.0.nupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.Core.1.12.0.nupkg
    :white_check_mark: Verified
  Copying: Yubico.DotNetPolyfills.1.12.0.nupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.DotNetPolyfills.1.12.0.nupkg
    :white_check_mark: Verified
  Copying: Yubico.YubiKey.1.12.0.nupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.YubiKey.1.12.0.nupkg
    :white_check_mark: Verified
✓ Copied 3 package(s)

  :arrows_counterclockwise: Processing: Symbols Packages.zip
    :open_file_folder: Extracting to: 1.12\unsigned\Symbols Packages
    :clipboard: Copying packages to unsigned directory
  Copying: Yubico.Core.1.12.0.snupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.Core.1.12.0.snupkg
    :white_check_mark: Verified
  Copying: Yubico.DotNetPolyfills.1.12.0.snupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.DotNetPolyfills.1.12.0.snupkg
    :white_check_mark: Verified
  Copying: Yubico.YubiKey.1.12.0.snupkg
  :closed_lock_with_key: Verifying attestation for: ..\Yubico.YubiKey.1.12.0.snupkg
    :white_check_mark: Verified
✓ Copied 3 package(s)

:package: Processing NuGet packages...

Signing contents of: Yubico.Core.1.12.0.nupkg
Extracting to: 1.12\signed\libraries\Yubico.Core.1.12.0
Cleaning package structure
Signing assemblies...
    :writing_hand: Signing: ..\net47\Yubico.Core.dll
    :writing_hand: Signing: ..\netstandard2.0\Yubico.Core.dll
    :writing_hand: Signing: ..\netstandard2.1\Yubico.Core.dll
Repacking signed content...
  Packing: Yubico.Core.nuspec

Signing contents of: Yubico.DotNetPolyfills.1.12.0.nupkg
Extracting to: 1.12\signed\libraries\Yubico.DotNetPolyfills.1.12.0
Cleaning package structure
Signing assemblies...
    :writing_hand: Signing: ..\netstandard2.0\Yubico.DotNetPolyfills.dll
    :writing_hand: Signing: ..\netstandard2.1\Yubico.DotNetPolyfills.dll
Repacking signed content...
  Packing: Yubico.DotNetPolyfills.nuspec

Signing contents of: Yubico.YubiKey.1.12.0.nupkg
Extracting to: 1.12\signed\libraries\Yubico.YubiKey.1.12.0
Cleaning package structure
Signing assemblies...
    :writing_hand: Signing: ..\net47\Yubico.YubiKey.dll
    :writing_hand: Signing: ..\netstandard2.0\Yubico.YubiKey.dll
    :writing_hand: Signing: ..\netstandard2.1\Yubico.YubiKey.dll
Repacking signed content...
  Packing: Yubico.YubiKey.nuspec

Copying symbol packages...
  Copying: Yubico.Core.1.12.0.snupkg
  Copying: Yubico.DotNetPolyfills.1.12.0.snupkg
  Copying: Yubico.YubiKey.1.12.0.snupkg

:lock_with_ink_pen: Signing final packages...
  :black_nib: Signing package: Yubico.Core.1.12.0.nupkg
  :black_nib: Signing package: Yubico.Core.1.12.0.snupkg
  :black_nib: Signing package: Yubico.DotNetPolyfills.1.12.0.nupkg
  :black_nib: Signing package: Yubico.DotNetPolyfills.1.12.0.snupkg
  :black_nib: Signing package: Yubico.YubiKey.1.12.0.nupkg
  :black_nib: Signing package: Yubico.YubiKey.1.12.0.snupkg

:bar_chart: Signed Packages Summary:
  NuGet Packages:
    :package: Yubico.Core.1.12.0.nupkg [522,12 KB]
    :package: Yubico.DotNetPolyfills.1.12.0.nupkg [41,36 KB]
    :package: Yubico.YubiKey.1.12.0.nupkg [1 742,20 KB]
  Symbol Packages:
    :mag: Yubico.Core.1.12.0.snupkg [129,79 KB]
    :mag: Yubico.DotNetPolyfills.1.12.0.snupkg [26,21 KB]
    :mag: Yubico.YubiKey.1.12.0.snupkg [444,79 KB]

:sparkles: Package signing process completed successfully! :sparkles:
Locate your signed packages here: 1.12\signed\packages