### PR TITLE
fix: Stop send short APDUs when exceeded max APDU size

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 using System;
+using System.Globalization;
+using Microsoft.Extensions.Logging;
 using Yubico.Core.Iso7816;
+using Yubico.Core.Logging;
 
 namespace Yubico.YubiKey.Pipelines
 {
@@ -23,7 +26,9 @@ namespace Yubico.YubiKey.Pipelines
     /// </summary>
     internal class CommandChainingTransform : IApduTransform
     {
-        public int MaxSize { get; internal set; } = 255;
+        private readonly ILogger _log = Log.GetLogger<CommandChainingTransform>();
+
+        public int MaxChunkSize { get; internal set; } = 255;
 
         readonly IApduTransform _pipeline;
 
@@ -41,33 +46,51 @@ namespace Yubico.YubiKey.Pipelines
                 throw new ArgumentNullException(nameof(command));
             }
 
-            if (command.Data.IsEmpty || command.Data.Length <= MaxSize)
+            // Send regular short APDU
+            int commandDataSize = command.Data.Length;
+            if (commandDataSize <= MaxChunkSize)
             {
+                _log.LogDebug("Sending short APDU");
                 return _pipeline.Invoke(command, commandType, responseType);
             }
 
+            // Send chained short APDU
             var sourceData = command.Data;
             ResponseApdu? responseApdu = null;
-
+            _log.LogDebug("APDU size exceeds size of short APDU, proceeding to send data in chunks instead");
             while (!sourceData.IsEmpty)
             {
-                int length = Math.Min(MaxSize, sourceData.Length);
-                var data = sourceData.Slice(0, length);
-                sourceData = sourceData.Slice(length);
+                int chunkLength = Math.Min(MaxChunkSize, sourceData.Length);
+                var dataChunk = sourceData[..chunkLength];
+                sourceData = sourceData[chunkLength..];
 
                 var partialApdu = new CommandApdu
                 {
-                    Cla = (byte)(command.Cla | (sourceData.IsEmpty ? 0 : 0x10)),
+                    Cla = (byte)(command.Cla | (sourceData.IsEmpty
+                        ? 0
+                        : 0x10)),
                     Ins = command.Ins,
                     P1 = command.P1,
                     P2 = command.P2,
-                    Data = data
+                    Data = dataChunk
                 };
 
                 responseApdu = _pipeline.Invoke(partialApdu, commandType, responseType);
+
+                // Stop sending data when the YubiKey response is 0x67 (when the chained data
+                // sent exceeds the max allowed length) and let caller handle the response
+                if (responseApdu.SW != SWConstants.WrongLength)
+                {
+                    continue;
+                }
+
+                _log.LogWarning("Sent data exceeds max allowed length by YubiKey. (SW: 0x{StatusWord})",
+                    responseApdu.SW.ToString("X4", CultureInfo.InvariantCulture));
+                
+                return responseApdu;
             }
 
-            return responseApdu!; // Covered by Debug.Assert above.
+            return responseApdu!;
         }
 
         public void Setup() => _pipeline.Setup();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/CommandChainingTransform.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.Pipelines
 
                 responseApdu = _pipeline.Invoke(partialApdu, commandType, responseType);
 
-                // Stop sending data when the YubiKey response is 0x67 (when the chained data
+                // Stop sending data when the YubiKey response is 0x6700 (when the chained data
                 // sent exceeds the max allowed length) and let caller handle the response
                 if (responseApdu.SW != SWConstants.WrongLength)
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardConnection.cs
@@ -34,9 +34,8 @@ namespace Yubico.YubiKey
         private readonly byte[]? _applicationId;
         private readonly ISmartCardConnection _smartCardConnection;
         private IApduTransform _apduPipeline;
-
         private bool _disposedValue;
-        private bool IsOath => GetIsAuth();
+        private bool IsOath => GetIsOauth();
         public ISelectApplicationData? SelectApplicationData { get; set; }
 
         /// <summary>
@@ -48,7 +47,7 @@ namespace Yubico.YubiKey
         public SmartCardConnection(
             ISmartCardDevice smartCardDevice,
             YubiKeyApplication yubiKeyApplication)
-            : this(smartCardDevice, yubiKeyApplication, (byte[]?)null)
+            : this(smartCardDevice, yubiKeyApplication, null)
         {
             if (yubiKeyApplication == YubiKeyApplication.Fido2)
             {
@@ -110,7 +109,7 @@ namespace Yubico.YubiKey
             _smartCardConnection = smartCardDevice.Connect();
 
             // Set up the pipeline
-            _apduPipeline =new SmartCardTransform(_smartCardConnection);
+            _apduPipeline = new SmartCardTransform(_smartCardConnection);
             _apduPipeline = AddResponseChainingTransform(_apduPipeline);
             _apduPipeline = new CommandChainingTransform(_apduPipeline);
         }
@@ -210,7 +209,7 @@ namespace Yubico.YubiKey
             SelectApplicationData = response.GetData();
         }
 
