### PR TITLE
Dennisdyallo/1.14 fixes

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/ApplicationSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/ApplicationSession.cs
@@ -30,9 +30,13 @@ namespace Yubico.YubiKey
     {
         /// <summary>
         /// The object that represents the connection to the YubiKey. Most
-        /// applications will ignore this, but it can be used to call Commands
+        /// applications will ignore this, but it can be used to issue commands
         /// directly.
         /// </summary>
+        /// <remarks> This property gives you direct access to the existing connection to the YubiKey using the
+        /// <see cref="IYubiKeyConnection"/> interface. To send your own commands, call the
+        /// <see cref="IYubiKeyConnection.SendCommand{TResponse}"/>
+        /// </remarks>
         public IYubiKeyConnection Connection { get; protected set; }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementCommand.cs
@@ -159,15 +159,11 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <param name="authProtocol">
         /// The Auth Protocol used to build the Auth Token.
         /// </param>
-        /// <param name="decryptAuthToken">If true, the <c>pinUvAuthToken</c> is assumed encrypted,
-        /// and thus the SDK will attempt to decrypt it before passing it to the YubiKey.
-        /// If false, no decryption will be attempted.</param>
         public CredentialManagementCommand(
             int subCommand,
             byte[]? subCommandParams,
             ReadOnlyMemory<byte> pinUvAuthToken,
-            PinUvAuthProtocolBase authProtocol,
-            bool decryptAuthToken = true)
+            PinUvAuthProtocolBase authProtocol)
         {
             if (authProtocol is null)
             {
@@ -189,9 +185,7 @@ namespace Yubico.YubiKey.Fido2.Commands
 
             // The pinUvAuthToken is an encrypted value, so there's no need to
             // overwrite the array.
-            byte[] authParam = decryptAuthToken
-                ? authProtocol.AuthenticateUsingPinToken(pinUvAuthToken.ToArray(), message)
-                : authProtocol.Authenticate(pinUvAuthToken.ToArray(), message);
+            byte[] authParam = authProtocol.AuthenticateUsingPinToken(pinUvAuthToken, message);
 
             PinUvAuthParam = authParam;
             PinUvAuthProtocol = authProtocol.Protocol;
@@ -213,6 +207,35 @@ namespace Yubico.YubiKey.Fido2.Commands
             _protocol = (int)protocol;
             PinUvAuthProtocol = null;
             PinUvAuthParam = null;
+        }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="CredentialManagementCommand"/> with a pre-computed PIN/UV auth param.
+        /// </summary>
+        /// <param name="subCommand">
+        /// The byte representing the subcommand to execute.
+        /// </param>
+        /// <param name="subCommandParams">
+        /// The parameters needed in order to execute the subcommand. Not all
+        /// subcommands have parameters, so this can be null.
+        /// </param>
+        /// <param name="pinUvAuthParam">
+        /// The pre-computed PIN/UV auth param for this command.
+        /// </param>
+        /// <param name="protocol">
+        /// The PIN/UV protocol version used to compute the auth param.
+        /// </param>
+        public CredentialManagementCommand(
+            int subCommand,
+            byte[]? subCommandParams,
+            ReadOnlyMemory<byte> pinUvAuthParam,
+            PinUvAuthProtocol protocol)
+        {
+            SubCommand = subCommand;
+            _encodedParams = subCommandParams;
+            _protocol = (int)protocol;
+            PinUvAuthParam = pinUvAuthParam;
+            PinUvAuthProtocol = protocol;
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextCommand.cs
@@ -12,7 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
 using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Fido2.PinProtocols;
 
 namespace Yubico.YubiKey.Fido2.Commands
 {
@@ -53,6 +55,22 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </summary>
         public EnumerateCredentialsGetNextCommand()
             : base(new CredentialManagementCommand(SubCmdGetEnumerateCredsGetNext))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="EnumerateCredentialsGetNextCommand"/> with a pre-computed PIN/UV auth param.
+        /// </summary>
+        /// <param name="pinUvAuthParam">
+        ///     The pre-computed PIN/UV auth param for this command.
+        /// </param>
+        /// <param name="protocol">
+        ///     The PIN/UV protocol version used to compute the auth param.
+        /// </param>
+        public EnumerateCredentialsGetNextCommand(
+            ReadOnlyMemory<byte> pinUvAuthParam,
+            PinUvAuthProtocol protocol)
+            : base(new CredentialManagementCommand(SubCmdGetEnumerateCredsGetNext, null, pinUvAuthParam, protocol))
         {
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginCommand.cs
@@ -60,19 +60,42 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <param name="authProtocol">
         ///     The Auth Protocol used to build the Auth Token.
         /// </param>
-        /// <param name="decryptAuthToken">If true, the <c>pinUvAuthToken</c> is assumed encrypted,
-        /// and thus the SDK will attempt to decrypt it before passing it to the YubiKey.
-        /// If false, no decryption will be attempted.</param>
         public EnumerateRpsBeginCommand(
             ReadOnlyMemory<byte> pinUvAuthToken,
-            PinUvAuthProtocolBase authProtocol,
-            bool decryptAuthToken = true)
-            : base(new CredentialManagementCommand(SubCmdEnumerateRpsBegin, null, pinUvAuthToken, authProtocol, decryptAuthToken))
+            PinUvAuthProtocolBase authProtocol)
+            : base(new CredentialManagementCommand(SubCmdEnumerateRpsBegin, null, pinUvAuthToken, authProtocol))
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="EnumerateRpsBeginCommand"/> with a pre-computed PIN/UV auth param.
+        /// </summary>
+        /// <param name="pinUvAuthParam">
+        ///     The pre-computed PIN/UV auth param for this command.
+        /// </param>
+        /// <param name="protocol">
+        ///     The PIN/UV protocol version used to compute the auth param.
+        /// </param>
+        public EnumerateRpsBeginCommand(
+            ReadOnlyMemory<byte> pinUvAuthParam,
+            PinUvAuthProtocol protocol)
+            : base(new CredentialManagementCommand(SubCmdEnumerateRpsBegin, null, pinUvAuthParam, protocol))
         {
         }
 
         /// <inheritdoc />
         public EnumerateRpsBeginResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new EnumerateRpsBeginResponse(responseApdu);
+
+        /// <summary>
+        /// Creates the authentication message for this command, consisting of only the subcommand byte.
+        /// </summary>
+        /// <returns>
+        /// The message to be used for PIN/UV authentication.
+        /// </returns>
+        public static byte[] GetAuthenticationMessage()
+        {
+            return new byte[] { SubCmdEnumerateRpsBegin };
+        }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateRpsBeginResponse.cs
@@ -72,9 +72,9 @@ namespace Yubico.YubiKey.Fido2.Commands
         {
             var credentialManagementData = _response.GetData();
 
-            if (!(credentialManagementData.RelyingParty is null)
-                && !(credentialManagementData.RelyingPartyIdHash is null)
-                && !(credentialManagementData.TotalRelyingPartyCount is null))
+            if (credentialManagementData.RelyingParty is not null
+                && credentialManagementData.RelyingPartyIdHash is not null
+                && credentialManagementData.TotalRelyingPartyCount is not null)
             {
                 if (credentialManagementData.RelyingParty.IsMatchingRelyingPartyId(credentialManagementData.RelyingPartyIdHash.Value))
                 {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetCredentialMetadataCommand.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/GetCredentialMetadataCommand.cs
@@ -51,26 +51,48 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <param name="authProtocol">
         /// The Auth Protocol used to build the Auth Token.
         /// </param>
-        /// <param name="decryptAuthToken">If true, the <c>pinUvAuthToken</c> is assumed encrypted,
-        /// and thus the SDK will attempt to decrypt it before passing it to the YubiKey.
-        /// If false, no decryption will be attempted.</param>
         public GetCredentialMetadataCommand(
             ReadOnlyMemory<byte> pinUvAuthToken,
-            PinUvAuthProtocolBase authProtocol,
-            bool decryptAuthToken = true)
+            PinUvAuthProtocolBase authProtocol)
             : base(
                 new CredentialManagementCommand(
                     SubCmdGetMetadata,
                     null,
                     pinUvAuthToken,
-                    authProtocol,
-                    decryptAuthToken))
+                    authProtocol))
         {
-            
+
+        }
+
+        /// <summary>
+        /// Constructs a new instance of <see cref="GetCredentialMetadataCommand"/> with a pre-computed PIN/UV auth param.
+        /// </summary>
+        /// <param name="pinUvAuthParam">
+        ///     The pre-computed PIN/UV auth param for this command.
+        /// </param>
+        /// <param name="protocol">
+        ///     The PIN/UV protocol version used to compute the auth param.
+        /// </param>
+        public GetCredentialMetadataCommand(
+            ReadOnlyMemory<byte> pinUvAuthParam,
+            PinUvAuthProtocol protocol)
+            : base(new CredentialManagementCommand(SubCmdGetMetadata, null, pinUvAuthParam, protocol))
+        {
         }
 
         /// <inheritdoc />
         public GetCredentialMetadataResponse CreateResponseForApdu(ResponseApdu responseApdu) =>
             new GetCredentialMetadataResponse(responseApdu);
+
+        /// <summary>
+        /// Creates the authentication message for this command, consisting of only the subcommand byte.
+        /// </summary>
+        /// <returns>
+        /// The message to be used for PIN/UV authentication.
+        /// </returns>
+        public static byte[] GetAuthenticationMessage()
+        {
+            return new byte[] { SubCmdGetMetadata };
+        }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.BioEnrollment.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.BioEnrollment.cs
@@ -41,7 +41,7 @@ namespace Yubico.YubiKey.Fido2
         /// </returns>
         public BioModality GetBioModality()
         {
-            _log.LogInformation("Get BioModality.");
+            Logger.LogInformation("Get BioModality.");
 
             var cmd = new GetBioModalityCommand();
             var response = Connection.SendCommand(cmd);
@@ -73,7 +73,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public FingerprintSensorInfo GetFingerprintSensorInfo()
         {
-            _log.LogInformation("Get fingerprint sensor info.");
+            Logger.LogInformation("Get fingerprint sensor info.");
 
             var cmd = new GetFingerprintSensorInfoCommand();
             var rsp = Connection.SendCommand(cmd);
@@ -229,7 +229,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public TemplateInfo EnrollFingerprint(string? friendlyName, int? timeoutMilliseconds)
         {
-            _log.LogInformation("Try to enroll a fingerprint.");
+            Logger.LogInformation("Try to enroll a fingerprint.");
 
             var keyCollector = EnsureKeyCollector();
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Config.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Config.cs
@@ -70,7 +70,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public bool TryEnableEnterpriseAttestation()
         {
-            _log.LogInformation("Try to EnableEnterpriseAttestation.");
+            Logger.LogInformation("Try to EnableEnterpriseAttestation.");
 
             var epValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.ep);
 
@@ -162,7 +162,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public bool TryToggleAlwaysUv()
         {
-            _log.LogInformation("Try to ToggleAlwaysUv.");
+            Logger.LogInformation("Try to ToggleAlwaysUv.");
 
             var alwaysUvValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.alwaysUv);
             if (alwaysUvValue != OptionValue.True && alwaysUvValue != OptionValue.False)
@@ -322,7 +322,7 @@ namespace Yubico.YubiKey.Fido2
             IReadOnlyList<string>? relyingPartyIds = null,
             bool? forceChangePin = null)
         {
-            _log.LogInformation("Try to set the PIN config (setMinPINLength).");
+            Logger.LogInformation("Try to set the PIN config (setMinPINLength).");
 
             var setMinPinValue = AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.setMinPINLength);
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
@@ -189,7 +189,6 @@ namespace Yubico.YubiKey.Fido2
 
             byte[] message = EnumerateRpsBeginCommand.GetAuthenticationMessage();
             byte[] authParam = AuthProtocol.Authenticate(currentToken.Value, message);
-
             var command = new EnumerateRpsBeginCommand(authParam, AuthProtocol.Protocol)
             {
                 IsPreview = isPreview

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Security.Cryptography;
 using Microsoft.Extensions.Logging;
 using Yubico.YubiKey.Fido2.Commands;
 
@@ -103,20 +104,20 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public (int discoverableCredentialCount, int remainingCredentialCount) GetCredentialMetadata()
         {
-            _log.LogInformation("Get credential metadata.");
+            Logger.LogInformation("Get credential metadata.");
+
+            using var currentToken = GetPreferredCredMgmtToken();
+
+            byte[] message = GetCredentialMetadataCommand.GetAuthenticationMessage();
+            byte[] authParam = AuthProtocol.Authenticate(currentToken.Value, message);
 
             bool isPreview = CredMgmtGetIsPreview();
-            var currentToken = GetPreferredCredMgmtToken();
-            var command = new GetCredentialMetadataCommand(currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+            var command = new GetCredentialMetadataCommand(authParam, AuthProtocol.Protocol)
             {
                 IsPreview = isPreview
             };
 
             var response = Connection.SendCommand(command);
-
-            // If the error is PinAuthInvalid, try again.
-            // If the result is not PinAuthInvalid, we know we're not going
-            // to try again, error or no error.
             if (response.CtapStatus == CtapStatus.PinAuthInvalid)
             {
                 var savePermissions = AuthTokenPermissions;
@@ -125,8 +126,10 @@ namespace Yubico.YubiKey.Fido2
                 AuthTokenRelyingPartyId = null;
                 try
                 {
-                    currentToken = GetPreferredCredMgmtToken(requestNewToken: true);
-                    command = new GetCredentialMetadataCommand(currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+                    using var nextToken = GetPreferredCredMgmtToken(requestNewToken: true);
+
+                    authParam = AuthProtocol.Authenticate(nextToken.Value, message);
+                    command = new GetCredentialMetadataCommand(authParam, AuthProtocol.Protocol)
                     {
                         IsPreview = isPreview
                     };
@@ -140,9 +143,6 @@ namespace Yubico.YubiKey.Fido2
                 }
             }
 
-            // This will return the data or throw an exception. We either have
-            // the data, have an error other than PinAuthInvalid, or we do have
-            // the error PinAuthInvalid but only after trying twice.
             return response.GetData();
         }
 
@@ -182,11 +182,15 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public IReadOnlyList<RelyingParty> EnumerateRelyingParties()
         {
-            _log.LogInformation("Enumerate relying parties.");
+            Logger.LogInformation("Enumerate relying parties.");
 
             bool isPreview = CredMgmtGetIsPreview();
-            var currentToken = GetPreferredCredMgmtToken();
-            var command = new EnumerateRpsBeginCommand(currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+            using var currentToken = GetPreferredCredMgmtToken();
+
+            byte[] message = EnumerateRpsBeginCommand.GetAuthenticationMessage();
+            byte[] authParam = AuthProtocol.Authenticate(currentToken.Value, message);
+
+            var command = new EnumerateRpsBeginCommand(authParam, AuthProtocol.Protocol)
             {
                 IsPreview = isPreview
             };
@@ -200,8 +204,10 @@ namespace Yubico.YubiKey.Fido2
                 AuthTokenRelyingPartyId = null;
                 try
                 {
-                    currentToken = GetPreferredCredMgmtToken(requestNewToken: true);
-                    command = new EnumerateRpsBeginCommand(currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+                    using var nextToken = GetPreferredCredMgmtToken(requestNewToken: true);
+
+                    authParam = AuthProtocol.Authenticate(nextToken.Value, message);    
+                    command = new EnumerateRpsBeginCommand(authParam, AuthProtocol.Protocol)
                     {
                         IsPreview = isPreview
                     };
@@ -290,12 +296,14 @@ namespace Yubico.YubiKey.Fido2
                 throw new ArgumentNullException(nameof(relyingParty));
             }
 
-            _log.LogInformation("Enumerate credentials for relying party: " + relyingParty.Id + ".");
+            Logger.LogInformation("Enumerate credentials for relying party: " + relyingParty.Id + ".");
 
+            using var currentToken = GetPreferredCredMgmtToken();
+
+            byte[] message = EnumerateCredentialsBeginCommand.GetAuthenticationMessage(relyingParty);
+            byte[] authParam = AuthProtocol.Authenticate(currentToken.Value, message);
             bool isPreview = CredMgmtGetIsPreview();
-            var currentToken = GetPreferredCredMgmtToken();
-            var command = new EnumerateCredentialsBeginCommand(
-                relyingParty, currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+            var command = new EnumerateCredentialsBeginCommand(relyingParty, authParam, AuthProtocol.Protocol)
             {
                 IsPreview = isPreview
             };
@@ -308,9 +316,11 @@ namespace Yubico.YubiKey.Fido2
                     AuthTokenRelyingPartyId = relyingParty.Id;
                 }
 
-                currentToken = GetPreferredCredMgmtToken(requestNewToken: true);
+                using var nextToken = GetPreferredCredMgmtToken(requestNewToken: true);
+
+                authParam = AuthProtocol.Authenticate(nextToken.Value, message);
                 command = new EnumerateCredentialsBeginCommand(
-                    relyingParty, currentToken.Value, AuthProtocol, decryptAuthToken: currentToken.IsEncrypted)
+                    relyingParty, authParam, AuthProtocol.Protocol)
                 {
                     IsPreview = isPreview
                 };
@@ -380,13 +390,12 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public void DeleteCredential(CredentialId credentialId)
         {
-            _log.LogInformation("Delete credential.");
-
-            bool isPreview = CredMgmtGetIsPreview();
+            Logger.LogInformation("Delete credential.");
 
             var currentToken = GetAuthToken(
                 false, PinUvAuthTokenPermissions.CredentialManagement, null);
 
+            bool isPreview = CredMgmtGetIsPreview();
             var command = new DeleteCredentialCommand(credentialId, currentToken, AuthProtocol)
             {
                 IsPreview = isPreview
@@ -461,7 +470,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public void UpdateUserInfoForCredential(CredentialId credentialId, UserEntity newUserInfo)
         {
-            _log.LogInformation("Update user information.");
+            Logger.LogInformation("Update user information.");
 
             var currentToken = GetAuthToken(false, PinUvAuthTokenPermissions.CredentialManagement, null);
 
@@ -529,17 +538,20 @@ namespace Yubico.YubiKey.Fido2
             var readOnlyToken = GetReadOnlyCredMgmtToken(requestNewToken);
             if (readOnlyToken is not null)
             {
-                return new AuthToken(readOnlyToken.Value, PinUvAuthTokenPermissions.PersistentCredentialManagementReadOnly, false, null);
+                return new AuthToken(readOnlyToken.Value, PinUvAuthTokenPermissions.PersistentCredentialManagementReadOnly, null);
             }
 
             var fullToken = GetAuthToken(requestNewToken, PinUvAuthTokenPermissions.CredentialManagement, null);
-            return new AuthToken(fullToken, PinUvAuthTokenPermissions.CredentialManagement, true, null);
+            return new AuthToken(AuthProtocol.Decrypt(fullToken), PinUvAuthTokenPermissions.CredentialManagement, null);
         }
 
-        // This is only supported on YubiKeys that support the encIdentifier (v5.8.0 and later).
-        // If the YubiKey does not support it, this will always return null.
         private ReadOnlyMemory<byte>? GetReadOnlyCredMgmtToken(bool requestNewToken = false)
         {
+            if (!YubiKey.HasFeature(YubiKeyFeature.FidoCtap22))
+            {
+                return null;
+            }
+
             if (AuthTokenPersistent is not null && !requestNewToken)
             {
                 return AuthTokenPersistent;
@@ -557,6 +569,28 @@ namespace Yubico.YubiKey.Fido2
             return AuthTokenPersistent;
         }
     }
-    internal readonly record struct AuthToken(ReadOnlyMemory<byte> Value, PinUvAuthTokenPermissions Permissions, bool IsEncrypted, string? RelyingPartyId);
+    internal sealed class AuthToken(
+        ReadOnlyMemory<byte> value,
+        PinUvAuthTokenPermissions permissions,
+        string? relyingPartyId) : IDisposable
+    {
+        private readonly Memory<byte> _value = value.ToArray();
+        private bool _disposed;
+
+        public PinUvAuthTokenPermissions Permissions { get; } = permissions;
+        public string? RelyingPartyId { get; } = relyingPartyId;
+        public ReadOnlyMemory<byte> Value => _disposed ? ReadOnlyMemory<byte>.Empty : _value;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            CryptographicOperations.ZeroMemory(_value.Span);
+            _disposed = true;
+        }
+    }
 }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.GetAssertion.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.GetAssertion.cs
@@ -92,7 +92,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public IReadOnlyList<GetAssertionData> GetAssertions(GetAssertionParameters parameters)
         {
-            _log.LogInformation("Get assertions.");
+            Logger.LogInformation("Get assertions.");
 
             if (parameters is null)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.LargeBlobs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.LargeBlobs.cs
@@ -107,7 +107,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public SerializedLargeBlobArray GetSerializedLargeBlobArray()
         {
-            _log.LogInformation("Get the current large blob array.");
+            Logger.LogInformation("Get the current large blob array.");
 
             // Does the YubiKey support Large Blobs?
             if (AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.largeBlobs) != OptionValue.True)
@@ -221,7 +221,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public void SetSerializedLargeBlobArray(SerializedLargeBlobArray serializedLargeBlobArray)
         {
-            _log.LogInformation("Set the YubiKey with a new large blob array.");
+            Logger.LogInformation("Set the YubiKey with a new large blob array.");
 
             if (serializedLargeBlobArray is null)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.MakeCredential.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.MakeCredential.cs
@@ -86,7 +86,7 @@ namespace Yubico.YubiKey.Fido2
         /// </exception>
         public MakeCredentialData MakeCredential(MakeCredentialParameters parameters)
         {
-            _log.LogInformation("Make credential.");
+            Logger.LogInformation("Make credential.");
 
             if (parameters is null)
             {

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
@@ -14,6 +14,7 @@
 
 using System;
 using System.Security.Cryptography;
+using CommunityToolkit.Diagnostics;
 using Microsoft.Extensions.Logging;
 using Yubico.Core.Logging;
 using Yubico.YubiKey.Fido2.Commands;
@@ -65,42 +66,9 @@ namespace Yubico.YubiKey.Fido2
     /// and ultimately release the connection to the YubiKey.
     /// </para>
     /// </remarks>
-    public sealed partial class Fido2Session : IDisposable
+    public sealed partial class Fido2Session : ApplicationSession
     {
-        private readonly ILogger _log = Log.GetLogger<Fido2Session>();
-        private bool _disposed;
         private AuthenticatorInfo? _authenticatorInfo;
-
-        /// <summary>
-        /// The object that represents the connection to the YubiKey. Most applications can ignore this, but it can be
-        /// used to call command classes and send APDUs directly to the YubiKey during advanced scenarios.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// Most common FIDO2 operations can be done using the various methods contained on the <see cref="Fido2Session"/>
-        /// class. There are some cases where you will need to issue a very specific command that is otherwise not
-        /// available to you using the session's methods.
-        /// </para>
-        /// <para>
-        /// This property gives you direct access to the existing connection to the YubiKey using the
-        /// <see cref="IYubiKeyConnection"/> interface. To send your own commands, call the
-        /// <see cref="IYubiKeyConnection.SendCommand{TResponse}"/> method like in the following example:
-        /// <example lang="C#">
-        /// var yubiKey = FindYubiKey();
-        ///
-        /// using (var fido2 = new Fido2Session(yubiKey))
-        /// {
-        ///     var command = new ClientPinCommand(){ /* Set properties to your needs */ };
-        ///
-        ///     // Sends a command to the FIDO2 application
-        ///     var response = fido2.Connection.SendCommand(command);
-        ///
-        ///     /* Read and handle the response */
-        /// }
-        /// </example>
-        /// </para>
-        /// </remarks>
-        public IYubiKeyConnection Connection { get; }
 
         /// <summary>
         /// A callback that this class will call when it needs the YubiKey
@@ -179,16 +147,10 @@ namespace Yubico.YubiKey.Fido2
             get
             {
                 var ppuat = GetReadOnlyCredMgmtToken();
-                return ppuat.HasValue 
-                    ? AuthenticatorInfo.GetIdentifier(ppuat.Value) 
+                return ppuat.HasValue
+                    ? AuthenticatorInfo.GetIdentifier(ppuat.Value)
                     : null;
             }
-        }
-
-        // The default constructor is explicitly defined to show that we do not want it used.
-        private Fido2Session()
-        {
-            throw new NotImplementedException();
         }
 
         /// <summary>
@@ -205,26 +167,24 @@ namespace Yubico.YubiKey.Fido2
         ///     }
         /// </code>
         /// </remarks>
-        /// <param name="yubiKeyDevice">
+        /// <param name="yubiKey">
         /// The object that represents the actual YubiKey on which the FIDO2 operations should be performed.
         /// </param>
         /// <param name="persistentPinUvAuthToken">If supplied, will be used for credential management read-only operations
         /// </param>
         /// <exception cref="ArgumentNullException">
-        /// The <paramref name="yubiKeyDevice"/> argument is <c>null</c>.
+        /// The <paramref name="yubiKey"/> argument is <c>null</c>.
         /// </exception>
-        public Fido2Session(IYubiKeyDevice yubiKeyDevice, ReadOnlyMemory<byte>? persistentPinUvAuthToken = null)
+        public Fido2Session(IYubiKeyDevice yubiKey, ReadOnlyMemory<byte>? persistentPinUvAuthToken = null)
+            : base(Log.GetLogger<Fido2Session>(), yubiKey, YubiKeyApplication.Fido2, keyParameters: null)
         {
-            if (yubiKeyDevice is null)
-            {
-                throw new ArgumentNullException(nameof(yubiKeyDevice));
-            }
+            Guard.IsNotNull(yubiKey, nameof(yubiKey));
 
-            _log.LogInformation(
+            Logger.LogInformation(
                 "Establishing a new FIDO2 session for YubiKey {SerialNumber}.",
-                yubiKeyDevice.SerialNumber);
+                yubiKey.SerialNumber);
 
-            Connection = yubiKeyDevice.Connect(YubiKeyApplication.Fido2);
+            // Connection = yubiKey.Connect(YubiKeyApplication.Fido2);
 
             AuthProtocol = GetPreferredPinProtocol();
             _authTokenPersistent = persistentPinUvAuthToken.HasValue
@@ -241,7 +201,7 @@ namespace Yubico.YubiKey.Fido2
         /// </returns>
         [Obsolete("The GetAuthenticatorInfo method is deprecated, please use the AuthenticatorInfo property instead.")]
         public AuthenticatorInfo GetAuthenticatorInfo() => AuthenticatorInfo;
-        
+
         private AuthenticatorInfo GetAuthenticatorInfoInternal()
         {
             var response = Connection.SendCommand(new GetInfoCommand());
@@ -256,27 +216,27 @@ namespace Yubico.YubiKey.Fido2
         private static CtapStatus GetCtapError(IYubiKeyResponse r) => (CtapStatus)(r.StatusWord & 0xFF);
 
         /// <inheritdoc />
-        public void Dispose()
+        protected override void Dispose(bool disposing)
         {
-            if (_disposed)
+            if (disposing)
             {
-                return;
+                Logger.LogInformation("Disposing of the FIDO2 session.");
+
+                if (_authTokenPersistent.HasValue)
+                {
+                    CryptographicOperations.ZeroMemory(_authTokenPersistent.Value.Span);
+                    _authTokenPersistent = null;
+                }
+
+                if (_disposeAuthProtocol)
+                {
+                    AuthProtocol.Dispose();
+                }
+
+                KeyCollector = null;
             }
 
-            Connection.Dispose();
-            if (_authTokenPersistent.HasValue)
-            {
-                CryptographicOperations.ZeroMemory(_authTokenPersistent.Value.Span);
-                _authTokenPersistent = null;
-            }
-
-            if (_disposeAuthProtocol)
-            {
-                AuthProtocol.Dispose();
-            }
-
-            KeyCollector = null;
-            _disposed = true;
+            base.Dispose(disposing);
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeature.cs
@@ -285,6 +285,11 @@ namespace Yubico.YubiKey
         /// <summary>
         /// Support for the PIV Curve25519 key type.
         /// </summary>
-        PivCurve25519
+        PivCurve25519,
+
+        /// <summary>
+        /// Support for the FIDO2 CTAP2.2 standard.
+        /// </summary>
+        FidoCtap22
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyFeatureExtensions.cs
@@ -256,6 +256,10 @@ namespace Yubico.YubiKey
                     yubiKeyDevice.FirmwareVersion >= FirmwareVersion.V4_3_4
                     && HasApplication(yubiKeyDevice, YubiKeyCapabilities.Oath),
 
+                YubiKeyFeature.FidoCtap22 =>
+                    yubiKeyDevice.FirmwareVersion >= FirmwareVersion.V5_8_0
+                    && HasApplication(yubiKeyDevice, YubiKeyCapabilities.Fido2),
+
                 _ => throw new ArgumentException(
                     string.Format(
                         CultureInfo.CurrentCulture,

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs
@@ -80,7 +80,8 @@ public class FidoSessionIntegrationTestBase : IDisposable
         {
             // Ignore errors related to non-existent credentials
         }
-
+        
+        KeyCollector.ResetRequestCounts();
     }
 
     ~FidoSessionIntegrationTestBase()

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs
@@ -14,6 +14,7 @@
 
 using System;
 using Xunit;
+using Yubico.YubiKey.Fido2.Commands;
 using Yubico.YubiKey.TestUtilities;
 
 namespace Yubico.YubiKey.Fido2;
@@ -88,7 +89,7 @@ public class FidoSessionIntegrationTestBase : IDisposable
     }
 
     protected Fido2Session GetSession(
-        StandardTestDevice deviceType = StandardTestDevice.Fw5,
+        StandardTestDevice deviceType = StandardTestDevice.Any,
         FirmwareVersion? minFw = null,
         Transport? transport = Transport.All,
         ReadOnlyMemory<byte>? persistentPinUvAuthToken = null)
@@ -122,7 +123,7 @@ public class FidoSessionIntegrationTestBase : IDisposable
                 session.TrySetPin(TestPin1);
             }
 
-            var isValid = session.TryVerifyPin(TestPin1, permissions: Commands.PinUvAuthTokenPermissions.CredentialManagement, null, out _, out _);
+            var isValid = session.TryVerifyPin(TestPin1, permissions: PinUvAuthTokenPermissions.CredentialManagement, null, out _, out _);
             Assert.True(isValid, "Pin was incorrect. Please reset the key and try again.");
 
             return session;


### PR DESCRIPTION
This pull request refactors the FIDO2 Credential Management command classes to simplify authentication handling and improve flexibility when constructing commands. The main changes remove the `decryptAuthToken` parameter from several constructors, standardize how PIN/UV authentication parameters are handled, and add new constructors for cases where the authentication parameter is pre-computed. Additionally, logging is updated to use a consistent logger, and some documentation is improved.

**FIDO2 Credential Management Command Refactoring:**

* Removed the `decryptAuthToken` parameter from constructors in `CredentialManagementCommand` and related command classes, simplifying how authentication tokens are handled. Now, authentication is always performed using the protocol's methods, and the SDK no longer conditionally decrypts tokens. [[1]](diffhunk://#diff-4a05c022b457295081ad43773d03227781c0b2a789736e43d5e8a7d657af7a98L162-R166) [[2]](diffhunk://#diff-4a05c022b457295081ad43773d03227781c0b2a789736e43d5e8a7d657af7a98L192-R188) [[3]](diffhunk://#diff-11966d898153989722b69248eb63dd2b6c8f2b68c44d632228a8eaef5d7c4b62L72-R123) [[4]](diffhunk://#diff-75a7ec693c89dfc9ad6bf2bec2966487308777d714cae5688357586e2b23f263L63-R99) [[5]](diffhunk://#diff-7a1319cf1b4624acc66fdefc14d33d19d1ce7f1f54a69a02f84b54f125a710eaL54-R96)
* Added new constructors to `CredentialManagementCommand`, `EnumerateCredentialsBeginCommand`, `EnumerateCredentialsGetNextCommand`, `EnumerateRpsBeginCommand`, and `GetCredentialMetadataCommand` to allow instantiating these commands with a pre-computed PIN/UV authentication parameter and protocol version. [[1]](diffhunk://#diff-4a05c022b457295081ad43773d03227781c0b2a789736e43d5e8a7d657af7a98R212-R240) [[2]](diffhunk://#diff-11966d898153989722b69248eb63dd2b6c8f2b68c44d632228a8eaef5d7c4b62L72-R123) [[3]](diffhunk://#diff-ccc16a10d128ca2bff3d86974cde190aed3cea3ace17e1afce304288c81971cdR61-R76) [[4]](diffhunk://#diff-75a7ec693c89dfc9ad6bf2bec2966487308777d714cae5688357586e2b23f263L63-R99) [[5]](diffhunk://#diff-7a1319cf1b4624acc66fdefc14d33d19d1ce7f1f54a69a02f84b54f125a710eaL54-R96)
* Introduced static methods like `GetAuthenticationMessage` to help callers generate the correct message to use for PIN/UV authentication for each command. [[1]](diffhunk://#diff-11966d898153989722b69248eb63dd2b6c8f2b68c44d632228a8eaef5d7c4b62L72-R123) [[2]](diffhunk://#diff-75a7ec693c89dfc9ad6bf2bec2966487308777d714cae5688357586e2b23f263L63-R99) [[3]](diffhunk://#diff-7a1319cf1b4624acc66fdefc14d33d19d1ce7f1f54a69a02f84b54f125a710eaL54-R96)

**Fido2Session and Logging Improvements:**

* Updated all logging in `Fido2Session` partial classes to use the unified `Logger` property instead of the private `_log` field, ensuring consistency in logging throughout the codebase. [[1]](diffhunk://#diff-89ebdd9b1e892f4fb0723fa55c717684da337a60be959ea3c0d98e2ec7169ce2L44-R44) [[2]](diffhunk://#diff-89ebdd9b1e892f4fb0723fa55c717684da337a60be959ea3c0d98e2ec7169ce2L76-R76) [[3]](diffhunk://#diff-89ebdd9b1e892f4fb0723fa55c717684da337a60be959ea3c0d98e2ec7169ce2L232-R232) [[4]](diffhunk://#diff-72d7c68eb8fcc0292c45636f2764c13929829f6deea0b35bd6f68c586fe7c8daL73-R73) [[5]](diffhunk://#diff-72d7c68eb8fcc0292c45636f2764c13929829f6deea0b35bd6f68c586fe7c8daL165-R165) [[6]](diffhunk://#diff-72d7c68eb8fcc0292c45636f2764c13929829f6deea0b35bd6f68c586fe7c8daL325-R325) [[7]](diffhunk://#diff-b16d8f43a4dd99adb7a4c2b6279fe424ab8af7054b07a2db8fae02af189fc75fL106-L119)
* Refactored the `GetCredentialMetadata` method in `Fido2Session.CredMgmt.cs` to use the new authentication parameter handling: it now computes the authentication parameter before constructing the command and uses the new constructor, retrying with a new token if needed. [[1]](diffhunk://#diff-b16d8f43a4dd99adb7a4c2b6279fe424ab8af7054b07a2db8fae02af189fc75fL106-L119) [[2]](diffhunk://#diff-b16d8f43a4dd99adb7a4c2b6279fe424ab8af7054b07a2db8fae02af189fc75fL128-R132) [[3]](diffhunk://#diff-b16d8f43a4dd99adb7a4c2b6279fe424ab8af7054b07a2db8fae02af189fc75fL143-L145)

**Documentation and Code Quality:**

* Improved XML documentation for properties and constructors, clarifying usage and intent, especially around authentication parameters and direct command access. [[1]](diffhunk://#diff-e84abff6b5cde33e1c49463adb5e8413239a1463cd1c6b1e603d55ec71b876f4L33-R39) [[2]](diffhunk://#diff-4a05c022b457295081ad43773d03227781c0b2a789736e43d5e8a7d657af7a98R212-R240) [[3]](diffhunk://#diff-11966d898153989722b69248eb63dd2b6c8f2b68c44d632228a8eaef5d7c4b62L72-R123) [[4]](diffhunk://#diff-75a7ec693c89dfc9ad6bf2bec2966487308777d714cae5688357586e2b23f263L63-R99) [[5]](diffhunk://#diff-7a1319cf1b4624acc66fdefc14d33d19d1ce7f1f54a69a02f84b54f125a710eaL54-R96)
* Minor code quality improvements, such as using `is not null` for null checks and adding missing using directives. [[1]](diffhunk://#diff-bd23ce494437eeade4230317868b7659de94dfe49224c2cc1ab4b760b665d059L75-R77) [[2]](diffhunk://#diff-ccc16a10d128ca2bff3d86974cde190aed3cea3ace17e1afce304288c81971cdR15-R17) [[3]](diffhunk://#diff-b16d8f43a4dd99adb7a4c2b6279fe424ab8af7054b07a2db8fae02af189fc75fR17)