### PR TITLE
docs: updated GitHub repo links to point to HEAD branch

### DIFF
--- a/docs/users-manual/application-piv/private-keys.md
+++ b/docs/users-manual/application-piv/private-keys.md
@@ -273,8 +273,8 @@ catch (ArgumentException ex)
 - [RFC 5208](https://tools.ietf.org/html/rfc5208) - PKCS#8 Private Key format
 - [RFC 7748](https://tools.ietf.org/html/rfc7748) - Curve25519 and Curve448
 - [RFC 7468](https://tools.ietf.org/html/rfc7468) - PEM encoding
-- [SDK PIV integration tests](https://github.com/Yubico/Yubico.NET.SDK/tree/main/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv)
+- [SDK PIV integration tests](https://github.com/Yubico/Yubico.NET.SDK/tree/HEAD/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv)
 - SDK unit tests for additional usage examples
-  - [Curve25519PrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PrivateKeyTests.cs)
-  - [ECPrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPrivateKeyTests.cs)
-  - [RSAPrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPrivateKeyTests.cs)
+  - [Curve25519PrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PrivateKeyTests.cs)
+  - [ECPrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPrivateKeyTests.cs)
+  - [RSAPrivateKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPrivateKeyTests.cs)

--- a/docs/users-manual/application-piv/public-keys.md
+++ b/docs/users-manual/application-piv/public-keys.md
@@ -241,8 +241,8 @@ catch (CryptographicException ex)
 - [RFC 5280](https://tools.ietf.org/html/rfc5280) - SubjectPublicKeyInfo format
 - [RFC 7468](https://tools.ietf.org/html/rfc7468) - PEM encoding
 - [RFC 7748](https://tools.ietf.org/html/rfc7748) - Curve25519 and Curve448
-- [SDK PIV integration tests](https://github.com/Yubico/Yubico.NET.SDK/tree/main/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv)
+- [SDK PIV integration tests](https://github.com/Yubico/Yubico.NET.SDK/tree/HEAD/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Piv)
 - SDK unit tests for additional usage examples:
-  - [Curve25519PublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/develop/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PublicKeyTests.cs)
-  - [ECPublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/develop/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs)
-  - [RSAPublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/develop/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPublicKeyTests.cs)
+  - [Curve25519PublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/Curve25519PublicKeyTests.cs)
+  - [ECPublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ECPublicKeyTests.cs)
+  - [RSAPublicKeyTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/RSAPublicKeyTests.cs)

--- a/docs/users-manual/sdk-programming-guide/pin-complexity-policy.md
+++ b/docs/users-manual/sdk-programming-guide/pin-complexity-policy.md
@@ -72,4 +72,4 @@ PIN complexity violations are reported for following FIDO2 operations:
 
 ### Example code
 
-For code samples demonstrating how to handle PIN complexity violations, see the [PivSampleCode](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs), [Fido2SampleCode](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/examples/Fido2SampleCode/KeyCollector/Fido2SampleKeyCollector.cs), and [PinComplexityTests](https://github.com/Yubico/Yubico.NET.SDK/blob/main/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs) integration tests.
+For code samples demonstrating how to handle PIN complexity violations, see the [PivSampleCode](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/examples/PivSampleCode/KeyCollector/SampleKeyCollector.cs), [Fido2SampleCode](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/examples/Fido2SampleCode/KeyCollector/Fido2SampleKeyCollector.cs), and [PinComplexityTests](https://github.com/Yubico/Yubico.NET.SDK/blob/HEAD/Yubico.YubiKey/tests/integration/Yubico/YubiKey/PinComplexityTests.cs) integration tests.


### PR DESCRIPTION
# Description

Updated remainder of .NET SDK GitHub repo links in documentation to point to `HEAD` branch instead of `develop` or `main`. 
