### PR TITLE
refactor(build): streamline version handling in build scripts

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -38,19 +38,12 @@ jobs:
       - run: |
           echo 'Running build script: Windows'
           cd Yubico.NativeShims
-          & ./build-windows.ps1
-      - name: Set version
-        if: github.event.inputs.version
-        shell: pwsh
-        run: |
-          $version = "${{ github.event.inputs.version }}"
-          # Update CMakeLists.txt
-          (Get-Content Yubico.NativeShims/CMakeLists.txt) -replace 'project\(Yubico.NativeShims VERSION [^)]+\)', "project(Yubico.NativeShims VERSION $version)" | Set-Content Yubico.NativeShims/CMakeLists.txt
-          # Update vcpkg.json
-          $vcpkg = Get-Content Yubico.NativeShims/vcpkg.json -Raw | ConvertFrom-Json
-          $vcpkg.version = $version
-          $vcpkg | ConvertTo-Json | Set-Content Yubico.NativeShims/vcpkg.json
-          echo "Set version to $version"
+          if ("${{ github.event.inputs.version }}" -ne "") {
+            $baseVersion = "${{ github.event.inputs.version }}".Split('-')[0]
+            & ./build-windows.ps1 -Version $baseVersion
+          } else {
+            & ./build-windows.ps1
+          }
       - uses: actions/upload-artifact@v4
         with:
           name: win-x64
@@ -82,16 +75,12 @@ jobs:
       - run: |
           echo 'Running build script: Linux (amd64)'
           cd Yubico.NativeShims
-          sh ./build-linux-amd64.sh
-      - name: Set version
-        if: github.event.inputs.version
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          # Update CMakeLists.txt
-          sed -i "s/project(Yubico.NativeShims VERSION [^)]*)/project(Yubico.NativeShims VERSION $VERSION)/" Yubico.NativeShims/CMakeLists.txt
-          # Update vcpkg.json
-          jq --arg v "$VERSION" '.version = $v' Yubico.NativeShims/vcpkg.json > tmp.json && mv tmp.json Yubico.NativeShims/vcpkg.json
-          echo "Set version to $VERSION"
+          if [ ! -z "${{ github.event.inputs.version }}" ]; then
+            BASE_VERSION=$(echo "${{ github.event.inputs.version }}" | cut -d'-' -f1)
+            sh ./build-linux-amd64.sh "$BASE_VERSION"
+          else
+            sh ./build-linux-amd64.sh
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: linux-x64
@@ -105,16 +94,12 @@ jobs:
       - run: |
           echo 'Running build script: Linux (arm64)'
           cd Yubico.NativeShims
-          sh ./build-linux-arm64.sh
-      - name: Set version
-        if: github.event.inputs.version
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          # Update CMakeLists.txt
-          sed -i "s/project(Yubico.NativeShims VERSION [^)]*)/project(Yubico.NativeShims VERSION $VERSION)/" Yubico.NativeShims/CMakeLists.txt
-          # Update vcpkg.json
-          jq --arg v "$VERSION" '.version = $v' Yubico.NativeShims/vcpkg.json > tmp.json && mv tmp.json Yubico.NativeShims/vcpkg.json
-          echo "Set version to $VERSION"
+          if [ ! -z "${{ github.event.inputs.version }}" ]; then
+            BASE_VERSION=$(echo "${{ github.event.inputs.version }}" | cut -d'-' -f1)
+            sh ./build-linux-arm64.sh "$BASE_VERSION"
+          else
+            sh ./build-linux-arm64.sh
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: linux-arm64
@@ -128,16 +113,12 @@ jobs:
       - run: |
           echo 'Running build script: macOS'
           cd Yubico.NativeShims
-          sh ./build-macOS.sh
-      - name: Set version
-        if: github.event.inputs.version
-        run: |
-          VERSION=${{ github.event.inputs.version }}
-          # Update CMakeLists.txt
-          sed -i "s/project(Yubico.NativeShims VERSION [^)]*)/project(Yubico.NativeShims VERSION $VERSION)/" Yubico.NativeShims/CMakeLists.txt
-          # Update vcpkg.json
-          jq --arg v "$VERSION" '.version = $v' Yubico.NativeShims/vcpkg.json > tmp.json && mv tmp.json Yubico.NativeShims/vcpkg.json
-          echo "Set version to $VERSION"
+          if [ ! -z "${{ github.event.inputs.version }}" ]; then
+            BASE_VERSION=$(echo "${{ github.event.inputs.version }}" | cut -d'-' -f1)
+            sh ./build-macOS.sh "$BASE_VERSION"
+          else
+            sh ./build-macOS.sh
+          fi
       - uses: actions/upload-artifact@v4
         with:
           name: osx-x64

