### PR TITLE
Replace Moq with NSubstitute

### DIFF
--- a/Yubico.Core/tests/Yubico.Core.UnitTests.csproj
+++ b/Yubico.Core/tests/Yubico.Core.UnitTests.csproj
@@ -43,13 +43,13 @@ limitations under the License. -->
     <DefineConstants>Linux</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <ProjectReference Include="..\src\Yubico.Core.csproj" />
     <PackageReference Include="Xunit.SkippableFact" Version="1.4.13" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
 
     <None Update="appsettings.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidConnectionTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Devices/Hid/HidConnectionTests.cs
@@ -20,33 +20,33 @@ namespace Yubico.Core.Devices.Hid.UnitTests
     {
         private static IHidDDevice GetMockedDevice()
         {
-            var mock = new Mock<IHidDDevice>();
-            return mock.Object;
+            var mock = Substitute.For<IHidDDevice>();
+            return mock;
         }
 
         private static byte[] GetFeatureReport() => Hex.HexToBytes("000102030405060708090A0B0C0D0E0F");
         private static byte[] GetInputReport() => Hex.HexToBytes("0001020304050607");
         private static byte[] GetOutputReport() => Hex.HexToBytes("00010203");
 
-        private static Mock<IHidDDevice> GetMockedFeatureDevice()
+        private static IHidDDevice GetMockedFeatureDevice()
         {
-            var mock = new Mock<IHidDDevice>();
-            _ = mock.Setup(hdd => hdd.FeatureReportByteLength).Returns(16);
-            _ = mock.Setup(hdd => hdd.InputReportByteLength).Throws(new Exception());
+            var mock = Substitute.For<IHidDDevice>();
+            _ = mock.When(hdd => hdd.FeatureReportByteLength).Returns(16);
+            _ = mock.InputReportByteLength).Throws(new Exception());
             _ = mock.Setup(hdd => hdd.OutputReportByteLength).Throws(new Exception());
-            _ = mock.Setup(hdd => hdd.GetInputReport()).Throws(new Exception());
-            _ = mock.Setup(hdd => hdd.GetFeatureReport()).Returns(GetFeatureReport());
+            _ = mock.Setup(hdd => hdd.GetInputReport()).Throw(new Exception());
+            _ = mock.When(hdd => hdd.GetFeatureReport().Returns(GetFeatureReport());
             return mock;
         }
 
-        private static Mock<IHidDDevice> GetMockedIODevice()
+        private static IHidDDevice GetMockedIODevice()
         {
-            var mock = new Mock<IHidDDevice>();
-            _ = mock.Setup(hdd => hdd.InputReportByteLength).Returns(8);
-            _ = mock.Setup(hdd => hdd.OutputReportByteLength).Returns(4);
-            _ = mock.Setup(hdd => hdd.FeatureReportByteLength).Throws(new Exception());
-            _ = mock.Setup(hdd => hdd.GetFeatureReport()).Throws(new Exception());
-            _ = mock.Setup(hdd => hdd.GetInputReport()).Returns(GetInputReport());
+            var mock = Substitute.For<IHidDDevice>();
+            _ = mock.InputReportByteLength.Returns(8);
+            _ = mock.OutputReportByteLength.Returns(4);
+            _ = mock.FeatureReportByteLength).Throws(new Exception());
+            _ = mock.Setup(hdd => hdd.GetFeatureReport()).Throw(new Exception());
+            _ = mock.Setup(hdd => hdd.GetInputReport().Returns(GetInputReport());
             return mock;
         }
 
@@ -59,34 +59,34 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         [Fact]
         public void Constructor_GivenFeatureDevice_CallsOpenFeatureConnection()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
-            mock.Verify(hdd => hdd.OpenFeatureConnection(), Times.Once());
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
+            mock.Received().OpenFeatureConnection();
         }
 
         [Fact]
         public void Constructor_GivenFeatureDevice_SetsInputReportSize()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
 
-            Assert.Equal(hc.InputReportSize, mock.Object.FeatureReportByteLength);
+            Assert.Equal(hc.InputReportSize, mock.FeatureReportByteLength);
         }
 
         [Fact]
         public void Constructor_GivenFeatureDevice_SetsOutputReportSize()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
 
-            Assert.Equal(hc.OutputReportSize, mock.Object.FeatureReportByteLength);
+            Assert.Equal(hc.OutputReportSize, mock.FeatureReportByteLength);
         }
 
         [Fact]
         public void SetReport_GivenNullReport_ThrowsArgumentNullException()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
 
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
             _ = Assert.Throws<ArgumentNullException>(() => hc.SetReport(null));
@@ -96,78 +96,78 @@ namespace Yubico.Core.Devices.Hid.UnitTests
         [Fact]
         public void SetReport_GivenFeatureReports_CallsSetFeatureReport()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
 
             hc.SetReport(GetFeatureReport());
 
