### PR TITLE
Skip waiting for the first connection to the key

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
@@ -155,7 +155,7 @@ namespace Yubico.YubiKey
                 : TimeSpan.FromSeconds(3.01);
 
             // We're only affected by the reclaim timeout if we're switching USB transports.
-            if (_device.LastActiveTransport == newTransport)
+            if (_device.LastActiveTransport == newTransport || _device.LastActiveTransport == Transport.None)
             {
                 _log.LogDebug(
                     "{Transport} transport is already active. No need to wait for reclaim.",

--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
@@ -154,13 +154,13 @@ namespace Yubico.YubiKey
                 ? TimeSpan.FromMilliseconds(100)
                 : TimeSpan.FromSeconds(3.01);
 
-            // We're only affected by the reclaim timeout if we're switching USB transports.
+            // Skip waiting if the transport is already active or was previously None
             if (_device.LastActiveTransport == newTransport || _device.LastActiveTransport == Transport.None)
             {
                 _log.LogDebug(
                     "{Transport} transport is already active. No need to wait for reclaim.",
                     _device.LastActiveTransport);
-
+                _device.LastActiveTransport = newTransport;
                 return;
             }
 

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/ReclaimTimeoutTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/ReclaimTimeoutTests.cs
@@ -93,7 +93,8 @@ namespace Yubico.YubiKey
             sw3.Stop();
 
             const long expectedLapse = 3000;
-            Assert.True(sw1.ElapsedMilliseconds > expectedLapse);
+            const long firstConnectionMaxTime = 100;
+            Assert.True(sw1.ElapsedMilliseconds < firstConnectionMaxTime);
             Assert.True(sw2.ElapsedMilliseconds > expectedLapse);
             Assert.True(sw3.ElapsedMilliseconds > expectedLapse);
         }


### PR DESCRIPTION
# Description
There is a 100ms/3s delay on the first connection. The change is in waitForReclaimTimeout, Possible fix is to change the early-return check from in ConnectionFactory.cs, line 158.

```
if (_device.LastActiveTransport == newTransport )

to

if (_device.LastActiveTransport == newTransport || _device.LastActiveTransport == Transport.None)
 {
     _device.LastActiveTransport = newTransport;
     return;
 }
```
Inside the if statement, _device.LastActiveTransport is updated to prevent it from remaining None indefinitely, which could lead to unexpected transport behavior.

Activity

Fixes: # <[YESDK-1432](https://yubico.atlassian.net/jira/software/c/projects/YESDK/issues/YESDK-1432?jql=project%20%3D%20%22YESDK%22%20ORDER%20BY%20created%20DESC)>

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

The test case public void SwitchingBetweenTransports_ForcesThreeSecondWait() has been updated to reflect this change. Now, the first connection no longer waits for three seconds, reducing the test duration from approximately 10s to 6s.

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
