### PR TITLE
build: updating windows runners to 2022

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -32,7 +32,7 @@ on:
 jobs:
   build-windows:
     name: Build Windows
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
       - run: |
@@ -115,7 +115,7 @@ jobs:
       contents: read
       packages: read
       attestations: write
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [build-windows, build-linux-amd64, build-linux-arm64, build-macos]
     env:
       PACKAGE_VERSION: ${{ github.event.inputs.version != '' && github.event.inputs.version || '1.0.0' }}
@@ -153,7 +153,7 @@ jobs:
 
   publish-internal:
     name: Publish to internal NuGet
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: pack
     environment: Internal NuGet feed
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
 
   build-artifacts:
     name: Build artifacts
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: run-tests
     permissions:
       id-token: write
@@ -166,7 +166,7 @@ jobs:
 
   publish-internal:
     name: Publish to internal NuGet
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: build-artifacts
     if: ${{ github.event.inputs.push-to-dev == 'true' }}
     permissions:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to use the `windows-2022` runner instead of `windows-2019`. This change ensures compatibility with newer environments and improves the consistency of the build and publish pipelines.

Reason: https://github.com/actions/runner-images/issues/12045

### Workflow updates for `windows-2022` runner:

* [`.github/workflows/build-nativeshims.yml`](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574L35-R35): Updated the `runs-on` configuration for the `build-windows`, `jobs`, and `publish-internal` jobs to use `windows-2022` instead of `windows-2019`. [[1]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574L35-R35) [[2]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574L118-R118) [[3]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574L156-R156)
* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L65-R65): Updated the `runs-on` configuration for the `build-artifacts` and `publish-internal` jobs to use `windows-2022` instead of `windows-2019`. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L65-R65) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L169-R169)