### PR TITLE
misc(nuget): Add metadata for NuGet

### DIFF
--- a/Yubico.Core/src/Yubico.Core.csproj
+++ b/Yubico.Core/src/Yubico.Core.csproj
@@ -37,17 +37,19 @@ limitations under the License. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet properties -->
-    <Description>
-      Yubico.Core is a support library used by other .NET Yubico libraries. You should likely never need to consume this package directly, as it will be included with other libraries.
-    </Description>
+    <PackageId>Yubico.Core</PackageId>
+    <Description>Yubico.Core is a support library used by other .NET Yubico libraries. You should likely never need to consume this package directly, as it will be included with other libraries.</Description>
     <PackageIcon>yubico-circle-y-mark.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageReleaseNotes>https://github.com/Yubico/Yubico.NET.SDK/releases/latest</PackageReleaseNotes>
+    <PackageTags>yubikey;security;authentication;multifactor;mfa;twofactor;cryptography;hardware-token;fido;fido2;u2f;security-key;passwordless;smartcard;pki;usb-security</PackageTags>
+    
+    <!-- Debug Symbols !-->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>https://github.com/Yubico/Yubico.NET.SDK/releases/latest</PackageReleaseNotes>
-
+    
     <!-- StrongName signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Yubico.NET.SDK.snk</AssemblyOriginatorKeyFile>

--- a/Yubico.YubiKey/src/Yubico.YubiKey.csproj
+++ b/Yubico.YubiKey/src/Yubico.YubiKey.csproj
@@ -36,16 +36,19 @@ limitations under the License. -->
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <!-- NuGet properties -->
-    <Description>
-      Yubico.YubiKey is the official .NET library for integrating with the YubiKey hardware authenticator. This library supports both macOS and Windows operating systems.
-    </Description>
+    <PackageId>Yubico.YubiKey</PackageId>
+    <Description>Yubico.YubiKey is the official .NET library for integrating with the YubiKey hardware authenticator. This library supports both macOS and Windows operating systems.</Description>
     <PackageIcon>yubico-circle-y-mark.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <PackageReleaseNotes>https://github.com/Yubico/Yubico.NET.SDK/releases/latest</PackageReleaseNotes>
+    <PackageTags>yubikey;security;authentication;multifactor;mfa;twofactor;cryptography;hardware-token;fido;fido2;u2f;security-key;passwordless;smartcard;pki;usb-security</PackageTags>
+
+    <!-- Debug Symbols !-->
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <PackageReleaseNotes>https://github.com/Yubico/Yubico.NET.SDK/releases/latest</PackageReleaseNotes>
+    
     <!-- StrongName signing -->
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Yubico.NET.SDK.snk</AssemblyOriginatorKeyFile>

--- a/build/Attribution.props
+++ b/build/Attribution.props
@@ -22,6 +22,7 @@ Sets repository-wide attribution settings such as Authors, Company, and copyrigh
   <PropertyGroup Label="Common attribution properties">
     <Authors>Yubico AB</Authors>
     <Company>Yubico AB</Company>
+    <Copyright>Copyright (c) Yubico $([System.DateTime]::Now.Year)</Copyright>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request introduces updates to NuGet package metadata and repository-wide attribution settings to improve clarity, consistency, and compliance. The most important changes include adding `PackageId` and `PackageTags` fields to `.csproj` files, updating the copyright information dynamically, and reorganizing metadata for better readability.

### NuGet Package Metadata Updates:
* `Yubico.Core.csproj` and `Yubico.YubiKey.csproj`: Added `PackageId` and `PackageTags` fields to enhance discoverability and consistency. The `PackageReleaseNotes` field was also reorganized for clarity. [[1]](diffhunk://#diff-47e13a32c0efadc4c63d3a708cf61bfd5175a662505f579f339ec326db947650L40-L49) [[2]](diffhunk://#diff-4e65a88c8f86e709a46c7dbbb5deea46b805c016191a13a541012be5d527f129L39-R51)

### Repository-Wide Attribution Updates:
* [`build/Attribution.props`](diffhunk://#diff-b08d7d61928666411174e0884af633f1271ec36ceb07b91cf87af2d401a19937R25): Added a dynamic copyright property that updates the year automatically based on the current date.