-            mock.Verify(hdd => hdd.SetFeatureReport(IsSeqEqual(GetFeatureReport())), Times.Once());
+            mock.Received().SetFeatureReport(IsSeqEqual(GetFeatureReport()));
         }
 
         [Fact]
         public void GetReport_GivenFeatureReports_CallsGetFeatureReport()
         {
-            Mock<IHidDDevice> mock = GetMockedFeatureDevice();
-            using var hc = new HidFeatureReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedFeatureDevice();
+            using var hc = new HidFeatureReportConnection(mock);
 
             byte[] report = hc.GetReport();
 
-            mock.Verify(hdd => hdd.GetFeatureReport(), Times.Once());
+            mock.Received().GetFeatureReport();
             Assert.Equal(GetFeatureReport(), report);
         }
 
         [Fact]
         public void Constructor_GivenIODevice_CallsOpenIOConnection()
         {
-            Mock<IHidDDevice> mock = GetMockedIODevice();
-            using var hc = new HidIOReportConnection(mock.Object);
-            mock.Verify(hdd => hdd.OpenIOConnection(), Times.Once());
+            IHidDDevice mock = GetMockedIODevice();
+            using var hc = new HidIOReportConnection(mock);
+            mock.Received().OpenIOConnection();
         }
 
         [Fact]
         public void Constructor_GivenIODevice_SetsInputReportSize()
         {
-            Mock<IHidDDevice> mock = GetMockedIODevice();
-            using var hc = new HidIOReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedIODevice();
+            using var hc = new HidIOReportConnection(mock);
 
-            Assert.Equal(hc.InputReportSize, mock.Object.InputReportByteLength);
+            Assert.Equal(hc.InputReportSize, mock.InputReportByteLength);
         }
 
         [Fact]
         public void Constructor_GivenIODevice_SetsOutputReportSize()
         {
-            Mock<IHidDDevice> mock = GetMockedIODevice();
-            using var hc = new HidIOReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedIODevice();
+            using var hc = new HidIOReportConnection(mock);
 
-            Assert.Equal(hc.OutputReportSize, mock.Object.OutputReportByteLength);
+            Assert.Equal(hc.OutputReportSize, mock.OutputReportByteLength);
         }
 
         [Fact]
         public void SetReport_GivenIOReports_CallsSetOutputReport()
         {
-            Mock<IHidDDevice> mock = GetMockedIODevice();
-            using var hc = new HidIOReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedIODevice();
+            using var hc = new HidIOReportConnection(mock);
 
             hc.SetReport(GetOutputReport());
 
-            mock.Verify(hdd => hdd.SetOutputReport(IsSeqEqual(GetOutputReport())), Times.Once());
+            mock.Received().SetOutputReport(IsSeqEqual(GetOutputReport()));
         }
 
         [Fact]
         public void GetReport_GivenIOReports_CallsGetInputReport()
         {
-            Mock<IHidDDevice> mock = GetMockedIODevice();
-            using var hc = new HidIOReportConnection(mock.Object);
+            IHidDDevice mock = GetMockedIODevice();
+            using var hc = new HidIOReportConnection(mock);
 
             byte[] report = hc.GetReport();
 
-            mock.Verify(hdd => hdd.GetInputReport(), Times.Once());
+            mock.Received().GetInputReport();
             Assert.Equal(GetInputReport(), report);
         }
 
         private static byte[] IsSeqEqual(byte[] val)
         {
-            return It.Is<byte[]>(b => b.SequenceEqual(val));
+            return Arg.Is<byte[]>(b => b.SequenceEqual(val));
         }
     }
 #endif

--- a/Yubico.Core/tests/Yubico/Core/Logging/LogTests.cs
+++ b/Yubico.Core/tests/Yubico/Core/Logging/LogTests.cs
@@ -14,7 +14,7 @@
 
 using System;
 using Microsoft.Extensions.Logging;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace Yubico.Core.Logging
@@ -49,14 +49,14 @@ namespace Yubico.Core.Logging
         public void ManualLoggerFactory_SettingInstance_OverridesDefaultFactory()
         {
             // Arrange
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
-            Log.Instance = mockLoggerFactory.Object;
+            var mockLoggerFactory = Substitute.For<ILoggerFactory>();
+            Log.Instance = mockLoggerFactory;
 
             // Act
             ILoggerFactory actualFactory = Log.Instance;
 
             // Assert
-            Assert.Same(mockLoggerFactory.Object, actualFactory);
+            Assert.Same(mockLoggerFactory, actualFactory);
         }
 
         // Ensure that LoggerFactory can be replaced manually using the Instance property.
@@ -65,16 +65,16 @@ namespace Yubico.Core.Logging
         public void Legacy_ManualLoggerFactory_SettingInstance_OverridesDefaultFactory()
         {
             // Arrange
-            var mockLoggerFactory = new Mock<ILoggerFactory>();
+            var mockLoggerFactory = Substitute.For<ILoggerFactory>();
 #pragma warning disable CS0618 // Type or member is obsolete
-            Log.LoggerFactory = mockLoggerFactory.Object;
+            Log.LoggerFactory = mockLoggerFactory;
 #pragma warning restore CS0618 // Type or member is obsolete
 
             // Act
             ILoggerFactory actualFactory = Log.Instance;
 
             // Assert
-            Assert.Same(mockLoggerFactory.Object, actualFactory);
+            Assert.Same(mockLoggerFactory, actualFactory);
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/ScpApduTransform.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/ScpApduTransform.cs
@@ -129,7 +129,7 @@ namespace Yubico.YubiKey.Pipelines
         }
 
         [DoesNotReturn]
-        private T ThrowIfUninitialized<T>() => throw new InvalidOperationException($"{nameof(Scp.ScpState)} has not been initialized. The Setup method must be called.");
+        private static T ThrowIfUninitialized<T>() => throw new InvalidOperationException($"{nameof(Scp.ScpState)} has not been initialized. The Setup method must be called.");
 
         private static bool ShouldNotEncode(Type commandType)
         {

--- a/Yubico.YubiKey/tests/unit/Yubico.YubiKey.UnitTests.csproj
+++ b/Yubico.YubiKey/tests/unit/Yubico.YubiKey.UnitTests.csproj
@@ -31,13 +31,13 @@ limitations under the License. -->
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="NSubstitute" Version="5.3.0" />
     <ProjectReference Include="..\..\src\Yubico.YubiKey.csproj" />
     <ProjectReference Include="..\utilities\Yubico.YubiKey.TestUtilities.csproj" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="xunit" Version="2.8.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1" PrivateAssets="all" IncludeAssets="runtime; build; native; contentfiles; analyzers; buildtransitive" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/ConnectionManagerTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/ConnectionManagerTests.cs
@@ -1,4 +1,4 @@
-// Copyright 2021 Yubico AB
+﻿// Copyright 2021 Yubico AB
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 
 using System;
 using System.Collections.Generic;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Devices;
 using Yubico.Core.Devices.Hid;
@@ -67,9 +67,9 @@ namespace Yubico.YubiKey
 
     public class ConnectionManagerTests
     {
-        private readonly Mock<IYubiKeyDevice> _yubiKeyDeviceMock = new Mock<IYubiKeyDevice>();
-        private readonly Mock<ISmartCardDevice> _smartCardDeviceMock = new Mock<ISmartCardDevice>();
-        private readonly Mock<ISmartCardConnection> _smartCardConnectionMock = new Mock<ISmartCardConnection>();
+        private readonly IYubiKeyDevice _yubiKeyDeviceMock = Substitute.For<IYubiKeyDevice>();
+        private readonly ISmartCardDevice _smartCardDeviceMock = Substitute.For<ISmartCardDevice>();
+        private readonly ISmartCardConnection _smartCardConnectionMock = Substitute.For<ISmartCardConnection>();
 
         public static IEnumerable<object[]> SupportedApplicationTuples =>
             new List<object[]>()
@@ -135,15 +135,13 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out IYubiKeyConnection? connection);
 
@@ -156,24 +154,21 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _yubiKeyDeviceMock
-                .Setup(x => x.Equals(It.IsAny<IYubiKeyDevice>()))
+            _ = _yubiKeyDeviceMock.Equals(Arg.Any<IYubiKeyDevice>())
                 .Returns(true);
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             _ = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out _);
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out IYubiKeyConnection? connection);
 
