### PR TITLE
fix(otp): getting incorrect firmware on special keys 

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
@@ -284,7 +284,7 @@ namespace Yubico.YubiKey.Otp
         /// <inheritdoc cref="OtpStatus.LongPressRequiresTouch"/>
         public bool LongPressRequiresTouch => _otpStatus.LongPressRequiresTouch;
 
-        internal FirmwareVersion FirmwareVersion => _otpStatus.FirmwareVersion;
+        internal FirmwareVersion FirmwareVersion => YubiKey.FirmwareVersion;
 
         FirmwareVersion IOtpSession.FirmwareVersion => FirmwareVersion;
 


### PR DESCRIPTION
# Description
Make OtpSession receive Firmware from key instead of APDU response which has limits for certain keys

Fixes: # <link to issue(s)>

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Local integration testing

**Test configuration**:
* OS version: *e.g. MacOS 15.6*
* Firmware version: 5.8.0.Alpha.1
* Yubikey model: 5 NFC 
