### PR TITLE
feat: Implement reading of VersionQualifier into YubikeyDeviceInfo

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/FirmwareVersion.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/FirmwareVersion.cs
@@ -61,7 +61,7 @@ namespace Yubico.YubiKey
             Minor = minor;
             Patch = patch;
         }
-        
+
         /// <summary>
         /// Parse a string of the form "major.minor.patch"
         /// </summary>
@@ -75,21 +75,42 @@ namespace Yubico.YubiKey
             {
                 throw new ArgumentNullException(nameof(versionString));
             }
-            
+
             string[] parts = versionString.Split('.');
             if (parts.Length != 3)
             {
                 throw new ArgumentException("Must include major.minor.patch", nameof(versionString));
             }
-            
+
             if (!byte.TryParse(parts[0], out byte major) ||
-                !byte.TryParse(parts[1], out byte minor) || 
+                !byte.TryParse(parts[1], out byte minor) ||
                 !byte.TryParse(parts[2], out byte patch))
             {
                 throw new ArgumentException("Major, minor and patch must be valid numbers", nameof(versionString));
             }
-            
+
             return new FirmwareVersion(major, minor, patch);
+        }
+
+        /// <summary>
+        /// Creates a <see cref="FirmwareVersion"/> from a byte array.
+        /// The byte array must contain exactly three bytes, representing the major, minor, and patch versions.
+        /// </summary>
+        /// <param name="bytes">A byte array containing the version information.</param>
+        /// <returns>A <see cref="FirmwareVersion"/> instance.</returns>
+        /// <exception cref="ArgumentException">Thrown if the byte array does not contain exactly three bytes.</exception>
+        /// <remarks>
+        /// The first byte represents the major version, the second byte represents the minor version,
+        /// and the third byte represents the patch version.
+        /// </remarks>
+        public static FirmwareVersion FromBytes(ReadOnlySpan<byte> bytes)
+        {
+            if (bytes.Length != 3)
+            {
+                throw new ArgumentException("Invalid length of data");
+            }
+
+            return new FirmwareVersion(bytes[0], bytes[1], bytes[2]);
         }
 
         public static bool operator >(FirmwareVersion left, FirmwareVersion right)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/VersionQualifier.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/VersionQualifier.cs