--- a/Yubico.NativeShims/CMakeLists.txt
+++ b/Yubico.NativeShims/CMakeLists.txt
@@ -1,5 +1,14 @@
 cmake_minimum_required(VERSION 3.13)
-project(Yubico.NativeShims VERSION 1.12)
+
+# Set default version if not provided via command line
+if(NOT DEFINED PROJECT_VERSION)
+    set(PROJECT_VERSION "1.14.0")
+endif()
+
+# Set VCPKG manifest version to match project version
+set(VCPKG_MANIFEST_VERSION ${PROJECT_VERSION})
+
+project(Yubico.NativeShims VERSION ${PROJECT_VERSION})
 include(CheckCCompilerFlag)
 
 if (APPLE OR UNIX)

--- a/Yubico.NativeShims/build-linux-amd64.sh
+++ b/Yubico.NativeShims/build-linux-amd64.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Get version parameter
+VERSION=$1
+
 # Set environment variables
 export VCPKG_INSTALLATION_ROOT=$GITHUB_WORKSPACE/vcpkg \
     PATH=/usr/local/bin:$PATH
@@ -43,9 +46,10 @@ rm -rf "$build_dir"
 mkdir -p "$build_dir"
 
 echo "Building for x64-linux ..."
-cmake -S . -B "$build_dir" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-    -DVCPKG_TARGET_TRIPLET=x64-linux
+CMAKE_ARGS="-S . -B $build_dir -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-linux"
+if [ ! -z "$VERSION" ]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPROJECT_VERSION=$VERSION"
+fi
+cmake $CMAKE_ARGS
 
 cmake --build "$build_dir" -- -j $(nproc)

--- a/Yubico.NativeShims/build-linux-arm64.sh
+++ b/Yubico.NativeShims/build-linux-arm64.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Get version parameter
+VERSION=$1
+
 # Set environment variables
 export VCPKG_INSTALLATION_ROOT=$GITHUB_WORKSPACE/vcpkg \
     VCPKG_FORCE_SYSTEM_BINARIES=1 \
@@ -57,11 +60,10 @@ rm -rf "$build_dir"
 mkdir -p "$build_dir"
 
 echo "Building for arm64-linux ..."
-cmake -S . -B "$build_dir" \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" \
-    -DVCPKG_TARGET_TRIPLET="arm64-linux" \
-    -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE="$(pwd)/cmake/aarch64-linux-gnu.toolchain.cmake" \
-    -DOPENSSL_ROOT_DIR=$(pwd)/linux-arm64/vcpkg_installed/arm64-linux
+CMAKE_ARGS="-S . -B $build_dir -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-linux -DVCPKG_CHAINLOAD_TOOLCHAIN_FILE=$(pwd)/cmake/aarch64-linux-gnu.toolchain.cmake -DOPENSSL_ROOT_DIR=$(pwd)/linux-arm64/vcpkg_installed/arm64-linux"
+if [ ! -z "$VERSION" ]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPROJECT_VERSION=$VERSION"
+fi
+cmake $CMAKE_ARGS
 
 cmake --build "$build_dir" -- -j $(nproc)

--- a/Yubico.NativeShims/build-macOS.sh
+++ b/Yubico.NativeShims/build-macOS.sh
@@ -1,3 +1,8 @@
+#!/bin/bash
+
+# Get version parameter
+VERSION=$1
+
 rm -rf build64 buildarm osx-arm64 osx-x64
 
 pushd $VCPKG_INSTALLATION_ROOT
@@ -5,25 +10,21 @@ git checkout master
 ./bootstrap-vcpkg.sh
 popd
 
-cmake \
-    -S . \
-    -B ./build64 \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake \
-    -DVCPKG_TARGET_TRIPLET=x64-osx \
-    -DCMAKE_OSX_ARCHITECTURES=x86_64
+CMAKE_ARGS="-S . -B ./build64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-osx -DCMAKE_OSX_ARCHITECTURES=x86_64"
+if [ ! -z "$VERSION" ]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPROJECT_VERSION=$VERSION"
+fi
+cmake $CMAKE_ARGS
 
 cmake --build ./build64
 mkdir -p osx-x64
 cp ./build64/libYubico.NativeShims.dylib ./osx-x64
 
-cmake \
-    -S . \
-    -B ./buildarm \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake \
-    -DVCPKG_TARGET_TRIPLET=arm64-osx \
-    -DCMAKE_OSX_ARCHITECTURES=arm64
+CMAKE_ARGS="-S . -B ./buildarm -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx -DCMAKE_OSX_ARCHITECTURES=arm64"
+if [ ! -z "$VERSION" ]; then
+    CMAKE_ARGS="$CMAKE_ARGS -DPROJECT_VERSION=$VERSION"
+fi
+cmake $CMAKE_ARGS
 
 cmake --build ./buildarm
 mkdir -p osx-arm64

