### PR TITLE
fix(hid): Enhance CmDevice initialization and error handling during device enumeration

### DIFF
--- a/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs
@@ -22,6 +22,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Win32.SafeHandles;
 using Yubico.Core.Buffers;
 using static Yubico.PlatformInterop.NativeMethods;
+#pragma warning disable CS0618 // Type or member is obsolete
 
 namespace Yubico.PlatformInterop
 {

--- a/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmPropertyAccessHelper.cs
+++ b/Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmPropertyAccessHelper.cs
@@ -34,10 +34,8 @@ namespace Yubico.PlatformInterop
 
         internal static object? TryGetProperty<T>(GetObjectProperty<T> getObjectProperty, T objectId, DEVPROPKEY propertyKey)
         {
-            CmErrorCode errorCode;
-
             IntPtr propertyBufferSize = IntPtr.Zero;
-            errorCode = getObjectProperty(
+            CmErrorCode errorCode = getObjectProperty(
                 objectId,
                 propertyKey,
                 out DEVPROP_TYPE propertyType,
@@ -47,9 +45,10 @@ namespace Yubico.PlatformInterop
 
             if (errorCode == CmErrorCode.CR_NO_SUCH_VALUE)
             {
-                return default;
+                return null;
             }
-            else if (errorCode != CmErrorCode.CR_BUFFER_SMALL)
+            
+            if (errorCode != CmErrorCode.CR_BUFFER_SMALL)
             {
                 throw new PlatformApiException(
                     "CONFIG_RET",


### PR DESCRIPTION

# Description
This pull request introduces significant improvements to device enumeration and error handling in the Windows HID device listener and the `CmDevice` class. The main changes involve making device creation more robust against transient errors, introducing factory methods for safer instantiation, and improving logging for diagnostics. Additionally, some code has been refactored for clarity and maintainability.

These changes make device enumeration more robust and the codebase easier to maintain, especially in scenarios where devices are rapidly connected or disconnected.

Fixes: #144 

**Device creation and error handling improvements:**

* Added static factory methods `FromDevicePath` and `FromDeviceInstance` to `CmDevice`, which safely handle exceptions and log errors when devices disappear or when the Configuration Manager API fails. The constructors are now marked as obsolete and direct usage is discouraged. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs`)
* Updated device enumeration methods such as `GetList`, `Parent`, and `Children` in `CmDevice` to use the new factory methods, ensuring that only valid devices are returned and errors are handled gracefully. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs`) [[1]](diffhunk://#diff-271e8251768f40c8f1e2b5313bf3cfcfa97ea4b7fb8d0023288c4dff1b42542bL31-R146) [[2]](diffhunk://#diff-271e8251768f40c8f1e2b5313bf3cfcfa97ea4b7fb8d0023288c4dff1b42542bL140-R217) [[3]](diffhunk://#diff-271e8251768f40c8f1e2b5313bf3cfcfa97ea4b7fb8d0023288c4dff1b42542bL158-R247)

**Windows HID device listener changes:**

* Modified `WindowsHidDeviceListener` to use the new `CmDevice.FromDevicePath` method when handling device arrival events. If device creation fails, a warning is logged and the event is ignored, preventing crashes during rapid device changes. (`Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs`)

**Code refactoring and clarity:**

* Moved property initialization logic in `CmDevice` to a dedicated `InitializeProperties` method, improving constructor clarity and maintainability. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs`)
* Refactored some method signatures and error handling logic for better readability and .NET best practices, such as updating `LocateDevNode` to be static and accept an explicit `instanceId`. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs`)

**Other minor improvements:**

* Improved logging and error messages throughout the device enumeration and property access code for easier diagnostics. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmDevice.cs`, `Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs`) [[1]](diffhunk://#diff-271e8251768f40c8f1e2b5313bf3cfcfa97ea4b7fb8d0023288c4dff1b42542bL31-R146) [[2]](diffhunk://#diff-d9dcc94bce22f1d4bc84b6f093836a79e380970674369de7f5ee34dfd3de57b2L122-R146)
* Minor code cleanup and style improvements in property access helper and event handler parameter formatting. (`Yubico.Core/src/Yubico/PlatformInterop/Windows/Cfgmgr32/CmPropertyAccessHelper.cs`, `Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs`) [[1]](diffhunk://#diff-d7a977f074edd644e578037e45fce4c5d5af5905eab877b3d0c93b1a13a575c4L37-R38) [[2]](diffhunk://#diff-d7a977f074edd644e578037e45fce4c5d5af5905eab877b3d0c93b1a13a575c4L50-R51) [[3]](diffhunk://#diff-d9dcc94bce22f1d4bc84b6f093836a79e380970674369de7f5ee34dfd3de57b2L106-R112)


## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test configuration**:
* OS version:  Windows 11
* Firmware version: 5.4.3
* Yubikey model[^1]: 5 USB A 

## Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
