### PR TITLE
fix: Remove incorrect auth token truncation from various commands

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollmentCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/BioEnrollmentCommand.cs
@@ -188,7 +188,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             // The pinUvAuthToken is an encrypted value, so there's no need to
             // overwrite the array.
             byte[] authParam = authProtocol.AuthenticateUsingPinToken(pinUvAuthToken.ToArray(), message);
-            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam, 0, 16);
+            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam);
             PinUvAuthProtocol = authProtocol.Protocol;
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/ConfigCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/ConfigCommand.cs
@@ -180,7 +180,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             // The pinUvAuthToken is an encrypted value, so there's no need to
             // overwrite the array.
             byte[] authParam = authProtocol.AuthenticateUsingPinToken(pinUvAuthToken.ToArray(), message);
-            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam, 0, 16);
+            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam);
             PinUvAuthProtocol = authProtocol.Protocol;
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementCommand.cs
@@ -184,7 +184,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             // The pinUvAuthToken is an encrypted value, so there's no need to
             // overwrite the array.
             byte[] authParam = authProtocol.AuthenticateUsingPinToken(pinUvAuthToken.ToArray(), message);
-            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam, 0, 16);
+            PinUvAuthParam = new ReadOnlyMemory<byte>(authParam);
             PinUvAuthProtocol = authProtocol.Protocol;
         }
 


### PR DESCRIPTION
# Description
See https://www.yubico.com/support/security-advisories/ysa-2025-02/. FW versions before 5.7.4 were only requiring the first 16 bytes of the fido2 pinUvAuthToken when using protocol 2, but should have been requiring the full 32 bytes. Several commands in the SDK were truncating the auth token to 16 bytes before passing it to these commands. The firmware bug has been fixed in 5.7.4 and so any fido2 commands that require a pinUvAuthToken now require the full 32 bytes under protocol 2. Since the SDK is only sending 16 bytes for several commands, they fail with CTAP2_ERR_PIN_AUTH_INVALID on 5.7.4+. 

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Tested with several of the existing integration tests
* BioEnrollmentCommandTests (some) with a 5.7.1 BIO A MPE
* ConfigCommandTests (some) and EnumCredsCommandTests, with a 5.7.4 C NFC and a 5.7.1 A NFC
  * Also validated that these commands fail with PinAuthInvalid when run with a 5.7.4 without the fix

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [no] I have run `dotnet format` to format my code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
  - Existing integration tests already cover the affected scenarios
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