-        private bool GetIsAuth() =>
+        private bool GetIsOauth() =>
             _yubiKeyApplication == YubiKeyApplication.Oath ||
             (_applicationId != null &&
             _applicationId.SequenceEqual(

--- a/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardMaxApduSizes.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/SmartCardMaxApduSizes.cs
@@ -1,0 +1,38 @@
+// Copyright 2024 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.YubiKey;
+
+#pragma warning disable CA1707 // Allow underscore in constant
+/// <summary>
+/// This contains the maximum size (in bytes) of APDU commands for the various YubiKey models.
+/// </summary>
+public static class SmartCardMaxApduSizes
+{
+    /// <summary>
+    /// The max APDU command size for the YubiKey NEO
+    /// </summary>
+    public const int NEO = 1390;
+    
+    /// <summary>
+    /// The max APDU command size for the YubiKey 4 and greater
+    /// </summary>
+    public const int YK4 = 2038;
+
+    /// <summary>
+    /// The max APDU command size for the YubiKey 4.3 and greater
+    /// </summary>
+    public const int YK4_3 = 3062;
+}
+#pragma warning restore CA1707

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/Commands/PutDataCommandTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/Commands/PutDataCommandTests.cs
@@ -1,0 +1,85 @@
+// Copyright 2024 Yubico AB
+// 
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+using Yubico.Core.Iso7816;
+using Yubico.Core.Tlv;
+using Yubico.YubiKey.TestUtilities;
+
+namespace Yubico.YubiKey.Piv.Commands;
+
+public class PutDataCommandTests
+{
+    [Theory]
+    [InlineData(StandardTestDevice.Fw5)]
+    public void SendCommand_With_TooLargeApdu_ReturnsResultFailed(
+        StandardTestDevice testDeviceType)
+    {
+        using var pivSession = GetSession(testDeviceType);
+        
+        var tooLargeTlv = new TlvObject(0x53, new byte[10000]);
+        var tlvBytes = tooLargeTlv.GetBytes();
+        var command = new PutDataCommand(0x5F0000, tlvBytes);
+
+        var response = pivSession.Connection.SendCommand(command);
+
+        Assert.Equal(ResponseStatus.Failed, response.Status);
+        Assert.Equal(SWConstants.WrongLength, response.StatusWord);
+
+        // Cleanup
+        pivSession.ResetApplication();
+    }
+
+    [Theory]
+    [InlineData(StandardTestDevice.Fw5)]
+    public void SendCommand_with_ValidSizeApdu_ReturnsResultSuccess(
+        StandardTestDevice testDeviceType)
+    {
+        // Arrange
+        using var pivSession = GetSession(testDeviceType);
+
+        var validSizeTlv = new TlvObject(0x53, new byte[SmartCardMaxApduSizes.YK4_3]);
+        var tlvBytes = validSizeTlv.GetBytes();
+        var command = new PutDataCommand(0x5F0000, tlvBytes);
+        
+        // Act
+        var response = pivSession.Connection.SendCommand(command);
+        var actualSize = command.CreateCommandApdu().AsByteArray().Length;
+        Assert.Equal(3078, actualSize); // This is the current max APDU size of the YubiKey 5 series.
+        Assert.Equal(ResponseStatus.Success, response.Status);
+        Assert.Equal(SWConstants.Success, response.StatusWord);
+        
+        // Cleanup
+        pivSession.ResetApplication();
+    }
+
+    private static PivSession GetSession(StandardTestDevice testDeviceType)
+    {
+        PivSession? pivSession = null;
+        try
+        {
+            var testDevice = IntegrationTestDeviceEnumeration.GetTestDevice(testDeviceType);
+            pivSession = new PivSession(testDevice);
+            var collectorObj = new Simple39KeyCollector();
+            pivSession.KeyCollector = collectorObj.Simple39KeyCollectorDelegate;
+            pivSession.AuthenticateManagementKey();
+            return pivSession;
+        }
+        catch
+        {
+            pivSession?.Dispose();
+            throw;
+        }
+    }
+}

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
@@ -153,7 +153,7 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform
                 .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
-                .Returns(new ResponseApdu([], 0x90))
+                .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedCla.Add(a.Cla));
 
             // Act
@@ -181,7 +181,7 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform
                 .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
-                .Returns(new ResponseApdu([], 0x90))
+                .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a));
 
             // Act
@@ -211,7 +211,7 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform
                 .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
-                .Returns(new ResponseApdu([], 0x90))
+                .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a.Data.ToArray()));
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
@@ -148,7 +148,7 @@ namespace Yubico.YubiKey.Pipelines
 
             // Arrange
             var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxSize = 4 };
+            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu { Data = Enumerable.Repeat<byte>(0xFF, 16).ToArray() };
 
             _ = mockTransform
@@ -169,7 +169,7 @@ namespace Yubico.YubiKey.Pipelines
 
             // Arrange
             var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxSize = 4 };
+            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu
             {
                 Ins = 1,
@@ -201,7 +201,7 @@ namespace Yubico.YubiKey.Pipelines
 
             // Arrange
             var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxSize = 4 };
+            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu
             {
                 Data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }


### PR DESCRIPTION
# Description
This PR stops sending data to the YubiKey after it has exceeded the max allowed APDU size. 
Previously, the SDK would hammer the YubiKey until it had emptied its buffer.

It also adds the MaxApduSize constants.

The valid sizes (in bytes) for the smartcard connection on the YubiKey are as follows
NEO: 1390 
YK4: 2038 
YK4_3 : 3062

Fixes: YESDK-1329

## Type of change

- [x] Refactor (non-breaking change which improves code quality or performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How has this been tested?
Added unit tests in SmartCardTransformTests.cs

**Test configuration**:
* OS version: Arch Linux
* Firmware version: 5.4.3
* Yubikey model[^1]: 5 USBA

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
