### PR TITLE
fix: Correct logger for OtpSession

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
@@ -14,9 +14,7 @@
 
 using System;
 using System.Globalization;
-using Microsoft.Extensions.Logging;
 using Yubico.Core.Logging;
-using Yubico.YubiKey.InterIndustry.Commands;
 using Yubico.YubiKey.Oath.Commands;
 using Yubico.YubiKey.Scp;
 
@@ -83,7 +81,7 @@ namespace Yubico.YubiKey.Oath
             : base(Log.GetLogger<OathSession>(), yubiKey, YubiKeyApplication.Oath, keyParameters)
         {
 
-            if (!(Connection.SelectApplicationData is OathApplicationData data))
+            if (Connection.SelectApplicationData is not OathApplicationData data)
             {
                 throw new InvalidOperationException(nameof(Connection.SelectApplicationData));
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
@@ -77,7 +77,7 @@ namespace Yubico.YubiKey.Otp
         /// <param name="keyParameters">An instance of <see cref="Scp03KeyParameters"/> containing the
         /// parameters for the SCP03 key. If <see langword="null"/>, the default parameters will be used. </param>
         public OtpSession(IYubiKeyDevice yubiKey, ScpKeyParameters? keyParameters = null)
-            : base(Log.GetLogger<OathSession>(), yubiKey, YubiKeyApplication.Otp, keyParameters)
+            : base(Log.GetLogger<OtpSession>(), yubiKey, YubiKeyApplication.Otp, keyParameters)
         {
             // Getting the OTP status allows the user to read the OTP status on the OtpSession object.
             _otpStatus = Connection.SendCommand(new ReadStatusCommand()).GetData();


### PR DESCRIPTION
This pull request makes several updates to the YubiKey SDK, focusing on improving code clarity and correctness. The changes include removing unused imports, modernizing syntax, and fixing a logging issue in the `OtpSession` class.

Code cleanup:

* [`Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs`](diffhunk://#diff-b49ba524772669f37d78cdb9d41d860c782c004475ab0dc1b72795b75a474cecL17-L19): Removed unused imports, including `Microsoft.Extensions.Logging` and `Yubico.YubiKey.InterIndustry.Commands`, to streamline the file.

Syntax modernization:

* [`Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs`](diffhunk://#diff-b49ba524772669f37d78cdb9d41d860c782c004475ab0dc1b72795b75a474cecL86-R84): Updated the conditional check to use the modern `is not` syntax for better readability and alignment with C# 9.0 features.

Bug fix:

* [`Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs`](diffhunk://#diff-32eb0e3e5f7f96c5745fd6e38f0f63c0d6dd41bf25f5762165608bb6ab858bcdL80-R80): Corrected the logger initialization to use `OtpSession` instead of `OathSession`, ensuring accurate logging context for the OTP session.