### PR TITLE
feat: Add FirmwareVersion.Parse(versionString)

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/FirmwareVersion.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FirmwareVersion.cs
@@ -61,6 +61,36 @@ namespace Yubico.YubiKey
             Minor = minor;
             Patch = patch;
         }
+        
+        /// <summary>
+        /// Parse a string of the form "major.minor.patch"
+        /// </summary>
+        /// <param name="versionString"></param>
+        /// <returns>Returns a FirmwareVersion instance</returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        /// <exception cref="ArgumentException"></exception>
+        public static FirmwareVersion Parse(string versionString)
+        {
+            if (versionString is null)
+            {
+                throw new ArgumentNullException(nameof(versionString));
+            }
+            
+            string[] parts = versionString.Split('.');
+            if (parts.Length != 3)
+            {
+                throw new ArgumentException("Must include major.minor.patch", nameof(versionString));
+            }
+            
+            if (!byte.TryParse(parts[0], out byte major) ||
+                !byte.TryParse(parts[1], out byte minor) || 
+                !byte.TryParse(parts[2], out byte patch))
+            {
+                throw new ArgumentException("Major, minor and patch must be valid numbers", nameof(versionString));
+            }
+            
+            return new FirmwareVersion(major, minor, patch);
+        }
 
         public static bool operator >(FirmwareVersion left, FirmwareVersion right)
         {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/FirmwareVersionTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/FirmwareVersionTests.cs
@@ -21,6 +21,38 @@ namespace Yubico.YubiKey
     public class FirmwareVersionTests
     {
         [Fact]
+        public void Parse_GivenValidString_ReturnsFirmwareVersion()
+        {
+            // Arrange
+            
+            string validString = "1.2.3";
+            
+            // Act
+            
+            var fw = FirmwareVersion.Parse(validString);
+            
+            // Assert
+            
+            Assert.Equal(1, fw.Major);
+            Assert.Equal(2, fw.Minor);
+            Assert.Equal(3, fw.Patch);
+        }
+        
+        
+        [Fact]
+        public void Parse_GivenInvalidString_ThrowsArgumentException()
+        {
+            // Arrange
+            
+            string invalidString = "1.2";
+            
+            // Act & Assert
+            
+            Assert.Throws<ArgumentException>(() => FirmwareVersion.Parse(invalidString));
+        }
+        
+        
+        [Fact]
         public void Major_GetSet_Succeeds()
         {
             var fw = new FirmwareVersion();


### PR DESCRIPTION
# Description
Adds a nifty FirmwareVersion.Parse(string versionString) to the class FirmwareVersion.
It parses a string of the form "major.minor.patch"

Fixes: YESDK-1425

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