@@ -62,14 +62,10 @@ internal class VersionQualifier
     /// <exception cref="ArgumentNullException"></exception>
     public VersionQualifier(FirmwareVersion firmwareVersion, VersionQualifierType type, long iteration)
     {
-        if (iteration < 0)
+        if (iteration < 0 || iteration > uint.MaxValue)
         {
-            throw new ArgumentOutOfRangeException(nameof(iteration), "Iteration must be a non-negative value.");
-        }
-
-        if (iteration > uint.MaxValue)
-        {
-            throw new ArgumentOutOfRangeException(nameof(iteration), "Iteration must be less than or equal to int.MaxValue.");
+            throw new ArgumentOutOfRangeException(nameof(iteration),
+                $"Iteration must be between 0 and {uint.MaxValue}.");
         }
 
         FirmwareVersion = firmwareVersion ?? throw new ArgumentNullException(nameof(firmwareVersion));

--- a/Yubico.YubiKey/src/Yubico/YubiKey/VersionQualifier.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/VersionQualifier.cs
@@ -1,0 +1,98 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Yubico.YubiKey;
+
+/// <summary>
+/// Represents the type of version qualifier for a firmware version.
+/// The version qualifier type indicates whether the version is an Alpha, Beta, or Final release.
+/// </summary>
+internal enum VersionQualifierType : byte
+{
+    Alpha = 0x00,
+    Beta = 0x01,
+    Final = 0x02
+}
+
+/// <summary>
+/// Represents a version qualifier for a firmware version.
+/// A version qualifier typically includes the firmware version, a type (such as Alpha, Beta, or Final),
+/// and an iteration number.
+/// </summary>
+internal class VersionQualifier
+{
+    /// <summary>
+    /// Represents the firmware version associated with this qualifier.
+    /// </summary>
+    public FirmwareVersion FirmwareVersion { get; }
+    /// <summary>
+    /// Represents the type of version qualifier, such as Alpha, Beta, or Final.
+    /// </summary>
+    public VersionQualifierType Type { get; }
+
+    /// <summary>
+    /// Represents the iteration number of the version qualifier.
+    /// </summary>
+    public long Iteration { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionQualifier"/> class.
+    /// This constructor allows you to specify the firmware version, type, and iteration.
+    /// The iteration must be a non-negative value and less than or equal to int.MaxValue.
+    /// If the firmware version is null, an <see cref="ArgumentNullException"/> will be thrown.
+    /// If the iteration is negative or greater than int.MaxValue, an <see cref="ArgumentOutOfRangeException"/> will be thrown.
+    /// </summary>
+    /// <param name="firmwareVersion">The firmware version associated with this qualifier.</param>
+    /// <param name="type">The type of version qualifier (Alpha, Beta, Final).</param>
+    /// <param name="iteration">The iteration number of the version qualifier, must be a non-negative value and less than or equal to int.MaxValue.</param>
+    /// <exception cref="ArgumentOutOfRangeException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    public VersionQualifier(FirmwareVersion firmwareVersion, VersionQualifierType type, long iteration)
+    {
+        if (iteration < 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(iteration), "Iteration must be a non-negative value.");
+        }
+
+        if (iteration > uint.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(nameof(iteration), "Iteration must be less than or equal to int.MaxValue.");
+        }
+
+        FirmwareVersion = firmwareVersion ?? throw new ArgumentNullException(nameof(firmwareVersion));
+        Type = type;
+        Iteration = iteration;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="VersionQualifier"/> class with default values.
+    /// The default firmware version is set to a new instance of <see cref="FirmwareVersion"/>,
+    /// the type is set to <see cref="VersionQualifierType.Final"/>, and the iteration is set to 0.
+    /// </summary>
+    public VersionQualifier()
+    {
+        FirmwareVersion = new FirmwareVersion();
+        Type = VersionQualifierType.Final;
+        Iteration = 0;
+    }
+
+    public override string ToString() => $"{FirmwareVersion}.{Type.ToString().ToLowerInvariant()}.{Iteration}";
+    public override bool Equals(object obj) => obj is VersionQualifier other &&
+            FirmwareVersion.Equals(other.FirmwareVersion) &&
+            Type == other.Type &&
+            Iteration == other.Iteration;
+    public override int GetHashCode() => HashCode.Combine(FirmwareVersion, Type, Iteration);
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -18,6 +18,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
+using Microsoft.Extensions.Logging;
+using Yubico.Core.Tlv;
 
 namespace Yubico.YubiKey
 {
@@ -73,8 +75,15 @@ namespace Yubico.YubiKey
         /// <inheritdoc />
         public FormFactor FormFactor { get; set; }
 
+        public string VersionName => VersionQualifier.Type == VersionQualifierType.Final
+            ? FirmwareVersion.ToString()
+            : VersionQualifier.ToString();
+
         /// <inheritdoc />
         public FirmwareVersion FirmwareVersion { get; set; }
+
+        /// <inheritdoc />
+        internal VersionQualifier VersionQualifier { get; set; }
 
         /// <inheritdoc />
         public TemplateStorageVersion? TemplateStorageVersion { get; set; }
@@ -109,6 +118,7 @@ namespace Yubico.YubiKey
         public YubiKeyDeviceInfo()
         {
             FirmwareVersion = new FirmwareVersion();
+            VersionQualifier = new VersionQualifier(FirmwareVersion, VersionQualifierType.Final, 0);
         }
 
         /// <summary>
@@ -191,6 +201,10 @@ namespace Yubico.YubiKey
                         };
 
                         break;
+
+                    case YubikeyDeviceManagementTags.VersionQualifierTag:
+                        // This tag is handled later in the method.
+                        break;
                     case YubikeyDeviceManagementTags.AutoEjectTimeoutTag:
                         deviceInfo.AutoEjectTimeout = BinaryPrimitives.ReadUInt16BigEndian(value);
                         break;
@@ -261,6 +275,55 @@ namespace Yubico.YubiKey
 
             deviceInfo.IsSkySeries |= skySeriesFlag;
 
+            if (!responseApduData.TryGetValue(YubikeyDeviceManagementTags.VersionQualifierTag, out var versionQualifierBytes))
+            {
+                deviceInfo.VersionQualifier = new VersionQualifier(deviceInfo.FirmwareVersion, VersionQualifierType.Final, 0);
+            }
+            else
+            {
+                if (versionQualifierBytes.Length != 0x0E)
+                {
+                    throw new ArgumentException("Invalid data length.");
+                }
+
+                const byte TAG_VERSION = 0x01;
+                const byte TAG_TYPE = 0x02;
+                const byte TAG_ITERATION = 0x03;
+
+                var data = TlvObjects.DecodeDictionary(versionQualifierBytes.Span);
+
+                if (!data.TryGetValue(TAG_VERSION, out var firmwareVersionBytes))
+                {
+                    throw new ArgumentException("TODO.");
+                }
+                if (!data.TryGetValue(TAG_TYPE, out var versionTypeBytes))
+                {
+                    throw new ArgumentException("TODO.");
+                }
+                if (!data.TryGetValue(TAG_ITERATION, out var iterationBytes))
+                {
+                    throw new ArgumentException("TODO.");
+                }
+
+                var qualifierVersion = FirmwareVersion.FromBytes(firmwareVersionBytes.Span);
+                var versionType = (VersionQualifierType)versionTypeBytes.Span[0];
+                uint iteration = BinaryPrimitives.ReadUInt32BigEndian(iterationBytes.Span);
+
+                deviceInfo.VersionQualifier = new VersionQualifier(
+                    qualifierVersion,
+                    versionType,
+                    iteration);
+            }
+
+            bool isFinalVersion = deviceInfo.VersionQualifier.Type == VersionQualifierType.Final;
+            if (!isFinalVersion)
+            {
+                var Logger = Core.Logging.Log.GetLogger<YubiKeyDeviceInfo>();
+                Logger.LogDebug("Overriding behavioral version with {FirmwareString}", deviceInfo.VersionQualifier.FirmwareVersion);
+            }
+
+            var computedVersion = isFinalVersion ? deviceInfo.FirmwareVersion : deviceInfo.VersionQualifier.FirmwareVersion;
+            deviceInfo.FirmwareVersion = computedVersion;
             return deviceInfo;
         }
 
@@ -308,6 +371,10 @@ namespace Yubico.YubiKey
                 FirmwareVersion = FirmwareVersion != new FirmwareVersion()
                     ? FirmwareVersion
                     : second.FirmwareVersion,
+
+                VersionQualifier = VersionQualifier != new VersionQualifier()
+                    ? VersionQualifier
+                    : second.VersionQualifier,
 
                 AutoEjectTimeout = DeviceFlags.HasFlag(DeviceFlags.TouchEject)
                     ? AutoEjectTimeout

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -307,7 +307,7 @@ namespace Yubico.YubiKey
 
                 var qualifierVersion = FirmwareVersion.FromBytes(firmwareVersionBytes.Span);
                 var versionType = (VersionQualifierType)versionTypeBytes.Span[0];
-                uint iteration = BinaryPrimitives.ReadUInt32BigEndian(iterationBytes.Span);
+                long iteration = BinaryPrimitives.ReadUInt32BigEndian(iterationBytes.Span);
 
                 deviceInfo.VersionQualifier = new VersionQualifier(
                     qualifierVersion,

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.cs
@@ -294,15 +294,15 @@ namespace Yubico.YubiKey
 
                 if (!data.TryGetValue(TAG_VERSION, out var firmwareVersionBytes))
                 {
-                    throw new ArgumentException("TODO.");
+                    throw new ArgumentException("Missing TLV field: TAG_VERSION.");
                 }
                 if (!data.TryGetValue(TAG_TYPE, out var versionTypeBytes))
                 {
-                    throw new ArgumentException("TODO.");
+                    throw new ArgumentException("Missing TLV field: TAG_TYPE.");
                 }
                 if (!data.TryGetValue(TAG_ITERATION, out var iterationBytes))
                 {
-                    throw new ArgumentException("TODO.");
+                    throw new ArgumentException("Missing TLV field: TAG_ITERATION.");
                 }
 
                 var qualifierVersion = FirmwareVersion.FromBytes(firmwareVersionBytes.Span);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubikeyDeviceManagementTags.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubikeyDeviceManagementTags.cs
@@ -42,6 +42,7 @@ namespace Yubico.YubiKey
         internal const byte PinComplexityTag = 0x16;
         internal const byte NfcRestrictedTag = 0x17;
         internal const byte ResetBlockedTag = 0x18;
+        internal const byte VersionQualifierTag = 0x19;
         internal const byte TemplateStorageVersionTag = 0x20; // FPS version tag
         internal const byte ImageProcessorVersionTag = 0x21; // STM version tag
         internal const byte TempTouchThresholdTag = 0x85;

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/VersionQualifierTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/VersionQualifierTests.cs
@@ -79,11 +79,6 @@ namespace Yubico.YubiKey
             Assert.Equal(qualifier1, qualifier2);
             Assert.Equal(qualifier1.GetHashCode(), qualifier2.GetHashCode());
             Assert.NotEqual(qualifier1, qualifier3);
-            // Hash codes are not guaranteed to be different for non-equal objects,
-            // but for these specific inputs, they likely will be.
-            // If this assertion fails, it might not indicate a bug in GetHashCode itself,
-            // as long as the Equals contract is maintained.
-            // Assert.NotEqual(qualifier1.GetHashCode(), qualifier3.GetHashCode());
         }
 
         [Fact]

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/VersionQualifierTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/VersionQualifierTests.cs
@@ -1,0 +1,97 @@
+// Copyright 2024 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, 
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Xunit;
+
+namespace Yubico.YubiKey
+{
+    public class VersionQualifierTests
+    {
+        [Fact]
+        public void TestVersion()
+        {
+            var version = new FirmwareVersion(5, 7, 2);
+            Assert.Equal(
+                version, new VersionQualifier(version, VersionQualifierType.Alpha, 1).FirmwareVersion);
+        }
+
+        [Fact]
+        public void TestType()
+        {
+            Assert.Equal(
+                VersionQualifierType.Alpha,
+                new VersionQualifier(new FirmwareVersion(5, 7, 2), VersionQualifierType.Alpha, 1).Type);
+            Assert.Equal(
+                VersionQualifierType.Beta,
+                new VersionQualifier(new FirmwareVersion(5, 7, 2), VersionQualifierType.Beta, 1).Type);
+            Assert.Equal(
+                VersionQualifierType.Final,
+                new VersionQualifier(new FirmwareVersion(5, 7, 2), VersionQualifierType.Final, 1).Type);
+        }
+
+        [Fact]
+        public void TestIteration()
+        {
+            var version = new FirmwareVersion(5, 7, 2);
+            var type = VersionQualifierType.Alpha;
+            Assert.Equal(0, new VersionQualifier(version, type, 0).Iteration);
+            Assert.Equal(128, new VersionQualifier(version, type, 128).Iteration);
+            Assert.Equal(255, new VersionQualifier(version, type, 255).Iteration);
+        }
+
+        [Fact]
+        public void TestToString()
+        {
+            Assert.Equal(
+                "5.7.2.alpha.0",
+                new VersionQualifier(new FirmwareVersion(5, 7, 2), VersionQualifierType.Alpha, 0).ToString());
+            Assert.Equal(
+                "5.6.6.beta.16384",
+                new VersionQualifier(new FirmwareVersion(5, 6, 6), VersionQualifierType.Beta, 16384).ToString());
+            Assert.Equal(
+                "3.4.0.final.2147483648",
+                new VersionQualifier(new FirmwareVersion(3, 4, 0), VersionQualifierType.Final, 0x80000000).ToString());
+            Assert.Equal(
+                "3.4.0.final.2147483647",
+                new VersionQualifier(new FirmwareVersion(3, 4, 0), VersionQualifierType.Final, 0x7fffffff).ToString());
+        }
+
+        [Fact]
+        public void TestEqualsAndHashCode()
+        {
+            var version1 = new FirmwareVersion(1, 0, 0);
+            var version2 = new FirmwareVersion(1, 0, 0);
+            var qualifier1 = new VersionQualifier(version1, VersionQualifierType.Alpha, 1);
+            var qualifier2 = new VersionQualifier(version2, VersionQualifierType.Alpha, 1);
+            var qualifier3 = new VersionQualifier(version1, VersionQualifierType.Beta, 2);
+
+            Assert.Equal(qualifier1, qualifier2);
+            Assert.Equal(qualifier1.GetHashCode(), qualifier2.GetHashCode());
+            Assert.NotEqual(qualifier1, qualifier3);
+            // Hash codes are not guaranteed to be different for non-equal objects,
+            // but for these specific inputs, they likely will be.
+            // If this assertion fails, it might not indicate a bug in GetHashCode itself,
+            // as long as the Equals contract is maintained.
+            // Assert.NotEqual(qualifier1.GetHashCode(), qualifier3.GetHashCode());
+        }
+
+        [Fact]
+        public void TestTypeFromValue()
+        {
+            Assert.Equal(VersionQualifierType.Alpha, (VersionQualifierType)0);
+            Assert.Equal(VersionQualifierType.Beta, (VersionQualifierType)1);
+            Assert.Equal(VersionQualifierType.Final, (VersionQualifierType)2);
+        }
+    }
+}

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
@@ -280,7 +280,6 @@ namespace Yubico.YubiKey
                 SetVersionTag(tag, version, tlvs);
             }
 
-            SetVersionQualifierTag(versionQualifier, tlvs);
 
             return YubiKeyDeviceInfo.CreateFromResponseData(tlvs); //We're testing this method
         }
