### PR TITLE
ci: Add dependabot scanning for dependency updates 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Europe/Stockholm"
+    groups:
+      all_packages:
+        update-types:
+          - "minor"
+          - "patch"
+        patterns:
+          - "*"
+    open-pull-requests-limit: 10
+  - package-ecosystem: "dotnet-sdk"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "09:00"
+      timezone: "Europe/Stockholm"
+    ignore:
+      - dependency-name: "*"
+        update-types: 
+          - "version-update:semver-major"


### PR DESCRIPTION
This pull request introduces a new `.github/dependabot.yml` configuration file to automate dependency updates for the project. The configuration specifies two package ecosystems (`nuget` and `dotnet-sdk`) with distinct update rules and schedules.

### Dependabot configuration setup:

* Configured updates for the `nuget` ecosystem:
  - Scheduled weekly updates on Wednesdays at 09:00 (Europe/Stockholm timezone).
  - Grouped updates for all packages, limited to minor and patch updates, with a maximum of 10 open pull requests.
* Configured updates for the `dotnet-sdk` ecosystem:
  - Scheduled weekly updates on Wednesdays at 09:00 (Europe/Stockholm timezone).
  - Ignored major version updates for all dependencies.