### PR TITLE
ci: fix links for build output and add image hash

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,13 @@ jobs:
       contents: read
       packages: read
       attestations: write
+    # Add an outputs section to the job to pass artifact IDs
+    outputs:
+      docs-log-id: ${{ steps.docs-log-upload.outputs.artifact-id }}
+      docs-id: ${{ steps.docs-upload.outputs.artifact-id }}
+      nuget-packages-id: ${{ steps.nuget-upload.outputs.artifact-id }}
+      symbols-packages-id: ${{ steps.symbols-upload.outputs.artifact-id }}
+      assemblies-id: ${{ steps.assemblies-upload.outputs.artifact-id }}
     steps:
       # Checkout the local repository
       - uses: actions/checkout@v4
@@ -99,6 +106,7 @@ jobs:
 
       # Upload documentation log
       - name: "Save build artifacts: Docs log"
+        id: docs-log-upload
         uses: actions/upload-artifact@v4
         with:
           name: Documentation log
@@ -107,6 +115,7 @@ jobs:
 
       # Upload documentation
       - name: "Save build artifacts: Docs"
+        id: docs-upload
         uses: actions/upload-artifact@v4
         with:
           name: Documentation
@@ -115,6 +124,7 @@ jobs:
           
       # Upload NuGet packages
       - name: "Save build artifacts: Nuget Packages"
+        id: nuget-upload
         uses: actions/upload-artifact@v4
         with:
           name: Nuget Packages
@@ -125,6 +135,7 @@ jobs:
       
       # Upload symbols
       - name: "Save build artifacts: Symbols Packages"
+        id: symbols-upload
         uses: actions/upload-artifact@v4
         with:
           name: Symbols Packages
@@ -135,6 +146,7 @@ jobs:
       
       # Upload assemblies
       - name: "Save build artifacts: Assemblies"
+        id: assemblies-upload
         uses: actions/upload-artifact@v4
         with:
           name: Assemblies
@@ -187,18 +199,28 @@ jobs:
   build-summary:
     name: Build summary
     runs-on: ubuntu-latest
-    needs: [build-artifacts, publish-internal, upload-docs] # Add upload-docs to needs
-    if: always() # Run this job even if other jobs fail
+    needs: [build-artifacts, publish-internal, upload-docs]
+    if: always()
     steps:
       - name: Generate build summary
         env:
-          # Pass job results and outputs into the step's environment
+          # Pass job results into the environment
           RUN_TESTS_RESULT: ${{ needs.run-tests.result }}
           BUILD_ARTIFACTS_RESULT: ${{ needs.build-artifacts.result }}
           UPLOAD_DOCS_RESULT: ${{ needs.upload-docs.result }}
           PUBLISH_INTERNAL_RESULT: ${{ needs.publish-internal.result }}
           DOCS_IMAGE_TAG: ${{ needs.upload-docs.outputs.image-tag }}
+          DOCS_IMAGE_HASH: ${{ needs.upload-docs.outputs.image-hash}}
+          
+          # Pass artifact IDs from the build-artifacts job outputs
+          DOCS_LOG_ID: ${{ needs.build-artifacts.outputs.docs-log-id }}
+          DOCS_ID: ${{ needs.build-artifacts.outputs.docs-id }}
+          NUGET_ID: ${{ needs.build-artifacts.outputs.nuget-packages-id }}
+          SYMBOLS_ID: ${{ needs.build-artifacts.outputs.symbols-packages-id }}
+          ASSEMBLIES_ID: ${{ needs.build-artifacts.outputs.assemblies-id }}
         run: |
+          ARTIFACT_URL_BASE="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts"
+
           echo "## Build Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Job Status" >> $GITHUB_STEP_SUMMARY
@@ -210,21 +232,25 @@ jobs:
           echo "| Publish to internal NuGet | **${{ env.PUBLISH_INTERNAL_RESULT }}** |" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