--- a/Yubico.NativeShims/build-windows.ps1
+++ b/Yubico.NativeShims/build-windows.ps1
@@ -1,3 +1,7 @@
+param(
+    [string]$Version
+)
+
 # Update to latest vcpkg baseline
 Push-Location $env:VCPKG_INSTALLATION_ROOT
 git checkout master
@@ -5,19 +9,25 @@ git checkout master
 Pop-Location
 
 # 32-bit builds
-cmake -S . -B build32 -A Win32 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x86-windows-static
+$cmakeArgs = @("-S", ".", "-B", "build32", "-A", "Win32", "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake", "-DVCPKG_TARGET_TRIPLET=x86-windows-static")
+if ($Version) { $cmakeArgs += "-DPROJECT_VERSION=$Version" }
+cmake @cmakeArgs
 cmake --build build32 --config Release
 New-Item -ItemType Directory -Path win-x86 -Force
 Copy-Item build32\Release\Yubico.NativeShims.dll win-x86
 
 # 64-bit builds
-cmake -S . -B build64 -A x64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=x64-windows-static
+$cmakeArgs = @("-S", ".", "-B", "build64", "-A", "x64", "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake", "-DVCPKG_TARGET_TRIPLET=x64-windows-static")
+if ($Version) { $cmakeArgs += "-DPROJECT_VERSION=$Version" }
+cmake @cmakeArgs
 cmake --build build64 --config Release
 New-Item -ItemType Directory -Path win-x64 -Force
 Copy-Item build64\Release\Yubico.NativeShims.dll win-x64
 
 # ARM64 builds
-cmake -S . -B buildarm -A arm64 -DCMAKE_TOOLCHAIN_FILE="$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake" -DVCPKG_TARGET_TRIPLET=arm64-windows-static
+$cmakeArgs = @("-S", ".", "-B", "buildarm", "-A", "arm64", "-DCMAKE_TOOLCHAIN_FILE=$env:VCPKG_INSTALLATION_ROOT\scripts\buildsystems\vcpkg.cmake", "-DVCPKG_TARGET_TRIPLET=arm64-windows-static")
+if ($Version) { $cmakeArgs += "-DPROJECT_VERSION=$Version" }
+cmake @cmakeArgs
 cmake --build buildarm --config Release
 New-Item -ItemType Directory -Path win-arm64 -Force
 Copy-Item buildarm\Release\Yubico.NativeShims.dll win-arm64

--- a/Yubico.NativeShims/vcpkg.json
+++ b/Yubico.NativeShims/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "yubico-nativeshims",
-  "version": "1.13.2",
   "dependencies": [
     "openssl"
   ]


### PR DESCRIPTION
This pull request refactors the versioning process for building the `Yubico.NativeShims` project across all platforms. Instead of updating version numbers directly in the workflow scripts and project files, the version is now passed as a parameter to the build scripts and injected into the build process via CMake. This streamlines version management and reduces duplication.

**Build and Versioning Improvements:**

* Updated `CMakeLists.txt` to set the project version from a `PROJECT_VERSION` variable, with a default fallback, and to synchronize the VCPKG manifest version.
* Modified all platform build scripts (`build-linux-amd64.sh`, `build-linux-arm64.sh`, `build-macOS.sh`, `build-windows.ps1`) to accept an optional version parameter and pass it to CMake via `-DPROJECT_VERSION`, ensuring consistent versioning across all builds. [[1]](diffhunk://#diff-3ff20114f00e77a1e463631a0cd2eb74ef70a76648a70ea22157d979c28f526dR3-R5) [[2]](diffhunk://#diff-3ff20114f00e77a1e463631a0cd2eb74ef70a76648a70ea22157d979c28f526dL46-R53) [[3]](diffhunk://#diff-24793e053a3cad26a41127717cf9747be291651853e9458cfaa34c9053576b93R3-R5) [[4]](diffhunk://#diff-24793e053a3cad26a41127717cf9747be291651853e9458cfaa34c9053576b93L60-R67) [[5]](diffhunk://#diff-968cc0212ab93ead159aae980423a3151e3ddc85c0d5d2017732fc044a5ac010R1-R27) [[6]](diffhunk://#diff-8abe17b0067e10c3c168800335f91452a7765a2e1dfbdce0e8edcf162bb25c5eR1-R30)
* Refactored the GitHub Actions workflow (`.github/workflows/build-nativeshims.yml`) to remove manual file editing for version bumps and instead pass the version as a parameter to the build scripts for each platform. [[1]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574R41-R46) [[2]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574R78-R83) [[3]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574R97-R102) [[4]](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574R116-R121)

**Project Metadata:**

* Removed the hardcoded version from `vcpkg.json` to rely on the build process for version injection, preventing accidental mismatches.