### PR TITLE
Fix docs about encodings for PIV signing command

### DIFF
--- a/docs/users-manual/application-piv/apdu/auth-sign.md
+++ b/docs/users-manual/application-piv/apdu/auth-sign.md
@@ -97,7 +97,7 @@ The signature is returned encoded as follows,
 
   For example, with RSA-2048, the signature will be
 
-  7C 82 01 04 82 828 01 00 <256-byte signature>
+  7C 82 01 04 82 82 01 00 <256-byte signature>
 
   With ECC-P256, the signature will be
 

--- a/docs/users-manual/application-piv/commands.md
+++ b/docs/users-manual/application-piv/commands.md
@@ -880,21 +880,22 @@ For example, if using PKCS 1 v 1.5, before calling, build the following block.
 
   For a 2048-bit key, the block is 256 bytes long (the leading 00 byte is one of the 256).
 
-  If the digest algorithm is SHA-256, the DER of the DigestInfo will be 49 bytes long:
+  If the digest algorithm is SHA-256, the DER of the DigestInfo will be 51 bytes long:
 
-  30 2f
-     30 0b
+  30 31
+     30 0d
         06 09
            60 86 48 01 65 03 04 02 01
+        05 00
      04 20
         <32-byte digest>
 
   The block to pass to the YubiKey will be
 
-  00 01 FF FF ... FF 00 \<49-byte DER of DigestInfo\>
+  00 01 FF FF ... FF 00 \<51-byte DER of DigestInfo\>
         ^          ^
         |          |
-        -------------- 204 bytes of 0xFF
+        -------------- 202 bytes of 0xFF
 ```
 
 PSS (Probabilistic Signature Scheme) is much more complicated. If you want to learn how to


### PR DESCRIPTION
# Description
* Fixed DER encoding of DigestInfo for PIV signing command
  * DER encoding was missing the mandatory NULL value (05 00) to ensure signatures are compatible with OpenSSL/BoringSSL
  * Matches this library's implementation: https://github.com/Yubico/Yubico.NET.SDK/blob/76e5dd67771f396a42ce5b405346d67150b2e486/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RsaFormat.cs#L172-L173
  * Matches BoringSSL: https://github.com/google/boringssl/blob/5622da92e1e7bacb5d0785ff5650a5a23b143b84/crypto/fipsmodule/rsa/rsa.cc.inc#L444-L445
* Fixed typo in response APDU for PIV signing command