@@ -186,18 +181,15 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _yubiKeyDeviceMock
-                .Setup(x => x.Equals(It.IsAny<IYubiKeyDevice>()))
+            _ = _yubiKeyDeviceMock.Equals(Arg.Any<IYubiKeyDevice>())
                 .Returns(false);
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out IYubiKeyConnection? connection1);
 
@@ -205,8 +197,8 @@ namespace Yubico.YubiKey
             Assert.NotNull(connection1);
 
             result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out IYubiKeyConnection? connection2);
 
@@ -219,15 +211,13 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 new byte[] { 1, 2, 3, 4 },
                 out IYubiKeyConnection? connection);
 
@@ -240,24 +230,21 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _yubiKeyDeviceMock
-                .Setup(x => x.Equals(It.IsAny<IYubiKeyDevice>()))
+            _ = _yubiKeyDeviceMock.Equals(Arg.Any<IYubiKeyDevice>())
                 .Returns(true);
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             _ = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 new byte[] { 1, 2, 3, 4 },
                 out _);
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 new byte[] { 1, 2, 3, 4 },
                 out IYubiKeyConnection? connection);
 
@@ -270,18 +257,15 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _yubiKeyDeviceMock
-                .Setup(x => x.Equals(It.IsAny<IYubiKeyDevice>()))
+            _ = _yubiKeyDeviceMock.Equals(Arg.Any<IYubiKeyDevice>())
                 .Returns(false);
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 new byte[] { 1, 2, 3, 4 },
                 out IYubiKeyConnection? connection1);
 
@@ -289,8 +273,8 @@ namespace Yubico.YubiKey
             Assert.NotNull(connection1);
 
             result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 new byte[] { 1, 2, 3, 4 },
                 out IYubiKeyConnection? connection2);
 
@@ -303,7 +287,7 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            void Action() => cm.EndConnection(_yubiKeyDeviceMock.Object);
+            void Action() => cm.EndConnection(_yubiKeyDeviceMock);
 
             _ = Assert.Throws<KeyNotFoundException>(Action);
         }
@@ -313,26 +297,23 @@ namespace Yubico.YubiKey
         {
             var cm = new ConnectionManager();
 
-            _ = _yubiKeyDeviceMock
-                .Setup(x => x.Equals(It.IsAny<IYubiKeyDevice>()))
+            _ = _yubiKeyDeviceMock.Equals(Arg.Any<IYubiKeyDevice>())
                 .Returns(true);
-            _ = _smartCardDeviceMock
-                .Setup(x => x.Connect()).Returns(_smartCardConnectionMock.Object);
-            _ = _smartCardConnectionMock
-                .Setup(x => x.Transmit(It.IsAny<CommandApdu>()))
+            _ = _smartCardDeviceMock.Connect().Returns(_smartCardConnectionMock);
+            _ = _smartCardConnectionMock.Transmit(Arg.Any<CommandApdu>())
                 .Returns(new ResponseApdu(Array.Empty<byte>(), SWConstants.Success));
 
             _ = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out _);
 
-            cm.EndConnection(_yubiKeyDeviceMock.Object);
+            cm.EndConnection(_yubiKeyDeviceMock);
 
             bool result = cm.TryCreateConnection(
-                _yubiKeyDeviceMock.Object,
-                _smartCardDeviceMock.Object,
+                _yubiKeyDeviceMock,
+                _smartCardDeviceMock,
                 YubiKeyApplication.Piv,
                 out IYubiKeyConnection? connection);
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Fido2SessionTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Fido2SessionTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2022 Yubico AB
+// Copyright 2022 Yubico AB
 //
 // Licensed under the Apache License, Version 2.0 (the "License").
 // You may not use this file except in compliance with the License.
@@ -42,7 +42,7 @@ namespace Yubico.YubiKey.Fido2
             var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
+            _ = mockConnection.SendCommand(Arg.Any<GetInfoCommand>())
                 .Returns(mockResponse);
 
             _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
@@ -60,13 +60,13 @@ namespace Yubico.YubiKey.Fido2
             var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
+            _ = mockConnection.SendCommand(Arg.Any<GetInfoCommand>())
                 .Returns(mockResponse);
 
             _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
                 .Returns(mockConnection);
 
-            var session = new Fido2Session(mockYubiKey);
+            _ = new Fido2Session(mockYubiKey);
 
             mockYubiKey.Received().Connect(YubiKeyApplication.Fido2);
         }
@@ -78,13 +78,13 @@ namespace Yubico.YubiKey.Fido2
             var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
+            _ = mockConnection.SendCommand(Arg.Any<GetInfoCommand>())
                 .Returns(mockResponse);
 
             _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
                 .Returns(mockConnection);
 
