### PR TITLE
Upgrade Ubuntu runners from 20.04 to 22.04

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -64,7 +64,7 @@ jobs:
 
   build-linux-amd64:
     name: Build Linux (amd64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -78,7 +78,7 @@ jobs:
           
   build-linux-arm64:
     name: Build Linux (arm64)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -64,7 +64,7 @@ jobs:
 
   build-linux-amd64:
     name: Build Linux (amd64)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -78,7 +78,7 @@ jobs:
           
   build-linux-arm64:
     name: Build Linux (arm64)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -64,7 +64,7 @@ jobs:
 
   build-linux-amd64:
     name: Build Linux (amd64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -78,7 +78,7 @@ jobs:
           
   build-linux-arm64:
     name: Build Linux (arm64)
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -64,7 +64,7 @@ jobs:
 
   build-linux-amd64:
     name: Build Linux (amd64)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -78,7 +78,7 @@ jobs:
           
   build-linux-arm64:
     name: Build Linux (arm64)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: |

--- a/Yubico.NativeShims/build-linux-amd64.sh
+++ b/Yubico.NativeShims/build-linux-amd64.sh
@@ -24,7 +24,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     g++ \
     gcc
 
-# Install latest version of CMake for Ubuntu 20.04
+# Install latest version of CMake for Ubuntu
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq

--- a/Yubico.NativeShims/build-linux-amd64.sh
+++ b/Yubico.NativeShims/build-linux-amd64.sh
@@ -24,7 +24,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     g++ \
     gcc
 
-# Install latest version of CMake for Ubuntu
+# Install latest version of CMake for Ubuntu 20.04
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -24,7 +24,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     ninja-build \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu \
-    linux-libc-dev \
+    linux-libc-dev
 
 # Install latest version of CMake for Ubuntu
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -19,10 +19,11 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     ca-certificates \
     pkg-config \
     gnupg \
+    libpcsclite-dev \
     zlib1g-dev \
     ninja-build \
     g++-aarch64-linux-gnu \
-    gcc-aarch64-linux-gnu
+    gcc-aarch64-linux-gnu \
 
 # Install latest version of CMake for Ubuntu
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -24,7 +24,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu
 
-# Install latest version of CMake for Ubuntu 20.04
+# Install latest version of CMake for Ubuntu
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -3,6 +3,7 @@
 # Set environment variables
 export VCPKG_INSTALLATION_ROOT=$GITHUB_WORKSPACE/vcpkg \
     VCPKG_FORCE_SYSTEM_BINARIES=1 \
+    VCPKG_DISABLE_METRICS=1 \
     PATH=/usr/local/bin:$VCPKG_INSTALLATION_ROOT:$PATH
 
 # Install necessary packages
@@ -23,10 +24,11 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     ninja-build \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu \
+    linux-libc-dev \
 
-# Install latest version of CMake for Ubuntu 20.04
+# Install latest version of CMake for Ubuntu
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ noble main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq
 sudo apt-get install cmake -yq
 
@@ -34,10 +36,10 @@ sudo apt-get install cmake -yq
 git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_INSTALLATION_ROOT} && ${VCPKG_INSTALLATION_ROOT}/bootstrap-vcpkg.sh
 
 # Install arm64 version of libpcsclite
-echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list > /dev/null
+echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-backports main restricted universe multiverse" | sudo tee /etc/apt/sources.list.d/arm64.list
 sudo dpkg --add-architecture arm64
 sudo apt-get update -qq
 sudo apt-get install libpcsclite-dev:arm64 -yq

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -25,7 +25,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     g++-aarch64-linux-gnu \
     gcc-aarch64-linux-gnu \
 
-# Install latest version of CMake for Ubuntu
+# Install latest version of CMake for Ubuntu 20.04
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
 echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -19,7 +19,6 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
     ca-certificates \
     pkg-config \
     gnupg \
-    libpcsclite-dev \
     zlib1g-dev \
     ninja-build \
     g++-aarch64-linux-gnu \
@@ -27,7 +26,7 @@ DEBIAN_FRONTEND=noninteractive sudo apt-get install -yq \
 
 # Install latest version of CMake for Ubuntu 20.04
 wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
-echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
+echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ jammy main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
 sudo apt-get update -qq
 sudo apt-get install cmake -yq
 
@@ -35,10 +34,10 @@ sudo apt-get install cmake -yq
 git clone https://github.com/Microsoft/vcpkg.git ${VCPKG_INSTALLATION_ROOT} && ${VCPKG_INSTALLATION_ROOT}/bootstrap-vcpkg.sh
 
 # Install arm64 version of libpcsclite
-echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-updates main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-security main restricted universe multiverse
-deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ focal-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list > /dev/null
+echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-updates main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-security main restricted universe multiverse
+deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports/ jammy-backports main restricted universe multiverse" | sudo tee -a /etc/apt/sources.list > /dev/null
 sudo dpkg --add-architecture arm64
 sudo apt-get update -qq
 sudo apt-get install libpcsclite-dev:arm64 -yq


### PR DESCRIPTION
This upgrades the ubuntu runners from 20.04 to 22.04 which allow for the compilation of Yubico.NativeShims.