### PR TITLE
Revert the initial three seconds delay changes

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
@@ -155,12 +155,11 @@ namespace Yubico.YubiKey
                 : TimeSpan.FromSeconds(3.01);
 
             // Skip waiting if the transport is already active or was previously None
-            if (_device.LastActiveTransport == newTransport || _device.LastActiveTransport == Transport.None)
+            if (_device.LastActiveTransport == newTransport)
             {
                 _log.LogDebug(
                     "{Transport} transport is already active. No need to wait for reclaim.",
                     _device.LastActiveTransport);
-                _device.LastActiveTransport = newTransport;
                 return;
             }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ConnectionFactory.cs
@@ -154,7 +154,7 @@ namespace Yubico.YubiKey
                 ? TimeSpan.FromMilliseconds(100)
                 : TimeSpan.FromSeconds(3.01);
 
-            // Skip waiting if the transport is already active or was previously None
+            // We're only affected by the reclaim timeout if we're switching USB transports.
             if (_device.LastActiveTransport == newTransport)
             {
                 _log.LogDebug(

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/ReclaimTimeoutTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/ReclaimTimeoutTests.cs
@@ -93,8 +93,7 @@ namespace Yubico.YubiKey
             sw3.Stop();
 
             const long expectedLapse = 3000;
-            const long firstConnectionMaxTime = 100;
-            Assert.True(sw1.ElapsedMilliseconds < firstConnectionMaxTime);
+            Assert.True(sw1.ElapsedMilliseconds > expectedLapse);
             Assert.True(sw2.ElapsedMilliseconds > expectedLapse);
             Assert.True(sw3.ElapsedMilliseconds > expectedLapse);
         }


### PR DESCRIPTION
# Description
This PR restores the three-second delay on the first connection. We observed a smart card access issue during FIDO pre-registration and suspect that the delay might be necessary. The root cause is still unclear, and there may be underlying issues. To ensure stability, we are reverting the change for now. Once we fully understand the cause, we can decide whether to reintroduce or remove the delay.

Fixes: # <https://yubico.atlassian.net/jira/software/c/projects/PROD/boards/289?assignee=600733d2afda13006ea0e1b4&selectedIssue=PROD-3573>

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* OS version: *e.g. Windows 11*
* Firmware version: *e.g. 5.7.2*
* Yubikey model[^1]: 

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
