### PR TITLE
Dennisdyallo/default-logger

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Logging/Log.cs
+++ b/Yubico.Core/src/Yubico/Core/Logging/Log.cs
@@ -158,34 +158,31 @@ namespace Yubico.Core.Logging
         //Creates a logging factory based on a JsonConfiguration in appsettings.json
         private static ILoggerFactory GetDefaultLoggerFactory()
         {
-            ILoggerFactory? configuredLoggingFactory = null;
-            try
+            string settingsPath = Path.Combine(Directory.GetCurrentDirectory(), "appsettings.json");
+            if (!File.Exists(settingsPath))
             {
-                IConfigurationRoot configuration = new ConfigurationBuilder()
+                return ErrorLoggerFactory;
+            }
+
+            IConfigurationRoot configuration = new ConfigurationBuilder()
                     .SetBasePath(Directory.GetCurrentDirectory())
-                    .AddJsonFile("appsettings.json", optional: true)
+                    .AddJsonFile("appsettings.json", optional: false)
                     .AddJsonFile("appsettings.Development.json", optional: true)
                     .Build();
 
-                configuredLoggingFactory = Microsoft.Extensions.Logging.LoggerFactory.Create(
-                    builder =>
-                    {
-                        IConfigurationSection loggingSection = configuration.GetSection("Logging");
-                        _ = builder.AddConfiguration(loggingSection);
-                        _ = builder.AddConsole();
-                    });
-            }
-#pragma warning disable CA1031
-            catch (Exception e)
-#pragma warning restore CA1031
-            {
-                Console.Error.WriteLine(e);
-            }
+            return Microsoft.Extensions.Logging.LoggerFactory.Create(
+                builder =>
+                {
+                    IConfigurationSection loggingSection = configuration.GetSection("Logging");
+                    _ = builder
+                        .AddConfiguration(loggingSection)
+                        .AddConsole();
+                });
+        }
 
-            return configuredLoggingFactory ?? Microsoft.Extensions.Logging.LoggerFactory.Create(
+        private static ILoggerFactory ErrorLoggerFactory => Microsoft.Extensions.Logging.LoggerFactory.Create(
                 builder => builder
                     .AddConsole()
                     .SetMinimumLevel(LogLevel.Error));
-        }
     }
 }

--- a/Yubico.YubiKey/examples/Fido2SampleCode/Fido2SampleCode.csproj
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/Fido2SampleCode.csproj
@@ -24,7 +24,12 @@ limitations under the License. -->
     <UseWindowsForms Condition=" '$(OS)' == 'Windows_NT'">true</UseWindowsForms>
   </PropertyGroup>
   <ItemGroup>
+<None Update="appsettings.json">
+  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+</None>
     <ProjectReference Include="..\SharedSampleCode\SharedSampleCode.csproj" />
+
   </ItemGroup>
+
 
 </Project>

--- a/Yubico.YubiKey/examples/Fido2SampleCode/appsettings.json
+++ b/Yubico.YubiKey/examples/Fido2SampleCode/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AppName": "FidoSampleCode",
+  "Logging": {
+    "LogLevel": {
+      "Yubico": "Error"
+    }
+  }
+}

--- a/Yubico.YubiKey/examples/OathSampleCode/OathSampleCode.csproj
+++ b/Yubico.YubiKey/examples/OathSampleCode/OathSampleCode.csproj
@@ -22,6 +22,9 @@ limitations under the License. -->
   </PropertyGroup>
 
   <ItemGroup>
+<None Update="appsettings.json">
+  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+</None>
     <ProjectReference Include="..\SharedSampleCode\SharedSampleCode.csproj" />
   </ItemGroup>
 

--- a/Yubico.YubiKey/examples/OathSampleCode/appsettings.json
+++ b/Yubico.YubiKey/examples/OathSampleCode/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AppName": "OathSampleCode",
+  "Logging": {
+    "LogLevel": {
+      "Yubico": "Error"
+    }
+  }
+}

--- a/Yubico.YubiKey/examples/PivSampleCode/PivSampleCode.csproj
+++ b/Yubico.YubiKey/examples/PivSampleCode/PivSampleCode.csproj
@@ -22,6 +22,9 @@ limitations under the License. -->
   </PropertyGroup>
 
   <ItemGroup>
+<None Update="appsettings.json">
+  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+</None>
     <ProjectReference Include="..\SharedSampleCode\SharedSampleCode.csproj" />
   </ItemGroup>
 

--- a/Yubico.YubiKey/examples/PivSampleCode/appsettings.json
+++ b/Yubico.YubiKey/examples/PivSampleCode/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AppName": "PivSampleCode",
+  "Logging": {
+    "LogLevel": {
+      "Yubico": "Error"
+    }
+  }
+}

--- a/Yubico.YubiKey/examples/U2fSampleCode/U2fSampleCode.csproj
+++ b/Yubico.YubiKey/examples/U2fSampleCode/U2fSampleCode.csproj
@@ -22,6 +22,9 @@ limitations under the License. -->
   </PropertyGroup>
 
   <ItemGroup>
+<None Update="appsettings.json">
+  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+</None>
     <ProjectReference Include="..\SharedSampleCode\SharedSampleCode.csproj" />
   </ItemGroup>
 

--- a/Yubico.YubiKey/examples/U2fSampleCode/appsettings.json
+++ b/Yubico.YubiKey/examples/U2fSampleCode/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "AppName": "U2FSampleCode",
+  "Logging": {
+    "LogLevel": {
+      "Yubico": "Error"
+    }
+  }
+}

--- a/Yubico.YubiKey/tests/integration/appsettings.json
+++ b/Yubico.YubiKey/tests/integration/appsettings.json
@@ -5,7 +5,7 @@
       "Yubico": "Debug"
     },
     "Console": {
-      "IncludeScopes": true,
+      "IncludeScopes": true
     }
   }
 }

--- a/Yubico.YubiKey/tests/unit/appsettings.json
+++ b/Yubico.YubiKey/tests/unit/appsettings.json
@@ -2,7 +2,7 @@
   "AppName": "UnitTests",
   "Logging": {
     "LogLevel": {
-      "Yubico": "Error"
+      "Yubico": "None"
     },
     "Console": {
       "IncludeScopes": true


### PR DESCRIPTION
# Description
Logger was inadvertently writing output for all log levels instead of just error messages.

With appsettings.json, you set the log level
Without, you either set the log level manually, or you get the default error console logger.

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Tested via the unit tests and sample test projects with and without an appsettings.json file. 

## Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
