### PR TITLE
build(linux): Optimize Zig compiler wrappers by adding optimization flags

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -114,13 +114,13 @@ jobs:
           # Create x86_64 C compiler wrapper
           cat > $HOME/zig-wrappers/zig-cc << 'EOF'
           #!/bin/bash
-          exec zig cc -target x86_64-linux-gnu.2.23 "$@"
+          exec zig cc -target x86_64-linux-gnu.2.23 -O2 -s "$@"
           EOF
 
           # Create x86_64 C++ compiler wrapper
           cat > $HOME/zig-wrappers/zig-c++ << 'EOF'
           #!/bin/bash
-          exec zig c++ -target x86_64-linux-gnu.2.23 "$@"
+          exec zig c++ -target x86_64-linux-gnu.2.23 -O2 -s "$@"
           EOF
 
           chmod +x $HOME/zig-wrappers/zig-cc
@@ -264,13 +264,13 @@ jobs:
           # Create aarch64 C compiler wrapper
           cat > $HOME/zig-wrappers/zig-cc << 'EOF'
           #!/bin/bash
-          exec zig cc -target aarch64-linux-gnu.2.23 "$@"
+          exec zig cc -target aarch64-linux-gnu.2.23 -O2 -s "$@"
           EOF
 
           # Create aarch64 C++ compiler wrapper
           cat > $HOME/zig-wrappers/zig-c++ << 'EOF'
           #!/bin/bash
-          exec zig c++ -target aarch64-linux-gnu.2.23 "$@"
+          exec zig c++ -target aarch64-linux-gnu.2.23 -O2 -s "$@"
           EOF
 
           chmod +x $HOME/zig-wrappers/zig-cc


### PR DESCRIPTION
This pull request makes a minor improvement to the build workflow by updating the Zig compiler wrapper scripts to produce smaller and optimized binaries.

Addressing increased build size as noted in #334 

**Build workflow optimization:**
  * [`.github/workflows/build-nativeshims.yml`](diffhunk://#diff-5efd4baa757594aa63fe53759dc2f1de6a4c8f596acce070d80b1ae8e95e5574L117-R123): Added the `-O2` optimization flag and the `-s` strip flag to the Zig C and C++ compiler wrapper scripts, ensuring binaries are optimized and stripped of unnecessary symbols.

**Build size for Linux**
| Before | After|
|--|--|
| [Old build](https://github.com/Yubico/Yubico.NET.SDK/actions/runs/19750530459) | [New build](https://github.com/Yubico/Yubico.NET.SDK/actions/runs/19765223127) |