-          echo "### Built Artifacts" >> $GITHUB_STEP_SUMMARY
-          echo "Links to artifacts produced by this build run:" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "- [Documentation log](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Documentation_log)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Documentation Site](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Documentation)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Nuget Packages](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Nuget_Packages)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Symbols Packages](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Symbols_Packages)" >> $GITHUB_STEP_SUMMARY
-          echo "- [Assemblies](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts/Assemblies)" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
+          # Only show artifacts list if the build succeeded
+          if [ "${{ env.BUILD_ARTIFACTS_RESULT }}" == "success" ]; then
+            echo "### Built Artifacts" >> $GITHUB_STEP_SUMMARY
+            echo "Direct links to artifacts produced by this build run:" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "- [Documentation log]($ARTIFACT_URL_BASE/${{ env.DOCS_LOG_ID }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Documentation Site]($ARTIFACT_URL_BASE/${{ env.DOCS_ID }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Nuget Packages]($ARTIFACT_URL_BASE/${{ env.NUGET_ID }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Symbols Packages]($ARTIFACT_URL_BASE/${{ env.SYMBOLS_ID }})" >> $GITHUB_STEP_SUMMARY
+            echo "- [Assemblies]($ARTIFACT_URL_BASE/${{ env.ASSEMBLIES_ID }})" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
 
-          # Conditionally add the Docker image tag to the summary if the upload-docs job was successful
+          # Conditionally add the Docker image tag to the summary
           if [ "${{ env.UPLOAD_DOCS_RESULT }}" == "success" ]; then
             echo "### Documentation Docker Image" >> $GITHUB_STEP_SUMMARY
             echo "A new documentation Docker image was pushed with the tag:" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             echo "${{ env.DOCS_IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
+              echo "${{ env.DOCS_IMAGE_HASH }}" >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/.github/workflows/upload-docs.yml
+++ b/.github/workflows/upload-docs.yml
@@ -37,7 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     # Define an output for this job
     outputs:
-      image-tag: ${{ steps.push_image.outputs.tag }}
+      image-tag: ${{ steps.push_image.outputs.imagetag }}
+      image-hash: ${{ steps.push_image.outputs.imagehash }}
     steps:
       # Checkout the local repository as we need the Dockerfile and other things even for this step.
       - uses: actions/checkout@v4
@@ -69,4 +70,5 @@ jobs:
           docker tag "${IMAGE_NAME}:${{ github.sha }}" "${FULL_IMAGE_TAG}"
           docker push "${FULL_IMAGE_TAG}"
           # Use GITHUB_OUTPUT to make the full tag available to the job and workflow
-          echo "tag=${FULL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "imagetag=${FULL_IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "imagehash=${{ github.sha }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to enhance artifact handling and build summaries. Key improvements include adding outputs for artifact IDs, refining artifact links in the build summary, and introducing additional outputs for Docker image metadata.

### Workflow Enhancements

#### Artifact Handling:
* Added outputs in `.github/workflows/build.yml` to capture artifact IDs for documentation logs, documentation, NuGet packages, symbols packages, and assemblies. These IDs are used to generate direct artifact links in the build summary.

* Assigned unique `id` values to artifact upload steps (`docs-log-upload`, `docs-upload`, `nuget-upload`, `symbols-upload`, `assemblies-upload`) for better integration with outputs. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R109) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R118) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R127) [[4]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R138) [[5]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R149)

#### Build Summary Improvements:
* Updated the build summary generation in `.github/workflows/build.yml` to include direct links to artifacts using the newly added outputs. Artifact links are conditionally displayed only if the build succeeds. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L190-R223) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R235-R254)

#### Docker Image Metadata:
* Enhanced `.github/workflows/upload-docs.yml` to include `imagehash` as an additional output alongside `imagetag`. This ensures both the tag and the hash of the Docker image are available for use in subsequent steps. [[1]](diffhunk://#diff-7dccc51e28d791f9f279fb3f64199300746a850eb302c32691132a56af7f645eL40-R41) [[2]](diffhunk://#diff-7dccc51e28d791f9f279fb3f64199300746a850eb302c32691132a56af7f645eL72-R74)