### PR TITLE
docs: improvements to slot access codes how-to

### DIFF
--- a/docs/users-manual/application-otp/how-to-slot-access-codes.md
+++ b/docs/users-manual/application-otp/how-to-slot-access-codes.md
@@ -38,7 +38,7 @@ Access codes can only be set, modified, or removed during one of the following s
 - [ConfigureStaticPassword()](xref:Yubico.YubiKey.Otp.OtpSession.ConfigureStaticPassword%28Yubico.YubiKey.Otp.Slot%29)
 - [UpdateSlot()](xref:Yubico.YubiKey.Otp.OtpSession.UpdateSlot%28Yubico.YubiKey.Otp.Slot%29)
 
-Therefore, the **only** way to modify a slot access code that doesn't result in the reconfiguration of the slot's current cryptographic credential is to use ``UpdateSlot()``. However, calling ``UpdateSlot()`` will revert a number of other slot settings (such as ``SetAppendCarriageReturn()``) to their default states unless otherwise specified during the operation. See [How to update slot settings](xref:OtpUpdateSlot) for more information.
+Of these options, the **only** method that allows you to configure a slot access code without changing the slot's current cryptographic credential is ``UpdateSlot()``. However, calling ``UpdateSlot()`` will revert a number of other slot settings (such as ``SetAppendCarriageReturn()``) to their default states unless otherwise specified during the operation. See [How to update slot settings](xref:OtpUpdateSlot) for more information.
 
 > [!NOTE]
 > If a slot is configured with an access code,

--- a/docs/users-manual/toc.yml
+++ b/docs/users-manual/toc.yml
@@ -115,7 +115,7 @@
               href: application-otp/how-to-delete-a-slot-configuration.md
             - name: How to swap slot configurations
               href: application-otp/how-to-swap-slot-configs.md
-            - name: How to set, reset, remove, and use slot access codes
+            - name: How to set, modify, remove, and use slot access codes
               href: application-otp/how-to-slot-access-codes.md
         - name: OTP commands and APDUs
           href: application-otp/otp-commands.md


### PR DESCRIPTION
# Description

Clarifies documentation on slot access code properties and improves examples. Takes the edits proposed in [PR #263 ](https://github.com/Yubico/Yubico.NET.SDK/pull/263) a step further. 


## How has this been tested?

Local docs build
