### PR TITLE
fix: ConnectionFactory incorrectly using SmartCardConnection

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
@@ -112,14 +112,6 @@ namespace Yubico.YubiKey
         /// </remarks>
         public IYubiKeyConnection CreateConnection(YubiKeyApplication application)
         {
-            if (_smartCardDevice != null)
-            {
-                _log.LogDebug("Connecting via the SmartCard interface.");
-
-                WaitForReclaimTimeout(Transport.SmartCard);
-                return new SmartCardConnection(_smartCardDevice, application);
-            }
-
             if (_hidKeyboardDevice != null && application == YubiKeyApplication.Otp)
             {
                 _log.LogDebug("Connecting via the Keyboard interface.");
@@ -128,12 +120,21 @@ namespace Yubico.YubiKey
                 return new KeyboardConnection(_hidKeyboardDevice);
             }
 
-            if (_hidFidoDevice != null && (application == YubiKeyApplication.Fido2 || application == YubiKeyApplication.FidoU2f))
+            bool isFidoApplication = application == YubiKeyApplication.Fido2 || application == YubiKeyApplication.FidoU2f;
+            if (_hidFidoDevice != null && isFidoApplication)
             {
                 _log.LogDebug("Connecting via the FIDO interface.");
 
                 WaitForReclaimTimeout(Transport.HidFido);
                 return new FidoConnection(_hidFidoDevice);
+            }
+            
+            if (_smartCardDevice != null)
+            {
+                _log.LogDebug("Connecting via the SmartCard interface.");
+
+                WaitForReclaimTimeout(Transport.SmartCard);
+                return new SmartCardConnection(_smartCardDevice, application);
             }
 
             throw new InvalidOperationException("No suitable interface present. Unable to establish connection to YubiKey.");

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
@@ -127,11 +127,9 @@ namespace Yubico.YubiKey.Oath
         {
             if (disposing)
             {
-                return;
+                KeyCollector = null;
+                base.Dispose(disposing);
             }
-
-            KeyCollector = null;
-            base.Dispose(disposing);
         }
     }
 }


### PR DESCRIPTION
# Description
The ConnectionFactory incorrectly selected the SmartCardConnection instead of the FIDO2Connection

Fixes: #178

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* OS version: *e.g. Windows 11*
* Firmware version: 5.4.3 and 5.7.2 keys
* Yubikey model[^1]: 

## Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
