### PR TITLE
fix(platforminterop): Fix preprocessor directives for code inclusion

### DIFF
--- a/Yubico.Core/src/Yubico/PlatformInterop/Libraries.Net47.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/Libraries.Net47.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if NET47
+#if NETFRAMEWORK
 
 using System;
 using System.IO;

--- a/Yubico.Core/src/Yubico/PlatformInterop/Libraries.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/Libraries.cs
@@ -14,7 +14,7 @@
 
 // As long as we have the Libraries.Net47.cs class which holds the opposite preprocessor directive check,
 // this check is required - as having both at the same time is not possible.
-#if !NET47 
+#if !NETFRAMEWORK
 
 namespace Yubico.PlatformInterop
 {


### PR DESCRIPTION
This pull request updates preprocessor directives to use `NETFRAMEWORK` instead of `NET47` for conditional compilation. This change helps ensure compatibility with all .NET Framework versions, not just 4.7.

Platform compatibility updates:

* Changed the preprocessor directive from `NET47` to `NETFRAMEWORK` in `Libraries.Net47.cs` to generalize framework targeting.
* Updated the conditional compilation check from `!NET47` to `!NETFRAMEWORK` in `Libraries.cs` for consistency with the new directive.