-            var session = new Fido2Session(mockYubiKey);
+            _ = new Fido2Session(mockYubiKey);
 
             mockConnection.Received().SendCommand(Arg.Any<GetInfoCommand>());
         }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Fido2SessionTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Fido2SessionTests.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Iso7816;
 using Yubico.YubiKey.Fido2.Commands;
@@ -38,19 +38,17 @@ namespace Yubico.YubiKey.Fido2
         [Fact]
         void Constructor_ValidYubiKeyDevice_Succeeds()
         {
-            var mockYubiKey = new Mock<IYubiKeyDevice>();
-            var mockConnection = new Mock<IYubiKeyConnection>();
+            var mockYubiKey = Substitute.For<IYubiKeyDevice>();
+            var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection
-                .Setup(c => c.SendCommand(It.IsAny<IYubiKeyCommand<IYubiKeyResponse>>()))
+            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
                 .Returns(mockResponse);
 
-            _ = mockYubiKey
-                .Setup(k => k.Connect(YubiKeyApplication.Fido2))
-                .Returns(mockConnection.Object);
+            _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
+                .Returns(mockConnection);
 
-            var session = new Fido2Session(mockYubiKey.Object);
+            var session = new Fido2Session(mockYubiKey);
 
             Assert.NotNull(session);
         }
@@ -58,41 +56,37 @@ namespace Yubico.YubiKey.Fido2
         [Fact]
         void Constructor_GivenValidYubiKeyDevice_ConnectsToFido2Application()
         {
-            var mockYubiKey = new Mock<IYubiKeyDevice>();
-            var mockConnection = new Mock<IYubiKeyConnection>();
+            var mockYubiKey = Substitute.For<IYubiKeyDevice>();
+            var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection
-                .Setup(c => c.SendCommand(It.IsAny<IYubiKeyCommand<IYubiKeyResponse>>()))
+            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
                 .Returns(mockResponse);
 
-            _ = mockYubiKey
-                .Setup(k => k.Connect(YubiKeyApplication.Fido2))
-                .Returns(mockConnection.Object);
+            _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
+                .Returns(mockConnection);
 
-            var session = new Fido2Session(mockYubiKey.Object);
+            var session = new Fido2Session(mockYubiKey);
 
-            mockYubiKey.Verify(k => k.Connect(YubiKeyApplication.Fido2), Times.Once);
+            mockYubiKey.Received().Connect(YubiKeyApplication.Fido2);
         }
 
         [Fact]
         void GetAuthenticatorInfo_SendsGetInfoCommand()
         {
-            var mockYubiKey = new Mock<IYubiKeyDevice>();
-            var mockConnection = new Mock<IYubiKeyConnection>();
+            var mockYubiKey = Substitute.For<IYubiKeyDevice>();
+            var mockConnection = Substitute.For<IYubiKeyConnection>();
             var mockResponse = new GetInfoResponse(new ResponseApdu(Fido2InfoTests.GetSampleEncoded(), SWConstants.Success));
 
-            _ = mockConnection
-                .Setup(c => c.SendCommand(It.IsAny<IYubiKeyCommand<IYubiKeyResponse>>()))
+            _ = mockConnection.SendCommand(Arg.Any<IYubiKeyCommand<IYubiKeyResponse>>())
                 .Returns(mockResponse);
 
-            _ = mockYubiKey
-                .Setup(k => k.Connect(YubiKeyApplication.Fido2))
-                .Returns(mockConnection.Object);
+            _ = mockYubiKey.Connect(YubiKeyApplication.Fido2)
+                .Returns(mockConnection);
 
-            var session = new Fido2Session(mockYubiKey.Object);
+            var session = new Fido2Session(mockYubiKey);
 
-            mockConnection.Verify(c => c.SendCommand(It.IsAny<GetInfoCommand>()));
+            mockConnection.Received().SendCommand(Arg.Any<GetInfoCommand>());
         }
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
@@ -79,9 +79,10 @@ namespace Yubico.YubiKey.Pipelines
             _ = transform.Invoke(commandApdu, typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(
-                x =>
-                    x.Invoke(Arg.Is<CommandApdu>(a => a == commandApdu), Arg.Any<Type>(), Arg.Any<Type>()));
+            mockTransform.Received(1).Invoke(
+                Arg.Is<CommandApdu>(a => a == commandApdu), 
+                Arg.Any<Type>(), 
+                Arg.Any<Type>());
         }
 
         [Fact]
@@ -115,9 +116,10 @@ namespace Yubico.YubiKey.Pipelines
             _ = transform.Invoke(commandApdu, typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(
-                x =>
-                    x.Invoke(Arg.Is<CommandApdu>(a => a == commandApdu), Arg.Any<Type>(), Arg.Any<Type>()));
+            mockTransform.Received(1).Invoke(
+                Arg.Is<CommandApdu>(a => a == commandApdu),
+                Arg.Any<Type>(),
+                Arg.Any<Type>());
         }
 
         [Fact]
@@ -151,8 +153,11 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
-                .Callback<CommandApdu, Type, Type>((a, b, c) => observedCla.Add(a.Cla));
-
+                .AndDoes(callInfo =>
+                {
+                    var apdu = callInfo.ArgAt<CommandApdu>(0);
+                    observedCla.Add(apdu.Cla);
+                });
             // Act
             _ = transform.Invoke(commandApdu, typeof(object), typeof(object));
 
@@ -178,7 +183,11 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
-                .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a));
+                .AndDoes(callInfo =>
+                {
+                    var apdu = callInfo.ArgAt<CommandApdu>(0);
+                    observedApdus.Add(apdu);
+                });
 
             // Act
             _ = transform.Invoke(commandApdu, typeof(object), typeof(object));
@@ -207,8 +216,11 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
-                .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a.Data.ToArray()));
-
+                .AndDoes(callInfo =>
+                {
+                    var apdu = callInfo.ArgAt<CommandApdu>(0);
+                    observedApdus.Add(apdu.Data.ToArray());
+                });
             // Act
             _ = transform.Invoke(commandApdu, typeof(object), typeof(object));
 
