### PR TITLE
fix(ci): Fix dotnet pack syntax

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
 
       # Build the project
       - name: Build Yubico.NET.SDK.sln
-        run: dotnet pack --configuration Release --nologo --verbosity minimal --treatWarningsAsErrors Yubico.NET.SDK.sln 
+        run: dotnet pack --configuration Release --nologo --verbosity minimal -p:treatWarningsAsErrors=true Yubico.NET.SDK.sln 
 
       # Build the documentation
       - name: Build docs


### PR DESCRIPTION
Fixes dotnet pack syntax

[`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L99-R99): Updated the `dotnet pack` command to use `-p:treatWarningsAsErrors=true`