### PR TITLE
fix: Fixed bug importing PIV private key in legacy classes

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyEncoder.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyEncoder.cs
@@ -190,7 +190,7 @@ internal static class AsnPrivateKeyEncoder
         writer.PopSequence();
 
         // PrivateKey as OCTET STRING
-        writer.WriteOctetString(ecPrivateKeyHandle.Data);
+        writer.WriteOctetString(ecPrivateKeyHandle.Data.Span);
         writer.PopSequence();
 
         return writer.Encode();
@@ -237,7 +237,7 @@ internal static class AsnPrivateKeyEncoder
         privateKeyWriter.WriteOctetString(privateKey);
         
         using var privateKeyBytesHandle = new ZeroingMemoryHandle(privateKeyWriter.Encode());
-        writer.WriteOctetString(privateKeyBytesHandle.Data);
+        writer.WriteOctetString(privateKeyBytesHandle.Data.Span);
 
         // End PrivateKeyInfo SEQUENCE
         writer.PopSequence();

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/EcdsaVerify.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/EcdsaVerify.cs
@@ -173,7 +173,6 @@ namespace Yubico.YubiKey.Cryptography
             ECDsa = ConvertPublicKey(publicPointSpan.ToArray());
         }
         
-        // TODO Test
         public EcdsaVerify(ECPublicKey publicKey)
         {
             if (publicKey is null)
@@ -181,7 +180,7 @@ namespace Yubico.YubiKey.Cryptography
                 throw new ArgumentNullException(nameof(publicKey));
             }
 