@@ -217,7 +229,7 @@ namespace Yubico.YubiKey.Pipelines
             Assert.Equal(new byte[] { 5, 6, 7, 8 }, observedApdus[1]);
             Assert.Equal(new byte[] { 9, 10 }, observedApdus[2]);
         }
-        
+
         [Fact]
         public void Invoke_CommandApduWithLargeDataBuffer_DoesntProcessAllBytes()
         {
@@ -233,9 +245,10 @@ namespace Yubico.YubiKey.Pipelines
 
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu([], 0x6700))
-                .Callback<CommandApdu, Type, Type>((a, b, c) =>
+                .AndDoes(callInfo =>
                 {
-                    observedApdus.Add(a.Data.ToArray());
+                    var apdu = callInfo.ArgAt<CommandApdu>(0);
+                    observedApdus.Add(apdu.Data.ToArray());
                 });
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/CommandChainingTransformTests.cs
@@ -15,7 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Iso7816;
 
@@ -27,36 +27,36 @@ namespace Yubico.YubiKey.Pipelines
         public void Cleanup_Called_CallsNextTransformCleanupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform);
 
             // Act
             transform.Cleanup();
 
             // Assert
-            mockTransform.Verify(x => x.Cleanup(), Times.Once());
+            mockTransform.Received().Cleanup();
         }
 
         [Fact]
         public void Setup_Called_CallsNextTransformSetupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform);
 
             // Act
             transform.Setup();
 
             // Assert
-            mockTransform.Verify(x => x.Setup(), Times.Once());
+            mockTransform.Received().Setup();
         }
 
         [Fact]
         public void Invoke_NullCommandApdu_ThrowsArgumentNullException()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform);
 
             // Act
 #pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
@@ -71,8 +71,8 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_CommandApduWithoutData_InvokesNextTransformWithSameApdu()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform);
             var commandApdu = new CommandApdu();
 
             // Act
@@ -81,7 +81,7 @@ namespace Yubico.YubiKey.Pipelines
             // Assert
             mockTransform.Verify(
                 x =>
-                    x.Invoke(It.Is<CommandApdu>(a => a == commandApdu), It.IsAny<Type>(), It.IsAny<Type>()));
+                    x.Invoke(Arg.Is<CommandApdu>(a => a == commandApdu), Arg.Any<Type>(), Arg.Any<Type>()));
         }
 
         [Fact]
@@ -89,12 +89,11 @@ namespace Yubico.YubiKey.Pipelines
         {
             // Arrange
             var expectedResponse = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            var mockTransform = new Mock<IApduTransform>();
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            var mockTransform = Substitute.For<IApduTransform>();
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
 
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var transform = new CommandChainingTransform(mockTransform);
             var commandApdu = new CommandApdu();
 
             // Act
@@ -108,8 +107,8 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_CommandApduWithSmallData_InvokesNextTransformWithSameApdu()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform);
             var commandApdu = new CommandApdu { Data = new byte[] { 0, 1, 2, 3 } };
 
             // Act
@@ -118,7 +117,7 @@ namespace Yubico.YubiKey.Pipelines
             // Assert
             mockTransform.Verify(
                 x =>
-                    x.Invoke(It.Is<CommandApdu>(a => a == commandApdu), It.IsAny<Type>(), It.IsAny<Type>()));
+                    x.Invoke(Arg.Is<CommandApdu>(a => a == commandApdu), Arg.Any<Type>(), Arg.Any<Type>()));
         }
 
         [Fact]
@@ -126,12 +125,11 @@ namespace Yubico.YubiKey.Pipelines
         {
             // Arrange
             var expectedResponse = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            var mockTransform = new Mock<IApduTransform>();
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            var mockTransform = Substitute.For<IApduTransform>();
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
 
-            var transform = new CommandChainingTransform(mockTransform.Object);
+            var transform = new CommandChainingTransform(mockTransform);
             var commandApdu = new CommandApdu { Data = new byte[] { 0, 1, 2, 3 } };
 
             // Act
@@ -147,12 +145,11 @@ namespace Yubico.YubiKey.Pipelines
             var observedCla = new List<byte>();
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu { Data = Enumerable.Repeat<byte>(0xFF, 16).ToArray() };
 
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedCla.Add(a.Cla));
 
@@ -169,8 +166,8 @@ namespace Yubico.YubiKey.Pipelines
             var observedApdus = new List<CommandApdu>();
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu
             {
                 Ins = 1,
@@ -179,8 +176,7 @@ namespace Yubico.YubiKey.Pipelines
                 Data = Enumerable.Repeat<byte>(0xFF, 16).ToArray()
             };
 
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a));
 
@@ -202,15 +198,14 @@ namespace Yubico.YubiKey.Pipelines
             var observedApdus = new List<byte[]>();
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu
             {
                 Data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
             };
 
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }))
                 .Callback<CommandApdu, Type, Type>((a, b, c) => observedApdus.Add(a.Data.ToArray()));
 
@@ -229,15 +224,14 @@ namespace Yubico.YubiKey.Pipelines
             var observedApdus = new List<byte[]>();
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new CommandChainingTransform(mockTransform.Object) { MaxChunkSize = 4 };
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new CommandChainingTransform(mockTransform) { MaxChunkSize = 4 };
             var commandApdu = new CommandApdu
             {
                 Data = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }
             };
 
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu([], 0x6700))
                 .Callback<CommandApdu, Type, Type>((a, b, c) =>
                 {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/OathResponseChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/OathResponseChainingTransformTests.cs
@@ -78,8 +78,7 @@ namespace Yubico.YubiKey.Pipelines
             _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once());
+            mockTransform.Received(1).Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -124,16 +123,14 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
-            ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
+            _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Exactly(2));
+            mockTransform.Received(2).Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -146,16 +143,14 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
-            ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
+            _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once);
+            mockTransform.Received(1).Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -167,8 +162,7 @@ namespace Yubico.YubiKey.Pipelines
             var response2 = new ResponseApdu(new byte[] { 5, 6, 7, 8, SW1Constants.Success, 0x00 });
             byte[] expectedData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
