### PR TITLE
refactor: Add consistent docs and proper naming for certain methods for creating keys

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyDecoder.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyDecoder.cs
@@ -15,7 +15,6 @@
 using System;
 using System.Formats.Asn1;
 using System.Globalization;
-using System.Linq;
 using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyDecoder.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPrivateKeyDecoder.cs
@@ -19,8 +19,23 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// A class that converts ASN.1 DER encoded private keys to parameters and values.
+/// </summary>
 internal class AsnPrivateKeyDecoder
 {
+    /// <summary>
+    /// Creates an instance of <see cref="IPrivateKey"/> from a PKCS#8
+    /// ASN.1 DER-encoded private key.
+    /// </summary>
+    /// <param name="pkcs8EncodedKey">
+    /// The ASN.1 DER-encoded private key.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="IPrivateKey"/>.
+    /// </returns>
+    /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the algorithm is not supported</exception>
     public static IPrivateKey CreatePrivateKey(ReadOnlyMemory<byte> pkcs8EncodedKey)
     {
         var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
@@ -66,8 +81,25 @@ internal class AsnPrivateKeyDecoder
                 ExceptionMessages.UnsupportedAlgorithm));
     }
 
-    public static Curve25519PrivateKey CreateCurve25519Key(ReadOnlyMemory<byte> pkcs8EncodedKey) =>
-        Curve25519PrivateKey.CreateFromPkcs8(pkcs8EncodedKey);
+    /// <summary>
+    /// Creates an instance of <see cref="Curve25519PrivateKey"/> from a PKCS#8
+    /// ASN.1 DER-encoded private key.
+    /// </summary>
+    /// <param name="pkcs8EncodedKey">
+    /// The ASN.1 DER-encoded private key.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="Curve25519PrivateKey"/>.
+    /// </returns>
+    /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
+    /// <exception cref="ArgumentException">Thrown if the algorithm is not <see cref="Oids.X25519"/> or 
+    /// <see cref="Oids.Ed25519"/></exception>
+    public static Curve25519PrivateKey CreateCurve25519Key(ReadOnlyMemory<byte> pkcs8EncodedKey)
+    {
+        (byte[] privateKey, var keyType) = GetCurve25519PrivateKeyData(pkcs8EncodedKey);
+        using var privateKeyHandle = new ZeroingMemoryHandle(privateKey);
+        return Curve25519PrivateKey.CreateFromValue(privateKeyHandle.Data, keyType);
+    }
 
     public static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(ReadOnlyMemory<byte> pkcs8EncodedKey)
     {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPublicKeyDecoder.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/AsnPublicKeyDecoder.cs
@@ -19,11 +19,26 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// A class that converts ASN.1 DER encoded X.509 SubjectPublicKeyInfo to instances of IPublicKey.
+/// </summary>
 internal class AsnPublicKeyDecoder
 {
-    public static IPublicKey CreatePublicKey(ReadOnlyMemory<byte> pkcs8EncodedKey)
+    /// <summary>
+    /// Creates an instance of <see cref="IPublicKey"/> from a
+    /// ASN.1 DER-encoded SubjectPublicKeyInfo.
+    /// </summary>
+    /// <param name="subjectPublicKeyInfo">
+    /// The ASN.1 DER-encoded SubjectPublicKeyInfo.
+    /// </param>
+    /// <returns>
+    /// A new instance of <see cref="IPublicKey"/>.
+    /// </returns>
+    /// <exception cref="CryptographicException">Thrown if public key does not match expected format.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the algorithm is not supported</exception>
+    public static IPublicKey CreatePublicKey(ReadOnlyMemory<byte> subjectPublicKeyInfo)
     {
-        var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
+        var reader = new AsnReader(subjectPublicKeyInfo, AsnEncodingRules.DER);
         var seqSubjectPublicKeyInfo = reader.ReadSequence();
         var seqAlgorithmIdentifier = seqSubjectPublicKeyInfo.ReadSequence();
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
@@ -45,7 +45,7 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// </summary>
     /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the private scalar value.</returns>
     public ReadOnlyMemory<byte> PrivateKey => _privateKey;
-    
+
     private Curve25519PrivateKey(
         ReadOnlyMemory<byte> privateKey,
         KeyType keyType)
@@ -61,9 +61,9 @@ public sealed class Curve25519PrivateKey : PrivateKey
 
         privateKey.CopyTo(_privateKey);
     }
-    
+
     /// <inheritdoc />
-    public override byte[] ExportPkcs8PrivateKey() 
+    public override byte[] ExportPkcs8PrivateKey()
     {
         ThrowIfDisposed();
         return AsnPrivateKeyEncoder.EncodeToPkcs8(_privateKey, KeyType);
@@ -96,7 +96,7 @@ public sealed class Curve25519PrivateKey : PrivateKey
         using var privateKeyHandle = new ZeroingMemoryHandle(privateKey);
         return new Curve25519PrivateKey(privateKeyHandle.Data, keyType);
     }
-    
+
     /// <summary>
     /// Creates an instance of <see cref="Curve25519PrivateKey"/> from the given
     /// <paramref name="privateKey"/> and <paramref name="keyType"/>.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
@@ -17,13 +17,21 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Represents a Curve25519 private key.
+/// </summary>
+/// <remarks>
+/// This sealed class encapsulates Curve25519 private key data and supports
+/// both Ed25519 and X25519 cryptographic operations.
+/// It also provides factory methods for creating instances from private key values or DER-encoded data.
+/// </remarks>
 public sealed class Curve25519PrivateKey : PrivateKey
 {
     private readonly Memory<byte> _privateKey;
 
     /// <inheritdoc />
     public override KeyType KeyType => KeyDefinition.KeyType;
-    
+
     /// <summary>
     /// Gets the key definition associated with this RSA private key.
     /// </summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PrivateKey.cs
@@ -78,10 +78,10 @@ public sealed class Curve25519PrivateKey : PrivateKey
 
     /// <summary>
     /// Creates an instance of <see cref="Curve25519PrivateKey"/> from a PKCS#8
-    /// DER-encoded private key.
+    /// ASN.1 DER-encoded private key.
     /// </summary>
     /// <param name="pkcs8EncodedKey">
-    /// The DER-encoded private key.
+    /// The ASN.1 DER-encoded private key.
     /// </param>
     /// <returns>
     /// A new instance of <see cref="Curve25519PrivateKey"/>.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
@@ -19,6 +19,14 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Represents a Curve25519 public key.
+/// </summary>
+/// <remarks>
+/// This sealed class encapsulates Curve25519 public key data as a compressed point
+/// and supports both Ed25519 and X25519 key types.
+/// It also provides factory methods for creating instances from public point values or DER-encoded data.
+/// </remarks>
 public sealed class Curve25519PublicKey : PublicKey
 {
     private readonly Memory<byte> _publicPoint;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
@@ -70,16 +70,16 @@ public sealed class Curve25519PublicKey : PublicKey
         AsnPublicKeyEncoder.EncodeToSubjectPublicKeyInfo(_publicPoint, KeyDefinition.KeyType);
 
     /// <summary>
-    /// Creates a new instance of <see cref="Curve25519PublicKey"/> from a DER-encoded public key.
+    /// Creates a new instance of <see cref="Curve25519PublicKey"/> from a DER-encoded SubjectPublicKeyInfo.
     /// </summary>
     /// <param name="subjectPublicKeyInfo">
-    /// The DER-encoded public key.
+    /// The DER-encoded SubjectPublicKeyInfo.
     /// </param>
     /// <returns>
     /// A new instance of <see cref="Curve25519PublicKey"/>.
     /// </returns>
     /// <exception cref="CryptographicException">
-    /// Thrown if the public key is invalid.
+    /// Thrown if the subjectPublicKeyInfo is invalid.
     /// </exception>
     public static Curve25519PublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
         AsnPublicKeyDecoder
@@ -111,6 +111,6 @@ public sealed class Curve25519PublicKey : PublicKey
     }
 
     [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
-    public static Curve25519PublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
-        CreateFromSubjectPublicKeyInfo(encodedKey);
+    public static Curve25519PublicKey CreateFromPkcs8(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
+        CreateFromSubjectPublicKeyInfo(subjectPublicKeyInfo);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
@@ -82,22 +82,10 @@ public sealed class Curve25519PublicKey : PublicKey
     /// <exception cref="CryptographicException">
     /// Thrown if the public key is invalid.
     /// </exception>
-    public static Curve25519PublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
-    {
-        var reader = new AsnReader(encodedKey, AsnEncodingRules.DER);
-        var seqSubjectPublicKeyInfo = reader.ReadSequence();
-        var seqAlgorithmIdentifier = seqSubjectPublicKeyInfo.ReadSequence();
-
-        string oidAlgorithm = seqAlgorithmIdentifier.ReadObjectIdentifier();
-        byte[] subjectPublicKey = seqSubjectPublicKeyInfo.ReadBitString(out int unusedBitCount);
-        if (unusedBitCount != 0)
-        {
-            throw new CryptographicException("Invalid public key encoding");
-        }
-
-        var keyType = KeyDefinitions.GetKeyTypeByOid(oidAlgorithm);
-        return CreateFromValue(subjectPublicKey, keyType);
-    }
+    public static Curve25519PublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
+        AsnPublicKeyDecoder
+            .CreatePublicKey(subjectPublicKeyInfo)
+            .Cast<Curve25519PublicKey>();
 
     /// <summary>
     /// Creates an instance of <see cref="Curve25519PublicKey"/> from the given
@@ -122,4 +110,8 @@ public sealed class Curve25519PublicKey : PublicKey
 
         return new Curve25519PublicKey(publicPoint, keyDefinition);
     }
+
+    [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
+    public static Curve25519PublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
+        CreateFromSubjectPublicKeyInfo(encodedKey);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/Curve25519PublicKey.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System;
-using System.Formats.Asn1;
 using System.Globalization;
 using System.Security.Cryptography;
 
@@ -60,7 +59,7 @@ public sealed class Curve25519PublicKey : PublicKey
 
         publicPoint.CopyTo(_publicPoint);
     }
-    
+
     /// <summary>
     /// Converts this public key to an ASN.1 DER encoded format (X.509 SubjectPublicKeyInfo).
     /// </summary>
@@ -73,7 +72,7 @@ public sealed class Curve25519PublicKey : PublicKey
     /// <summary>
     /// Creates a new instance of <see cref="Curve25519PublicKey"/> from a DER-encoded public key.
     /// </summary>
-    /// <param name="encodedKey">
+    /// <param name="subjectPublicKeyInfo">
     /// The DER-encoded public key.
     /// </param>
     /// <returns>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPrivateKey.cs
@@ -34,7 +34,7 @@ namespace Yubico.YubiKey.Cryptography
         /// An <see cref="ECParameters"/> structure containing the curve parameters, key, and other
         /// cryptographic elements needed for EC operations.
         /// </value>
-        public ECParameters Parameters { get;}
+        public ECParameters Parameters { get; }
 
         /// <summary>
         /// Gets the key definition associated with this RSA private key.
@@ -85,7 +85,7 @@ namespace Yubico.YubiKey.Cryptography
             Parameters = ecdsaObject.ExportParameters(true);
             KeyDefinition = KeyDefinitions.GetByOid(Parameters.Curve.Oid);
         }
-        
+
         /// <inheritdoc/>
         public override byte[] ExportPkcs8PrivateKey()
         {
@@ -116,10 +116,9 @@ namespace Yubico.YubiKey.Cryptography
         public static ECPrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
         {
             var parameters = AsnPrivateKeyDecoder.CreateECParameters(encodedKey);
+
             return CreateFromParameters(parameters);
         }
-        
-        #pragma warning disable CS0618 // Type or member is obsolete.
 
         /// <summary>
         /// Creates an instance of <see cref="ECPrivateKey"/> from the given <paramref name="parameters"/>.
@@ -127,7 +126,6 @@ namespace Yubico.YubiKey.Cryptography
         /// <param name="parameters">The parameters to create the key from.</param>
         /// <returns>An instance of <see cref="ECPrivateKey"/>.</returns>
         public static ECPrivateKey CreateFromParameters(ECParameters parameters) => new(parameters);
-        #pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Creates a new instance of <see cref="ECPrivateKey"/> from the given

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPrivateKey.cs
@@ -21,8 +21,9 @@ namespace Yubico.YubiKey.Cryptography
     /// Represents the parameters for an Elliptic Curve (EC) private key.
     /// </summary>
     /// <remarks>
-    /// This class encapsulates the parameters specific to EC private keys and
-    /// contains the necessary private key data.
+    /// This class encapsulates the parameters specific to EC private keys
+    /// and provides factory methods for creating instances from EC parameters
+    /// or DER-encoded data.
     /// </remarks>
     public class ECPrivateKey : PrivateKey
     {
@@ -119,6 +120,12 @@ namespace Yubico.YubiKey.Cryptography
         }
         
         #pragma warning disable CS0618 // Type or member is obsolete.
+
+        /// <summary>
+        /// Creates an instance of <see cref="ECPrivateKey"/> from the given <paramref name="parameters"/>.
+        /// </summary>
+        /// <param name="parameters">The parameters to create the key from.</param>
+        /// <returns>An instance of <see cref="ECPrivateKey"/>.</returns>
         public static ECPrivateKey CreateFromParameters(ECParameters parameters) => new(parameters);
         #pragma warning restore CS0618 // Type or member is obsolete
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
@@ -99,7 +99,7 @@ public class ECPublicKey : PublicKey
 
     /// <inheritdoc />
     public override byte[] ExportSubjectPublicKeyInfo() => AsnPublicKeyEncoder.EncodeToSubjectPublicKeyInfo(Parameters);
-    
+
     /// <summary>
     /// Creates an instance of <see cref="ECPublicKey"/> from the given <paramref name="parameters"/>.
     /// </summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
@@ -148,6 +148,12 @@ public class ECPublicKey : PublicKey
     /// <exception cref="CryptographicException">
     /// Thrown if the public key is invalid.
     /// </exception>
+    public static ECPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> encodedKey) =>
+        AsnPublicKeyDecoder
+            .CreatePublicKey(encodedKey)
+            .Cast<ECPublicKey>();
+
+    [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
     public static ECPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
-        (ECPublicKey)AsnPublicKeyDecoder.CreatePublicKey(encodedKey);
+    CreateFromSubjectPublicKeyInfo(encodedKey);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
@@ -18,11 +18,11 @@ using System.Security.Cryptography;
 namespace Yubico.YubiKey.Cryptography;
 
 /// <summary>
-/// Represents the parameters for an Elliptic Curve (EC) public key.
+/// Represents an Elliptic Curve (EC) public key.
 /// </summary>
 /// <remarks>
-/// This class encapsulates the parameters specific to EC public keys,
-/// ensuring that the key only contains necessary public key components.
+/// This class encapsulates EC public key parameters and provides cryptographic operations
+/// for NIST elliptic curves and provides factory methods for creating instances from EC parameters or DER-encoded data.
 /// </remarks>
 public class ECPublicKey : PublicKey
 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ECPublicKey.cs
@@ -141,19 +141,19 @@ public class ECPublicKey : PublicKey
     }
 
     /// <summary>
-    /// Creates an instance of <see cref="ECPublicKey"/> from a DER-encoded public key.
+    /// Creates an instance of <see cref="ECPublicKey"/> from a DER-encoded SubjectPublicKeyInfo.
     /// </summary>
-    /// <param name="encodedKey">The DER-encoded public key.</param>
+    /// <param name="subjectPublicKeyInfo">The DER-encoded SubjectPublicKeyInfo.</param>
     /// <returns>An instance of <see cref="IPublicKey"/>.</returns>
     /// <exception cref="CryptographicException">
-    /// Thrown if the public key is invalid.
+    /// Thrown if the subjectPublicKeyInfo is invalid.
     /// </exception>
-    public static ECPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> encodedKey) =>
+    public static ECPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
         AsnPublicKeyDecoder
-            .CreatePublicKey(encodedKey)
+            .CreatePublicKey(subjectPublicKeyInfo)
             .Cast<ECPublicKey>();
 
     [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
-    public static ECPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
-    CreateFromSubjectPublicKeyInfo(encodedKey);
+    public static ECPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
+    CreateFromSubjectPublicKeyInfo(subjectPublicKeyInfo);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IKeyBase.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IKeyBase.cs
@@ -14,6 +14,13 @@
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Defines the base contract for all cryptographic keys, providing key type identification.
+/// </summary>
+/// <remarks>
+/// This interface serves as the foundation for both public and private key abstractions,
+/// enabling polymorphic key type handling across different cryptographic algorithms.
+/// </remarks>
 public interface IKeyBase
 {
     /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPrivateKey.cs
@@ -14,6 +14,14 @@
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Defines the contract for cryptographic private keys.
+/// </summary>
+/// <remarks>
+/// This interface extends <see cref="IKeyBase"/> to include private key-specific operations
+/// for PKCS#8 export and secure memory cleanup.
+/// Known implementations include <see cref="ECPrivateKey"/>, <see cref="RSAPrivateKey"/> and <see cref="Curve25519PrivateKey"/>,.
+/// </remarks>
 public interface IPrivateKey : IKeyBase
 {
     /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPrivateKeyExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPrivateKeyExtensions.cs
@@ -16,15 +16,33 @@ using System;
 
 namespace Yubico.YubiKey.Cryptography;
 
+
+/// <summary>
+/// Extension methods for <see cref="IPrivateKey"/> to provide type-safe casting operations.
+/// </summary>
 public static class IPrivateKeyExtensions
 {
     /// <summary>
-    /// Casts the key to the specified type.
+    /// Safely casts an <see cref="IPrivateKey"/> instance to a specific derived type.
     /// </summary>
-    /// <param name="key"></param>
-    /// <typeparam name="T"></typeparam>
-    /// <returns></returns>
-    /// <exception cref="InvalidCastException"></exception>
+    /// <typeparam name="T">The target type that implements <see cref="IPrivateKey"/>.</typeparam>
+    /// <param name="key">The private key instance to cast.</param>
+    /// <returns>The private key cast to the specified type <typeparamref name="T"/>.</returns>
+    /// <exception cref="InvalidCastException">
+    /// Thrown when the <paramref name="key"/> cannot be cast to type <typeparamref name="T"/>.
+    /// The exception message includes both the source and target type names for debugging.
+    /// </exception>
+    /// <example>
+    /// <code>
+    /// IPrivateKey genericKey = GetPrivateKey();
+    /// RsaPrivateKey rsaKey = genericKey.Cast&lt;RsaPrivateKey&gt;();
+    /// // throws InvalidCastException if genericKey is not an RsaPrivateKey
+    /// </code>
+    /// </example>
+    /// <remarks>
+    /// This method provides a more explicit alternative to direct casting with clearer error messages.
+    /// Prefer this over unsafe casting operations when type safety is critical for cryptographic operations.
+    /// </remarks>
     public static T Cast<T>(this IPrivateKey key) where T : class, IPrivateKey =>
         key as T ?? throw new InvalidCastException($"Cannot cast {key.GetType()} to {typeof(T)}");
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/IPublicKey.cs
@@ -14,6 +14,17 @@
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Defines the contract for cryptographic public keys.
+/// </summary>
+/// <remarks>
+/// This interface extends <see cref="IKeyBase"/> to include public key-specific operations
+/// for X.509 SubjectPublicKeyInfo export.
+/// <para>
+/// Concrete implementations include <see cref="ECPublicKey"/>, <see cref="RSAPublicKey"/> and <see cref="Curve25519PublicKey"/>, each providing
+/// algorithm-specific public key handling and export mechanisms.
+/// </para>
+/// </remarks>
 public interface IPublicKey : IKeyBase
 {
     /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/PrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/PrivateKey.cs
@@ -16,6 +16,17 @@ using System;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Abstract base class for private key implementations.
+/// </summary>
+/// <remarks>
+/// This class implements the standard .NET disposal pattern to ensure secure cleanup
+/// of sensitive cryptographic material and provides disposal state checking for derived classes.
+/// <para>
+/// Concrete implementations include <see cref="ECPrivateKey"/>, <see cref="RSAPrivateKey"/> and <see cref="Curve25519PrivateKey"/>,
+/// each providing algorithm-specific key handling and cryptographic operations.
+/// </para>
+/// </remarks>
 public abstract class PrivateKey : IPrivateKey, IDisposable
 {
     private bool _disposed;
@@ -43,6 +54,17 @@ public abstract class PrivateKey : IPrivateKey, IDisposable
         GC.SuppressFinalize(this);
     }
 
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException"/> if this instance has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown when this method is called after the object has been disposed.
+    /// </exception>
+    /// <remarks>
+    /// This method should be called at the beginning of all public methods and properties
+    /// in derived classes to prevent operations on disposed cryptographic key material.
+    /// The exception message includes the concrete type name for debugging purposes.
+    /// </remarks>
     protected void ThrowIfDisposed()
     {
         if (_disposed)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/PublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/PublicKey.cs
@@ -14,11 +14,22 @@
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Abstract base class for public key implementations.
+/// </summary>
+/// <remarks>
+/// This class provides common structure for public key types, requiring derived classes
+/// to implement key type identification and X.509 export operations.
+/// <para>
+/// Concrete implementations include <see cref="ECPublicKey"/>, <see cref="RSAPublicKey"/> and <see cref="Curve25519PublicKey"/>, each providing
+/// algorithm-specific public key handling and export mechanisms.
+/// </para>
+/// </remarks>
 public abstract class PublicKey : IPublicKey
 {
     /// <inheritdoc />
     public abstract KeyType KeyType { get; }
-    
+
     /// <inheritdoc />
     public abstract byte[] ExportSubjectPublicKeyInfo();
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
@@ -17,6 +17,14 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Represents the parameters for an RSA private key.
+/// </summary>
+/// <remarks>
+/// This class encapsulates the parameters specific to RSA private keys 
+/// and provides factory methods for creating instances from EC parameters
+/// or DER-encoded data.
+/// </remarks>
 public sealed class RSAPrivateKey : PrivateKey
 {
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
@@ -22,7 +22,7 @@ namespace Yubico.YubiKey.Cryptography;
 /// </summary>
 /// <remarks>
 /// This class encapsulates the parameters specific to RSA private keys 
-/// and provides factory methods for creating instances from EC parameters
+/// and provides factory methods for creating instances from RSA parameters
 /// or DER-encoded data.
 /// </remarks>
 public sealed class RSAPrivateKey : PrivateKey

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPrivateKey.cs
@@ -47,14 +47,14 @@ public sealed class RSAPrivateKey : PrivateKey
     /// A <see cref="KeyDefinition"/> object that describes the key's properties, including its type and length.
     /// </value>
     public KeyDefinition KeyDefinition { get; }
-    
+
     /// <inheritdoc />
     public override KeyType KeyType => KeyDefinition.KeyType;
 
     private RSAPrivateKey(RSAParameters parameters)
     {
         int keyLengthBits = parameters.DP?.Length * 8 * 2 ?? 0;
-        
+
         Parameters = parameters.NormalizeParameters();
         KeyDefinition = KeyDefinitions.GetByRSALength(keyLengthBits);
     }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
@@ -97,20 +97,20 @@ public sealed class RSAPublicKey : PublicKey
     }
 
     /// <summary>
-    /// Creates a new instance of <see cref="IPublicKey"/> from a DER-encoded public key.
+    /// Creates a new instance of <see cref="IPublicKey"/> from ASN.1 DER-encoded SubjectPublicKeyInfo.
     /// </summary>
-    /// <param name="encodedKey">The DER-encoded public key.</param>
+    /// <param name="subjectPublicKeyInfo">The DER-encoded SubjectPublicKeyInfo.</param>
     /// <returns>A new instance of <see cref="IPublicKey"/>.</returns>
     /// <exception cref="CryptographicException">
     /// Thrown if the public key is invalid.
     /// </exception>
-    public static RSAPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> encodedKey) =>
+    public static RSAPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
         AsnPublicKeyDecoder
-            .CreatePublicKey(encodedKey)
+            .CreatePublicKey(subjectPublicKeyInfo)
             .Cast<RSAPublicKey>();
 
 
     [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
-    public static RSAPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
-        CreateFromSubjectPublicKeyInfo(encodedKey);
+    public static RSAPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> subjectPublicKeyInfo) =>
+        CreateFromSubjectPublicKeyInfo(subjectPublicKeyInfo);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
@@ -104,6 +104,13 @@ public sealed class RSAPublicKey : PublicKey
     /// <exception cref="CryptographicException">
     /// Thrown if the public key is invalid.
     /// </exception>
+    public static RSAPublicKey CreateFromSubjectPublicKeyInfo(ReadOnlyMemory<byte> encodedKey) =>
+        AsnPublicKeyDecoder
+            .CreatePublicKey(encodedKey)
+            .Cast<RSAPublicKey>();
+
+
+    [Obsolete("Use CreateFromSubjectPublicKeyInfo instead", false)]
     public static RSAPublicKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey) =>
-        (RSAPublicKey)AsnPublicKeyDecoder.CreatePublicKey(encodedKey);
+        CreateFromSubjectPublicKeyInfo(encodedKey);
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
@@ -37,14 +37,14 @@ public sealed class RSAPublicKey : PublicKey
     /// The parameters are used in cryptographic operations such as decryption and digital signature creation.
     /// </remarks>
     public RSAParameters Parameters { get; }
-    
+
     /// <summary>
     /// Gets the key definition associated with this RSA private key.
     /// </summary>
     /// <value>
     /// A <see cref="KeyDefinition"/> object that describes the key's properties, including its type and length.
     /// </value>
-    public KeyDefinition KeyDefinition  { get; }
+    public KeyDefinition KeyDefinition { get; }
 
     /// <inheritdoc />
     public override KeyType KeyType => KeyDefinition.KeyType;
@@ -82,8 +82,8 @@ public sealed class RSAPublicKey : PublicKey
     /// </exception>
     public static RSAPublicKey CreateFromParameters(RSAParameters parameters)
     {
-        if (parameters.D != null || 
-            parameters.P != null || 
+        if (parameters.D != null ||
+            parameters.P != null ||
             parameters.Q != null ||
             parameters.DP != null ||
             parameters.DQ != null ||
@@ -92,7 +92,7 @@ public sealed class RSAPublicKey : PublicKey
         {
             throw new ArgumentException("Parameters must not contain private key data");
         }
-        
+
         return new RSAPublicKey(parameters);
     }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/RSAPublicKey.cs
@@ -17,6 +17,13 @@ using System.Security.Cryptography;
 
 namespace Yubico.YubiKey.Cryptography;
 
+/// <summary>
+/// Represents an RSA public key.
+/// </summary>
+/// <remarks>
+/// This sealed class encapsulates RSA public key parameters (Modulus and Exponent)
+/// and provides factory methods for creating instances from RSA parameters or DER-encoded data.
+/// </remarks>
 public sealed class RSAPublicKey : PublicKey
 {
     /// <summary>

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/KeyAgreeTests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv/KeyAgreeTests.cs
@@ -47,7 +47,7 @@ namespace Yubico.YubiKey.Piv
             if (keyType is KeyType.X25519)
             {
                 var testSelectedPublicKeyPeer = TestKeys.GetTestPublicKey(keyType, 2);
-                peerPublicKey = Curve25519PublicKey.CreateFromPkcs8(testSelectedPublicKeyPeer.EncodedKey);
+                peerPublicKey = Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(testSelectedPublicKeyPeer.EncodedKey);
             }
             else
             {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PublicKeyTests.cs
@@ -46,7 +46,7 @@ public class Curve25519PublicKeyTests
         var testPublicKey = TestKeys.GetTestPublicKey(keyType);
             
         // Act
-        var publicKey = Curve25519PublicKey.CreateFromPkcs8(testPublicKey.EncodedKey);
+        var publicKey = Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(testPublicKey.EncodedKey);
         Assert.NotNull(publicKey);
 
         // Assert
@@ -63,7 +63,7 @@ public class Curve25519PublicKeyTests
         var testPublicPoint = testKey.GetPublicPoint();
 
         // Act
-        var publicKey = Curve25519PublicKey.CreateFromPkcs8(testKey.EncodedKey); 
+        var publicKey = Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(testKey.EncodedKey); 
 
         // Assert
         Assert.NotNull(publicKey);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs
@@ -43,7 +43,7 @@ namespace Yubico.YubiKey.Cryptography
         
             // Act
             var publicKey = ecdsa.ExportSubjectPublicKeyInfo();
-            var publicKeyParams = ECPublicKey.CreateFromPkcs8(publicKey);
+            var publicKeyParams = ECPublicKey.CreateFromSubjectPublicKeyInfo(publicKey);
             var ecPublicKeyParams = publicKeyParams as ECPublicKey;
             Assert.NotNull(ecPublicKeyParams);
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPublicKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPublicKeyTests.cs
@@ -35,7 +35,7 @@ namespace Yubico.YubiKey.Cryptography
             var publicKeyPkcs = rsa.ExportSubjectPublicKeyInfo();
 
             // Act
-            var publicKey = RSAPublicKey.CreateFromPkcs8(publicKeyPkcs);
+            var publicKey = RSAPublicKey.CreateFromSubjectPublicKeyInfo(publicKeyPkcs);
 
             // Assert
             Assert.Null(publicKey.Parameters.D);

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKey.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKey.cs
@@ -80,8 +80,8 @@ public class TestKey : TestCrypto
         }
 
         return KeyDefinition is { IsEllipticCurve: true, AlgorithmOid: Oids.ECDSA }
-            ? ECPublicKey.CreateFromPkcs8(EncodedKey).PublicPoint.ToArray()
-            : Curve25519PublicKey.CreateFromPkcs8(EncodedKey).PublicPoint.ToArray();
+            ? ECPublicKey.CreateFromSubjectPublicKeyInfo(EncodedKey).PublicPoint.ToArray()
+            : Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(EncodedKey).PublicPoint.ToArray();
     }
 
     public IPublicKey AsPublicKey()
@@ -93,15 +93,15 @@ public class TestKey : TestCrypto
         
         if (KeyDefinition.IsRSA)
         {
-            return RSAPublicKey.CreateFromPkcs8(EncodedKey);
+            return RSAPublicKey.CreateFromSubjectPublicKeyInfo(EncodedKey);
         }
 
         if (KeyDefinition is { IsEllipticCurve: true, AlgorithmOid: Oids.ECDSA })
         {
-            return ECPublicKey.CreateFromPkcs8(EncodedKey);
+            return ECPublicKey.CreateFromSubjectPublicKeyInfo(EncodedKey);
         }
 
-        return Curve25519PublicKey.CreateFromPkcs8(EncodedKey);
+        return Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(EncodedKey);
     }
 
     public byte[] GetPrivateKeyValue()

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKeyExtensions.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestKeyExtensions.cs
@@ -50,19 +50,19 @@ namespace Yubico.YubiKey.TestUtilities
             var keyDefinition = key.KeyDefinition;
             if (keyDefinition.IsRSA)
             {
-                var rsaPublicKey = RSAPublicKey.CreateFromPkcs8(key.EncodedKey);
+                var rsaPublicKey = RSAPublicKey.CreateFromSubjectPublicKeyInfo(key.EncodedKey);
                 var rsaPivEncodedKey = rsaPublicKey.EncodeAsPiv();
                 return PivPublicKey.Create(rsaPivEncodedKey, key.KeyType.GetPivAlgorithm());
             }
 
             if (keyDefinition is { IsEllipticCurve: true, AlgorithmOid: Oids.ECDSA })
             {
-                var ecPublicKey = ECPublicKey.CreateFromPkcs8(key.EncodedKey);
+                var ecPublicKey = ECPublicKey.CreateFromSubjectPublicKeyInfo(key.EncodedKey);
                 var ecPivEncodedKey = ecPublicKey.EncodeAsPiv();
                 return PivPublicKey.Create(ecPivEncodedKey, key.KeyType.GetPivAlgorithm());
             }
 
-            var cvPublicKey = Curve25519PublicKey.CreateFromPkcs8(key.EncodedKey);
+            var cvPublicKey = Curve25519PublicKey.CreateFromSubjectPublicKeyInfo(key.EncodedKey);
             var cvPivEncodedKey = cvPublicKey.EncodeAsPiv();
             return PivPublicKey.Create(cvPivEncodedKey, keyDefinition.KeyType.GetPivAlgorithm());
         }

--- a/docs/users-manual/application-piv/private-keys.md
+++ b/docs/users-manual/application-piv/private-keys.md
@@ -112,7 +112,7 @@ YubiKey-formatted private key to a `PrivateKeyInfo` or PEM format.
 Unfortunately, PIV does not define its own format of encoding private keys, although
 Yubico has defined an encoding that is very similar to the PIV public key format.
 However, the SDK's PIV application APIs that work with a private keys require them to be
-instances of the [PivPrivateKey](xref:Yubico.YubiKey.Piv.PivPrivateKey) class.
+instances of the `PivPrivateKey` class.
 Hence, when importing a private key into a YubiKey, your application will need to be able
 to "convert" from `PrivateKeyInfo` or PEM to `PivPrivateKey`.
 

--- a/docs/users-manual/application-u2f/u2f-commands.md
+++ b/docs/users-manual/application-u2f/u2f-commands.md
@@ -111,9 +111,9 @@ All YubiKeys with the FIDO U2F application.
 
 ### SDK classes
 
-[GetDeviceInfoCommand](xref:Yubico.YubiKey.U2f.Commands.GetDeviceInfoCommand)
+[GetPagedDeviceInfoCommand](xref:Yubico.YubiKey.U2f.Commands.GetPagedDeviceInfoCommand)
 
-[GetDeviceInfoResponse](xref:Yubico.YubiKey.U2f.Commands.GetDeviceInfoResponse)
+[GetPagedDeviceInfoResponse](xref:Yubico.YubiKey.U2f.Commands.GetPagedDeviceInfoResponse)
 
 ### Input
 

--- a/docs/users-manual/getting-started/whats-new.md
+++ b/docs/users-manual/getting-started/whats-new.md
@@ -152,12 +152,12 @@ Bug fixes:
 
 Miscellaneous:
 - The way that YubiKey device info is read by the SDK has changed, and as a result, the following GetDeviceInfo command classes have been deprecated ([#91](https://github.com/Yubico/Yubico.NET.SDK/pull/91)): 
-  - [Yubico.YubiKey.Management.Commands.GetDeviceInfoCommand](xref:Yubico.YubiKey.Management.Commands.GetDeviceInfoCommand)
-  - [Yubico.YubiKey.Otp.Commands.GetDeviceInfoCommand](xref:Yubico.YubiKey.Otp.Commands.GetDeviceInfoCommand)
-  - [Yubico.YubiKey.U2f.Commands.GetDeviceInfoCommand](xref:Yubico.YubiKey.U2f.Commands.GetDeviceInfoCommand)
-  - [Yubico.YubiKey.Management.Commands.GetDeviceInfoResponse](xref:Yubico.YubiKey.Management.Commands.GetDeviceInfoResponse)
-  - [Yubico.YubiKey.Otp.Commands.GetDeviceInfoResponse](xref:Yubico.YubiKey.Otp.Commands.GetDeviceInfoResponse)
-  - [Yubico.YubiKey.U2f.Commands.GetDeviceInfoResponse](xref:Yubico.YubiKey.U2f.Commands.GetDeviceInfoResponse)
+  - `Yubico.YubiKey.Management.Commands.GetDeviceInfoCommand`
+  - `Yubico.YubiKey.Otp.Commands.GetDeviceInfoCommand`
+  - `Yubico.YubiKey.U2f.Commands.GetDeviceInfoCommand`
+  - `Yubico.YubiKey.Management.Commands.GetDeviceInfoResponse`
+  - `Yubico.YubiKey.Otp.Commands.GetDeviceInfoResponse`
+  - `Yubico.YubiKey.U2f.Commands.GetDeviceInfoResponse`
 - Integration test guardrails have been added to ensure tests are done only on specified keys. ([#100](https://github.com/Yubico/Yubico.NET.SDK/pull/100)).
 - Unit tests were run on all platforms in CI ([#80](https://github.com/Yubico/Yubico.NET.SDK/pull/80)).
 
@@ -260,8 +260,8 @@ Features:
   class.
 
 - **SCP03 architecture**. The process for building an SCP03 connection was updated.
-  The previous method ([Yubico.YubiKey.YubiKeyDeviceExtensions.WithScp03()](xref:Yubico.YubiKey.YubiKeyDeviceExtensions.WithScp03%28Yubico.YubiKey.YubiKeyDevice%2CYubico.YubiKey.Scp03.StaticKeys%29)) is now deprecated, and
-  the new method ([Yubico.YubiKey.IYubiKeyDevice.ConnectScp03()](xref:Yubico.YubiKey.IYubiKeyDevice.ConnectScp03%28Yubico.YubiKey.YubiKeyApplication%2CYubico.YubiKey.Scp03.StaticKeys%29)) simply requires passing in the SCP03 key set to the
+  The previous method (`Yubico.YubiKey.YubiKeyDeviceExtensions.WithScp03()`) is now deprecated, and
+  the new method (`Yubico.YubiKey.IYubiKeyDevice.ConnectScp03()` simply requires passing in the SCP03 key set to the
   PivSession constructor. It is also possible to build an
   IYubiKeyConnection that uses SCP03 via [Yubico.YubiKey.Piv.PivSession()](xref:Yubico.YubiKey.Piv.PivSession.%23ctor%28Yubico.YubiKey.IYubiKeyDevice%2CYubico.YubiKey.Scp03.StaticKeys%29).
 

--- a/docs/users-manual/sdk-programming-guide/secure-channel-protocol.md
+++ b/docs/users-manual/sdk-programming-guide/secure-channel-protocol.md
@@ -252,7 +252,7 @@ The next sections will detail specific key management and protocol details for b
 
 ### Static keys structure
 
-SCP03 relies on a set of shared, secret, symmetric cryptographic keys. Each key set consists of three 16-byte AES-128 keys encapsulated in the [`StaticKeys`](xref:Yubico.YubiKey.Scp03.StaticKeys) class:
+SCP03 relies on a set of shared, secret, symmetric cryptographic keys. Each key set consists of three 16-byte AES-128 keys encapsulated in the [`StaticKeys`](xref:Yubico.YubiKey.Scp.StaticKeys) class:
 
 - Channel encryption key (Key-ENC)
 - Channel MAC key (Key-MAC) 


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the cryptographic key classes in the `Yubico.YubiKey` library. The changes focus on improving code clarity, adding comprehensive documentation, and modernizing factory methods for creating key instances. Below are the most important changes grouped by theme.

### Documentation Enhancements:

* Added detailed XML documentation to most cryptographic key classes and interfaces, such as `Curve25519PrivateKey`, `Curve25519PublicKey`, `ECPrivateKey`, `ECPublicKey`, `RSAPrivateKey`, and `RSAPublicKey`. These updates include class summaries, remarks, and examples for better understanding of their purpose and usage. [[1]](diffhunk://#diff-5e98fb4c37622f7d40738ff80ed8fb4bef27fe6e9987e2943d06424abc58d478R20-R27) [[2]](diffhunk://#diff-8a41ef467d2fc0c20b4ae294a23541bfb920e92dcefe1e0fc3ca5e9afef145e3L16-R28) [[3]](diffhunk://#diff-fce1e7accb702e1c06968a283294ab94e52d24e6895d2af46e17adaa3daaa643L24-R26) [[4]](diffhunk://#diff-049ea578ce69ccfc3fadf3a13ebba28c812c6ef75a7dd0913b6548c991298491L21-R25) [[5]](diffhunk://#diff-ed62153f222680d5e4e9808bf06fedce188031564cb6b9d1bdc48022b49f31c3R20-R27) [[6]](diffhunk://#diff-ac905ca52a74ad1d9b83b33c31cc7ddc572822aff1e0b3b3021700f9e7a74521R20-R26)

* Introduced XML documentation for interfaces like `IKeyBase`, `IPrivateKey`, and `IPublicKey`, describing their role and the cryptographic operations they support. [[1]](diffhunk://#diff-8ebd1ef80829a9d77ff0944922a5d98cf92fbae0216dc5d52adb0a79131fb6a4R17-R23) [[2]](diffhunk://#diff-a86d7fcd3e67c53449c6e099152c683ba89f720cc39ab7639a49d0dc0b9ff588R17-R24) [[3]](diffhunk://#diff-c39656051e811d043027861a1ea0dc1eef069c9254b2a06c66e7ecb3242e9197R17-R27)

### Factory Method Modernization:

* Replaced older factory methods (e.g., `CreateFromPkcs8`) with new, more descriptive methods like `CreateFromSubjectPublicKeyInfo`. The older methods are now marked as `[Obsolete]` to guide developers toward using the updated APIs. This change applies to `Curve25519PublicKey`, `ECPublicKey`, and `RSAPublicKey`. [[1]](diffhunk://#diff-8a41ef467d2fc0c20b4ae294a23541bfb920e92dcefe1e0fc3ca5e9afef145e3L77-R87) [[2]](diffhunk://#diff-8a41ef467d2fc0c20b4ae294a23541bfb920e92dcefe1e0fc3ca5e9afef145e3R112-R115) [[3]](diffhunk://#diff-049ea578ce69ccfc3fadf3a13ebba28c812c6ef75a7dd0913b6548c991298491R151-R158) [[4]](diffhunk://#diff-ac905ca52a74ad1d9b83b33c31cc7ddc572822aff1e0b3b3021700f9e7a74521R107-R115)

### Code Simplification:

* Simplified key creation logic by delegating to the `AsnPublicKeyDecoder` utility, which centralizes the decoding of DER-encoded key data. This reduces redundancy and ensures consistent handling of cryptographic key formats. [[1]](diffhunk://#diff-8a41ef467d2fc0c20b4ae294a23541bfb920e92dcefe1e0fc3ca5e9afef145e3L77-R87) [[2]](diffhunk://#diff-049ea578ce69ccfc3fadf3a13ebba28c812c6ef75a7dd0913b6548c991298491R151-R158) [[3]](diffhunk://#diff-ac905ca52a74ad1d9b83b33c31cc7ddc572822aff1e0b3b3021700f9e7a74521R107-R115)

### Abstract Base Class Improvements:

* Enhanced the `PrivateKey` and `PublicKey` abstract base classes with additional documentation and safeguards. For example, `PrivateKey` now includes a `ThrowIfDisposed` method to prevent operations on disposed instances. [[1]](diffhunk://#diff-cf2ab70911b5cdeb8c1f8e6615fcde7f25db473430a55cd73b447ffac5193a05R19-R29) [[2]](diffhunk://#diff-cf2ab70911b5cdeb8c1f8e6615fcde7f25db473430a55cd73b447ffac5193a05R57-R67) [[3]](diffhunk://#diff-490ba56898775b12fcea470b5c03794ce80462ee3626e1f128a1538d600a2059R17-R27)

### Cleanup:

* Removed unused `System.Linq` and `System.Formats.Asn1` imports from various files to improve code cleanliness. [[1]](diffhunk://#diff-ee4133721e1cdda546763798216c4c8ba6fe691dce59ab6965e3c64fc657a68eL18) [[2]](diffhunk://#diff-8a41ef467d2fc0c20b4ae294a23541bfb920e92dcefe1e0fc3ca5e9afef145e3L16-R28)