### PR TITLE
fix: trim NUL bytes from HID device paths

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDeviceListener.cs
@@ -172,7 +172,7 @@ namespace Yubico.Core.Devices.Hid
                 {
                     case CM_NOTIFY_ACTION.DEVICEINTERFACEARRIVAL:
                         {
-                            string instancePath = System.Text.Encoding.Unicode.GetString(buffer);
+                            string instancePath = System.Text.Encoding.Unicode.GetString(buffer, 0, stringSize).TrimEnd('\0');
                             var cmDevice = CmDevice.FromDevicePath(instancePath);
                             if (cmDevice == null)
                             {


### PR DESCRIPTION
# Description
GetString(buffer) decoded the full eventDataSize
buffer, but only stringSize bytes were populated
by Marshal.Copy. The remaining bytes (zeros from
allocation) produced trailing U+0000 characters
in the device path string.

These null characters propagate into log output.
The structured (JSON) sink escapes them as \u0000, but the text sink writes literal zero bytes,
corrupting human-readable log files.

Scope the decode to stringSize and TrimEnd('\0')
to also strip the CM API null terminator.

Fixes: # ad-hoc

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Ran scenario, observed log files no longer have literal zero bytes

**Test configuration**:
* OS version: Windows 11
* Firmware version: 5.7.4
* Yubikey model[^1]: CNFC

## Checklist:

- [X] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [X] I have performed a self-review of my own code
- [ ] I have run `dotnet format` to format my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
