### PR TITLE
build: Prevent prerelease dependencies from being referenced 

### DIFF
--- a/.github/workflows/build-pull-requests.yml
+++ b/.github/workflows/build-pull-requests.yml
@@ -52,7 +52,8 @@ jobs:
         with:
           global-json-file: global.json
 
-      - name: Add local NuGet repository
+      # Add local NuGet repository so that we can use internal pre-release versions
+      - name: Add local NuGet repository for prerelease versions
         run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
       - name: Build Yubico.NET.SDK.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
       # Build the project
       - name: Build Yubico.NET.SDK.sln
-        run: dotnet pack --configuration Release --nologo --verbosity minimal Yubico.NET.SDK.sln
+        run: dotnet pack --configuration Release --nologo --verbosity minimal --treatWarningsAsErrors Yubico.NET.SDK.sln 
 
       # Build the documentation
       - name: Build docs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,13 +86,12 @@ jobs:
         if: ${{ github.event.inputs.version && (contains(github.event.inputs.version, 'prerelease') || contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'beta') || contains(github.event.inputs.version, 'rc')) }}
         run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
-      - name: Modify version for internal builds
-        if: ${{ github.event.inputs.push-to-dev == 'true' }}
+      - name: Set build version
+        if: ${{ github.event.inputs.version }}
         run: |
           $file = gci ./build/Versions.props
           $versionProp = [xml](gc $file.FullName)
-          $versionProp.Project.PropertyGroup.YubicoCoreVersion = "${{ github.event.inputs.version }}"
-          $versionProp.Project.PropertyGroup.YubicoYubiKeyVersion = "${{ github.event.inputs.version }}"
+          $versionProp.Project.PropertyGroup.CommonVersion = "${{ github.event.inputs.version }}"
           $versionProp.Save($file.FullName)
 
       # Build the project

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,10 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: "./global.json"
-      - name: Add local NuGet repository
+
+      # Add local NuGet repository so that we can use internal pre-release versions
+      - name: Add local NuGet repository for prerelease versions
+        if: ${{ github.event.inputs.version && (contains(github.event.inputs.version, 'prerelease') || contains(github.event.inputs.version, 'alpha') || contains(github.event.inputs.version, 'beta') || contains(github.event.inputs.version, 'rc')) }}
         run: dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
       - name: Modify version for internal builds

--- a/build/sign.ps1
+++ b/build/sign.ps1
@@ -202,8 +202,8 @@ function Process-ZipPackage {
         Get-ChildItem -Path $extractPath -Recurse -Filter "*.nuspec" |
         ForEach-Object { 
             Write-Host "        📥 Packing: $($_.Name)"
-            $output = & $NuGetPath pack $_.FullName -OutputDirectory $Directories.Packages 2>&1
-            
+            $output = & $NuGetPath pack $_.FullName -OutputDirectory $Directories.Packages -p TreatWarningsAsErrors=true 2>&1
+
             if ($LASTEXITCODE -ne 0) {
                 $output | ForEach-Object { Write-Host $_ }
                 throw "Packing failed for file: $($_.FullName)"


### PR DESCRIPTION
This PR closes #280 by preventing prerelease versions of Yubico-packages from ever being referenced into a published NuGet-package.

Depending on the order of the builds necessary (Yubico.NativeShims, Yubico.SDK.NET.sln), along with using the wildcard references to Yubico.NativeShims in Yubico.Core.csproj, a situation could occur that would result in the `dotnet pack` command in `.github/workflows/build.yml` would resolve the latest prerelease instead of the latest stable release.

This PR prevents publishing of such packages, at the build, and sign level of the packages, by only including the internal nuget sources (which contain internal release builds) on prerelease builds, as well treating warnings as errors in the sign step. This will throw the error to the developer and the build/sign/publish-flow cannot proceed.

Below is a summary of the most important changes:

### Workflow Enhancements

* Updated `.github/workflows/build-pull-requests.yml` to include a comment and rename the step for adding a local NuGet repository to clarify its purpose for internal pre-release versions.
* Enhanced `.github/workflows/build.yml` to conditionally add a local NuGet repository based on the presence of pre-release version identifiers (`prerelease`, `alpha`, `beta`, `rc`) in the input version. This ensures pre-release builds are handled appropriately.

### Version Handling

* Standardized version property updates in `.github/workflows/build.yml` by replacing individual version updates (`YubicoCoreVersion`, `YubicoYubiKeyVersion`) with a unified `CommonVersion` property.

### Build Quality

* Modified both `.github/workflows/build.yml` and `build/sign.ps1` to treat warnings as errors during the build and packaging processes by adding the `--treatWarningsAsErrors` and `-p TreatWarningsAsErrors=true` flags, respectively. This enforces stricter quality checks. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L83-R99) [[2]](diffhunk://#diff-f5c2bb46eb85eb5dd40a8d2b518631f38499af1df2fdbc85550c5ced617b40fdL205-R205)