### PR TITLE
github: Add issue type to GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -2,7 +2,7 @@ name: 🐞 Bug
 description: File a bug/issue.
 title: "[BUG] <title>"
 labels: ["bug"]
-issue_type: Bug
+type: Bug
 projects: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -2,6 +2,7 @@ name: 🐞 Bug
 description: File a bug/issue.
 title: "[BUG] <title>"
 labels: ["bug"]
+issue_type: Bug
 projects: []
 assignees: []
 body:

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -2,6 +2,7 @@ name: 💡 Feature Request
 description: Suggest an idea for this project.
 title: "[Feature]: <title>"
 labels: ["enhancement"]
+issue_type: Feature
 projects: []
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/3-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/3-feature-request.yml
@@ -2,7 +2,7 @@ name: 💡 Feature Request
 description: Suggest an idea for this project.
 title: "[Feature]: <title>"
 labels: ["enhancement"]
-issue_type: Feature
+type: Feature
 projects: []
 body:
   - type: markdown


### PR DESCRIPTION
This pull request updates the issue templates in the `.github/ISSUE_TEMPLATE` directory to include a `type` field for better categorization of issues.

Enhancements to issue templates:

* [`.github/ISSUE_TEMPLATE/2-bug-report.yml`](diffhunk://#diff-7b1d4ddf04b840c3e0192aaf577d0113bfad655091af7c7ac114f72d0d3f3098R5): Added a `type: Bug` field to the bug report template to explicitly categorize it as a bug.
* [`.github/ISSUE_TEMPLATE/3-feature-request.yml`](diffhunk://#diff-5aa1e77f2707b998783cd4ec258dd9e923d7f90b436bcd332c01860cce21b880R5): Added a `type: Feature` field to the feature request template to explicitly categorize it as a feature.