### PR TITLE
docs: add GitHub repository links to documentation

### DIFF
--- a/docs/core-api/index.md
+++ b/docs/core-api/index.md
@@ -19,7 +19,7 @@ limitations under the License. -->
 # .NET YubiKey SDK: Core API reference
 
 This section of the documentation contains the specific information about each class in
-the Yubico.Core library.
+the [Yubico.Core](https://github.com/Yubico/Yubico.NET.SDK/tree/HEAD/Yubico.Core) library.
 
 For a high-level overview and discussions of the concepts and operations of the YubiKey
 and this SDK, visit the [User's Manual](../users-manual/intro.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,9 @@ limitations under the License. -->
 The SDK allows you to integrate the YubiKey and its applications into your .NET-based
 application or library.
 
+## GitHub repository
+The SDK is open source and available on [GitHub](https://github.com/Yubico/Yubico.NET.SDK). Contributions, issue reports, and feedback are welcome.
+
 ## SDK documentation
 
 The documentation for the .NET YubiKey SDK is split into two main sections:

--- a/docs/users-manual/intro.md
+++ b/docs/users-manual/intro.md
@@ -17,3 +17,5 @@ limitations under the License. -->
 This manual gives general information about the SDK and how to use it. After reading about
 a topic, you can get programming details from the [API Documentation](../yubikey-api/index.md)
 section.
+
+The SDK is open source and available on [GitHub](https://github.com/Yubico/Yubico.NET.SDK).

--- a/docs/yubikey-api/index.md
+++ b/docs/yubikey-api/index.md
@@ -5,7 +5,7 @@ uid: YubiKeyApiIndexPage
 # .NET YubiKey SDK: YubiKey API reference
 
 This section of the documentation contains the specific information about each class in
-the Yubico.YubiKey library.
+the [Yubico.YubiKey](https://github.com/Yubico/Yubico.NET.SDK/tree/HEAD/Yubico.YubiKey) library.
 
 For a high-level overview and discussions of the concepts and operations of the YubiKey
 and this SDK, visit the [User's Manual](../users-manual/intro.md).


### PR DESCRIPTION
This pull request updates the documentation to better reference the SDK's GitHub repository and provide direct links to the relevant source code. The most important changes are grouped below:

Repository visibility and contribution information:

* Added a section in `docs/index.md` to highlight that the SDK is open source, available on GitHub, and welcomes contributions and feedback.
* Added a note in `docs/users-manual/intro.md` stating that the SDK is open source and available on GitHub.

Direct source code links in API documentation:

* Updated `docs/core-api/index.md` to link directly to the `Yubico.Core` library on GitHub for easier navigation.
* Updated `docs/yubikey-api/index.md` to link directly to the `Yubico.YubiKey` library on GitHub for easier navigation.