### PR TITLE
Adding Appcompat.md to toc.tml for visibility on the documentation site

### DIFF
--- a/Yubico.YubiKey/docs/users-manual/toc.yml
+++ b/Yubico.YubiKey/docs/users-manual/toc.yml
@@ -56,6 +56,8 @@
     href: sdk-programming-guide/device-notifications.md
   - name: PIN complexity policy
     href: sdk-programming-guide/pin-complexity-policy.md
+  - name: Maintaining compatibility
+    href: sdk-programming-guide/appcompat.md
 
 - name: "Application: OTP"
   homepage: application-otp/otp-overview.md


### PR DESCRIPTION
# Description

Added missing file (appcompat.md) to the toc.

## How has this been tested?

Local docs build


