### PR TITLE
feat: Add ToString override to CommandApdu and ResponseApdu

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Iso7816/CommandApdu.cs
+++ b/Yubico.Core/src/Yubico/Core/Iso7816/CommandApdu.cs
@@ -327,5 +327,7 @@ namespace Yubico.Core.Iso7816
 
             return leField;
         }
+
+        public override string ToString() => $"CLA: 0x{Cla:X2} INS: 0x{Ins:X2} P1: 0x{P1:X2} P2: 0x{P2:X2} Lc: {Nc} Le: {Ne} Data: {Data.Length} bytes";
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Iso7816/ResponseApdu.cs
+++ b/Yubico.Core/src/Yubico/Core/Iso7816/ResponseApdu.cs
@@ -85,5 +85,7 @@ namespace Yubico.Core.Iso7816
             SW2 = (byte)(sw & 0xFF);
             Data = dataWithoutSW.ToArray();
         }
+
+        public override string ToString() => $"SW1: 0x{SW1:X2} SW2: 0x{SW2:X2} Data: {Data.Span.Length} bytes";
     }
 }


### PR DESCRIPTION
This pull request introduces `ToString` overrides in the `CommandApdu` and `ResponseApdu` classes to provide a human-readable string representation of their internal state. These changes improve debugging and logging capabilities.

Enhancements to debugging and logging:

* [`Yubico.Core/src/Yubico/Core/Iso7816/CommandApdu.cs`](diffhunk://#diff-7c42c1f871dc1569e72d212077e7ce60a37bb0ba4efcc452ca942d313b182c9eR330-R331): Added a `ToString` override to display the `CLA`, `INS`, `P1`, `P2`, `Lc`, `Le`, and the length of the `Data` field in a formatted string.
* [`Yubico.Core/src/Yubico/Core/Iso7816/ResponseApdu.cs`](diffhunk://#diff-6acb0ca020bc7ba94a8d7757ad361275d68156e653ae16aaa655a0916e85325eR88-R89): Added a `ToString` override to display the `SW1`, `SW2`, and the length of the `Data` field in a formatted string.