@@ -296,25 +295,6 @@ namespace Yubico.YubiKey
             {
                 tlvs.Add(versionTag, versionAsBytes);
             }
-        }
-
-        private static void SetVersionQualifierTag(VersionQualifier? versionQualifier, Dictionary<int, ReadOnlyMemory<byte>> tlvs)
-        {
-            if (versionQualifier is null)
-            {
-                return;
-            }
-
-            var tlvVq = TlvObjects.EncodeMany(
-                new TlvObject(0x01, VersionToBytes(versionQualifier.FirmwareVersion)),
-                new TlvObject(0x02, [(byte)versionQualifier.Type]),
-                new TlvObject(0x03, [0, 0, 0, (byte)versionQualifier.Iteration]));
-
-            var tlvVqLength = tlvVq.Length;
-            Debug.WriteLine($"VersionQualifier TLV length: {tlvVqLength}");
-
-            const byte versionQualifierTag = 0x019;
-            tlvs.Add(versionQualifierTag, tlvVq);
         }
 
         private static byte[] VersionToBytes(FirmwareVersion version) => [version.Major, version.Minor, version.Patch];

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
@@ -16,7 +16,6 @@ using System;
 using System.Collections.Generic;
 using Xunit;
 using Yubico.Core.Buffers;
-using Yubico.Core.Tlv;
 
 namespace Yubico.YubiKey
 {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
@@ -14,7 +14,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using Xunit;
 using Yubico.Core.Buffers;
 using Yubico.Core.Tlv;

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/YubikeyDeviceInfoTests.cs
@@ -262,7 +262,7 @@ namespace Yubico.YubiKey
 
         private static YubiKeyDeviceInfo DefaultInfo() => YubiKeyDeviceInfo.CreateFromResponseData([]);
 
-        private static YubiKeyDeviceInfo DeviceInfoFor(int tag, byte[] deviceInfoData, FirmwareVersion? version = null, VersionQualifier? versionQualifier = null)
+        private static YubiKeyDeviceInfo DeviceInfoFor(int tag, byte[] deviceInfoData, FirmwareVersion? version = null)
         {
             if (deviceInfoData.Length == 0)
             {


### PR DESCRIPTION
# Description
This pull request introduces several enhancements and new features to the `Yubico.YubiKey` library, focusing on firmware version handling, version qualifiers, and unit tests. The most important changes include adding a `VersionQualifier` class, updating `YubiKeyDeviceInfo` to support version qualifiers, and introducing comprehensive unit tests for these updates.

Fixes: YESDK-1451

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

I have ran unit tests similar to those in the Java Yubikit SDK. I have yet to run them on actual keys.

**Test configuration**:
* OS version: Linux
* Firmware version: N/A
* Yubikey model[^1]: N/A

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)





### Firmware Version Enhancements:
* **New method to parse firmware versions from byte arrays:** Added `FirmwareVersion.FromBytes` method to create a `FirmwareVersion` instance from a byte array containing major, minor, and patch versions. Includes validation for the byte array length. (`FirmwareVersion.cs`, [Yubico.YubiKey/src/Yubico/YubiKey/FirmwareVersion.csR95-R115](diffhunk://#diff-b0a093d1f4d8799aced01ace5cf080bd20fada633ccb5258214d60cbf978e3b1R95-R115))

### Version Qualifier Feature:
* **Introduced `VersionQualifier` class:** Added a new class to represent version qualifiers, including the firmware version, type (Alpha, Beta, Final), and iteration number. Includes constructors, validation, and overrides for `ToString`, `Equals`, and `GetHashCode`. (`VersionQualifier.cs`, [Yubico.YubiKey/src/Yubico/YubiKey/VersionQualifier.csR1-R98](diffhunk://#diff-edaf2fc292f2bd450675e265d18392a4f932290fd8a04704ad2700fc11158d85R1-R98))
* **Added `VersionQualifierTag` constant:** Updated `YubikeyDeviceManagementTags` to include a new tag for version qualifiers. (`YubikeyDeviceManagementTags.cs`, [Yubico.YubiKey/src/Yubico/YubiKey/YubikeyDeviceManagementTags.csR45](diffhunk://#diff-c1b8247f6b814d781460e1da94884ab424ee85a0337429b1916680ba9163f211R45))

### Integration with `YubiKeyDeviceInfo`:
* **Support for version qualifiers in `YubiKeyDeviceInfo`:** Added a `VersionQualifier` property and logic to handle version qualifiers in the `CreateFromResponseData` method. The firmware version is overridden by the version qualifier when applicable. (`YubiKeyDeviceInfo.cs`, [[1]](diffhunk://#diff-a12d59304ef74d141c2c3bd02da5f02ea792c4adf7dd1af73ecaa2145d294806R78-R87) [[2]](diffhunk://#diff-a12d59304ef74d141c2c3bd02da5f02ea792c4adf7dd1af73ecaa2145d294806R278-R326)
* **Updated `YubiKeyDeviceInfo` constructor:** Default `VersionQualifier` is initialized to `Final` with iteration 0. (`YubiKeyDeviceInfo.cs`, [Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceInfo.csR121](diffhunk://#diff-a12d59304ef74d141c2c3bd02da5f02ea792c4adf7dd1af73ecaa2145d294806R121))

### Unit Tests:
* **Tests for `VersionQualifier`:** Comprehensive unit tests for `VersionQualifier` class, covering initialization, string representation, equality, and hash code functionality. (`VersionQualifierTests.cs`, [Yubico.YubiKey/tests/unit/Yubico/YubiKey/VersionQualifierTests.csR1-R97](diffhunk://#diff-13788577ff3f3e2bd5d0853693ade524ce904cee36592edcc6ce441f4f413f99R1-R97))
* **Refactored `YubiKeyDeviceInfoTests`:** Improved test readability by introducing a `DefaultInfo` helper method to streamline test setup. (`YubikeyDeviceInfoTests.cs`, [[1]](diffhunk://#diff-5d61a0cca4b4ca7d46460fa08a0a0838e6a65d5ccbabb39e8ca20be78e0d8296L58-R60) [[2]](diffhunk://#diff-5d61a0cca4b4ca7d46460fa08a0a0838e6a65d5ccbabb39e8ca20be78e0d8296L91-R93) [[3]](diffhunk://#diff-5d61a0cca4b4ca7d46460fa08a0a0838e6a65d5ccbabb39e8ca20be78e0d8296L142-R144)