### PR TITLE
fix(macOS): Hard coding the default frameworks path in order to resolve macOS frameworks

### DIFF
--- a/Yubico.Core/src/Yubico/PlatformInterop/macOS/Interop.Libraries.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/macOS/Interop.Libraries.cs
@@ -16,8 +16,8 @@ namespace Yubico.PlatformInterop
 {
     internal static partial class Libraries
     {
-        internal const string CoreFoundation = "CoreFoundation.framework/CoreFoundation";
-        internal const string IOKitFramework = "IOKit.framework/IOKit";
-        internal const string WinSCard = "PCSC.framework/PCSC";
+        internal const string CoreFoundation = "/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation";
+        internal const string IOKitFramework = "/System/Library/Frameworks/IOKit.framework/IOKit";
+        internal const string WinSCard = "/System/Library/Frameworks/PCSC.framework/PCSC";
     }
 }


### PR DESCRIPTION
# Description
This pull request updates the `Libraries` class in `Yubico.Core/src/Yubico/PlatformInterop/macOS/Interop.Libraries.cs` to use absolute paths for macOS framework references. This change ensures compatibility with the system's directory structure.
This is due to an [ongoing issue](https://github.com/dotnet/runtime/issues/112080#issuecomment-2703953237) at MSFT and dotnet, where the .NET runtime is no longer searching the correct framework paths since NET7. This fix works for NET6,7,8,9.  

## Updates to macOS framework paths:
* Changed the `CoreFoundation`, `IOKitFramework`, and `WinSCard` constants to use absolute paths (`/System/Library/Frameworks/...`) instead of relative paths (`.framework/...`) to align with macOS system conventions.

## Fixes: #205 

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* OS version: *e.g. Windows 11*
* Firmware version: *e.g. 5.7.2*
* Yubikey model[^1]: 

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
