### PR TITLE
misc: Removed Bouncy Castle license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -260,16 +260,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
-
-==================================================
-The following license applies to
-\Yubico.YubiKey\src\Yubico\YubiKey\Cryptography\AesCmac.cs
-
-Copyright (c) 2000 - 2021 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org)
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This pull request includes a change to the `LICENSE.txt` file. The change involves removing the license information for the `AesCmac.cs` file from the Bouncy Castle library.

(Since we are now using using OpenSSL and CryptographicProviders, removed in [3f2d52a](https://github.com/Yubico/Yubico.NET.SDK/commit/3f2d52a6d6d505e051de9e6dcce174dba64892db))

License information removal:

* [`LICENSE.txt`](diffhunk://#diff-d0ed4cc3fb70489fe51c7e0ac180cba2a7472124f9f9e9ae67b01a37fbd580b7L263-L275): Removed the license information for `Yubico.YubiKey\src\Yubico\YubiKey\Cryptography\AesCmac.cs`, which was previously included under the Bouncy Castle license.