### PR TITLE
fix: Fido2Session would incorrectly throw exceptions on older keys

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.Pin.cs
@@ -375,11 +375,11 @@ namespace Yubico.YubiKey.Fido2
 
             if (AuthenticatorInfo.GetOptionValue(AuthenticatorOptions.pinUvAuthToken) == OptionValue.True)
             {
-                AddPermissions(permissions, relyingPartyId);
+                AddPermissions(permissions, relyingPartyId); // This will set the auth token
             }
             else
             {
-                AddPermissions(PinUvAuthTokenPermissions.None, null); // TODO use VerifyPin here instead directly!!
+                _ = TryVerifyPin(); // This will set the auth token
             }
 
             return AuthToken ?? ReadOnlyMemory<byte>.Empty;


### PR DESCRIPTION
This pull request makes targeted improvements to the permission validation. The main focus is on clarifying when certain checks and actions should occur based on the requested permissions and authenticator capabilities.

Fixes: #191 

**Validation logic enhancements:**

* Refined the `ValidateParameters` method to only check for the presence of a relying party ID and the support for `pinUvAuthToken` when permissions are actually being requested, preventing incorrect exceptions and making the logic clearer.

**Authentication token handling:**

* Updated the `GetAuthToken` method to clarify that `AddPermissions` sets the auth token when `pinUvAuthToken` is supported, and switched to using `TryVerifyPin` to set the auth token when it is not supported, improving code readability and intent.