@@ -186,8 +180,7 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/OathResponseChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/OathResponseChainingTransformTests.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Iso7816;
 
@@ -25,36 +25,36 @@ namespace Yubico.YubiKey.Pipelines
         public void Cleanup_Called_CallsNextTransformCleanupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             transform.Cleanup();
 
             // Assert
-            mockTransform.Verify(x => x.Cleanup(), Times.Once());
+            mockTransform.Received().Cleanup();
         }
 
         [Fact]
         public void Setup_Called_CallsNextTransformSetupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             transform.Setup();
 
             // Assert
-            mockTransform.Verify(x => x.Setup(), Times.Once());
+            mockTransform.Received().Setup();
         }
 
         [Fact]
         public void Invoke_NullArgument_ThrowsArgumentNullException()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
 #pragma warning disable CS8625 // JUSTIFICATION: Null argument test case
@@ -69,30 +69,28 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_Called_CallsNextTransformInvokeMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            var mockTransform = Substitute.For<IApduTransform>();
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }));
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()), Times.Once());
+                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once());
         }
 
         [Fact]
         public void Invoke_SuccessfulResponseApdu_ReturnsResponse()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var expectedResponse = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -105,12 +103,11 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_FailedResponseApdu_ReturnsResponse()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var expectedResponse = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -123,21 +120,20 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_BytesAvailableThenSuccess_CallsInvokeTwice()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()), Times.Exactly(2));
+                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Exactly(2));
         }
 
         [Fact]
@@ -146,36 +142,34 @@ namespace Yubico.YubiKey.Pipelines
             byte expectedIns = 0xA5;
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.Is<CommandApdu>(c => c.Ins == expectedIns), It.IsAny<Type>(), It.IsAny<Type>()), Times.Once);
+                x.Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once);
         }
 
         [Fact]
         public void Invoke_BytesAvailble_ConcatsAllBuffers()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { 1, 2, 3, 4, SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { 5, 6, 7, 8, SW1Constants.Success, 0x00 });
             byte[] expectedData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -188,14 +182,13 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_BytesAvailable_ReturnsLastStatusWord()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new OathResponseChainingTransform(mockTransform.Object);
+            var transform = new OathResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ResponseChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ResponseChainingTransformTests.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Iso7816;
 
@@ -25,36 +25,36 @@ namespace Yubico.YubiKey.Pipelines
         public void Cleanup_Called_CallsNextTransformCleanupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             transform.Cleanup();
 
             // Assert
-            mockTransform.Verify(x => x.Cleanup(), Times.Once());
+            mockTransform.Received().Cleanup();
         }
 
         [Fact]
         public void Setup_Called_CallsNextTransformSetupMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             transform.Setup();
 
             // Assert
-            mockTransform.Verify(x => x.Setup(), Times.Once());
+            mockTransform.Received().Setup();
         }
 
         [Fact]
         public void Invoke_NullArgument_ThrowsArgumentNullException()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var mockTransform = Substitute.For<IApduTransform>();
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
 #pragma warning disable CS8625 // JUSTIFICATION: Null argument test case
@@ -69,30 +69,28 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_Called_CallsNextTransformInvokeMethod()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            var mockTransform = Substitute.For<IApduTransform>();
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(new ResponseApdu(new byte[] { 0x90, 0x00 }));
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()), Times.Once());
+                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once());
         }
 
         [Fact]
         public void Invoke_SuccessfulResponseApdu_ReturnsResponse()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var expectedResponse = new ResponseApdu(new byte[] { 0x90, 0x00 });
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -105,12 +103,11 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_FailedResponseApdu_ReturnsResponse()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var expectedResponse = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
-            _ = mockTransform
-                .Setup(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(expectedResponse);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -123,21 +120,20 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_BytesAvailableThenSuccess_CallsInvokeTwice()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()), Times.Exactly(2));
+                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Exactly(2));
         }
 
         [Fact]
@@ -146,36 +142,34 @@ namespace Yubico.YubiKey.Pipelines
             byte expectedIns = 0xC0;
 
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
             mockTransform.Verify(x =>
-                x.Invoke(It.Is<CommandApdu>(c => c.Ins == expectedIns), It.IsAny<Type>(), It.IsAny<Type>()), Times.Once);
+                x.Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once);
         }
 
         [Fact]
         public void Invoke_BytesAvailble_ConcatsAllBuffers()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { 1, 2, 3, 4, SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { 5, 6, 7, 8, SW1Constants.Success, 0x00 });
             byte[] expectedData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -188,14 +182,13 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_BytesAvailable_ReturnsLastStatusWord()
         {
             // Arrange
-            var mockTransform = new Mock<IApduTransform>();
+            var mockTransform = Substitute.For<IApduTransform>();
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
-            _ = mockTransform
-                .SetupSequence(x => x.Invoke(It.IsAny<CommandApdu>(), It.IsAny<Type>(), It.IsAny<Type>()))
+            _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
                 .Returns(response1)
                 .Returns(response2);
-            var transform = new ResponseChainingTransform(mockTransform.Object);
+            var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ResponseChainingTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ResponseChainingTransformTests.cs
@@ -78,8 +78,7 @@ namespace Yubico.YubiKey.Pipelines
             _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once());
+            mockTransform.Received(1).Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -124,16 +123,14 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
-            ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
+            _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>()), Times.Exactly(2));
+            mockTransform.Received(2).Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -146,16 +143,14 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.Success, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
-            ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
+            _ = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
 
             // Assert
-            mockTransform.Verify(x =>
-                x.Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>()), Times.Once);
+            mockTransform.Received(1).Invoke(Arg.Is<CommandApdu>(c => c.Ins == expectedIns), Arg.Any<Type>(), Arg.Any<Type>());
         }
 
         [Fact]