-            if (!publicKey.KeyType.IsECDsa() || !publicKey.KeyType.IsCurve25519())
+            if (!publicKey.KeyType.IsECDsa())
             {
                 throw new ArgumentException("Invalid key type", nameof(publicKey));
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairResponse.cs
@@ -85,7 +85,9 @@ namespace Yubico.YubiKey.Piv.Commands
     ///   PivPublicKey pubKey = generateKeyPairResponse.GetData();
     /// </code>
     /// </remarks>
+    #pragma warning disable CS0618 // Type or member is obsolete
     public class GenerateKeyPairResponse : PivResponse, IYubiKeyResponseWithData<PivPublicKey>
+    #pragma warning restore CS0618 // Type or member is obsolete
     {
         private byte _slotNumber;
         private PivAlgorithm _algorithm;
@@ -190,10 +192,14 @@ namespace Yubico.YubiKey.Piv.Commands
         /// <exception cref="InvalidOperationException">
         /// Thrown when <see cref="YubiKeyResponse.Status"/> is not <see cref="ResponseStatus.Success"/>.
         /// </exception>
+        #pragma warning disable CS0618 // Type or member is obsolete
         public PivPublicKey GetData() =>
+            #pragma warning restore CS0618 // Type or member is obsolete
             Status switch
             {
+                #pragma warning disable CS0618 // Type or member is obsolete
                 ResponseStatus.Success => PivPublicKey.Create(ResponseApdu.Data, Algorithm),
+                #pragma warning restore CS0618 // Type or member is obsolete
                 _ => throw new InvalidOperationException(StatusMessage),
             };
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/GenerateKeyPairResponse.cs
@@ -194,13 +194,12 @@ namespace Yubico.YubiKey.Piv.Commands
         /// </exception>
         #pragma warning disable CS0618 // Type or member is obsolete
         public PivPublicKey GetData() =>
-            #pragma warning restore CS0618 // Type or member is obsolete
             Status switch
             {
-                #pragma warning disable CS0618 // Type or member is obsolete
                 ResponseStatus.Success => PivPublicKey.Create(ResponseApdu.Data, Algorithm),
-                #pragma warning restore CS0618 // Type or member is obsolete
                 _ => throw new InvalidOperationException(StatusMessage),
             };
+        #pragma warning restore CS0618 // Type or member is obsolete
+            
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ImportAsymmetricKeyCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Commands/ImportAsymmetricKeyCommand.cs
@@ -215,7 +215,8 @@ namespace Yubico.YubiKey.Piv.Commands
         /// <exception cref="ArgumentException">
         /// The <c>privateKey</c> argument does not contain a key.
         /// </exception>
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+
         public ImportAsymmetricKeyCommand(
             PivPrivateKey privateKey,
             byte slotNumber,
@@ -274,7 +275,8 @@ namespace Yubico.YubiKey.Piv.Commands
         /// <exception cref="ArgumentException">
         /// The <c>privateKey</c> argument does not contain a key.
         /// </exception>
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+
         public ImportAsymmetricKeyCommand(PivPrivateKey privateKey)
         {
             if (privateKey is null)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/KeyExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/KeyExtensions.cs
@@ -53,6 +53,7 @@ public static class KeyExtensions
     /// <param name="parameters">The private key parameters to encode.</param>
     /// <returns>A BER encoded byte array containing the encoded private key.</returns>
     /// <exception cref="ArgumentException">Thrown when the key type is not supported or when RSA key components have invalid lengths.</exception>
+    /// <remarks>This method returns a newly allocated array containing sensitive information.</remarks>
     public static Memory<byte> EncodeAsPiv(this IPrivateKey parameters) =>
         parameters switch
         {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/KeyExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/KeyExtensions.cs
@@ -33,31 +33,37 @@ public static class KeyExtensions
     /// <param name="parameters">The public key parameters to encode.</param>
     /// <returns>A BER encoded byte array containing the encoded public key.</returns>
     /// <exception cref="ArgumentException">Thrown when the key type is not supported.</exception>
-    public static Memory<byte> EncodeAsPiv(this IPublicKey parameters)
-    {
-        return parameters switch
+    public static Memory<byte> EncodeAsPiv(this IPublicKey parameters) =>
+        parameters switch
         {
             ECPublicKey p => PivKeyEncoder.EncodeECPublicKey(p),
             RSAPublicKey p => PivKeyEncoder.EncodeRSAPublicKey(p),
             Curve25519PublicKey p => PivKeyEncoder.EncodeCurve25519PublicKey(p),
-            _ => throw new ArgumentException("The type conversion for the specified key type is not supported", nameof(parameters))
+            
+            #pragma warning disable CS0618 // Type or member is obsolete
+            PivPublicKey p => p.PivEncodedPublicKey.ToArray(),
+            #pragma warning restore CS0618 // Type or member is obsolete
+            _ => throw new ArgumentException(
+                "The type conversion for the specified key type is not supported", nameof(parameters))
         };
-    }
-    
+
     /// <summary>
     /// Encodes a private key into the PIV format.
     /// </summary>
     /// <param name="parameters">The private key parameters to encode.</param>
     /// <returns>A BER encoded byte array containing the encoded private key.</returns>
     /// <exception cref="ArgumentException">Thrown when the key type is not supported or when RSA key components have invalid lengths.</exception>
-    public static Memory<byte> EncodeAsPiv(this IPrivateKey parameters)
-    {
-        return parameters switch
+    public static Memory<byte> EncodeAsPiv(this IPrivateKey parameters) =>
+        parameters switch
         {
             ECPrivateKey p => PivKeyEncoder.EncodeECPrivateKey(p),
             RSAPrivateKey p => PivKeyEncoder.EncodeRSAPrivateKey(p),
             Curve25519PrivateKey p => PivKeyEncoder.EncodeCurve25519PrivateKey(p),
-            _ => throw new ArgumentException("The type conversion for the specified key type is not supported", nameof(parameters))
+            
+            #pragma warning disable CS0618 // Type or member is obsolete
+            PivPrivateKey p => p.EncodedPrivateKey.ToArray(),
+            #pragma warning restore CS0618 // Type or member is obsolete
+            _ => throw new ArgumentException(
+                "The type conversion for the specified key type is not supported", nameof(parameters))
         };
-    }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/PivKeyEncoder.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/Converters/PivKeyEncoder.cs
@@ -20,11 +20,11 @@ using Yubico.YubiKey.Cryptography;
 namespace Yubico.YubiKey.Piv.Converters;
 
 /// <summary>
-/// This class converts from a Piv Encoded Key to either instances of the common IPublicKey and IPrivateKey
-/// or concrete the concrete types that inherit these interfaces.
+/// This class converts from IPublicKey, IPrivateKey and implementations of either to a PIV-encoded key.
 /// </summary>
-internal class PivKeyEncoder
+internal static class PivKeyEncoder
 {
+    [Obsolete("KeyExtensions instead", false)]
     public static Memory<byte> EncodePublicKey(IPublicKey publicKey)
     {
         return publicKey switch
@@ -35,7 +35,7 @@ internal class PivKeyEncoder
             _ => throw new ArgumentException("Unsupported public key type."),
         };
     }
-    
+
     public static Memory<byte> EncodeRSAPublicKey(RSAPublicKey publicKey)
     {
         var rsaParameters = publicKey.Parameters;
@@ -70,17 +70,17 @@ internal class PivKeyEncoder
 
         return tlvWriter.Encode();
     }
-    
-    public static Memory<byte> EncodePrivateKey(IPrivateKey publicKey)
-    {
-        return publicKey switch
+
+    [Obsolete("KeyExtensions instead", false)]
+    public static Memory<byte> EncodePrivateKey(IPrivateKey publicKey) =>
+        publicKey switch
         {
             Curve25519PrivateKey curve25519PrivateKey => EncodeCurve25519PrivateKey(curve25519PrivateKey),
             ECPrivateKey ecPrivateKey => EncodeECPrivateKey(ecPrivateKey),
             RSAPrivateKey rsaPrivateKey => EncodeRSAPrivateKey(rsaPrivateKey),
+
             _ => throw new ArgumentException("Unsupported public key type."),
         };
-    }
 
     public static Memory<byte> EncodeECPrivateKey(ECPrivateKey privateKey)
     {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
@@ -13,10 +13,12 @@
 // limitations under the License.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Security.Cryptography;
 using Yubico.Core.Tlv;
+using Yubico.YubiKey.Cryptography;
 
 namespace Yubico.YubiKey.Piv
 {
@@ -28,12 +30,11 @@ namespace Yubico.YubiKey.Piv
     /// of a point on the curve. So for ECC P-256, each coordinate is 32 bytes
     /// (256 bits), so the private value will be 32 bytes.
     /// </remarks>
-    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+    [Obsolete(
+        "Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead",
+        false)]
     public sealed class PivEccPrivateKey : PivPrivateKey
     {
-        private const int EccP256PrivateKeySize = 32;
-        private const int EccP384PrivateKeySize = 48;
-
         private Memory<byte> _privateValue;
 
         // <summary>
@@ -70,12 +71,12 @@ namespace Yubico.YubiKey.Piv
         /// </exception>
         [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use ECPublicKey, ECPrivateKey instead", false)]
         public PivEccPrivateKey(
-            ReadOnlySpan<byte> privateValue, 
+            ReadOnlySpan<byte> privateValue,
             PivAlgorithm? algorithm = null)
         {
             if (algorithm.HasValue)
             {
-                ValidateSize(privateValue, algorithm);
+                ValidateSize(privateValue, algorithm.Value);
                 Algorithm = algorithm.Value;
             }
             else
@@ -89,17 +90,17 @@ namespace Yubico.YubiKey.Piv
                 PivAlgorithm.EccX25519 => PivConstants.PrivateECX25519Tag,
                 _ => PivConstants.PrivateECDsaTag
             };
-            
+
             var tlvWriter = new TlvWriter();
             tlvWriter.WriteValue(tag, privateValue);
             EncodedKey = tlvWriter.Encode();
             _privateValue = new Memory<byte>(privateValue.ToArray());
         }
 
-        private static void ValidateSize(ReadOnlySpan<byte> privateValue, [DisallowNull] PivAlgorithm? algorithm)
+        private static void ValidateSize(ReadOnlySpan<byte> privateValue, PivAlgorithm algorithm)
         {
-            int expectedSize = algorithm.Value.GetPivKeyDefinition().KeyDefinition.LengthInBytes;
-            if(privateValue.Length != expectedSize)
+            int expectedSize = algorithm.GetPivKeyDefinition().KeyDefinition.LengthInBytes;
+            if (privateValue.Length != expectedSize)
             {
                 throw new ArgumentException(
                     string.Format(
@@ -109,13 +110,16 @@ namespace Yubico.YubiKey.Piv
 
         private static PivAlgorithm GetBySize(ReadOnlySpan<byte> privateValue)
         {
-            return privateValue.Length switch
+            int privateValueSize = privateValue.Length;
+            var allowed = new List<KeyDefinition> { KeyDefinitions.P256, KeyDefinitions.P384 };
+            if (allowed.SingleOrDefault(kd => kd.LengthInBytes == privateValueSize) is { } keyDefinition)
             {
-                EccP256PrivateKeySize => PivAlgorithm.EccP256,
-                EccP384PrivateKeySize => PivAlgorithm.EccP384,
-                _ => throw new ArgumentException(string.Format(
-                    CultureInfo.CurrentCulture, ExceptionMessages.InvalidPrivateKeyData))
-            };
+                return keyDefinition.GetPivKeyDefinition().Algorithm;
+            }
+
+            throw new ArgumentException(
+                string.Format(
+                    CultureInfo.CurrentCulture, ExceptionMessages.InvalidPrivateKeyData));
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPrivateKey.cs
@@ -28,7 +28,7 @@ namespace Yubico.YubiKey.Piv
     /// of a point on the curve. So for ECC P-256, each coordinate is 32 bytes
     /// (256 bits), so the private value will be 32 bytes.
     /// </remarks>
-    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public sealed class PivEccPrivateKey : PivPrivateKey
     {
         private const int EccP256PrivateKeySize = 32;
@@ -132,7 +132,6 @@ namespace Yubico.YubiKey.Piv
         /// <exception cref="ArgumentException">
         /// The encoding of the private key is not supported.
         /// </exception>
-        [Obsolete("Obsolete")]
         public static PivEccPrivateKey CreateEccPrivateKey(
             ReadOnlyMemory<byte> encodedPrivateKey,
             PivAlgorithm? pivAlgorithm)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivEccPublicKey.cs
@@ -46,6 +46,7 @@ namespace Yubico.YubiKey.Piv
     /// examine the encoding.
     /// </para>
     /// </remarks>
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public sealed class PivEccPublicKey : PivPublicKey
     {
         private const int EccP256PublicKeySize = 65;
@@ -83,7 +84,7 @@ namespace Yubico.YubiKey.Piv
         /// <exception cref="ArgumentException">
         /// The format of the public point is not supported.
         /// </exception>
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public PivEccPublicKey(ReadOnlySpan<byte> publicPoint, PivAlgorithm? algorithm = null)
         {
             if (!LoadEccPublicKey(publicPoint, algorithm))
@@ -213,9 +214,6 @@ namespace Yubico.YubiKey.Piv
             }
 
             PivEncodedKey = tlvWriter.Encode();
-
-            // The Metadate encoded key is the contents of the nested. So set
-            // that to be a slice of the EncodedKey.
             YubiKeyEncodedKey = PivEncodedKey[SliceIndex..];
 
             _publicPoint = new Memory<byte>(publicPoint.ToArray());

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivMetadata.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivMetadata.cs
@@ -314,7 +314,8 @@ namespace Yubico.YubiKey.Piv
         /// <summary>
         /// The public key associated with the private key in the given slot.
         /// </summary>
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+
         public PivPublicKey PublicKey { get; private set; } 
         
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPrivateKey.cs
@@ -62,6 +62,7 @@ namespace Yubico.YubiKey.Piv
     /// </code>
     /// </para>
     /// </remarks>
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public class PivPrivateKey : PrivateKey
     {
         protected Memory<byte> EncodedKey { get; set; }
@@ -107,6 +108,8 @@ namespace Yubico.YubiKey.Piv
         /// <exception cref="ArgumentException">
         /// The key data supplied is not a supported encoding.
         /// </exception>
+        
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public static PivPrivateKey Create(ReadOnlyMemory<byte> encodedPrivateKey, PivAlgorithm? pivAlgorithm = null)
         {
             byte tag = 0;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivPublicKey.cs
@@ -14,6 +14,8 @@
 
 using System;
 using System.Globalization;
+using Yubico.YubiKey.Cryptography;
+using Yubico.YubiKey.Piv.Converters;
 
 namespace Yubico.YubiKey.Piv
 {
@@ -68,7 +70,8 @@ namespace Yubico.YubiKey.Piv
     /// without the nested <c>7F49</c> tag.
     /// </para>
     /// </remarks>
-    public class PivPublicKey
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+    public class PivPublicKey : PublicKey
     {
         /// <summary>
         /// The algorithm of the key in this object.
@@ -77,6 +80,8 @@ namespace Yubico.YubiKey.Piv
         /// RSA or ECC.
         /// </value>
         public PivAlgorithm Algorithm { get; protected set; }
+
+        public override KeyType KeyType => Algorithm.GetKeyType();
 
         protected Memory<byte> PivEncodedKey { get; set; }
         protected Memory<byte> YubiKeyEncodedKey { get; set; }
@@ -124,21 +129,28 @@ namespace Yubico.YubiKey.Piv
         /// </exception>
         public static PivPublicKey Create(ReadOnlyMemory<byte> encodedPublicKey, PivAlgorithm? algorithm = null)
         {
-            // Try to decode as an RSA public key. If that works, we're done. If
-            // not, try ECC. If that doesn't work, exception.
             bool isCreated = PivRsaPublicKey.TryCreate(out var publicKeyObject, encodedPublicKey);
-            if (!isCreated)
+            if (isCreated)
             {
-                if (PivEccPublicKey.TryCreate(out publicKeyObject, encodedPublicKey, algorithm) == false)
-                {
-                    throw new ArgumentException(
-                        string.Format(
-                            CultureInfo.CurrentCulture,
-                            ExceptionMessages.InvalidPublicKeyData));
-                }
+                return publicKeyObject;
             }
 
-            return publicKeyObject;
+            isCreated = PivEccPublicKey.TryCreate(out publicKeyObject, encodedPublicKey, algorithm);
+            if (isCreated)
+            {
+                return publicKeyObject;
+            }
+
+            throw new ArgumentException(
+                string.Format(
+                    CultureInfo.CurrentCulture,
+                    ExceptionMessages.InvalidPublicKeyData));
+        }
+
+        public override byte[] ExportSubjectPublicKeyInfo()
+        {
+            var publicKey = PivKeyDecoder.CreatePublicKey(PivEncodedPublicKey, Algorithm.GetKeyType());
+            return publicKey.ExportSubjectPublicKeyInfo();
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPrivateKey.cs
@@ -49,6 +49,7 @@ namespace Yubico.YubiKey.Piv
     /// then then examine the encoding.
     /// </para>
     /// </remarks>
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public sealed class PivRsaPrivateKey : PivPrivateKey
     {
         private Memory<byte> _primeP;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivRsaPublicKey.cs
@@ -59,6 +59,7 @@ namespace Yubico.YubiKey.Piv
     /// and public exponent, then examine the encoding.
     /// </para>
     /// </remarks>
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public sealed class PivRsaPublicKey : PivPublicKey
     {
         private readonly byte[] _exponentF4 = { 0x01, 0x00, 0x01 };

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Attestation.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Attestation.cs
@@ -202,7 +202,8 @@ namespace Yubico.YubiKey.Piv
         }
 
 
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+
         public void ReplaceAttestationKeyAndCertificate(PivPrivateKey privateKey, X509Certificate2 certificate)
         {
             byte[] certDer = CheckVersionKeyAndCertRequirements(privateKey.Algorithm.GetKeyType(), certificate);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Crypto.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.Crypto.cs
@@ -267,7 +267,8 @@ namespace Yubico.YubiKey.Piv
                     ExceptionMessages.IncorrectCiphertextLength));
         }
         
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+
         public byte[] KeyAgree(byte slotNumber, PivPublicKey correspondentPublicKey)
         {
             if (correspondentPublicKey is null)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey.Piv
         /// </summary>
         private const byte CompressedCert = 1;
         
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public PivPublicKey GenerateKeyPair(
             byte slotNumber,
             PivAlgorithm algorithm,
@@ -266,7 +266,7 @@ namespace Yubico.YubiKey.Piv
         /// <exception cref="NotSupportedException">
         /// If the specified <see cref="PivAlgorithm"/> is not supported by the provided <see cref="IYubiKeyDevice"/>.
         /// </exception>
-        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey is deprecated. Use IPublicKey, IPrivateKey instead", false)]
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey, PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public void ImportPrivateKey(
             byte slotNumber,
             PivPrivateKey privateKey,
@@ -400,8 +400,9 @@ namespace Yubico.YubiKey.Piv
 
             RefreshManagementKeyAuthentication();
 
+            var pivEncodedKey = privateKey.EncodeAsPiv();
             var command = new ImportAsymmetricKeyCommand(
-                privateKey.EncodeAsPiv(), 
+                pivEncodedKey, 
                 privateKey.KeyType,
                 slotNumber, 
                 pinPolicy, 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -400,9 +400,9 @@ namespace Yubico.YubiKey.Piv
 
             RefreshManagementKeyAuthentication();
 
-            var pivEncodedKey = privateKey.EncodeAsPiv();
+            using var pivEncodedKeyHandle = new ZeroingMemoryHandle(privateKey.EncodeAsPiv());
             var command = new ImportAsymmetricKeyCommand(
-                pivEncodedKey, 
+                pivEncodedKeyHandle.Data, 
                 privateKey.KeyType,
                 slotNumber, 
                 pinPolicy, 

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/ImportTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/ImportTests.cs
@@ -112,14 +112,13 @@ namespace Yubico.YubiKey.Piv
         [InlineData(KeyType.ECP256, StandardTestDevice.Fw5)]
         [InlineData(KeyType.Ed25519, StandardTestDevice.Fw5)]
         [Obsolete()]
-        public void Import_KeyAndMatchingCer2t(
+        public void Import_with_PivEccPrivateKey_Succeeds(
             KeyType keyType,
             StandardTestDevice testDeviceType)
         {
             using var pivSession = GetSession(testDeviceType);
             var testPrivateKey = TestKeys.GetTestPrivateKey(keyType);
-            var piv = testPrivateKey.AsPivPrivateKey();
-            
+            var piv = new PivEccPrivateKey(testPrivateKey.GetPrivateKey(), keyType.GetPivAlgorithm());
             pivSession.ImportPrivateKey(0x90, piv);
         }
 

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/ImportTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/ImportTests.cs
@@ -38,7 +38,9 @@ namespace Yubico.YubiKey.Piv
         {
             // Arrange
             var (testPublicKey, testPrivateKey) = TestKeys.GetKeyPair(keyType);
+#pragma warning disable CS0618 // Type or member is obsolete
             var testPivPublicKey = testPublicKey.AsPivPublicKey();
+#pragma warning restore CS0618 // Type or member is obsolete
             var keyParameters = AsnPrivateKeyDecoder.CreatePrivateKey(testPrivateKey.EncodedKey);
 
             const PivPinPolicy expectedPinPolicy = PivPinPolicy.Once;
@@ -103,6 +105,22 @@ namespace Yubico.YubiKey.Piv
 
             pivSession.ImportPrivateKey(0x90, privateKey);
             pivSession.ImportCertificate(0x90, testCert.AsX509Certificate2());
+        }
+        
+        
+        [SkippableTheory(typeof(NotSupportedException), typeof(DeviceNotFoundException))]
+        [InlineData(KeyType.ECP256, StandardTestDevice.Fw5)]
+        [InlineData(KeyType.Ed25519, StandardTestDevice.Fw5)]
+        [Obsolete()]
+        public void Import_KeyAndMatchingCer2t(
+            KeyType keyType,
+            StandardTestDevice testDeviceType)
+        {
+            using var pivSession = GetSession(testDeviceType);
+            var testPrivateKey = TestKeys.GetTestPrivateKey(keyType);
+            var piv = testPrivateKey.AsPivPrivateKey();
+            
+            pivSession.ImportPrivateKey(0x90, piv);
         }
 
         [SkippableTheory(typeof(NotSupportedException), typeof(DeviceNotFoundException))]

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPrivateKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPrivateKeyTests.cs
@@ -29,7 +29,9 @@ namespace Yubico.YubiKey.Cryptography
         {
             // Arrange
             var testKey = TestKeys.GetTestPrivateKey(KeyType.ECP256);
+#pragma warning disable CS0618 // Type or member is obsolete
             var pivPrivateKey = testKey.AsPivPrivateKey();
+#pragma warning restore CS0618 // Type or member is obsolete
             var pivPrivateKeyEncoded = pivPrivateKey.EncodedPrivateKey;
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs
@@ -16,7 +16,9 @@ namespace Yubico.YubiKey.Cryptography
         {
             // Arrange
             var testKey = TestKeys.GetTestPublicKey(keyType);
+#pragma warning disable CS0618 // Type or member is obsolete
             var pivPublicKey = testKey.AsPivPublicKey();
+#pragma warning restore CS0618 // Type or member is obsolete
             var pivPublicKeyEncoded = pivPublicKey.PivEncodedPublicKey;
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPrivateKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPrivateKeyTests.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using System.Linq;
 using System.Security.Cryptography;
 using Xunit;
@@ -44,6 +45,7 @@ public class RSAPrivateKeyTests
     }
 
     [Fact]
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public void CreateFromPivEncoding_WithValidParameters_CreatesInstance()
     {
         // Arrange

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RsaPublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RsaPublicKeyTests.cs
@@ -15,7 +15,9 @@ namespace Yubico.YubiKey.Cryptography
         {
             // Arrange
             var testKey = TestKeys.GetTestPublicKey(KeyType.RSA2048);
+#pragma warning disable CS0618 // Type or member is obsolete
             var pivPublicKey = testKey.AsPivPublicKey();
+#pragma warning restore CS0618 // Type or member is obsolete
             var pivPublicKeyEncoded = pivPublicKey.PivEncodedPublicKey;
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZeroingMemoryHandleTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZeroingMemoryHandleTests.cs
@@ -65,7 +65,7 @@ public class ZeroingMemoryHandleTests
                 // Simulate combining key and IV for an operation
                 for (int i = 0; i < 5; i++)
                 {
-                    resultData[i] = (byte)(keyHandle.Data[i] ^ ivHandle.Data[i]);
+                    resultData[i] = (byte)(keyHandle.Data.Span[i] ^ ivHandle.Data.Span[i]);
                 }
             }
 
@@ -148,14 +148,14 @@ public class ZeroingMemoryHandleTests
         Assert.All(sensitiveData, b => Assert.Equal(0, b));
     }
 
-// Mock processors for testing
+    // Mock processors for testing
     private static class FirstLayerProcessor
     {
         public static byte[] Process(ZeroingMemoryHandle handle)
         {
             // Simulate processing
             var result = new byte[handle.Data.Length];
-            Buffer.BlockCopy(handle.Data, 0, result, 0, handle.Data.Length);
+            handle.Data.CopyTo(result);
             return result;
         }
     }
@@ -167,7 +167,7 @@ public class ZeroingMemoryHandleTests
             // Simulate more processing
             for (int i = 0; i < originalHandle.Data.Length; i++)
             {
-                intermediateResult[i] ^= originalHandle.Data[i];
+                intermediateResult[i] ^= originalHandle.Data.Span[i];
             }
             return intermediateResult;
         }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/Commands/GenPairResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/Commands/GenPairResponseTests.cs
@@ -141,7 +141,9 @@ namespace Yubico.YubiKey.Piv.Commands
             byte[] keyData = GetCorrectEncodingForAlgorithm(keyType);
 
             var response = new GenerateKeyPairResponse(responseApdu, 0x8F, keyType.GetPivAlgorithm());
+#pragma warning disable CS0618 // Type or member is obsolete
             PivPublicKey getData = response.GetData();
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var keyDataSpan = new ReadOnlySpan<byte>(keyData);
             bool compareResult = keyDataSpan.SequenceEqual(getData.PivEncodedPublicKey.Span);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivEncoderDecoderTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivEncoderDecoderTests.cs
@@ -92,7 +92,9 @@ public class PivEncoderDecoderTests
         var testKey = TestKeys.GetTestPublicKey(keyType);
 
         // Get test key as PivPublicKey
+#pragma warning disable CS0618 // Type or member is obsolete
         var testPivPublicKey = testKey.AsPivPublicKey();
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.NotNull(testPivPublicKey);
 
         // Convert from PivEncoding to PublicKey using Key Converter.

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPrivateKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPrivateKeyTests.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Linq;
 using System.Security.Cryptography;
 using Xunit;
 using Yubico.YubiKey.Cryptography;
@@ -21,8 +20,19 @@ using Yubico.YubiKey.TestUtilities;
 
 namespace Yubico.YubiKey.Piv
 {
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public class PivPrivateKeyTests
     {
+        [Theory]
+        [InlineData(KeyType.ECP256)]
+        [InlineData(KeyType.Ed25519)]
+        public void Constructor_with_Algorithm_SetsAlgorithm(KeyType keyType)
+        {
+            var pk = new PivEccPrivateKey(new byte[32], keyType.GetPivAlgorithm());
+            Assert.Equal(keyType.GetPivAlgorithm(), pk.Algorithm);
+            Assert.Equal(keyType, pk.KeyType);
+        }
+        
         [Theory]
         [InlineData(KeyType.RSA1024)]
         [InlineData(KeyType.RSA2048)]
@@ -241,6 +251,7 @@ namespace Yubico.YubiKey.Piv
         [Theory]
         [InlineData(KeyType.ECP256)]
         [InlineData(KeyType.ECP384)]
+        [Obsolete("Obsolete")]
         public void EccConstructor_Components_BuildsEncoding(
             KeyType keyType)
         {
@@ -305,7 +316,9 @@ namespace Yubico.YubiKey.Piv
         [Fact]
         public void EccConstructor_NullData_ThrowsExcpetion()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             _ = Assert.Throws<ArgumentException>(() => new PivEccPrivateKey(null));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Theory]
@@ -382,7 +395,9 @@ namespace Yubico.YubiKey.Piv
                 offset = keySize - eccParams.D!.Length;
                 Array.Copy(eccParams.D, 0, privateValue, offset, eccParams.D.Length);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 var eccPriKey = new PivEccPrivateKey(privateValue);
+#pragma warning restore CS0618 // Type or member is obsolete
                 privateKey = (PivPrivateKey)eccPriKey;
             }
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPrivateKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPrivateKeyTests.cs
@@ -25,10 +25,17 @@ namespace Yubico.YubiKey.Piv
     {
         [Theory]
         [InlineData(KeyType.ECP256)]
+        [InlineData(KeyType.ECP384)]
         [InlineData(KeyType.Ed25519)]
         public void Constructor_with_Algorithm_SetsAlgorithm(KeyType keyType)
         {
-            var pk = new PivEccPrivateKey(new byte[32], keyType.GetPivAlgorithm());
+            var keyBytes = keyType switch
+            {
+                KeyType.ECP384 => new byte[48],
+                _ => new byte[32],
+            };
+            
+            var pk = new PivEccPrivateKey(keyBytes, keyType.GetPivAlgorithm());
             Assert.Equal(keyType.GetPivAlgorithm(), pk.Algorithm);
             Assert.Equal(keyType, pk.KeyType);
         }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Piv/PivPublicKeyTests.cs
@@ -20,8 +20,24 @@ using Yubico.YubiKey.TestUtilities;
 
 namespace Yubico.YubiKey.Piv
 {
-    public class PivPublicKeyTests
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
+    public class PivPublicKeyTests // TODO add test to verify interface implementations
     {
+
+        [Fact]
+        public void ExportSubjectPublicKeyInfo_ReturnsSubjectPublicKeyInfo()
+        {
+            var testKey = TestKeys.GetTestPublicKey(KeyType.ECP256);
+            var tlvPublicKey = testKey.AsPivPublicKey();
+            var subjectPublicKeyInfo = tlvPublicKey.ExportSubjectPublicKeyInfo();
+            var ecPublicKey = ECPublicKey.CreateFromPkcs8(subjectPublicKeyInfo);
+            
+            Assert.Equal(KeyType.ECP256, tlvPublicKey.KeyType);
+            Assert.NotEmpty(subjectPublicKeyInfo); 
+            Assert.Equal(testKey.EncodedKey, subjectPublicKeyInfo);
+            Assert.Equal(subjectPublicKeyInfo, ecPublicKey.ExportSubjectPublicKeyInfo());
+        }
+        
         [Theory]
         [InlineData(KeyType.RSA1024)]
         [InlineData(KeyType.RSA2048)]

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/KeyConverter.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/KeyConverter.cs
@@ -63,6 +63,7 @@ namespace Yubico.YubiKey.TestUtilities
     // Build an object from a PivPublicKey object and get a PEM string or RSA or
     // ECDsa object.
     // It is also possible to get a public key from a private key.
+    [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
     public class KeyConverter
     {
         private const string RequestedKeyMessage = "Requested key was unavailable.";
@@ -768,7 +769,9 @@ namespace Yubico.YubiKey.TestUtilities
             // var eccOid = eccParams.Curve.Oid.Value!;
             // var keyDefinition = KeyDefinitions.GetByOid(eccOid);
             // var eccPriKey = new PivEccPrivateKey(privateValue, keyDefinition.KeyType.GetPivAlgorithm());
+#pragma warning disable CS0618 // Type or member is obsolete
             var eccPriKey = new PivEccPrivateKey(privateValue);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             _pivPrivateKey = eccPriKey;
         }

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/PivKeyExtensions.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/PivKeyExtensions.cs
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.YubiKey.Cryptography;
 using Yubico.YubiKey.Piv;
 using Yubico.YubiKey.Piv.Converters;
 
 namespace Yubico.YubiKey.TestUtilities;
 
+[Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
 public static class PivKeyExtensions
 {
     public static RSAPrivateKey ConvertToGeneric(

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/SampleKeyPairs.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/SampleKeyPairs.cs
@@ -15,6 +15,7 @@
 using System.Security.Cryptography.X509Certificates;
 using Yubico.YubiKey.Cryptography;
 using Yubico.YubiKey.Piv;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Yubico.YubiKey.TestUtilities
 {

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKeyExtensions.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKeyExtensions.cs
@@ -11,6 +11,7 @@ namespace Yubico.YubiKey.TestUtilities
         /// Converts the key to a PIV private key format.
         /// </summary>
         /// <returns>PivPrivateKey instance</returns>
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public static PivPrivateKey AsPivPrivateKey(
             this TestKey key)
         {
@@ -38,6 +39,7 @@ namespace Yubico.YubiKey.TestUtilities
         /// Converts the key to a PIV public key format.
         /// </summary>
         /// <returns>PivPublicKey instance</returns>
+        [Obsolete("Usage of PivEccPublic/PivEccPrivateKey PivRsaPublic/PivRsaPrivateKey is deprecated. Use implementations of ECPublicKey, ECPrivateKey and RSAPublicKey, RSAPrivateKey instead", false)]
         public static PivPublicKey AsPivPublicKey(
             this TestKey key)
         {


### PR DESCRIPTION
This PR fixes #228 where one could where a legacy PivPrivateKey would not be handled properly in the new `ImportPrivateKey(byte slotNumber, IPrivateKey)`. [[1]](https://github.com/Yubico/Yubico.NET.SDK/pull/231/files#diff-3df895fe2adbf52e5498d1798903f38cf8a9dd0040b6d9db7ec9f77d0a7f658eR44)

Additionally, deprecating older key types (`PivEccPublic`, `PivEccPrivateKey`, etc.) in favor of modern implementations (`ECPublicKey`, `ECPrivateKey`, `RSAPublicKey`, etc.) and refining code structure. Below are the most significant changes grouped by theme:

Summarized by Copilot:
### Deprecation of Legacy Key Types
* Marked `PivEccPublic`, `PivEccPrivateKey`, `PivRsaPublic`, and `PivRsaPrivateKey` as obsolete, encouraging the use of `ECPublicKey`, `ECPrivateKey`, `RSAPublicKey`, and similar implementations instead. This affects multiple classes, including `PivEccPrivateKey`, `PivEccPublicKey`, and `PivPrivateKey`. [[1]](diffhunk://#diff-61723096c680d6c6384cb3bd3312c536af7257ff77b5d26227a5304423ae634eR161) [[2]](diffhunk://#diff-3dd31b5b5c9e9ebf77019f168ecb15ef62a420b298ab0850f6b1abdea57647d4R31) [[3]](diffhunk://#diff-f73582180f398e38efa080518e0dfd3a93c97cada7cb4bd088602200305c8c7eR49) [[4]](diffhunk://#diff-2a0baf075c637c3378cdcac6077ce5ef8ccfdad6021e6690486b1a80ac96da7fR65)

### Memory Handling Improvements
* Updated `ZeroingMemoryHandle` to use `Memory<byte>` instead of `byte[]`, simplifying the class and improving memory safety. Removed unnecessary methods like `CopyTo` and `Slice`.
* Changed calls to use `.Span` when accessing `Memory<byte>` in `AsnPrivateKeyEncoder.cs` to improve compatibility and performance. [[1]](diffhunk://#diff-2d236d74d1945bc22db805a3ccf89340984b6808e1483fb3eec8abacffbd6f90L193-R193) [[2]](diffhunk://#diff-2d236d74d1945bc22db805a3ccf89340984b6808e1483fb3eec8abacffbd6f90L240-R240)

### New Constructor and Validation Enhancements
* Added a new constructor to `EcdsaVerify` for `ECPublicKey` with validation for key type and curve.
* Refactored size validation logic for ECC private keys into dedicated helper methods in `PivEccPrivateKey`. [[1]](diffhunk://#diff-3dd31b5b5c9e9ebf77019f168ecb15ef62a420b298ab0850f6b1abdea57647d4R71-R83) [[2]](diffhunk://#diff-3dd31b5b5c9e9ebf77019f168ecb15ef62a420b298ab0850f6b1abdea57647d4R99-R120)

### Obsolete Method and Class Updates
* Deprecated methods in `PivKeyEncoder` for encoding keys, redirecting users to `KeyExtensions` for modern alternatives. [[1]](diffhunk://#diff-313579ef7d4d7e1e813aef235f0292f0d345db4ae8bcf09dc52d5e3202ffd4b3L23-R27) [[2]](diffhunk://#diff-313579ef7d4d7e1e813aef235f0292f0d345db4ae8bcf09dc52d5e3202ffd4b3L74-L83)
* Updated `KeyExtensions` to handle obsolete `PivPublicKey` and `PivPrivateKey` with warnings for backward compatibility.

### Code Cleanup and Refactoring
* Simplified and clarified logic in multiple places, such as removing redundant comments and unused code in `PivEccPublicKey` and `PivMetadata`. [[1]](diffhunk://#diff-f73582180f398e38efa080518e0dfd3a93c97cada7cb4bd088602200305c8c7eL216-L218) [[2]](diffhunk://#diff-84a87c6d1f737f9abda9353232821eff3a74d99c510c2c4588eda6206c065a03L317-R318)