### PR TITLE
docs: updates to PIN PIN and touch policy documentation

### DIFF
--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -16,100 +16,81 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
 
-# PIV PIN, touch and bio policies
+# PIV PIN, touch, and biometric policies
 
-Suppose you want to use one of the PIV keys to sign or decrypt. The application running on
-your host device will call one or more commands to perform the operation. Do you need to
-enter the PIN to perform the operation? Do you need to touch the YubiKey?
+The YubiKey's PIV PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots (including the management key).
 
-Suppose you want to to generate a new key pair, you need to authenticate the management
-key to perform that operation. But do you need to touch the YubiKey as well? What about fingerprints?
+These policies apply to operations such as signing, decrypting, performing a key agreement, and generating a new key pair. For a full list of operations affected by PIN and touch policies, see [Operations that require the PIN](xref:UsersManualPinPukMgmtKey#operations-that-require-the-pin) and [Operations that require the management key](xref:UsersManualPinPukMgmtKey#operations-that-require-the-management-key).
 
-This article answers those questions.
+## Policy properties
 
-## Related articles
+PIN and touch policies can be configured when a key is generated or imported into a YubiKey PIV slot. Once the policies have been set during key generation/import, they cannot be changed. If a PIN and/or touch policy is not specified at that time, the slot's default policies will be applied to the key. Default policies vary depending on the slot and are programmed into the YubiKey's firmware. Note that policy configuration is supported on YubiKeys with firmware version 4 and later; earlier YubiKeys are limited to the usage of slots' default policies.
 
-[PIV commands access control](access-control.md)
+A key's policies, whether explicitly configured or not, are properties of the key itself. This means that you can move a key from one slot to another (for example, from slot 9A to one of the retired key slots), and its policies do not change.
 
-[The PIV PIN, PUK, and management key](pin-puk-mgmt-key.md)
+Biometric policies are a type of PIN policy and can only be used with YubiKey Bio Series — Multi-protocol Edition keys (YubiKey Bio Series – FIDO Edition key do not support PIV).
 
-## What are the possible policies?
+The management key (slot 9B) only has a touch policy. The PIN is never needed to perform a management key operation (with the exception of [Set PIN Retries](commands.md#set-pin-retries), but in this case the PIN is needed because this is a command related to the PIN itself). The PIN and PUK (slots 80 and 81) do not have PIN *or* touch policies.
 
-#### PIN policies
+Keys generated/imported into the following slots have both PIN **and** touch policies:
 
-* Never: the PIN is never needed
-* Always: the PIN needed for every use
-* Once: the PIN is needed once per session
+- 9A (Authentication)
+- 9C (Digital Signature)
+- 9D (Key Management)
+- 9E (Card Authentication)
+- F9 (Attestation)
+- 82-95 (Retired Key Slots)
 
-#### Touch policies
+## PIN policy options
 
-* Never: a touch is never needed
-* Always: a touch is needed for every use
-* Cached: a touch is not needed if the YubiKey had been touched in the last 15 seconds,
-otherwise a touch is needed (Only available for YubiKey versions 4.3 and greater)
+The three main PIN policy options are as follows:
 
-#### Biometric policies
-For **YubiKey Bio** versions 5.7 and greater, there are two more possible policies
-* Match Once: A biometric or PIN verification is required for each session
-* Match Always: A biometric or PIN verification is required on every object access
+* ``Never``: the PIN is never needed.
+* ``Always``: the PIN is needed for every key operation.
+* ``Once``: the PIN is needed once per session.
+
+Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-3.pdf), YubiKey FIPS Series keys with firmware version 5.7.1 or later cannot set PIN policy to ``Never``.
 
 > [!WARNING]
-> It is important to point out that setting the PIN policy to "never" reduces security
+> It is important to note that setting the PIN policy to ``Never`` reduces security
 > dramatically. This feature was added only because of customer demand for convenience.
-> Yubico recommends setting the PIN policy to "always" or "once".
+> Yubico recommends setting the PIN policy to ``Always`` or ``Once``.
 
-Note that if you do not specify a PIN or touch policy, there is a default. What the
-default is will be described below.
+### Biometric policy options
 
-Note also that with management keys there is only a touch policy. The PIN is never needed
-to perform a management key operation (with the exception of
-[Set PIN Retries](commands.md#set-pin-retries), but in this case the PIN is needed
-becasue that is a command related to the PIN itself).
+Biometric policies are a type of PIN policy that are available for YubiKey Bio Series — Multi-protocol Edition keys with firmware 5.7 or later. There are two biometric policy options:
 
-## Older YubiKeys (prior to YubiKey 4)
+* Match Once: a biometric or PIN verification is required for each session.
+* Match Always: a biometric or PIN verification is required on every object access.
 
-The ability to use PIN and touch policies other than the default was not available prior
-to YubiKey 4. What this means is that when using a PIV key in a YubiKey, there was a
-default policy only and no way to generate or import a key to use a different policy.
+## Touch policy options
 
-## Default policy
+There are three touch policy options:
 
-The default policies are programmed into the YubiKey upon manufacture. All YubiKeys,
-before version 4 and after, are programmed with the same default policies. In the future,
-there could be a YubiKey with a different default policy. But for now, the default PIN and
-touch policies are the following.
+* Never: a touch is never needed.
+* Always: a touch is needed for every key operation.
+* Cached: if more than 15 seconds have elapsed since the last time the YubiKey was touched, a touch is needed (only available for YubiKeys with firmware version 4.3 and later).
 
-* Slot 9C PIN policy: Always (the PIN is required before each private key operation)
-* PIN policy: Once (the PIN is required once per session to use a private key to sign,
-  decrypt, or perform key agreement)
-* Touch policy: Never (touch is never required to use any PIV key, private or management)
+## Default policies
 
-> Note:
->
-> The default PIN policy for slot 9C is different from the default for the other slots.
-> This is from the PIV standard. So remember that if you generate a key in slot 9C and set
-> the PIN policy to default, the actual PIN policy will be Always. It is a good idea to
-> simply always specify the PIN policy you want, Never or Once, rather than Default.
+The default PIN and touch policies are programmed into the YubiKey's firmware upon manufacture. Starting with firmware version 4, YubiKeys (with the exception of YubiKey FIPS Series keys with firmware version 5.7.1 or later) have the following default policies:
 
-> Note:
->
-> Touch is not a part of the PIV standard. That is why the first YubiKeys that supported
-> PIV did not have the option of touch when using a PIV key. This non-standard ability to
-> require touch was added to YubiKey in version 4 to augment security.
+* Slot 9C PIN policy: Always
+* Slot 9E PIN policy: Never
+* General PIN policy: Once
+* Touch policy: Never
 
-## Changing the policy: management key (slot 9B)
+Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-3.pdf), **YubiKey FIPS Series keys with firmware version 5.7.1 or later have a default 9E PIN policy of ``Once``**. The other default polices listed above are the same for FIPS keys.
 
-If you want a touch policy different from the default for the management key, use the
-[Set Management Key command](commands.md#set-management-key). This will set the actual
-key value as well as the touch policy. With this command you can enter the current key
-along with a different touch policy to change the policy only, or enter the same touch
-policy with a new key to change the key only, or change both key and policy.
+It's also important to note that slots 9C and 9E have different default PIN policies than all other slots due to the requirements mandated by the PIV standard (see [NIST SP 800-73pt1, section 3](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73pt1-5.pdf)). Touch is not a part of the PIV standard, which is why the default touch policy is ``Never``. The ability to require touch was added to the YubiKey in firmware version 4 to augment security.
 
-## Setting keys to a non-default policy (all slots other than 80, 81, 9B, F9)
+When generating or importing a key into one of the PIV slots, these default policies will be applied to the key unless otherwise specified.
+
+## Setting keys to a non-default policy (all slots other than 80, 81, 9B, and F9)
 
 If you want a policy different from the default for a private key, you must specify that
 policy when the key is [generated](commands.md#generate-asymmetric) or
-[imported](commands.md#import-asymmetric). Once the key is on the YubiKey there is no
+[imported](commands.md#import-asymmetric). Once the key is on the YubiKey, there is no
 way to change the policy.
 
 Note that you can specify different policies for keys in different slots (if the YubiKey
@@ -121,20 +102,7 @@ that has a PIN policy of "always", while a key imported into slot 86 has a PIN p
 > dramatically. This feature was added only because of customer demand for convenience.
 > Yubico recommends setting the PIN policy to "always" or "once".
 
-## Examples
-
-### Management key
-
-You have a new YubiKey and one of the first things you do is change the management key
-from the default. You call the
-[Set Management Key command](commands.md#set-management-key) and provide the new key
-data and specify the touch policy. Suppose you set the policy to "always".
-
-Now whenever you call the
-[Authenticate management key](commands.md#authenticate-management-key) command, the
-authentication won't be complete until the YubiKey has been touched.
-
-### Private key
+### Example scenarios
 
 Suppose you generate a new key pair for slot 9C using the
 [Generate asymmetric key pair](commands.md#generate-asymmetric) command. You set
@@ -147,3 +115,78 @@ Suppose you generate a new key pair for slot 9D. You set the PIN policy to once,
 touch policy to never. Now when you first decrypt using that key in a session, you will
 need to authenticate the PIN, but won't need to touch. The next time you decrypt in the
 session, you will not need the PIN nor touch.
+
+## Changing the touch policy for the management key (slot 9B)
+
+Unlike other slots, the management key (slot 9B) only has a touch policy, which by default is ``Never``. However, when changing the management key, you can set this policy to one of the other touch policy options (``Always`` or ``Cached``). Once reconfigured with one of these other policies, the user will be required to touch the YubiKey at the specified frequency tp perform management key operations.
+
+To change the management key with the SDK, we have two options: the ``PivSession`` method, ``TryChangeManagementKey()``, or the lower-level ``SetManagementKeyCommand()``.
+
+### TryChangeManagementKey() example
+
+To change the management key and set a new touch policy using the ``PivSession``, simply call``TryChangeManagementKey()`` and provide the current management key, the new management key, and the desired touch policy. In this example, let's set the touch policy to ``Always``:
+
+```csharp
+using (PivSession pivtest = new PivSession(yubiKey))
+{
+    // currentKey and newKey set elsewhere.
+    pivtest.TryChangeManagementKey(currentKey, newKey, PivTouchPolicy.Always);
+}
+```
+
+Note that ``TryChangeManagementKey()`` is an overloaded method. In addition to specifying the new key's touch policy, you can also specify a particular algorithm. If these properties are not specified, the slot's default touch policy and default algorithm will be used for the new management key. Also, if you call the method without providing the current and new management keys directly, the SDK will call upon the KeyCollector to fetch them from the user.
+
+### SetManagementKeyCommand() example
+
+Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps: first we must initiate the PIV management key authentication process with ``InitializeAuthenticateManagementKeyCommand``, then we can finish management key authentication with ``CompleteAuthenticateManagementKeyCommand()``, and finally we can set the new management key and touch policy via ``SetManagementKeyCommand()``:
+
+```csharp
+
+``` 
+
+If you want to set a new a touch policy for the management key, use the
+[SetManagementKeyCommand](commands.md#set-management-key). This command will set both the actual
+key value as well as the touch policy. With ``SetManagementKeyCommand``, you can:
+
+- enter the current key with a different touch policy to change the policy only
+- enter the same touch policy with a new key to change the key only
+- enter a new key and a new policy to change both key and policy
+
+Suppose you want to change the management key and set its touch policy to "always". To do so, call
+``SetManagementKeyCommand`` and provide the new key
+data and the touch policy:
+
+```csharp
+// newKey set elsewhere
+SetManagementKeyCommand(newKey, PivTouchPolicy.Always);
+```
+
+Now, whenever you call the
+[Authenticate management key](commands.md#authenticate-management-key) command, the
+authentication won't be complete until the YubiKey has been touched.
+
+## Retrieving an existing key's PIN and touch policies
+
+Once a key has been generated or imported into a slot, you can check the PIN and touch policies it was configured with via the YubiKey's PIV metadata. Note that this feature is only available for YubiKeys with firmware version 5.3 and later. On older YubiKeys, there is no way to retrieve a key's policies after configuration.
+
+To check a key's policies, start a ``PivSession``, call ``GetMetadata`` on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
+
+```csharp
+using (PivSession pivtest = new PivSession(yubiKey))
+{
+    // Get the metadata from the key in slot 9A.
+    PivMetadata metadata = pivtest.GetMetadata(0x9A);
+
+    // Extract the properties from the metadata.
+    PivPinPolicy pinPolicy = metadata.PinPolicy;
+    PivTouchPolicy touchPolicy = metadata.TouchPolicy;
+}
+```
+
+Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``.
+
+## Related articles
+
+[PIV access control](access-control.md)
+
+[The PIV PIN, PUK, and management key](pin-puk-mgmt-key.md)

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -125,7 +125,7 @@ Generating and importing keys, however, requires management key authentication b
 using (PivSession pivSession = new PivSession(yubiKey))
 {
     // Perform management key authentication first (managementKey set elsewhere).
-    pivSession.TryAuthenticateManagementKey(managementKey, true);
+    pivSession.TryAuthenticateManagementKey(managementKey);
 
     pivSession.GenerateKeyPair(PivSlot.Signing, KeyType.RSA2048, PivPinPolicy.Once, PivTouchPolicy.Always);
 

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -16,9 +16,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
 
-# PIV PIN, touch, and biometric policies
+# PIN, touch, and biometric policies
 
-The YubiKey's PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots (including the management key).
+The YubiKey's PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots, including the management key.
 
 These policies apply to operations such as signing, decrypting, performing a key agreement, and authenticating the management key (required when generating a key pair, importing a private key or certificate, etc).
 
@@ -28,11 +28,11 @@ PIN and touch policies can be configured when a private key is generated or impo
 
 A key's policies, whether explicitly configured or not, are properties of the key itself. This means that you can move a key from one slot to another (for example, from slot 9A to one of the retired key slots), and its policies do not change.
 
-Biometric policies are a type of PIN policy and can only be used with YubiKey Bio Series — Multi-protocol Edition keys (YubiKey Bio Series – FIDO Edition key do not support PIV).
+Biometric policies are a type of PIN policy and can only be used with YubiKey Bio Series — Multi-protocol Edition keys. (YubiKey Bio Series – FIDO Edition keys do not support PIV.)
 
-The management key (slot 9B) only has a touch policy. The PIN is never needed to perform a management key operation (with the exception of [Set PIN Retries](commands.md#set-pin-retries), but in this case the PIN is needed because this is a command related to the PIN itself). The PIN and PUK (slots 80 and 81) do not have PIN *or* touch policies.
+The management key (slot 9B) only has a touch policy. The PIN is never needed to perform a management key operation (with the exception of [SetPinRetriesCommand](commands.md#set-pin-retries) because it is related to the PIN itself). The PIN and PUK (slots 80 and 81) do not have PIN *or* touch policies.
 
-Keys generated/imported into the following slots have both PIN **and** touch policies:
+Keys generated or imported into the following slots have both PIN and touch policies:
 
 - 9A (Authentication)
 - 9C (Digital Signature)
@@ -69,20 +69,22 @@ There are three touch policy options:
 
 * ``Never``: a touch is never needed.
 * ``Always``: a touch is needed for every key operation.
-* ``Cached``: if more than 15 seconds have elapsed since the last time the YubiKey was touched, a touch is needed (only available for YubiKeys with firmware version 4.3 and later).
+* ``Cached``: if more than 15 seconds have elapsed since the last time the YubiKey was touched, a touch is needed. 
+
+``Cached`` is only available for YubiKeys with firmware version 4.3 and later.
 
 ## Default policies
 
-The default PIN and touch policies are programmed into the YubiKey's firmware upon manufacture. Starting with firmware version 4, YubiKeys (with the exception of YubiKey FIPS Series keys with firmware version 5.7.1 or later) have the following default policies:
+The default PIN and touch policies are programmed into the YubiKey's firmware upon manufacture. Starting with firmware version 4, YubiKeys (with the exception of YubiKey FIPS Series keys with firmware version 5.7.1 and later) have the following default policies:
 
 * Slot 9C PIN policy: ``Always``
 * Slot 9E PIN policy: ``Never``
 * General PIN policy: ``Once``
 * Touch policy: ``Never``
 
-Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-3.pdf), **YubiKey FIPS Series keys with firmware version 5.7.1 or later have a default 9E PIN policy of ``Once``**. The other default polices listed above are the same for FIPS keys.
+Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-3.pdf), **YubiKey FIPS Series keys with firmware version 5.7.1 and later have a default 9E PIN policy of ``Once``**. The other default polices listed above are the same for these keys.
 
-It's also important to note that slots 9C and 9E have different default PIN policies than all other slots due to the requirements mandated by the PIV standard (see [NIST SP 800-73pt1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73pt1-5.pdf), section 3). Touch is not a part of the PIV standard, which is why the default touch policy is ``Never``. The ability to require touch was added to the YubiKey in firmware version 4 to augment security.
+Slots 9C and 9E have different default PIN policies than all other slots due to the requirements mandated by the PIV standard (see [NIST SP 800-73pt1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73pt1-5.pdf), section 3). Touch is not a part of the PIV standard, which is why the default touch policy is ``Never``. The ability to require touch was added to the YubiKey in firmware version 4 to augment security.
 
 When generating or importing a key into one of the PIV slots, these default policies will be applied to the key unless otherwise specified.
 
@@ -111,13 +113,13 @@ When specifying the touch policy with the SDK, you must select one of the [PivTo
 - ``Never``
 - ``None``
 
-It should also be noted that selecting ``None`` for either the PIN policy or touch policy during generation/import does not remove the policy field from the private key. The YubiKey's firmware interprets ``None`` as an invalid policy and will use the slot's default policy instead.
+Selecting ``None`` for either the PIN policy or touch policy during generation/import does not remove the policy field from the private key. The YubiKey's firmware interprets ``None`` as an invalid policy and will use the slot's default policy instead.
 
 ### GenerateKeyPair() and ImportPrivateKey() example
 
 In this example, we will generate a key in slot 9C and import a key into slot 9D using the [GenerateKeyPair](xref:Yubico.YubiKey.Piv.PivSession.GenerateKeyPair%28System.Byte%2CYubico.YubiKey.Cryptography.KeyType%2CYubico.YubiKey.Piv.PivPinPolicy%2CYubico.YubiKey.Piv.PivTouchPolicy%29) and [ImportPrivateKey](xref:Yubico.YubiKey.Piv.PivSession.ImportPrivateKey%28System.Byte%2CYubico.YubiKey.Cryptography.IPrivateKey%2CYubico.YubiKey.Piv.PivPinPolicy%2CYubico.YubiKey.Piv.PivTouchPolicy%29) PIV session methods, respectively. When calling each method, we will specify the intended slot via the [PivSlot](xref:Yubico.YubiKey.Piv.PivSlot) class. For the 9C key, we will set its PIN policy to ``Once`` and its touch policy to ``Always``. For the 9D key, we will set its PIN policy to ``Always`` and its touch policy to ``Cached``.
 
-With ``GenerateKeyPair``, we must specify the key's algorithm via the [KeyType](xref:Yubico.YubiKey.Cryptography.KeyType) class. ``ImportPrivateKey``, on the other hand, must be provided the private key to be imported, which must be an implementation of the [PrivateKey](xref:Yubico.YubiKey.Cryptography.PrivateKey) class.
+With ``GenerateKeyPair``, we must also specify the key's algorithm via the [KeyType](xref:Yubico.YubiKey.Cryptography.KeyType) class. For ``ImportPrivateKey``, we must provide the private key to be imported, which must be an implementation of the [PrivateKey](xref:Yubico.YubiKey.Cryptography.PrivateKey) class.
 
 Generating and importing keys, however, requires management key authentication before those operations can complete. When you call ``GenerateKeyPair`` or ``ImportPrivateKey``, the SDK will call on your [KeyCollector](xref:Yubico.YubiKey.Piv.PivSession.KeyCollector) to collect the management key from the user and perform authentication automatically. However, we can also perform management key authentication manually (by providing the management key directly instead of using the KeyCollector) via [TryAuthenticateManagementKey](xref:Yubico.YubiKey.Piv.PivSession.TryAuthenticateManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.Boolean%29), which we will call in this example:
 
@@ -127,10 +129,18 @@ using (PivSession pivSession = new PivSession(yubiKey))
     // Perform management key authentication first (managementKey set elsewhere).
     pivSession.TryAuthenticateManagementKey(managementKey);
 
-    pivSession.GenerateKeyPair(PivSlot.Signing, KeyType.RSA2048, PivPinPolicy.Once, PivTouchPolicy.Always);
+    pivSession.GenerateKeyPair(
+        PivSlot.Signing, 
+        KeyType.RSA2048, 
+        PivPinPolicy.Once, 
+        PivTouchPolicy.Always);
 
     // privateKey set elsewhere.
-    pivSession.ImportPrivateKey(PivSlot.KeyManagement, privateKey, PivPinPolicy.Always, PivTouchPolicy.Cached);
+    pivSession.ImportPrivateKey(
+        PivSlot.KeyManagement, 
+        privateKey, 
+        PivPinPolicy.Always, 
+        PivTouchPolicy.Cached);
 }
 ```
 
@@ -158,24 +168,37 @@ Note that ``TryChangeManagementKey()`` is an overloaded method. In addition to s
 
 ### SetManagementKeyCommand() example
 
-Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps: first we must initiate the PIV management key authentication process with [InitializeAuthenticateManagementKeyCommand](xref:Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.PivAlgorithm%29), then we can finish management key authentication with [CompleteAuthenticateManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.CompleteAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyResponse%2CSystem.ReadOnlySpan%7BSystem.Byte%7D%29), and finally we can set the new management key and touch policy via [SetManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.SetManagementKeyCommand.%23ctor%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CYubico.YubiKey.Piv.PivTouchPolicy%2CYubico.YubiKey.Piv.PivAlgorithm%29):
+Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps:
+
+1. First we must initiate the PIV management key authentication process with [InitializeAuthenticateManagementKeyCommand](xref:Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.PivAlgorithm%29). 
+1. Then we can finish management key authentication with [CompleteAuthenticateManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.CompleteAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyResponse%2CSystem.ReadOnlySpan%7BSystem.Byte%7D%29).
+1. And finally we can set the new management key and touch policy via [SetManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.SetManagementKeyCommand.%23ctor%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CYubico.YubiKey.Piv.PivTouchPolicy%2CYubico.YubiKey.Piv.PivAlgorithm%29).
 
 ```csharp
 IYubiKeyConnection connection = yubiKey.Connect(YubiKeyApplication.Piv);
 
-// When initializing management key authentication with the command classes, we must specify the current
-// management key's algorithm. (If you aren't sure about the algorithm, retrieve it from the key's metadata first.)
-InitializeAuthenticateManagementKeyCommand initAuthManKeyCommand = new InitializeAuthenticateManagementKeyCommand(PivAlgorithm.Aes192);
-InitializeAuthenticateManagementKeyResponse initAuthManKeyResponse = connection.SendCommand(initAuthManKeyCommand);
+// Specify the current management key's algorithm. (If you aren't sure about the
+// algorithm, retrieve it from the key's metadata first.)
+InitializeAuthenticateManagementKeyCommand initAuthManKeyCommand = 
+    new InitializeAuthenticateManagementKeyCommand(PivAlgorithm.Aes192);
 
-// Complete the management key authentication by passing in the initialization response and the current management
-// key (currentKey set elsewhere).
-CompleteAuthenticateManagementKeyCommand authManKeyCommand = new CompleteAuthenticateManagementKeyCommand(initAuthManKeyResponse, currentKey);
-CompleteAuthenticateManagementKeyResponse authManKeyResponse = connection.SendCommand(authManKeyCommand);
+InitializeAuthenticateManagementKeyResponse initAuthManKeyResponse = 
+    connection.SendCommand(initAuthManKeyCommand);
 
-// When setting the new management key and its touch policy, we must also specify the new key's algorithm.
-SetManagementKeyCommand setManKeyCommand = new SetManagementKeyCommand(newKey, PivTouchPolicy.Always, PivAlgorithm.Aes192);
-SetManagementKeyResponse setManKeyResponse = connection.SendCommand(setManKeyCommand);
+// Pass in the initialization response and the current management key 
+// (currentKey set elsewhere).
+CompleteAuthenticateManagementKeyCommand authManKeyCommand = 
+    new CompleteAuthenticateManagementKeyCommand(initAuthManKeyResponse, currentKey);
+
+CompleteAuthenticateManagementKeyResponse authManKeyResponse = 
+    connection.SendCommand(authManKeyCommand);
+
+// Also specify the new key's algorithm.
+SetManagementKeyCommand setManKeyCommand = 
+    new SetManagementKeyCommand(newKey, PivTouchPolicy.Always, PivAlgorithm.Aes192);
+
+SetManagementKeyResponse setManKeyResponse = 
+    connection.SendCommand(setManKeyCommand);
 ```
 
 In this example, we set the management key's touch policy to ``Always``. This means that all future calls to ``CompleteAuthenticateManagementKeyCommand`` will not complete until the YubiKey has been touched.

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -18,7 +18,7 @@ limitations under the License. -->
 
 # PIV PIN, touch, and biometric policies
 
-The YubiKey's PIV PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots (including the management key).
+The YubiKey's PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots (including the management key).
 
 These policies apply to operations such as signing, decrypting, performing a key agreement, and generating a new key pair. For a full list of operations affected by PIN and touch policies, see [Operations that require the PIN](xref:UsersManualPinPukMgmtKey#operations-that-require-the-pin) and [Operations that require the management key](xref:UsersManualPinPukMgmtKey#operations-that-require-the-management-key).
 
@@ -118,7 +118,7 @@ session, you will not need the PIN nor touch.
 
 ## Changing the touch policy for the management key (slot 9B)
 
-Unlike other slots, the management key (slot 9B) only has a touch policy, which by default is ``Never``. However, when changing the management key, you can set this policy to one of the other touch policy options (``Always`` or ``Cached``). Once reconfigured with one of these other policies, the user will be required to touch the YubiKey at the specified frequency tp perform management key operations.
+Unlike other slots, the management key (slot 9B) only has a touch policy, which by default is ``Never``. However, when changing the management key, you can set this policy to one of the other touch policy options (``Always`` or ``Cached``). Once reconfigured with one of these other policies, the user will be required to touch the YubiKey at the specified frequency to perform management key operations.
 
 To change the management key with the SDK, we have two options: the ``PivSession`` method, ``TryChangeManagementKey()``, or the lower-level ``SetManagementKeyCommand()``.
 
@@ -134,42 +134,35 @@ using (PivSession pivtest = new PivSession(yubiKey))
 }
 ```
 
-Note that ``TryChangeManagementKey()`` is an overloaded method. In addition to specifying the new key's touch policy, you can also specify a particular algorithm. If these properties are not specified, the slot's default touch policy and default algorithm will be used for the new management key. Also, if you call the method without providing the current and new management keys directly, the SDK will call upon the KeyCollector to fetch them from the user.
+Note that ``TryChangeManagementKey()`` is an overloaded method. In addition to specifying the new key's touch policy, you can also specify a particular algorithm. If these properties are not specified, the slot's default touch policy and default algorithm will be used for the new management key. Also, if you call the method without providing the current and new management keys directly, the SDK will call upon your KeyCollector to fetch them from the user.
 
 ### SetManagementKeyCommand() example
 
 Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps: first we must initiate the PIV management key authentication process with ``InitializeAuthenticateManagementKeyCommand``, then we can finish management key authentication with ``CompleteAuthenticateManagementKeyCommand()``, and finally we can set the new management key and touch policy via ``SetManagementKeyCommand()``:
 
 ```csharp
+IYubiKeyConnection connection = yubiKey.Connect(YubiKeyApplication.Piv);
 
-``` 
+// When initializing management key authentication with the command classes, we must specify the current management key's algorithm. (If you aren't sure about the algorithm, retrieve it from the key's metadata first.)
+InitializeAuthenticateManagementKeyCommand initAuthManKeyCommand = new InitializeAuthenticateManagementKeyCommand(PivAlgorithm.Aes192);
+InitializeAuthenticateManagementKeyResponse initAuthManKeyResponse = connection.SendCommand(initAuthManKeyCommand);
 
-If you want to set a new a touch policy for the management key, use the
-[SetManagementKeyCommand](commands.md#set-management-key). This command will set both the actual
-key value as well as the touch policy. With ``SetManagementKeyCommand``, you can:
+// Complete the management key authentication by passing in the initialization response and the current management key (currentKey set elsewhere).
+CompleteAuthenticateManagementKeyCommand authManKeyCommand = new CompleteAuthenticateManagementKeyCommand(initAuthManKeyResponse, currentKey);
+CompleteAuthenticateManagementKeyResponse authManKeyResponse = connection.SendCommand(authManKeyCommand);
 
-- enter the current key with a different touch policy to change the policy only
-- enter the same touch policy with a new key to change the key only
-- enter a new key and a new policy to change both key and policy
-
-Suppose you want to change the management key and set its touch policy to "always". To do so, call
-``SetManagementKeyCommand`` and provide the new key
-data and the touch policy:
-
-```csharp
-// newKey set elsewhere
-SetManagementKeyCommand(newKey, PivTouchPolicy.Always);
+// When setting the new management key and its touch policy, we must also specify the new key's algorithm.
+SetManagementKeyCommand setManKeyCommand = new SetManagementKeyCommand(newKey, PivTouchPolicy.Always, PivAlgorithm.Aes192);
+SetManagementKeyResponse setManKeyResponse = connection.SendCommand(setManKeyCommand);
 ```
 
-Now, whenever you call the
-[Authenticate management key](commands.md#authenticate-management-key) command, the
-authentication won't be complete until the YubiKey has been touched.
+In this example, we set the management key's touch policy to ``Always``. This means that future calls to ``CompleteAuthenticateManagementKeyCommand`` will not complete until the YubiKey has been touched.
 
 ## Retrieving an existing key's PIN and touch policies
 
-Once a key has been generated or imported into a slot, you can check the PIN and touch policies it was configured with via the YubiKey's PIV metadata. Note that this feature is only available for YubiKeys with firmware version 5.3 and later. On older YubiKeys, there is no way to retrieve a key's policies after configuration.
+Once a key has been generated or imported into a slot, you can check the PIN and touch policies it was configured with via the key's PIV metadata. Note that this feature is only available for YubiKeys with firmware version 5.3 and later. On older YubiKeys, there is no way to retrieve a key's policies after configuration.
 
-To check a key's policies, start a ``PivSession``, call ``GetMetadata`` on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
+To check a key's policies, create an instance of a ``PivSession`` with the desired YubiKey, call ``GetMetadata`` on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
 
 ```csharp
 using (PivSession pivtest = new PivSession(yubiKey))
@@ -183,7 +176,7 @@ using (PivSession pivtest = new PivSession(yubiKey))
 }
 ```
 
-Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``.
+Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``. Slots 80 and 81 (PIN and PUK) do not have PIN or touch policies and will always return ``None`` for those properties in the metadata. The management key (9B), on the other hand, has a touch policy but no PIN policy. In order to maintain consistency with the data format, the YubiKey will return the undefined value "0" for 9B's PIN policy. This is not a valid PIN policy, and the SDK translates it to ``Default`` in the metadata.
 
 ## Related articles
 

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -24,7 +24,7 @@ These policies apply to operations such as signing, decrypting, performing a key
 
 ## Policy properties
 
-PIN and touch policies can be configured when a key is generated or imported into a YubiKey PIV slot. Once the policies have been set during key generation/import, they cannot be changed. If a PIN and/or touch policy is not specified at that time, the slot's default policies will be applied to the key. Default policies vary depending on the slot and are programmed into the YubiKey's firmware. Note that policy configuration is supported on YubiKeys with firmware version 4 and later; earlier YubiKeys are limited to the usage of slots' default policies.
+PIN and touch policies can be configured when a private key is generated or imported into a YubiKey's PIV slot. Once the policies have been set during key generation/import, they cannot be changed. If a PIN and/or touch policy is not specified at that time, the slot's default policies will be applied to the key. Default policies vary depending on the slot and are programmed into the YubiKey's firmware. Note that policy configuration is supported on YubiKeys with firmware version 4 and later; earlier YubiKeys are limited to the slots' default policies.
 
 A key's policies, whether explicitly configured or not, are properties of the key itself. This means that you can move a key from one slot to another (for example, from slot 9A to one of the retired key slots), and its policies do not change.
 
@@ -60,29 +60,29 @@ Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specif
 
 Biometric policies are a type of PIN policy that are available for YubiKey Bio Series — Multi-protocol Edition keys with firmware 5.7 or later. There are two biometric policy options:
 
-* Match Once: a biometric or PIN verification is required for each session.
-* Match Always: a biometric or PIN verification is required on every object access.
+* ``Match Once``: a biometric or PIN verification is required for each session.
+* ``Match Always``: a biometric or PIN verification is required on every object access.
 
 ## Touch policy options
 
 There are three touch policy options:
 
-* Never: a touch is never needed.
-* Always: a touch is needed for every key operation.
-* Cached: if more than 15 seconds have elapsed since the last time the YubiKey was touched, a touch is needed (only available for YubiKeys with firmware version 4.3 and later).
+* ``Never``: a touch is never needed.
+* ``Always``: a touch is needed for every key operation.
+* ``Cached``: if more than 15 seconds have elapsed since the last time the YubiKey was touched, a touch is needed (only available for YubiKeys with firmware version 4.3 and later).
 
 ## Default policies
 
 The default PIN and touch policies are programmed into the YubiKey's firmware upon manufacture. Starting with firmware version 4, YubiKeys (with the exception of YubiKey FIPS Series keys with firmware version 5.7.1 or later) have the following default policies:
 
-* Slot 9C PIN policy: Always
-* Slot 9E PIN policy: Never
-* General PIN policy: Once
-* Touch policy: Never
+* Slot 9C PIN policy: ``Always``
+* Slot 9E PIN policy: ``Never``
+* General PIN policy: ``Once``
+* Touch policy: ``Never``
 
 Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specification](https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.201-3.pdf), **YubiKey FIPS Series keys with firmware version 5.7.1 or later have a default 9E PIN policy of ``Once``**. The other default polices listed above are the same for FIPS keys.
 
-It's also important to note that slots 9C and 9E have different default PIN policies than all other slots due to the requirements mandated by the PIV standard (see [NIST SP 800-73pt1, section 3](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73pt1-5.pdf)). Touch is not a part of the PIV standard, which is why the default touch policy is ``Never``. The ability to require touch was added to the YubiKey in firmware version 4 to augment security.
+It's also important to note that slots 9C and 9E have different default PIN policies than all other slots due to the requirements mandated by the PIV standard (see [NIST SP 800-73pt1](https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-73pt1-5.pdf), section 3). Touch is not a part of the PIV standard, which is why the default touch policy is ``Never``. The ability to require touch was added to the YubiKey in firmware version 4 to augment security.
 
 When generating or importing a key into one of the PIV slots, these default policies will be applied to the key unless otherwise specified.
 
@@ -118,13 +118,13 @@ session, you will not need the PIN nor touch.
 
 ## Changing the touch policy for the management key (slot 9B)
 
-Unlike other slots, the management key (slot 9B) only has a touch policy, which by default is ``Never``. However, when changing the management key, you can set this policy to one of the other touch policy options (``Always`` or ``Cached``). Once reconfigured with one of these other policies, the user will be required to touch the YubiKey at the specified frequency to perform management key operations.
+The management key (slot 9B) has a touch policy only, and its default value is ``Never``. However, when changing the management key, you can set this policy to one of the other touch policy options (``Always`` or ``Cached``). Once reconfigured with one of these other policies, the user will be required to touch the YubiKey at the specified frequency to perform management key operations.
 
-To change the management key with the SDK, we have two options: the ``PivSession`` method, ``TryChangeManagementKey()``, or the lower-level ``SetManagementKeyCommand()``.
+To change the management key with the SDK, there are two options: the ``PivSession`` method, ``TryChangeManagementKey()``, or the lower-level ``SetManagementKeyCommand()``.
 
 ### TryChangeManagementKey() example
 
-To change the management key and set a new touch policy using the ``PivSession``, simply call``TryChangeManagementKey()`` and provide the current management key, the new management key, and the desired touch policy. In this example, let's set the touch policy to ``Always``:
+To change the management key and set a new touch policy using the ``PivSession``, simply call [TryChangeManagementKey()](xref:Yubico.YubiKey.Piv.PivSession.TryChangeManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.ReadOnlyMemory%7BSystem.Byte%7D%2CYubico.YubiKey.Piv.PivTouchPolicy%29) and provide the current management key, the new management key, and the desired touch policy. In this example, let's set the touch policy to ``Always``:
 
 ```csharp
 using (PivSession pivtest = new PivSession(yubiKey))
@@ -138,16 +138,18 @@ Note that ``TryChangeManagementKey()`` is an overloaded method. In addition to s
 
 ### SetManagementKeyCommand() example
 
-Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps: first we must initiate the PIV management key authentication process with ``InitializeAuthenticateManagementKeyCommand``, then we can finish management key authentication with ``CompleteAuthenticateManagementKeyCommand()``, and finally we can set the new management key and touch policy via ``SetManagementKeyCommand()``:
+Unlike the ``PivSession``, using the PIV command classes to change the management key requires three steps: first we must initiate the PIV management key authentication process with [InitializeAuthenticateManagementKeyCommand](xref:Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.PivAlgorithm%29), then we can finish management key authentication with [CompleteAuthenticateManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.CompleteAuthenticateManagementKeyCommand.%23ctor%28Yubico.YubiKey.Piv.Commands.InitializeAuthenticateManagementKeyResponse%2CSystem.ReadOnlySpan%7BSystem.Byte%7D%29), and finally we can set the new management key and touch policy via [SetManagementKeyCommand()](xref:Yubico.YubiKey.Piv.Commands.SetManagementKeyCommand.%23ctor%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CYubico.YubiKey.Piv.PivTouchPolicy%2CYubico.YubiKey.Piv.PivAlgorithm%29):
 
 ```csharp
 IYubiKeyConnection connection = yubiKey.Connect(YubiKeyApplication.Piv);
 
-// When initializing management key authentication with the command classes, we must specify the current management key's algorithm. (If you aren't sure about the algorithm, retrieve it from the key's metadata first.)
+// When initializing management key authentication with the command classes, we must specify the current
+// management key's algorithm. (If you aren't sure about the algorithm, retrieve it from the key's metadata first.)
 InitializeAuthenticateManagementKeyCommand initAuthManKeyCommand = new InitializeAuthenticateManagementKeyCommand(PivAlgorithm.Aes192);
 InitializeAuthenticateManagementKeyResponse initAuthManKeyResponse = connection.SendCommand(initAuthManKeyCommand);
 
-// Complete the management key authentication by passing in the initialization response and the current management key (currentKey set elsewhere).
+// Complete the management key authentication by passing in the initialization response and the current management
+// key (currentKey set elsewhere).
 CompleteAuthenticateManagementKeyCommand authManKeyCommand = new CompleteAuthenticateManagementKeyCommand(initAuthManKeyResponse, currentKey);
 CompleteAuthenticateManagementKeyResponse authManKeyResponse = connection.SendCommand(authManKeyCommand);
 
@@ -156,13 +158,13 @@ SetManagementKeyCommand setManKeyCommand = new SetManagementKeyCommand(newKey, P
 SetManagementKeyResponse setManKeyResponse = connection.SendCommand(setManKeyCommand);
 ```
 
-In this example, we set the management key's touch policy to ``Always``. This means that future calls to ``CompleteAuthenticateManagementKeyCommand`` will not complete until the YubiKey has been touched.
+In this example, we set the management key's touch policy to ``Always``. This means that all future calls to ``CompleteAuthenticateManagementKeyCommand`` will not complete until the YubiKey has been touched.
 
 ## Retrieving an existing key's PIN and touch policies
 
 Once a key has been generated or imported into a slot, you can check the PIN and touch policies it was configured with via the key's PIV metadata. Note that this feature is only available for YubiKeys with firmware version 5.3 and later. On older YubiKeys, there is no way to retrieve a key's policies after configuration.
 
-To check a key's policies, create an instance of a ``PivSession`` with the desired YubiKey, call ``GetMetadata`` on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
+To check a key's policies, create an instance of a ``PivSession`` with the desired YubiKey, call [GetMetadata](xref:Yubico.YubiKey.Piv.PivSession.GetMetadata%28System.Byte%29) on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
 
 ```csharp
 using (PivSession pivtest = new PivSession(yubiKey))
@@ -176,7 +178,9 @@ using (PivSession pivtest = new PivSession(yubiKey))
 }
 ```
 
-Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``. Slots 80 and 81 (PIN and PUK) do not have PIN or touch policies and will always return ``None`` for those properties in the metadata. The management key (9B), on the other hand, has a touch policy but no PIN policy. In order to maintain consistency with the data format, the YubiKey will return the undefined value "0" for 9B's PIN policy. This is not a valid PIN policy, and the SDK translates it to ``Default`` in the metadata.
+Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``. Slots 80 and 81 (PIN and PUK) do not have PIN or touch policies and will always return ``None`` for those properties in the metadata.
+
+The management key (9B)has a touch policy but no PIN policy. In order to maintain consistency with the data format, the YubiKey will return the undefined value "0" for 9B's PIN policy. This is not a valid PIN policy, and the SDK translates it to ``Default`` in the metadata.
 
 ## Related articles
 

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -119,18 +119,18 @@ In this example, we will generate a key in slot 9C and import a key into slot 9D
 
 With ``GenerateKeyPair``, we must specify the key's algorithm via the [KeyType](xref:Yubico.YubiKey.Cryptography.KeyType) class. ``ImportPrivateKey``, on the other hand, must be provided the private key to be imported, which must be an implementation of the [PrivateKey](xref:Yubico.YubiKey.Cryptography.PrivateKey) class.
 
-Generating and importing keys, however, requires management key authentication before those operations can complete. When you call ``GenerateKeyPair`` or ``ImportPrivateKey``, the SDK will call on your [KeyCollector](xref:Yubico.YubiKey.Piv.PivSession.KeyCollector) to collect the management key from the user and perform authentication automatically. However, we can also perform management key authentication manually (by providing the management key directly instead of using the KeyCollector) via [TryAuthenticateManagementKey](xref:Yubico.YubiKey.Piv.PivSession.TryAuthenticateManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.Boolean%29), which we will call in this example.
+Generating and importing keys, however, requires management key authentication before those operations can complete. When you call ``GenerateKeyPair`` or ``ImportPrivateKey``, the SDK will call on your [KeyCollector](xref:Yubico.YubiKey.Piv.PivSession.KeyCollector) to collect the management key from the user and perform authentication automatically. However, we can also perform management key authentication manually (by providing the management key directly instead of using the KeyCollector) via [TryAuthenticateManagementKey](xref:Yubico.YubiKey.Piv.PivSession.TryAuthenticateManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.Boolean%29), which we will call in this example:
 
 ```csharp
-using (PivSession pivtest = new PivSession(yubiKey))
+using (PivSession pivSession = new PivSession(yubiKey))
 {
     // Perform management key authentication first (managementKey set elsewhere).
-    pivtest.TryAuthenticateManagementKey(managementKey, true);
+    pivSession.TryAuthenticateManagementKey(managementKey, true);
 
-    pivtest.GenerateKeyPair(PivSlot.Signing, KeyType.RSA2048, PivPinPolicy.Once, PivTouchPolicy.Always);
+    pivSession.GenerateKeyPair(PivSlot.Signing, KeyType.RSA2048, PivPinPolicy.Once, PivTouchPolicy.Always);
 
     // privateKey set elsewhere.
-    pivtest.ImportPrivateKey(PivSlot.KeyManagement, privateKey, PivPinPolicy.Always, PivTouchPolicy.Cached);
+    pivSession.ImportPrivateKey(PivSlot.KeyManagement, privateKey, PivPinPolicy.Always, PivTouchPolicy.Cached);
 }
 ```
 
@@ -147,10 +147,10 @@ To change the management key with the SDK, there are two options: the ``PivSessi
 To change the management key and set a new touch policy using the ``PivSession``, simply call [TryChangeManagementKey()](xref:Yubico.YubiKey.Piv.PivSession.TryChangeManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.ReadOnlyMemory%7BSystem.Byte%7D%2CYubico.YubiKey.Piv.PivTouchPolicy%29) and provide the current management key, the new management key, and the desired touch policy. In this example, let's set the touch policy to ``Always``:
 
 ```csharp
-using (PivSession pivtest = new PivSession(yubiKey))
+using (PivSession pivSession = new PivSession(yubiKey))
 {
     // currentKey and newKey set elsewhere.
-    pivtest.TryChangeManagementKey(currentKey, newKey, PivTouchPolicy.Always);
+    pivSession.TryChangeManagementKey(currentKey, newKey, PivTouchPolicy.Always);
 }
 ```
 
@@ -187,10 +187,10 @@ Once a key has been generated or imported into a slot, you can check the PIN and
 To check a key's policies, create an instance of a ``PivSession`` with the desired YubiKey, call [GetMetadata](xref:Yubico.YubiKey.Piv.PivSession.GetMetadata%28System.Byte%29) on a specific PIV slot, and extract the ``PinPolicy`` and ``TouchPolicy`` properties:
 
 ```csharp
-using (PivSession pivtest = new PivSession(yubiKey))
+using (PivSession pivSession = new PivSession(yubiKey))
 {
     // Get the metadata from the key in slot 9A.
-    PivMetadata metadata = pivtest.GetMetadata(0x9A);
+    PivMetadata metadata = pivSession.GetMetadata(0x9A);
 
     // Extract the properties from the metadata.
     PivPinPolicy pinPolicy = metadata.PinPolicy;

--- a/docs/users-manual/application-piv/pin-touch-policies.md
+++ b/docs/users-manual/application-piv/pin-touch-policies.md
@@ -20,7 +20,7 @@ limitations under the License. -->
 
 The YubiKey's PIN, touch, and biometric policies determine when PIN verification, biometric verification, and touch are required in order to perform an operation with a private key from one of the YubiKey's PIV slots (including the management key).
 
-These policies apply to operations such as signing, decrypting, performing a key agreement, and generating a new key pair. For a full list of operations affected by PIN and touch policies, see [Operations that require the PIN](xref:UsersManualPinPukMgmtKey#operations-that-require-the-pin) and [Operations that require the management key](xref:UsersManualPinPukMgmtKey#operations-that-require-the-management-key).
+These policies apply to operations such as signing, decrypting, performing a key agreement, and authenticating the management key (required when generating a key pair, importing a private key or certificate, etc).
 
 ## Policy properties
 
@@ -61,7 +61,7 @@ Due to PIV card activation requirements in section 4.3 of the [FIPS 201-3 specif
 Biometric policies are a type of PIN policy that are available for YubiKey Bio Series — Multi-protocol Edition keys with firmware 5.7 or later. There are two biometric policy options:
 
 * ``Match Once``: a biometric or PIN verification is required for each session.
-* ``Match Always``: a biometric or PIN verification is required on every object access.
+* ``Match Always``: a biometric or PIN verification is required for every key operation.
 
 ## Touch policy options
 
@@ -86,35 +86,55 @@ It's also important to note that slots 9C and 9E have different default PIN poli
 
 When generating or importing a key into one of the PIV slots, these default policies will be applied to the key unless otherwise specified.
 
-## Setting keys to a non-default policy (all slots other than 80, 81, 9B, and F9)
+## Setting a key's PIN and touch policies (all slots other than 80, 81, and 9B)
 
-If you want a policy different from the default for a private key, you must specify that
-policy when the key is [generated](commands.md#generate-asymmetric) or
-[imported](commands.md#import-asymmetric). Once the key is on the YubiKey, there is no
-way to change the policy.
+You can set a private key's PIN and touch policies to something other than the slot's default options only when generating or importing the key onto the YubiKey (firmware version 4 and later). Note that you can specify different policies for keys in different slots. For example, you can generate a new key in slot 9A
+that has a PIN policy of ``Always``, while a key imported into slot 86 has a PIN policy of ``Once``.
 
-Note that you can specify different policies for keys in different slots (if the YubiKey
-has the option of setting policies). For example, you can generate a new key in slot 9A
-that has a PIN policy of "always", while a key imported into slot 86 has a PIN policy of
-"once".
+When specifying the PIN policy with the SDK, you must select one of the [PivPinPolicy](xref:Yubico.YubiKey.Piv.PivPinPolicy) enum fields:
 
-> It is important to point out that setting the PIN policy to "never" reduces security
-> dramatically. This feature was added only because of customer demand for convenience.
-> Yubico recommends setting the PIN policy to "always" or "once".
+- ``Always``
+- ``Default``
+- ``MatchAlways``
+- ``MatchOnce``
+- ``Never``
+- ``None``
+- ``Once``
 
-### Example scenarios
+However, note that if you choose ``MatchOnce`` or ``MatchAlways`` and your YubiKey is not a YubiKey Bio Series — Multi-protocol Edition key, the SDK will throw an exception. And as a reminder, setting the PIN policy to ``Never`` reduces security dramatically and is not recommended by Yubico.
 
-Suppose you generate a new key pair for slot 9C using the
-[Generate asymmetric key pair](commands.md#generate-asymmetric) command. You set
-the PIN policy to never and the touch policy to always. Now when you call the
-[Authenticate: sign](commands.md#authenticate-sign) command, you won't need to
-combine it with [PIN verification](commands.md#verify) to make it work, but the
-YubiKey won't complete the signing process until the YubiKey has been touched.
+When specifying the touch policy with the SDK, you must select one of the [PivTouchPolicy](xref:Yubico.YubiKey.Piv.PivTouchPolicy) enum fields:
 
-Suppose you generate a new key pair for slot 9D. You set the PIN policy to once, and the
-touch policy to never. Now when you first decrypt using that key in a session, you will
-need to authenticate the PIN, but won't need to touch. The next time you decrypt in the
-session, you will not need the PIN nor touch.
+- ``Always``
+- ``Cached``
+- ``Default``
+- ``Never``
+- ``None``
+
+It should also be noted that selecting ``None`` for either the PIN policy or touch policy during generation/import does not remove the policy field from the private key. The YubiKey's firmware interprets ``None`` as an invalid policy and will use the slot's default policy instead.
+
+### GenerateKeyPair() and ImportPrivateKey() example
+
+In this example, we will generate a key in slot 9C and import a key into slot 9D using the [GenerateKeyPair](xref:Yubico.YubiKey.Piv.PivSession.GenerateKeyPair%28System.Byte%2CYubico.YubiKey.Cryptography.KeyType%2CYubico.YubiKey.Piv.PivPinPolicy%2CYubico.YubiKey.Piv.PivTouchPolicy%29) and [ImportPrivateKey](xref:Yubico.YubiKey.Piv.PivSession.ImportPrivateKey%28System.Byte%2CYubico.YubiKey.Cryptography.IPrivateKey%2CYubico.YubiKey.Piv.PivPinPolicy%2CYubico.YubiKey.Piv.PivTouchPolicy%29) PIV session methods, respectively. When calling each method, we will specify the intended slot via the [PivSlot](xref:Yubico.YubiKey.Piv.PivSlot) class. For the 9C key, we will set its PIN policy to ``Once`` and its touch policy to ``Always``. For the 9D key, we will set its PIN policy to ``Always`` and its touch policy to ``Cached``.
+
+With ``GenerateKeyPair``, we must specify the key's algorithm via the [KeyType](xref:Yubico.YubiKey.Cryptography.KeyType) class. ``ImportPrivateKey``, on the other hand, must be provided the private key to be imported, which must be an implementation of the [PrivateKey](xref:Yubico.YubiKey.Cryptography.PrivateKey) class.
+
+Generating and importing keys, however, requires management key authentication before those operations can complete. When you call ``GenerateKeyPair`` or ``ImportPrivateKey``, the SDK will call on your [KeyCollector](xref:Yubico.YubiKey.Piv.PivSession.KeyCollector) to collect the management key from the user and perform authentication automatically. However, we can also perform management key authentication manually (by providing the management key directly instead of using the KeyCollector) via [TryAuthenticateManagementKey](xref:Yubico.YubiKey.Piv.PivSession.TryAuthenticateManagementKey%28System.ReadOnlyMemory%7BSystem.Byte%7D%2CSystem.Boolean%29), which we will call in this example.
+
+```csharp
+using (PivSession pivtest = new PivSession(yubiKey))
+{
+    // Perform management key authentication first (managementKey set elsewhere).
+    pivtest.TryAuthenticateManagementKey(managementKey, true);
+
+    pivtest.GenerateKeyPair(PivSlot.Signing, KeyType.RSA2048, PivPinPolicy.Once, PivTouchPolicy.Always);
+
+    // privateKey set elsewhere.
+    pivtest.ImportPrivateKey(PivSlot.KeyManagement, privateKey, PivPinPolicy.Always, PivTouchPolicy.Cached);
+}
+```
+
+After performing this configuration, every time a signing operation is performed with the key in slot 9C, the YubiKey must be touched, but the PIN will only need to be authenticated once per session. And when performing a decryption operation with the key in slot 9D, the PIN must be authenticated every time, but the YubiKey will only need to be touched if more than 15 seconds have elapsed since the previous touch.
 
 ## Changing the touch policy for the management key (slot 9B)
 
@@ -180,7 +200,7 @@ using (PivSession pivtest = new PivSession(yubiKey))
 
 Note that if the slot does not contain a key, the SDK will throw an exception when trying to call ``GetMetadata``. Slots 80 and 81 (PIN and PUK) do not have PIN or touch policies and will always return ``None`` for those properties in the metadata.
 
-The management key (9B)has a touch policy but no PIN policy. In order to maintain consistency with the data format, the YubiKey will return the undefined value "0" for 9B's PIN policy. This is not a valid PIN policy, and the SDK translates it to ``Default`` in the metadata.
+The management key (9B) has a touch policy but no PIN policy. In order to maintain consistency with the data format, the YubiKey will return the undefined value "0" for 9B's PIN policy. This is not a valid PIN policy, and the SDK translates it to ``Default`` in the metadata.
 
 ## Related articles
 

--- a/docs/users-manual/toc.yml
+++ b/docs/users-manual/toc.yml
@@ -176,7 +176,7 @@
           href: application-piv/access-control.md
         - name: PIN-only mode
           href: application-piv/pin-only.md
-        - name: PIN and touch policy
+        - name: PIN, touch, and biometric policies
           href: application-piv/pin-touch-policies.md
         - name: Keeping track of slot contents
           href: application-piv/keeping-track.md


### PR DESCRIPTION
# Description

Major updates to the PIV PIN and touch policy docs:

- Added info on policy behavior for 5.7 FIPS keys.
- Restructured the document.
- Added new sample code.
- Added docs on retrieving policy info in the PIV metadata.
- Clarified policy properties.
- Added info on firmware and SDK behavior.

Fixes: YESDK-1459

## How has this been tested?

Local docs build. Sample code tested in Visual Studio with version 1.15.1 of the SDK.