@@ -167,8 +162,7 @@ namespace Yubico.YubiKey.Pipelines
             var response2 = new ResponseApdu(new byte[] { 5, 6, 7, 8, SW1Constants.Success, 0x00 });
             byte[] expectedData = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new ResponseChainingTransform(mockTransform);
 
             // Act
@@ -186,8 +180,7 @@ namespace Yubico.YubiKey.Pipelines
             var response1 = new ResponseApdu(new byte[] { SW1Constants.BytesAvailable, 0x00 });
             var response2 = new ResponseApdu(new byte[] { SW1Constants.NoPreciseDiagnosis, 0x00 });
             _ = mockTransform.Invoke(Arg.Any<CommandApdu>(), Arg.Any<Type>(), Arg.Any<Type>())
-                .Returns(response1)
-                .Returns(response2);
+                .Returns(response1, response2);
             var transform = new ResponseChainingTransform(mockTransform);
 
             // Act

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ScpApduTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/ScpApduTransformTests.cs
@@ -106,7 +106,7 @@ namespace Yubico.YubiKey.Pipelines
                     testCase.CommandType,
                     testCase.ResponseType);
 
-                _previous.Reset();
+                _previous.ClearReceivedCalls();
             }
         }
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/SmartCardTransformTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Pipelines/SmartCardTransformTests.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using System;
-using Moq;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Devices.SmartCard;
 using Yubico.Core.Iso7816;
@@ -34,8 +34,8 @@ namespace Yubico.YubiKey.Pipelines
         public void Cleanup_DoesNothing()
         {
             // Arrange
-            var mockConnection = new Mock<ISmartCardConnection>();
-            var transform = new SmartCardTransform(mockConnection.Object);
+            var mockConnection = Substitute.For<ISmartCardConnection>();
+            var transform = new SmartCardTransform(mockConnection);
 
             // Act
             Exception? exception = Record.Exception(() => transform.Cleanup());
@@ -48,32 +48,30 @@ namespace Yubico.YubiKey.Pipelines
         public void Invoke_GivenCommandApdu_CallsTrasmitWithExactApdu()
         {
             // Arrange
-            var mockConnection = new Mock<ISmartCardConnection>();
-            _ = mockConnection
-                .Setup(m => m.Transmit(AnyCommandApdu()))
+            var mockConnection = Substitute.For<ISmartCardConnection>();
+            _ = mockConnection.Transmit(AnyCommandApdu())
                 .Returns(SuccessResponse());
 
-            var transform = new SmartCardTransform(mockConnection.Object);
+            var transform = new SmartCardTransform(mockConnection);
             var expectedApdu = new CommandApdu();
 
             // Act
             _ = transform.Invoke(expectedApdu, typeof(object), typeof(object));
 
             // Assert
-            mockConnection.Verify(m => m.Transmit(It.Is<CommandApdu>(a => a == expectedApdu)));
+            mockConnection.Received().Transmit(Arg.Is<CommandApdu>(a => a == expectedApdu));
         }
 
         [Fact]
         public void Invoke_GivenCommandApdu_ReturnsExactResponseFromTransmit()
         {
             // Arrange
-            var mockConnection = new Mock<ISmartCardConnection>();
+            var mockConnection = Substitute.For<ISmartCardConnection>();
             ResponseApdu expectedResponse = SuccessResponse();
-            _ = mockConnection
-                .Setup(m => m.Transmit(AnyCommandApdu()))
+            _ = mockConnection.Transmit(AnyCommandApdu())
                 .Returns(expectedResponse);
 
-            var transform = new SmartCardTransform(mockConnection.Object);
+            var transform = new SmartCardTransform(mockConnection);
 
             // Act
             ResponseApdu actualResponse = transform.Invoke(new CommandApdu(), typeof(object), typeof(object));
@@ -83,7 +81,7 @@ namespace Yubico.YubiKey.Pipelines
         }
 
         private static CommandApdu AnyCommandApdu() =>
-            It.IsAny<CommandApdu>();
+            Arg.Any<CommandApdu>();
 
         private static ResponseApdu SuccessResponse() =>
             new ResponseApdu(new byte[] { 0x90, 0x00 });

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Scp/Scp03StateTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Scp/Scp03StateTests.cs
@@ -1,5 +1,5 @@
-using System;
-using Moq;
+﻿using System;
+using NSubstitute;
 using Xunit;
 using Yubico.Core.Iso7816;
 using Yubico.YubiKey.Cryptography;
@@ -16,54 +16,54 @@ namespace Yubico.YubiKey.Scp
 
         public Scp03StateTests()
         {
-            var parent = new Mock<IApduTransform>();
+            var parent = Substitute.For<IApduTransform>();
             var keyParams = Scp03KeyParameters.DefaultKey;
             var hostChallenge = new byte[8];
             var cardChallenge = new byte[8];
 
             ResponseData = GetFakeResponseApduData(hostChallenge, cardChallenge);
 
-            parent.Setup(p => p.Invoke(
-                    It.IsAny<CommandApdu>(),
+            parent.Invoke(
+                    Arg.Any<CommandApdu>(),
                     typeof(InitializeUpdateCommand),
-                    typeof(InitializeUpdateResponse)))
+                    typeof(InitializeUpdateResponse))
                 .Returns(new ResponseApdu(ResponseData));
 
-            parent.Setup(p => p.Invoke(
-                    It.IsAny<CommandApdu>(),
+            parent.Invoke(
+                    Arg.Any<CommandApdu>(),
                     typeof(ExternalAuthenticateCommand),
-                    typeof(ExternalAuthenticateResponse)))
+                    typeof(ExternalAuthenticateResponse))
                 .Returns(new ResponseApdu(ResponseData));
 
             // Act
-            State = Scp03State.CreateScpState(parent.Object, keyParams, hostChallenge);
+            State = Scp03State.CreateScpState(parent, keyParams, hostChallenge);
         }
 
         [Fact]
         public void CreateScpState_ValidParameters_InitializesCorrectly()
         {
             // Arrange
-            var parent = new Mock<IApduTransform>();
+            var parent = Substitute.For<IApduTransform>();
             var keyParams = Scp03KeyParameters.DefaultKey;
             var hostChallenge = new byte[8];
             var cardChallenge = new byte[8];
 
             var responseApduData = GetFakeResponseApduData(hostChallenge, cardChallenge);
 
-            parent.Setup(p => p.Invoke(
-                    It.IsAny<CommandApdu>(),
+            parent.Invoke(
+                    Arg.Any<CommandApdu>(),
                     typeof(InitializeUpdateCommand),
-                    typeof(InitializeUpdateResponse)))
+                    typeof(InitializeUpdateResponse))
                 .Returns(new ResponseApdu(responseApduData));
 
-            parent.Setup(p => p.Invoke(
-                    It.IsAny<CommandApdu>(),
+            parent.Invoke(
+                    Arg.Any<CommandApdu>(),
                     typeof(ExternalAuthenticateCommand),
-                    typeof(ExternalAuthenticateResponse)))
+                    typeof(ExternalAuthenticateResponse))
                 .Returns(new ResponseApdu(responseApduData));
 
             // Act
-            var state = Scp03State.CreateScpState(parent.Object, keyParams, hostChallenge);
+            var state = Scp03State.CreateScpState(parent, keyParams, hostChallenge);
 
             // Assert
             Assert.NotNull(state);
@@ -86,12 +86,12 @@ namespace Yubico.YubiKey.Scp
         public void CreateScpState_NullKeyParams_ThrowsArgumentNullException()
         {
             // Arrange
-            var pipeline = new Mock<IApduTransform>();
+            var pipeline = Substitute.For<IApduTransform>();
             byte[] hostChallenge = new byte[8];
 
             // Act & Assert
             Assert.Throws<ArgumentNullException>(() =>
-                Scp03State.CreateScpState(pipeline.Object, null!, hostChallenge));
+                Scp03State.CreateScpState(pipeline, null!, hostChallenge));
         }
 
         [Fact]

--- a/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestDeviceSelection.cs
+++ b/Yubico.YubiKey/tests/utilities/Yubico/YubiKey/TestUtilities/TestDeviceSelection.cs
@@ -151,7 +151,7 @@ namespace Yubico.YubiKey.TestUtilities
                 ThrowDeviceNotFoundException("No matching YubiKey found", devices);
             }
 
