### PR TITLE
ci: Add comprehensive summary for build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ on:
         type: string
   schedule:
     - cron: '0 0 * * *' # Every day at midnight
-        
+
 jobs:
   run-tests:
     name: Run tests
@@ -183,3 +183,48 @@ jobs:
           dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
           dotnet nuget push $core --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
           dotnet nuget push $yubikey --source "github" --api-key ${{ secrets.GITHUB_TOKEN }}
+
+  build-summary:
+    name: Build summary
+    runs-on: ubuntu-latest
+    needs: [build-artifacts, publish-internal, upload-docs] # Add upload-docs to needs
+    if: always() # Run this job even if other jobs fail
+    steps:
+      - name: Generate build summary
+        env:
+          # Pass job results and outputs into the step's environment
+          RUN_TESTS_RESULT: ${{ needs.run-tests.result }}
+          BUILD_ARTIFACTS_RESULT: ${{ needs.build-artifacts.result }}
+          UPLOAD_DOCS_RESULT: ${{ needs.upload-docs.result }}
+          PUBLISH_INTERNAL_RESULT: ${{ needs.publish-internal.result }}
+          DOCS_IMAGE_TAG: ${{ needs.upload-docs.outputs.image-tag }}
+        run: |
+          echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Job Status" >> $GITHUB_STEP_SUMMARY
+          echo "| Job | Status |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| Run tests | **${{ env.RUN_TESTS_RESULT }}** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Build artifacts | **${{ env.BUILD_ARTIFACTS_RESULT }}** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Upload docs | **${{ env.UPLOAD_DOCS_RESULT }}** |" >> $GITHUB_STEP_SUMMARY
+          echo "| Publish to internal NuGet | **${{ env.PUBLISH_INTERNAL_RESULT }}** |" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          echo "### Built Artifacts" >> $GITHUB_STEP_SUMMARY
+          echo "Links to artifacts produced by this build run:" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "- [Documentation log](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Documentation_log)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Documentation Site](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Documentation)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Nuget Packages](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Nuget_Packages)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Symbols Packages](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Symbols_Packages)" >> $GITHUB_STEP_SUMMARY
+          echo "- [Assemblies](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Assemblies)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # Conditionally add the Docker image tag to the summary if the upload-docs job was successful
+          if [ "${{ env.UPLOAD_DOCS_RESULT }}" == "success" ]; then
+            echo "### Documentation Docker Image" >> $GITHUB_STEP_SUMMARY
+            echo "A new documentation Docker image was pushed with the tag:" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "${{ env.DOCS_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
+            echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -14,8 +14,13 @@
 
 name: Upload documentation to GCP
 
-on: 
+on:
   workflow_call:
+    # Define an output for this reusable workflow
+    outputs:
+      image-tag:
+        description: "The full tag of the pushed documentation Docker image"
+        value: ${{ jobs.upload_docs.outputs.image-tag }}
 
 permissions:
   id-token: write
@@ -30,6 +35,9 @@ env:
 jobs:
   upload_docs:
     runs-on: ubuntu-latest
+    # Define an output for this job
+    outputs:
+      image-tag: ${{ steps.push_image.outputs.tag }}
     steps:
       # Checkout the local repository as we need the Dockerfile and other things even for this step.
       - uses: actions/checkout@v4
@@ -44,7 +52,7 @@ jobs:
       - name: Docker build
         run: |
           docker build -t "${IMAGE_NAME}:${{ github.sha }}" .
-      
+
       # Authenticate to Google Cloud
       - name: Authenticate
         uses: google-github-actions/auth@v2
@@ -54,8 +62,11 @@ jobs:
 
       # Push our docker image to GCP
       - name: Push Docker image
+        id: push_image # Add an ID to reference this step's outputs
         run: |
           gcloud auth configure-docker ${IMAGE_REGISTRY_URL} --project ${IMAGE_REGISTRY_PROJECT}
-          docker tag "${IMAGE_NAME}:${{ github.sha }}" "${IMAGE_REGISTRY_URL}/${IMAGE_REGISTRY_PROJECT}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${{ github.sha }}"
-          docker push "${IMAGE_REGISTRY_URL}/${IMAGE_REGISTRY_PROJECT}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${{ github.sha }}"
-          echo "New image tag: ${{ github.sha }}"
+          FULL_IMAGE_TAG="${IMAGE_REGISTRY_URL}/${IMAGE_REGISTRY_PROJECT}/${IMAGE_REPOSITORY}/${IMAGE_NAME}:${{ github.sha }}"
+          docker tag "${IMAGE_NAME}:${{ github.sha }}" "${FULL_IMAGE_TAG}"
+          docker push "${FULL_IMAGE_TAG}"
+          # Use GITHUB_OUTPUT to make the full tag available to the job and workflow
+          echo "tag=${FULL_IMAGE_TAG}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request introduces enhancements to the GitHub Actions workflows to improve build summaries and streamline the handling of Docker image tags in the documentation upload process. Key changes include adding a new job for generating build summaries, defining outputs for reusable workflows, and making Docker image tags accessible for downstream jobs.

### Enhancements to build workflows:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R186-R230): Added a new `build-summary` job to generate a comprehensive build summary, including job statuses, artifact links, and conditional Docker image tag information. The job runs regardless of other job failures and uses outputs from dependent jobs.

### Improvements to documentation upload workflow:

* [`.github/workflows/upload-docs.yml`](diffhunk://#diff-7dccc51e28d791f9f279fb3f64199300746a850eb302c32691132a56af7f645eR19-R23): Defined an output (`image-tag`) for the reusable workflow to expose the full tag of the pushed Docker image.
* [`.github/workflows/upload-docs.yml`](diffhunk://#diff-7dccc51e28d791f9f279fb3f64199300746a850eb302c32691132a56af7f645eR38-R40): Added an `image-tag` output to the `upload_docs` job, making the Docker image tag accessible for downstream workflows.
* [`.github/workflows/upload-docs.yml`](diffhunk://#diff-7dccc51e28d791f9f279fb3f64199300746a850eb302c32691132a56af7f645eR65-R72): Enhanced the `Push Docker image` step by introducing an ID (`push_image`) to reference its outputs and using `GITHUB_OUTPUT` to store the full image tag.