-            return device;
+            return device!;
         }
 
         [DoesNotReturn]


### PR DESCRIPTION
This pull request updates unit tests across multiple files to replace the `Moq` mocking library with `NSubstitute`. 

### Transition to `NSubstitute` for Mocking:

#### Test Framework Updates:
* [`Yubico.Core/tests/Yubico.Core.UnitTests.csproj`](diffhunk://#diff-ee808297e9f4a1c86785fc217491dc426cb1538b78550a01be1923c227873ec9R46-L52): Removed the `Moq` package and added the `NSubstitute` package (`Version 5.3.0`).
* [`Yubico.YubiKey/tests/unit/Yubico.YubiKey.UnitTests.csproj`](diffhunk://#diff-996dd45b63b3c63719489920cef0d8f3c96667e9fab09a15337163447a12288dR34-L40): Similar updates as above, replacing `Moq` with `NSubstitute`.

#### Core Device Tests:
* [`Yubico.Core/tests/Yubico/Core/Devices/Hid/HidConnectionTests.cs`](diffhunk://#diff-ca49e7dc62a03edf6718044e52d4496d2dac5a240887dc3401a89148f728af83L23-R49): Replaced `Moq` mocks with `NSubstitute` substitutes for `IHidDDevice`. Updated setup methods to use `NSubstitute` syntax, simplifying mock creation and verification. [[1]](diffhunk://#diff-ca49e7dc62a03edf6718044e52d4496d2dac5a240887dc3401a89148f728af83L23-R49) [[2]](diffhunk://#diff-ca49e7dc62a03edf6718044e52d4496d2dac5a240887dc3401a89148f728af83L62-R89) [[3]](diffhunk://#diff-ca49e7dc62a03edf6718044e52d4496d2dac5a240887dc3401a89148f728af83L99-R170)

#### Logging Tests:
* [`Yubico.Core/tests/Yubico/Core/Logging/LogTests.cs`](diffhunk://#diff-c9e1e017d077e330c0b10ace4b7aca5cbf920ef15de77febc25729603f5d216dL17-R17): Updated logger factory mocks to use `NSubstitute`, simplifying assertions and setup for `ILoggerFactory`. [[1]](diffhunk://#diff-c9e1e017d077e330c0b10ace4b7aca5cbf920ef15de77febc25729603f5d216dL17-R17) [[2]](diffhunk://#diff-c9e1e017d077e330c0b10ace4b7aca5cbf920ef15de77febc25729603f5d216dL52-R59) [[3]](diffhunk://#diff-c9e1e017d077e330c0b10ace4b7aca5cbf920ef15de77febc25729603f5d216dL68-R77)

#### Connection Manager Tests:
* [`Yubico.YubiKey/tests/unit/Yubico/YubiKey/ConnectionManagerTests.cs`](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L70-R72): Transitioned `IYubiKeyDevice`, `ISmartCardDevice`, and `ISmartCardConnection` mocks to `NSubstitute`. Updated mock setup and verification for connection-related tests. [[1]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L70-R72) [[2]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L138-R144) [[3]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L159-R171) [[4]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L189-R201) [[5]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L222-R220) [[6]](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L243-R247)

### Minor Formatting Adjustments:
* [`Yubico.YubiKey/tests/unit/Yubico/YubiKey/ConnectionManagerTests.cs`](diffhunk://#diff-cfaf2d2ce17a55f38eaeb5f87eb7ba209381d2f9b0e4c59d4da51e05bada24f3L1-R1): Corrected encoding issue in the file header.

These updates enhance the maintainability of the test codebase by adopting a more concise and expressive mocking library.