### PR TITLE
feat: Add support for Zlib compression/decompression 

### DIFF
--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -2445,6 +2445,15 @@ namespace Yubico.YubiKey {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error generating key pair: {0}.
+        /// </summary>
+        internal static string GenerateKeyPairFailed {
+            get {
+                return ResourceManager.GetString("GenerateKeyPairFailed", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Certificate data too short to determine compression format..
         /// </summary>
         internal static string CertificateDataTooShortToDetectFormat {

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.Designer.cs
@@ -2443,5 +2443,131 @@ namespace Yubico.YubiKey {
                 return ResourceManager.GetString("YubiKeyOperationFailed", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Certificate data too short to determine compression format..
+        /// </summary>
+        internal static string CertificateDataTooShortToDetectFormat {
+            get {
+                return ResourceManager.GetString("CertificateDataTooShortToDetectFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Could not detect compression format..
+        /// </summary>
+        internal static string CouldNotDetectCompressionFormat {
+            get {
+                return ResourceManager.GetString("CouldNotDetectCompressionFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Decompressed data length {0} does not match expected length {1} from GIDS header..
+        /// </summary>
+        internal static string DecompressedLengthMismatch {
+            get {
+                return ResourceManager.GetString("DecompressedLengthMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The stream does not support writing..
+        /// </summary>
+        internal static string StreamDoesNotSupportWriting {
+            get {
+                return ResourceManager.GetString("StreamDoesNotSupportWriting", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The stream does not support reading..
+        /// </summary>
+        internal static string StreamDoesNotSupportReading {
+            get {
+                return ResourceManager.GetString("StreamDoesNotSupportReading", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid CompressionMode value..
+        /// </summary>
+        internal static string InvalidCompressionModeValue {
+            get {
+                return ResourceManager.GetString("InvalidCompressionModeValue", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reading is not supported on compression streams..
+        /// </summary>
+        internal static string ReadingNotSupportedOnCompressionStreams {
+            get {
+                return ResourceManager.GetString("ReadingNotSupportedOnCompressionStreams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Writing is not supported on decompression streams..
+        /// </summary>
+        internal static string WritingNotSupportedOnDecompressionStreams {
+            get {
+                return ResourceManager.GetString("WritingNotSupportedOnDecompressionStreams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CopyTo is not supported on compression streams..
+        /// </summary>
+        internal static string CopyToNotSupportedOnCompressionStreams {
+            get {
+                return ResourceManager.GetString("CopyToNotSupportedOnCompressionStreams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to CopyToAsync is not supported on compression streams..
+        /// </summary>
+        internal static string CopyToAsyncNotSupportedOnCompressionStreams {
+            get {
+                return ResourceManager.GetString("CopyToAsyncNotSupportedOnCompressionStreams", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unexpected end of stream while reading zlib header..
+        /// </summary>
+        internal static string UnexpectedEndOfZlibHeader {
+            get {
+                return ResourceManager.GetString("UnexpectedEndOfZlibHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid zlib header checksum..
+        /// </summary>
+        internal static string InvalidZlibHeaderChecksum {
+            get {
+                return ResourceManager.GetString("InvalidZlibHeaderChecksum", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported zlib compression method: {0}. Only deflate (8) is supported..
+        /// </summary>
+        internal static string UnsupportedZlibCompressionMethod {
+            get {
+                return ResourceManager.GetString("UnsupportedZlibCompressionMethod", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Zlib streams with a preset dictionary are not supported..
+        /// </summary>
+        internal static string ZlibPresetDictionaryNotSupported {
+            get {
+                return ResourceManager.GetString("ZlibPresetDictionaryNotSupported", resourceCulture);
+            }
+        }
     }
 }

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -916,4 +916,46 @@
   <data name="KeyAgreementReceiptMissmatch" xml:space="preserve">
     <value>Key agreement receipts do not match</value>
   </data>
+  <data name="CertificateDataTooShortToDetectFormat" xml:space="preserve">
+    <value>Certificate data too short to determine compression format.</value>
+  </data>
+  <data name="CouldNotDetectCompressionFormat" xml:space="preserve">
+    <value>Could not detect compression format.</value>
+  </data>
+  <data name="DecompressedLengthMismatch" xml:space="preserve">
+    <value>Decompressed data length {0} does not match expected length {1} from GIDS header.</value>
+  </data>
+  <data name="StreamDoesNotSupportWriting" xml:space="preserve">
+    <value>The stream does not support writing.</value>
+  </data>
+  <data name="StreamDoesNotSupportReading" xml:space="preserve">
+    <value>The stream does not support reading.</value>
+  </data>
+  <data name="InvalidCompressionModeValue" xml:space="preserve">
+    <value>Invalid CompressionMode value.</value>
+  </data>
+  <data name="ReadingNotSupportedOnCompressionStreams" xml:space="preserve">
+    <value>Reading is not supported on compression streams.</value>
+  </data>
+  <data name="WritingNotSupportedOnDecompressionStreams" xml:space="preserve">
+    <value>Writing is not supported on decompression streams.</value>
+  </data>
+  <data name="CopyToNotSupportedOnCompressionStreams" xml:space="preserve">
+    <value>CopyTo is not supported on compression streams.</value>
+  </data>
+  <data name="CopyToAsyncNotSupportedOnCompressionStreams" xml:space="preserve">
+    <value>CopyToAsync is not supported on compression streams.</value>
+  </data>
+  <data name="UnexpectedEndOfZlibHeader" xml:space="preserve">
+    <value>Unexpected end of stream while reading zlib header.</value>
+  </data>
+  <data name="InvalidZlibHeaderChecksum" xml:space="preserve">
+    <value>Invalid zlib header checksum.</value>
+  </data>
+  <data name="UnsupportedZlibCompressionMethod" xml:space="preserve">
+    <value>Unsupported zlib compression method: {0}. Only deflate (8) is supported.</value>
+  </data>
+  <data name="ZlibPresetDictionaryNotSupported" xml:space="preserve">
+    <value>Zlib streams with a preset dictionary are not supported.</value>
+  </data>
 </root>

--- a/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
+++ b/Yubico.YubiKey/src/Resources/ExceptionMessages.resx
@@ -916,6 +916,9 @@
   <data name="KeyAgreementReceiptMissmatch" xml:space="preserve">
     <value>Key agreement receipts do not match</value>
   </data>
+  <data name="GenerateKeyPairFailed" xml:space="preserve">
+    <value>Error generating key pair: {0}</value>
+  </data>
   <data name="CertificateDataTooShortToDetectFormat" xml:space="preserve">
     <value>Certificate data too short to determine compression format.</value>
   </data>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
@@ -1,0 +1,585 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This implementation is based on RFC 1950 (ZLIB Compressed Data Format Specification).
+// It handles the zlib framing (header + Adler-32 trailer) around raw deflate data,
+// delegating the actual inflate/deflate work to the standard System.IO.Compression.DeflateStream.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Yubico.YubiKey.Cryptography
+{
+    /// <summary>
+    /// Provides methods and properties used to compress and decompress streams by
+    /// using the zlib data format specification (RFC 1950).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The zlib format wraps raw DEFLATE compressed data with a 2-byte header
+    /// (CMF and FLG) and a 4-byte Adler-32 checksum trailer. This class handles
+    /// the framing and delegates the actual compression/decompression to
+    /// <see cref="DeflateStream"/>.
+    /// </para>
+    /// <para>
+    /// This implementation targets .NET Standard 2.0 / 2.1 / .NET Framework 4.7.2
+    /// where <c>System.IO.Compression.ZLibStream</c> is not available.
+    /// </para>
+    /// </remarks>
+    internal sealed class ZLibStream : Stream
+    {
+        /// <summary>
+        /// The default zlib CMF byte: deflate method (CM=8), window size 2^15 (CINFO=7).
+        /// </summary>
+        private const byte DefaultCmf = 0x78;
+
+        /// <summary>
+        /// The FLG byte for default compression level.
+        /// Chosen so that (DefaultCmf * 256 + DefaultFlg) % 31 == 0.
+        /// </summary>
+        private const byte DefaultFlg = 0x9C;
+
+        private readonly CompressionMode _mode;
+        private readonly bool _leaveOpen;
+        private DeflateStream? _deflateStream;
+        private bool _headerProcessed;
+        private bool _disposed;
+
+        // For compression: tracks written data for Adler-32 computation
+        private uint _adlerA = 1;
+        private uint _adlerB;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZLibStream"/> class by using the
+        /// specified stream and compression mode.
+        /// </summary>
+        /// <param name="stream">The stream to which compressed data is written or from
+        /// which data to decompress is read.</param>
+        /// <param name="mode">One of the enumeration values that indicates whether to
+        /// compress data to the stream or decompress data from the stream.</param>
+        public ZLibStream(Stream stream, CompressionMode mode)
+            : this(stream, mode, leaveOpen: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZLibStream"/> class by using the
+        /// specified stream, compression mode, and whether to leave the stream open.
+        /// </summary>
+        /// <param name="stream">The stream to which compressed data is written or from
+        /// which data to decompress is read.</param>
+        /// <param name="mode">One of the enumeration values that indicates whether to
+        /// compress data to the stream or decompress data from the stream.</param>
+        /// <param name="leaveOpen"><see langword="true"/> to leave the stream object open
+        /// after disposing the <see cref="ZLibStream"/> object; otherwise,
+        /// <see langword="false"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="stream"/> is
+        /// <see langword="null"/>.</exception>
+        /// <exception cref="ArgumentException"><paramref name="mode"/> is
+        /// <see cref="CompressionMode.Decompress"/> and the stream does not support
+        /// reading, or <paramref name="mode"/> is <see cref="CompressionMode.Compress"/>
+        /// and the stream does not support writing.</exception>
+        public ZLibStream(Stream stream, CompressionMode mode, bool leaveOpen)
+        {
+            BaseStream = stream ?? throw new ArgumentNullException(nameof(stream));
+            _mode = mode;
+            _leaveOpen = leaveOpen;
+
+            if (mode == CompressionMode.Compress)
+            {
+                if (!stream.CanWrite)
+                {
+                    throw new ArgumentException("The stream does not support writing.", nameof(stream));
+                }
+            }
+            else if (mode == CompressionMode.Decompress)
+            {
+                if (!stream.CanRead)
+                {
+                    throw new ArgumentException("The stream does not support reading.", nameof(stream));
+                }
+            }
+            else
+            {
+                throw new ArgumentException("Invalid CompressionMode value.", nameof(mode));
+            }
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZLibStream"/> class by using the
+        /// specified stream and compression level.
+        /// </summary>
+        /// <param name="stream">The stream to which compressed data is written.</param>
+        /// <param name="compressionLevel">One of the enumeration values that indicates
+        /// whether to emphasize speed or compression efficiency when compressing data.</param>
+        public ZLibStream(Stream stream, CompressionLevel compressionLevel)
+            : this(stream, compressionLevel, leaveOpen: false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ZLibStream"/> class by using the
+        /// specified stream, compression level, and whether to leave the stream open.
+        /// </summary>
+        /// <param name="stream">The stream to which compressed data is written.</param>
+        /// <param name="compressionLevel">One of the enumeration values that indicates
+        /// whether to emphasize speed or compression efficiency when compressing data.</param>
+        /// <param name="leaveOpen"><see langword="true"/> to leave the stream object open
+        /// after disposing the <see cref="ZLibStream"/> object; otherwise,
+        /// <see langword="false"/>.</param>
+        public ZLibStream(Stream stream, CompressionLevel compressionLevel, bool leaveOpen)
+        {
+            BaseStream = stream ?? throw new ArgumentNullException(nameof(stream));
+
+            if (!stream.CanWrite)
+            {
+                throw new ArgumentException("The stream does not support writing.", nameof(stream));
+            }
+
+            _mode = CompressionMode.Compress;
+            _leaveOpen = leaveOpen;
+
+            // Write the zlib header immediately
+            WriteZLibHeader(compressionLevel);
+
+            _deflateStream = new DeflateStream(stream, compressionLevel, leaveOpen: true);
+            _headerProcessed = true;
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => !_disposed && _mode == CompressionMode.Decompress;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => !_disposed && _mode == CompressionMode.Compress;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <summary>
+        /// Gets a reference to the underlying stream.
+        /// </summary>
+        public Stream BaseStream { get; }
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("Reading is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            return _deflateStream!.Read(buffer, offset, count);
+        }
+
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("Reading is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            return _deflateStream!.ReadAsync(buffer, offset, count, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override int ReadByte()
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("Reading is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            return _deflateStream!.ReadByte();
+        }
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Compress)
+            {
+                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+            }
+
+            EnsureCompressionInitialized();
+
+            // Track uncompressed data for Adler-32
+            UpdateAdler32(buffer, offset, count);
+
+            _deflateStream!.Write(buffer, offset, count);
+        }
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Compress)
+            {
+                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+            }
+
+            EnsureCompressionInitialized();
+
+            // Track uncompressed data for Adler-32
+            UpdateAdler32(buffer, offset, count);
+
+            return _deflateStream!.WriteAsync(buffer, offset, count, cancellationToken);
+        }
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("Reading is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            return _deflateStream!.ReadAsync(buffer, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Compress)
+            {
+                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+            }
+
+            EnsureCompressionInitialized();
+
+            // Track uncompressed data for Adler-32
+            if (!buffer.IsEmpty)
+            {
+                byte[] temp = buffer.ToArray();
+                UpdateAdler32(temp, 0, temp.Length);
+            }
+
+            return _deflateStream!.WriteAsync(buffer, cancellationToken);
+        }
+#endif
+
+        /// <inheritdoc/>
+        public override void Flush()
+        {
+            ThrowIfDisposed();
+            _deflateStream?.Flush();
+        }
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (_deflateStream != null)
+            {
+                return _deflateStream.FlushAsync(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin) =>
+            throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override void SetLength(long value) =>
+            throw new NotSupportedException();
+
+#if NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
+        public override void CopyTo(Stream destination, int bufferSize)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("CopyTo is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            _deflateStream!.CopyTo(destination, bufferSize);
+        }
+#endif
+
+        /// <inheritdoc/>
+        public override Task CopyToAsync(Stream destination, int bufferSize, CancellationToken cancellationToken)
+        {
+            ThrowIfDisposed();
+
+            if (_mode != CompressionMode.Decompress)
+            {
+                throw new InvalidOperationException("CopyToAsync is not supported on compression streams.");
+            }
+
+            EnsureDecompressionInitialized();
+
+            return _deflateStream!.CopyToAsync(destination, bufferSize, cancellationToken);
+        }
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                if (disposing)
+                {
+                    if (_mode == CompressionMode.Compress && _deflateStream != null)
+                    {
+                        // Flush and close the deflate stream to finalize compressed data
+                        _deflateStream.Dispose();
+                        _deflateStream = null;
+
+                        // Write the Adler-32 checksum trailer (big-endian)
+                        WriteAdler32Trailer();
+                    }
+                    else
+                    {
+                        _deflateStream?.Dispose();
+                        _deflateStream = null;
+                    }
+
+                    if (!_leaveOpen)
+                    {
+                        BaseStream.Dispose();
+                    }
+                }
+
+                _disposed = true;
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Reads and validates the 2-byte zlib header (RFC 1950 section 2.2).
+        /// After validation, creates the internal <see cref="DeflateStream"/>
+        /// positioned at the start of the raw deflate data.
+        /// </summary>
+        /// <exception cref="InvalidDataException">The zlib header is invalid.</exception>
+        private void ReadAndValidateZLibHeader()
+        {
+            int cmf = BaseStream.ReadByte();
+            int flg = BaseStream.ReadByte();
+
+            if (cmf == -1 || flg == -1)
+            {
+                throw new InvalidDataException("Unexpected end of stream while reading zlib header.");
+            }
+
+            // Validate the header checksum: (CMF * 256 + FLG) must be divisible by 31
+            if (((cmf * 256) + flg) % 31 != 0)
+            {
+                throw new InvalidDataException("Invalid zlib header checksum.");
+            }
+
+            // Extract compression method (lower 4 bits of CMF)
+            int compressionMethod = cmf & 0x0F;
+            if (compressionMethod != 8)
+            {
+                throw new InvalidDataException(
+                    $"Unsupported zlib compression method: {compressionMethod}. Only deflate (8) is supported.");
+            }
+
+            // Check FDICT flag (bit 5 of FLG) - preset dictionary not supported
+            bool hasPresetDictionary = (flg & 0x20) != 0;
+            if (hasPresetDictionary)
+            {
+                throw new InvalidDataException(
+                    "Zlib streams with a preset dictionary are not supported.");
+            }
+        }
+
+        /// <summary>
+        /// Writes the 2-byte zlib header to the base stream.
+        /// </summary>
+        private void WriteZLibHeader(CompressionLevel compressionLevel)
+        {
+            byte cmf = DefaultCmf;
+            byte flg;
+
+            // Choose FLEVEL based on compression level and ensure header checksum is valid
+            switch (compressionLevel)
+            {
+                case CompressionLevel.NoCompression:
+                    // FLEVEL = 0 (compressor used fastest algorithm)
+                    flg = ComputeFlg(cmf, 0);
+                    break;
+                case CompressionLevel.Fastest:
+                    // FLEVEL = 1 (compressor used fast algorithm)
+                    flg = ComputeFlg(cmf, 1);
+                    break;
+                default:
+                    // FLEVEL = 2 (default) - covers Optimal and SmallestSize
+                    flg = DefaultFlg;
+                    break;
+            }
+
+            BaseStream.WriteByte(cmf);
+            BaseStream.WriteByte(flg);
+        }
+
+        /// <summary>
+        /// Computes the FLG byte given a CMF byte and desired FLEVEL (0-3).
+        /// Ensures that (CMF * 256 + FLG) % 31 == 0 per RFC 1950.
+        /// </summary>
+        private static byte ComputeFlg(byte cmf, int flevel)
+        {
+            // FLG layout: FLEVEL (2 bits) | FDICT (1 bit, 0) | FCHECK (5 bits)
+            int flgBase = (flevel & 0x03) << 6;
+            int remainder = ((cmf * 256) + flgBase) % 31;
+            int fcheck = (31 - remainder) % 31;
+
+            return (byte)(flgBase | fcheck);
+        }
+
+        /// <summary>
+        /// Writes the 4-byte Adler-32 checksum trailer in big-endian byte order.
+        /// </summary>
+        private void WriteAdler32Trailer()
+        {
+            uint checksum = (_adlerB << 16) | _adlerA;
+
+            BaseStream.WriteByte((byte)(checksum >> 24));
+            BaseStream.WriteByte((byte)(checksum >> 16));
+            BaseStream.WriteByte((byte)(checksum >> 8));
+            BaseStream.WriteByte((byte)checksum);
+        }
+
+        /// <summary>
+        /// Updates the running Adler-32 checksum with the given data.
+        /// </summary>
+        /// <remarks>
+        /// Adler-32 is defined in RFC 1950 section 9. It consists of two 16-bit
+        /// checksums A and B: A = 1 + sum of all bytes, B = sum of all A values,
+        /// both modulo 65521.
+        /// </remarks>
+        private void UpdateAdler32(byte[] buffer, int offset, int count)
+        {
+            const uint modAdler = 65521;
+
+            for (int i = offset; i < offset + count; i++)
+            {
+                _adlerA = (_adlerA + buffer[i]) % modAdler;
+                _adlerB = (_adlerB + _adlerA) % modAdler;
+            }
+        }
+
+        /// <summary>
+        /// Ensures the zlib header has been read and the internal DeflateStream
+        /// is initialized for decompression.
+        /// </summary>
+        private void EnsureDecompressionInitialized()
+        {
+            if (!_headerProcessed)
+            {
+                ReadAndValidateZLibHeader();
+                _deflateStream = new DeflateStream(BaseStream, CompressionMode.Decompress, leaveOpen: true);
+                _headerProcessed = true;
+            }
+        }
+
+        /// <summary>
+        /// Ensures the zlib header has been written and the internal DeflateStream
+        /// is initialized for compression.
+        /// </summary>
+        private void EnsureCompressionInitialized()
+        {
+            if (!_headerProcessed)
+            {
+                // Default compression level header
+                BaseStream.WriteByte(DefaultCmf);
+                BaseStream.WriteByte(DefaultFlg);
+                _deflateStream = new DeflateStream(BaseStream, CompressionLevel.Optimal, leaveOpen: true);
+                _headerProcessed = true;
+            }
+        }
+
+        private void ThrowIfDisposed()
+        {
+            if (_disposed)
+            {
+                throw new ObjectDisposedException(GetType().FullName);
+            }
+        }
+
+        /// <summary>
+        /// Computes the Adler-32 checksum over an entire byte array.
+        /// </summary>
+        /// <param name="data">The data to compute the checksum for.</param>
+        /// <returns>The 32-bit Adler-32 checksum value.</returns>
+        internal static uint ComputeAdler32(byte[] data)
+        {
+            return ComputeAdler32(data, 0, data.Length);
+        }
+
+        /// <summary>
+        /// Computes the Adler-32 checksum over a segment of a byte array.
+        /// </summary>
+        /// <param name="data">The data to compute the checksum for.</param>
+        /// <param name="offset">The offset into the data to start from.</param>
+        /// <param name="count">The number of bytes to include.</param>
+        /// <returns>The 32-bit Adler-32 checksum value.</returns>
+        internal static uint ComputeAdler32(byte[] data, int offset, int count)
+        {
+            const uint modAdler = 65521;
+            uint a = 1;
+            uint b = 0;
+
+            for (int i = offset; i < offset + count; i++)
+            {
+                a = (a + data[i]) % modAdler;
+                b = (b + a) % modAdler;
+            }
+
+            return (b << 16) | a;
+        }
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
@@ -36,6 +36,17 @@ namespace Yubico.YubiKey.Cryptography
     /// <see cref="DeflateStream"/>.
     /// </para>
     /// <para>
+    /// During <b>compression</b>, an Adler-32 checksum of all written bytes is
+    /// computed and appended as a 4-byte big-endian trailer when the stream is
+    /// disposed, producing a fully RFC 1950-compliant zlib stream.
+    /// </para>
+    /// <para>
+    /// During <b>decompression</b>, the 2-byte zlib header is validated (checksum,
+    /// compression method, and FDICT flag), but the 4-byte Adler-32 trailer is
+    /// <b>not</b> verified. Corruption that is not caught by the underlying DEFLATE
+    /// decoder will go undetected.
+    /// </para>
+    /// <para>
     /// This implementation targets .NET Standard 2.0 / 2.1 / .NET Framework 4.7.2
     /// where <c>System.IO.Compression.ZLibStream</c> is not available.
     /// </para>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Cryptography/ZLibStream.cs
@@ -103,19 +103,19 @@ namespace Yubico.YubiKey.Cryptography
             {
                 if (!stream.CanWrite)
                 {
-                    throw new ArgumentException("The stream does not support writing.", nameof(stream));
+                    throw new ArgumentException(ExceptionMessages.StreamDoesNotSupportWriting, nameof(stream));
                 }
             }
             else if (mode == CompressionMode.Decompress)
             {
                 if (!stream.CanRead)
                 {
-                    throw new ArgumentException("The stream does not support reading.", nameof(stream));
+                    throw new ArgumentException(ExceptionMessages.StreamDoesNotSupportReading, nameof(stream));
                 }
             }
             else
             {
-                throw new ArgumentException("Invalid CompressionMode value.", nameof(mode));
+                throw new ArgumentException(ExceptionMessages.InvalidCompressionModeValue, nameof(mode));
             }
         }
 
@@ -147,7 +147,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (!stream.CanWrite)
             {
-                throw new ArgumentException("The stream does not support writing.", nameof(stream));
+                throw new ArgumentException(ExceptionMessages.StreamDoesNotSupportWriting, nameof(stream));
             }
 
             _mode = CompressionMode.Compress;
@@ -191,7 +191,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("Reading is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.ReadingNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -206,7 +206,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("Reading is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.ReadingNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -221,7 +221,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("Reading is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.ReadingNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -236,7 +236,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Compress)
             {
-                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+                throw new InvalidOperationException(ExceptionMessages.WritingNotSupportedOnDecompressionStreams);
             }
 
             EnsureCompressionInitialized();
@@ -254,7 +254,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Compress)
             {
-                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+                throw new InvalidOperationException(ExceptionMessages.WritingNotSupportedOnDecompressionStreams);
             }
 
             EnsureCompressionInitialized();
@@ -273,7 +273,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("Reading is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.ReadingNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -288,7 +288,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Compress)
             {
-                throw new InvalidOperationException("Writing is not supported on decompression streams.");
+                throw new InvalidOperationException(ExceptionMessages.WritingNotSupportedOnDecompressionStreams);
             }
 
             EnsureCompressionInitialized();
@@ -340,7 +340,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("CopyTo is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.CopyToNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -356,7 +356,7 @@ namespace Yubico.YubiKey.Cryptography
 
             if (_mode != CompressionMode.Decompress)
             {
-                throw new InvalidOperationException("CopyToAsync is not supported on compression streams.");
+                throw new InvalidOperationException(ExceptionMessages.CopyToAsyncNotSupportedOnCompressionStreams);
             }
 
             EnsureDecompressionInitialized();
@@ -411,13 +411,13 @@ namespace Yubico.YubiKey.Cryptography
 
             if (cmf == -1 || flg == -1)
             {
-                throw new InvalidDataException("Unexpected end of stream while reading zlib header.");
+                throw new InvalidDataException(ExceptionMessages.UnexpectedEndOfZlibHeader);
             }
 
             // Validate the header checksum: (CMF * 256 + FLG) must be divisible by 31
             if (((cmf * 256) + flg) % 31 != 0)
             {
-                throw new InvalidDataException("Invalid zlib header checksum.");
+                throw new InvalidDataException(ExceptionMessages.InvalidZlibHeaderChecksum);
             }
 
             // Extract compression method (lower 4 bits of CMF)
@@ -425,15 +425,17 @@ namespace Yubico.YubiKey.Cryptography
             if (compressionMethod != 8)
             {
                 throw new InvalidDataException(
-                    $"Unsupported zlib compression method: {compressionMethod}. Only deflate (8) is supported.");
+                    string.Format(
+                        System.Globalization.CultureInfo.CurrentCulture,
+                        ExceptionMessages.UnsupportedZlibCompressionMethod,
+                        compressionMethod));
             }
 
             // Check FDICT flag (bit 5 of FLG) - preset dictionary not supported
             bool hasPresetDictionary = (flg & 0x20) != 0;
             if (hasPresetDictionary)
             {
-                throw new InvalidDataException(
-                    "Zlib streams with a preset dictionary are not supported.");
+                throw new InvalidDataException(ExceptionMessages.ZlibPresetDictionaryNotSupported);
             }
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -683,18 +683,17 @@ namespace Yubico.YubiKey.Piv
         /// </summary>
         /// <remarks>
         /// <para>
-        /// Supports the following compressed formats in order of detection:
+        /// Attempts to decompress using the following formats in order of detection:
         /// </para>
         /// <list type="number">
         /// <item><description>GZip (magic bytes 0x1F, 0x8B) — as specified by the PIV standard for
         /// compressed certificates.</description></item>
-        /// <item><description>Zlib (RFC 1950) — CMF byte with compression method 8 (deflate) and valid
-        /// header checksum. Common first bytes: 0x78 0x01/0x5E/0x9C/0xDA.</description></item>
-        /// <item><description>Net iD 4-byte header (0x01, 0x00 magic + 2-byte LE uncompressed length)
-        /// followed by GZip, zlib, or raw deflate data, as used by some third-party PIV
-        /// middleware.</description></item>
-        /// <item><description>Raw deflate as a last-resort fallback.</description></item>
+        /// <item><description>Zlib 4-byte header (0x01, 0x00 magic + 2-byte LE uncompressed length)
+        /// followed by compressed data, as used by some third-party PIV middleware.</description></item>
         /// </list>
+        /// <para>
+        /// If none of the above formats are detected, throws an exception.
+        /// </para>
         /// </remarks>
         static private byte[] DecompressWithFormatDetection(byte[] data)
         {
@@ -709,40 +708,13 @@ namespace Yubico.YubiKey.Piv
                 return Decompress(data);
             }
 
-            // Check for standard zlib (RFC 1950) header:
-            // CMF lower nibble must be 8 (deflate), and (CMF*256 + FLG) % 31 == 0
-            if (IsZlibHeader(data[0], data[1]))
-            {
-                return DecompressZlib(data);
-            }
-
-            // Check for Net iD prefix (0x01, 0x00) followed by compressed payload
+            // Check for Zlib magic bytes (0x01, 0x00) followed by compressed payload
             if (data[0] == 0x01 && data[1] == 0x00 && data.Length > 2)
             {
-                return DecompressNetId(data);
+                return DecompressZlib(data, offset: 4); // Skip header
             }
 
-            // Last resort: try raw deflate (no header/trailer)
-            return DecompressRawDeflate(data);
-        }
-
-        /// <summary>
-        /// Determines whether two bytes form a valid zlib (RFC 1950) header.
-        /// </summary>
-        /// <param name="cmf">The CMF (Compression Method and Flags) byte.</param>
-        /// <param name="flg">The FLG (Flags) byte.</param>
-        /// <returns><see langword="true"/> if the bytes form a valid zlib header
-        /// using the deflate compression method.</returns>
-        static private bool IsZlibHeader(byte cmf, byte flg)
-        {
-            // Compression method must be 8 (deflate)
-            if ((cmf & 0x0F) != 8)
-            {
-                return false;
-            }
-
-            // Header checksum: (CMF * 256 + FLG) must be divisible by 31
-            return ((cmf * 256) + flg) % 31 == 0;
+            throw new InvalidOperationException("Couldn't detect compression format.");
         }
 
         /// <summary>
@@ -762,70 +734,5 @@ namespace Yubico.YubiKey.Piv
                 }
             }
         }
-
-        /// <summary>
-        /// Decompresses raw deflate data (no zlib or gzip wrapper) starting at the specified offset.
-        /// </summary>
-        static private byte[] DecompressRawDeflate(byte[] data, int offset = 0)
-        {
-            using (var dataStream = new MemoryStream(data, offset, data.Length - offset))
-            {
-                using (var decompressor = new DeflateStream(dataStream, CompressionMode.Decompress))
-                {
-                    using (var decompressedStream = new MemoryStream())
-                    {
-                        decompressor.CopyTo(decompressedStream);
-                        return decompressedStream.ToArray();
-                    }
-                }
-            }
-        }
-
-        /// <summary>
-        /// Decompresses Net iD formatted data.
-        /// </summary>
-        /// <remarks>
-        /// <para>
-        /// The Net iD format uses a 4-byte header:
-        /// </para>
-        /// <list type="bullet">
-        /// <item><description>Bytes 0–1: Magic prefix (0x01, 0x00).</description></item>
-        /// <item><description>Bytes 2–3: Uncompressed data length in little-endian byte order.</description></item>
-        /// </list>
-        /// <para>
-        /// After the 4-byte header, the payload may be GZip, standard zlib
-        /// (RFC 1950), or raw deflate data. This method detects the sub-format
-        /// and decompresses accordingly.
-        /// </para>
-        /// </remarks>
-        static private byte[] DecompressNetId(byte[] data)
-        {
-            // Net iD header: 2-byte magic (0x01, 0x00) + 2-byte little-endian uncompressed length
-            const int netIdHeaderLength = 4;
-
-            if (data.Length <= netIdHeaderLength)
-            {
-                throw new InvalidOperationException(
-                    "Net iD compressed data is too short to contain a valid payload.");
-            }
-
-            // Check if the payload after the Net iD header is GZip
-            if (data.Length > netIdHeaderLength + 1 &&
-                data[netIdHeaderLength] == 0x1F && data[netIdHeaderLength + 1] == 0x8B)
-            {
-                return Decompress(data, offset: netIdHeaderLength);
-            }
-
-            // Check if the payload after the Net iD header is standard zlib
-            if (data.Length > netIdHeaderLength + 1 &&
-                IsZlibHeader(data[netIdHeaderLength], data[netIdHeaderLength + 1]))
-            {
-                return DecompressZlib(data, offset: netIdHeaderLength);
-            }
-
-            // Otherwise treat as raw deflate
-            return DecompressRawDeflate(data, offset: netIdHeaderLength);
-        }
-
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -700,7 +700,7 @@ namespace Yubico.YubiKey.Piv
         {
             if (data.Length < 2)
             {
-                throw new InvalidOperationException("Certificate data too short to determine compression format.");
+                throw new InvalidOperationException(ExceptionMessages.CertificateDataTooShortToDetectFormat);
             }
 
             // Check for GZip magic bytes (0x1F, 0x8B)
@@ -715,7 +715,7 @@ namespace Yubico.YubiKey.Piv
                 return DecompressGids(data);
             }
 
-            throw new InvalidOperationException("Couldn't detect compression format.");
+            throw new InvalidOperationException(ExceptionMessages.CouldNotDetectCompressionFormat);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace Yubico.YubiKey.Piv
                 throw new InvalidOperationException(
                     string.Format(
                         CultureInfo.CurrentCulture,
-                        "Decompressed data length {0} does not match expected length {1} from GIDS header.",
+                        ExceptionMessages.DecompressedLengthMismatch,
                         decompressed.Length,
                         expectedLength));
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -688,8 +688,9 @@ namespace Yubico.YubiKey.Piv
         /// <list type="number">
         /// <item><description>GZip (magic bytes 0x1F, 0x8B) — as specified by the PIV standard for
         /// compressed certificates.</description></item>
-        /// <item><description>Zlib 4-byte header (0x01, 0x00 magic + 2-byte LE uncompressed length)
-        /// followed by compressed data, as used by some third-party PIV middleware.</description></item>
+        /// <item><description>GIDS (magic bytes 0x01, 0x00 + 2-byte LE uncompressed length)
+        /// followed by zlib (RFC 1950) compressed data, as used by the GIDS smartcard
+        /// standard.</description></item>
         /// </list>
         /// <para>
         /// If none of the above formats are detected, throws an exception.
@@ -708,13 +709,49 @@ namespace Yubico.YubiKey.Piv
                 return Decompress(data);
             }
 
-            // Check for Zlib magic bytes (0x01, 0x00) followed by compressed payload
-            if (data[0] == 0x01 && data[1] == 0x00 && data.Length > 2)
+            // Check for GIDS header (0x01, 0x00) followed by 2-byte LE length and zlib payload
+            if (data[0] == 0x01 && data[1] == 0x00 && data.Length > 4)
             {
-                return DecompressZlib(data, offset: 4); // Skip header
+                return DecompressGids(data);
             }
 
             throw new InvalidOperationException("Couldn't detect compression format.");
+        }
+
+        /// <summary>
+        /// Decompresses GIDS-formatted data.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The GIDS format uses a 4-byte header:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>Bytes 0–1: Magic prefix (0x01, 0x00).</description></item>
+        /// <item><description>Bytes 2–3: Expected uncompressed data length in little-endian byte order.</description></item>
+        /// </list>
+        /// <para>
+        /// After the 4-byte header, the payload is zlib (RFC 1950) compressed data.
+        /// The decompressed length is validated against the expected length from the header.
+        /// </para>
+        /// </remarks>
+        static private byte[] DecompressGids(byte[] data)
+        {
+            const int gidsHeaderLength = 4;
+
+            int expectedLength = data[2] | (data[3] << 8);
+            byte[] decompressed = DecompressZlib(data, offset: gidsHeaderLength);
+
+            if (decompressed.Length != expectedLength)
+            {
+                throw new InvalidOperationException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        "Decompressed data length {0} does not match expected length {1} from GIDS header.",
+                        decompressed.Length,
+                        expectedLength));
+            }
+
+            return decompressed;
         }
 
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -176,7 +176,11 @@ namespace Yubico.YubiKey.Piv
             
             if (response.Status != ResponseStatus.Success)
             {
-                throw new InvalidOperationException("Error generating key pair: " + response);
+                throw new InvalidOperationException(
+                    string.Format(
+                        CultureInfo.CurrentCulture,
+                        ExceptionMessages.GenerateKeyPairFailed,
+                        response));
             }
 
             return PivKeyDecoder.CreatePublicKey(response.Data, keyType);
@@ -710,7 +714,7 @@ namespace Yubico.YubiKey.Piv
             }
 
             // Check for GIDS header (0x01, 0x00) followed by 2-byte LE length and zlib payload
-            if (data[0] == 0x01 && data[1] == 0x00 && data.Length > 4)
+            if (data[0] == 0x01 && data[1] == 0x00 && data.Length >= 6)
             {
                 return DecompressGids(data);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.KeyPairs.cs
@@ -605,14 +605,16 @@ namespace Yubico.YubiKey.Piv
 
             try
             {
-                return new X509Certificate2(Decompress(certBytesCopy));
+                byte[] decompressedData = DecompressWithFormatDetection(certBytesCopy);
+                return new X509Certificate2(decompressedData);
             }
-            catch (Exception)
+            catch (Exception ex)
             {
                 throw new InvalidOperationException(
                     string.Format(
                         CultureInfo.CurrentCulture,
-                        ExceptionMessages.FailedDecompressingCertificate));
+                        ExceptionMessages.FailedDecompressingCertificate),
+                    ex);
             }
         }
 
@@ -661,14 +663,169 @@ namespace Yubico.YubiKey.Piv
             return compressedStream.ToArray();
         }
 
-        static private byte[] Decompress(byte[] data)
+        static private byte[] Decompress(byte[] data, int offset = 0)
         {
-            using var dataStream = new MemoryStream(data);
-            using var decompressor = new GZipStream(dataStream, CompressionMode.Decompress);
-            using var decompressedStream = new MemoryStream();
-            decompressor.CopyTo(decompressedStream);
-            
-            return decompressedStream.ToArray();
+            using (var dataStream = new MemoryStream(data, offset, data.Length - offset))
+            {
+                using (var decompressor = new GZipStream(dataStream, CompressionMode.Decompress))
+                {
+                    using (var decompressedStream = new MemoryStream())
+                    {
+                        decompressor.CopyTo(decompressedStream);
+                        return decompressedStream.ToArray();
+                    }
+                }
+            }
         }
+
+        /// <summary>
+        /// Decompresses a certificate by detecting the compression format.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Supports the following compressed formats in order of detection:
+        /// </para>
+        /// <list type="number">
+        /// <item><description>GZip (magic bytes 0x1F, 0x8B) — as specified by the PIV standard for
+        /// compressed certificates.</description></item>
+        /// <item><description>Zlib (RFC 1950) — CMF byte with compression method 8 (deflate) and valid
+        /// header checksum. Common first bytes: 0x78 0x01/0x5E/0x9C/0xDA.</description></item>
+        /// <item><description>Net iD 4-byte header (0x01, 0x00 magic + 2-byte LE uncompressed length)
+        /// followed by GZip, zlib, or raw deflate data, as used by some third-party PIV
+        /// middleware.</description></item>
+        /// <item><description>Raw deflate as a last-resort fallback.</description></item>
+        /// </list>
+        /// </remarks>
+        static private byte[] DecompressWithFormatDetection(byte[] data)
+        {
+            if (data.Length < 2)
+            {
+                throw new InvalidOperationException("Certificate data too short to determine compression format.");
+            }
+
+            // Check for GZip magic bytes (0x1F, 0x8B)
+            if (data[0] == 0x1F && data[1] == 0x8B)
+            {
+                return Decompress(data);
+            }
+
+            // Check for standard zlib (RFC 1950) header:
+            // CMF lower nibble must be 8 (deflate), and (CMF*256 + FLG) % 31 == 0
+            if (IsZlibHeader(data[0], data[1]))
+            {
+                return DecompressZlib(data);
+            }
+
+            // Check for Net iD prefix (0x01, 0x00) followed by compressed payload
+            if (data[0] == 0x01 && data[1] == 0x00 && data.Length > 2)
+            {
+                return DecompressNetId(data);
+            }
+
+            // Last resort: try raw deflate (no header/trailer)
+            return DecompressRawDeflate(data);
+        }
+
+        /// <summary>
+        /// Determines whether two bytes form a valid zlib (RFC 1950) header.
+        /// </summary>
+        /// <param name="cmf">The CMF (Compression Method and Flags) byte.</param>
+        /// <param name="flg">The FLG (Flags) byte.</param>
+        /// <returns><see langword="true"/> if the bytes form a valid zlib header
+        /// using the deflate compression method.</returns>
+        static private bool IsZlibHeader(byte cmf, byte flg)
+        {
+            // Compression method must be 8 (deflate)
+            if ((cmf & 0x0F) != 8)
+            {
+                return false;
+            }
+
+            // Header checksum: (CMF * 256 + FLG) must be divisible by 31
+            return ((cmf * 256) + flg) % 31 == 0;
+        }
+
+        /// <summary>
+        /// Decompresses zlib (RFC 1950) data starting at the specified offset.
+        /// </summary>
+        static private byte[] DecompressZlib(byte[] data, int offset = 0)
+        {
+            using (var dataStream = new MemoryStream(data, offset, data.Length - offset))
+            {
+                using (var decompressor = new ZLibStream(dataStream, CompressionMode.Decompress))
+                {
+                    using (var decompressedStream = new MemoryStream())
+                    {
+                        decompressor.CopyTo(decompressedStream);
+                        return decompressedStream.ToArray();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decompresses raw deflate data (no zlib or gzip wrapper) starting at the specified offset.
+        /// </summary>
+        static private byte[] DecompressRawDeflate(byte[] data, int offset = 0)
+        {
+            using (var dataStream = new MemoryStream(data, offset, data.Length - offset))
+            {
+                using (var decompressor = new DeflateStream(dataStream, CompressionMode.Decompress))
+                {
+                    using (var decompressedStream = new MemoryStream())
+                    {
+                        decompressor.CopyTo(decompressedStream);
+                        return decompressedStream.ToArray();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Decompresses Net iD formatted data.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The Net iD format uses a 4-byte header:
+        /// </para>
+        /// <list type="bullet">
+        /// <item><description>Bytes 0–1: Magic prefix (0x01, 0x00).</description></item>
+        /// <item><description>Bytes 2–3: Uncompressed data length in little-endian byte order.</description></item>
+        /// </list>
+        /// <para>
+        /// After the 4-byte header, the payload may be GZip, standard zlib
+        /// (RFC 1950), or raw deflate data. This method detects the sub-format
+        /// and decompresses accordingly.
+        /// </para>
+        /// </remarks>
+        static private byte[] DecompressNetId(byte[] data)
+        {
+            // Net iD header: 2-byte magic (0x01, 0x00) + 2-byte little-endian uncompressed length
+            const int netIdHeaderLength = 4;
+
+            if (data.Length <= netIdHeaderLength)
+            {
+                throw new InvalidOperationException(
+                    "Net iD compressed data is too short to contain a valid payload.");
+            }
+
+            // Check if the payload after the Net iD header is GZip
+            if (data.Length > netIdHeaderLength + 1 &&
+                data[netIdHeaderLength] == 0x1F && data[netIdHeaderLength + 1] == 0x8B)
+            {
+                return Decompress(data, offset: netIdHeaderLength);
+            }
+
+            // Check if the payload after the Net iD header is standard zlib
+            if (data.Length > netIdHeaderLength + 1 &&
+                IsZlibHeader(data[netIdHeaderLength], data[netIdHeaderLength + 1]))
+            {
+                return DecompressZlib(data, offset: netIdHeaderLength);
+            }
+
+            // Otherwise treat as raw deflate
+            return DecompressRawDeflate(data, offset: netIdHeaderLength);
+        }
+
     }
 }

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
@@ -490,6 +490,38 @@ namespace Yubico.YubiKey.Cryptography
             Assert.Equal(original, decompressed);
         }
 
+        [Fact]
+        public void Compress_WritesCorrectAdler32Trailer()
+        {
+            // "Wikipedia" has the well-known Adler-32 value 0x11E60398.
+            // Verify that the last 4 bytes of the compressed output match the
+            // Adler-32 of the original data in big-endian order.
+            byte[] original = Encoding.ASCII.GetBytes("Wikipedia");
+
+            byte[] compressed;
+            using (var output = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(output, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = output.ToArray();
+            }
+
+            Assert.True(compressed.Length >= 6, "Compressed output too short to contain header + trailer.");
+
+            // Parse the 4-byte big-endian Adler-32 trailer
+            uint trailer = ((uint)compressed[compressed.Length - 4] << 24)
+                         | ((uint)compressed[compressed.Length - 3] << 16)
+                         | ((uint)compressed[compressed.Length - 2] << 8)
+                         | compressed[compressed.Length - 1];
+
+            uint expected = ZLibStream.ComputeAdler32(original);
+            Assert.Equal(0x11E60398u, expected); // sanity-check known test vector
+            Assert.Equal(expected, trailer);
+        }
+
         /// <summary>
         /// Simulates the GIDS format: 4-byte GIDS header (0x01, 0x00 magic +
         /// 2-byte LE uncompressed length) followed by standard zlib-compressed data.

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
@@ -1,0 +1,542 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using Xunit;
+
+namespace Yubico.YubiKey.Cryptography
+{
+    public class ZLibStreamTests
+    {
+        // "Hello, World!" compressed with zlib (RFC 1950).
+        private static readonly byte[] ZLibCompressedHelloWorld =
+        {
+            0x78, 0x9C, 0xF3, 0x48, 0xCD, 0xC9, 0xC9, 0xD7,
+            0x51, 0x08, 0xCF, 0x2F, 0xCA, 0x49, 0x51, 0x04,
+            0x00, 0x20, 0x5E, 0x04, 0x8A
+        };
+        private const string HelloWorldText = "Hello, World!";
+
+        [Fact]
+        public void Decompress_ValidZLibData_ReturnsOriginalData()
+        {
+            // Pure zlib (RFC 1950) data without any prefix.
+            string hex = "789c8b2c4dcaf4ce2c5148cb2f5270cc4b29cacf4c5128492d2e5148492c4904009f2e0aa4";
+
+            byte[] data = Convert.FromHexString(hex);
+
+            using var compressedStream = new MemoryStream(data);
+            using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
+            using var resultStream = new MemoryStream();
+
+            zlibStream.CopyTo(resultStream);
+            string result = Encoding.UTF8.GetString(resultStream.ToArray());
+
+            Assert.Equal("YubiKit for Android test data", result);
+        }
+
+        [Fact]
+        public void Decompress_NetIdFormat_StripsHeaderAndDecompresses()
+        {
+            // Net iD format: 4-byte header (01 00 = magic, 1D 00 = LE uncompressed length 29)
+            // followed by standard zlib (RFC 1950) data.
+            string hex = "01001d00789c8b2c4dcaf4ce2c5148cb2f5270cc4b29cacf4c5128492d2e5148492c4904009f2e0aa4";
+
+            byte[] data = Convert.FromHexString(hex);
+
+            // Strip 4-byte Net iD header, then decompress the zlib payload
+            const int netIdHeaderLength = 4;
+            using var compressedStream = new MemoryStream(data, netIdHeaderLength, data.Length - netIdHeaderLength);
+            using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
+            using var resultStream = new MemoryStream();
+
+            zlibStream.CopyTo(resultStream);
+            string result = Encoding.UTF8.GetString(resultStream.ToArray());
+
+            Assert.Equal("YubiKit for Android test data", result);
+        }
+
+        [Fact]
+        public void Decompress_ReadByteArray_ReturnsOriginalData()
+        {
+            using var compressedStream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
+
+            byte[] buffer = new byte[256];
+            int totalRead = 0;
+            int bytesRead;
+
+            while ((bytesRead = zlibStream.Read(buffer, totalRead, buffer.Length - totalRead)) > 0)
+            {
+                totalRead += bytesRead;
+            }
+
+            string result = Encoding.UTF8.GetString(buffer, 0, totalRead);
+            Assert.Equal(HelloWorldText, result);
+        }
+
+        [Fact]
+        public void Decompress_ReadByte_ReturnsCorrectFirstByte()
+        {
+            using var compressedStream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
+
+            int firstByte = zlibStream.ReadByte();
+
+            Assert.Equal((int)'H', firstByte);
+        }
+
+        [Fact]
+        public void Compress_ThenDecompress_RoundTrips()
+        {
+            byte[] original = Encoding.UTF8.GetBytes("The quick brown fox jumps over the lazy dog.");
+
+            // Compress
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            // Verify zlib header is present
+            Assert.Equal(0x78, compressed[0]);
+
+            // Decompress
+            byte[] decompressed;
+            using (var compressedStream = new MemoryStream(compressed))
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        zlibStream.CopyTo(resultStream);
+                        decompressed = resultStream.ToArray();
+                    }
+                }
+            }
+
+            Assert.Equal(original, decompressed);
+        }
+
+        [Fact]
+        public void Compress_EmptyData_RoundTrips()
+        {
+            byte[] original = Array.Empty<byte>();
+
+            // Compress
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            // Decompress
+            byte[] decompressed;
+            using (var compressedStream = new MemoryStream(compressed))
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        zlibStream.CopyTo(resultStream);
+                        decompressed = resultStream.ToArray();
+                    }
+                }
+            }
+
+            Assert.Equal(original, decompressed);
+        }
+
+        [Fact]
+        public void Compress_LargeData_RoundTrips()
+        {
+            // Create a large repetitive payload (~10KB)
+            var sb = new StringBuilder();
+            for (int i = 0; i < 500; i++)
+            {
+                sb.AppendLine($"Line {i}: The quick brown fox jumps over the lazy dog.");
+            }
+
+            byte[] original = Encoding.UTF8.GetBytes(sb.ToString());
+
+            // Compress
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            // Should actually be smaller due to repetition
+            Assert.True(compressed.Length < original.Length);
+
+            // Decompress
+            byte[] decompressed;
+            using (var compressedStream = new MemoryStream(compressed))
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        zlibStream.CopyTo(resultStream);
+                        decompressed = resultStream.ToArray();
+                    }
+                }
+            }
+
+            Assert.Equal(original, decompressed);
+        }
+
+        [Fact]
+        public void Decompress_InvalidHeader_ThrowsInvalidDataException()
+        {
+            // Invalid zlib header — checksum fails
+            byte[] invalidData = { 0x78, 0x00, 0x00, 0x00 };
+
+            using var stream = new MemoryStream(invalidData);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<InvalidDataException>(() => zlibStream.ReadByte());
+        }
+
+        [Fact]
+        public void Decompress_NonDeflateCompressionMethod_ThrowsInvalidDataException()
+        {
+            // CMF = 0x09 means compression method 9 (not deflate)
+            // FLG must satisfy (CMF * 256 + FLG) % 31 == 0
+            // 0x09 * 256 = 2304, 2304 % 31 = 10, so FLG = 31 - 10 = 21 = 0x15
+            byte[] invalidData = { 0x09, 0x15, 0x00, 0x00 };
+
+            using var stream = new MemoryStream(invalidData);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<InvalidDataException>(() => zlibStream.ReadByte());
+        }
+
+        [Fact]
+        public void Decompress_TruncatedHeader_ThrowsInvalidDataException()
+        {
+            byte[] truncatedData = { 0x78 };
+
+            using var stream = new MemoryStream(truncatedData);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<InvalidDataException>(() => zlibStream.ReadByte());
+        }
+
+        [Fact]
+        public void Constructor_NullStream_ThrowsArgumentNullException()
+        {
+#pragma warning disable CS8625 // Cannot convert null literal to non-nullable reference type.
+            Assert.Throws<ArgumentNullException>(() => new ZLibStream(null, CompressionMode.Decompress));
+#pragma warning restore CS8625
+        }
+
+        [Fact]
+        public void CanRead_DecompressMode_ReturnsTrue()
+        {
+            using var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.True(zlibStream.CanRead);
+            Assert.False(zlibStream.CanWrite);
+            Assert.False(zlibStream.CanSeek);
+        }
+
+        [Fact]
+        public void CanWrite_CompressMode_ReturnsTrue()
+        {
+            using var stream = new MemoryStream();
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Compress);
+
+            Assert.True(zlibStream.CanWrite);
+            Assert.False(zlibStream.CanRead);
+            Assert.False(zlibStream.CanSeek);
+        }
+
+        [Fact]
+        public void Write_InDecompressMode_ThrowsInvalidOperationException()
+        {
+            using var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<InvalidOperationException>(() => zlibStream.Write(new byte[] { 1 }, 0, 1));
+        }
+
+        [Fact]
+        public void Read_InCompressMode_ThrowsInvalidOperationException()
+        {
+            using var stream = new MemoryStream();
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Compress);
+
+            Assert.Throws<InvalidOperationException>(() => zlibStream.Read(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void Seek_ThrowsNotSupportedException()
+        {
+            using var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<NotSupportedException>(() => zlibStream.Seek(0, SeekOrigin.Begin));
+        }
+
+        [Fact]
+        public void Length_ThrowsNotSupportedException()
+        {
+            using var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Throws<NotSupportedException>(() => _ = zlibStream.Length);
+        }
+
+        [Fact]
+        public void Dispose_ThenRead_ThrowsObjectDisposedException()
+        {
+            var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            zlibStream.Dispose();
+
+            Assert.Throws<ObjectDisposedException>(() => zlibStream.Read(new byte[1], 0, 1));
+        }
+
+        [Fact]
+        public void LeaveOpen_True_DoesNotDisposeBaseStream()
+        {
+            var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            var zlibStream = new ZLibStream(stream, CompressionMode.Decompress, leaveOpen: true);
+
+            zlibStream.Dispose();
+
+            // Stream should still be accessible
+            Assert.True(stream.CanRead);
+        }
+
+        [Fact]
+        public void LeaveOpen_False_DisposesBaseStream()
+        {
+            var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            var zlibStream = new ZLibStream(stream, CompressionMode.Decompress, leaveOpen: false);
+
+            zlibStream.Dispose();
+
+            // Stream should be disposed
+            Assert.False(stream.CanRead);
+        }
+
+        [Fact]
+        public void BaseStream_ReturnsUnderlyingStream()
+        {
+            var stream = new MemoryStream(ZLibCompressedHelloWorld);
+            using var zlibStream = new ZLibStream(stream, CompressionMode.Decompress);
+
+            Assert.Same(stream, zlibStream.BaseStream);
+        }
+
+        [Fact]
+        public void CompressedOutput_HasValidZLibHeader()
+        {
+            byte[] compressed;
+            using (var output = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(output, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    byte[] data = Encoding.UTF8.GetBytes("test");
+                    zlibStream.Write(data, 0, data.Length);
+                }
+
+                compressed = output.ToArray();
+            }
+
+            // Verify CMF byte: deflate (method 8), window size 15 (CINFO 7)
+            Assert.Equal(0x78, compressed[0]);
+
+            // Verify header checksum: (CMF * 256 + FLG) % 31 == 0
+            int headerCheck = (compressed[0] * 256) + compressed[1];
+            Assert.Equal(0, headerCheck % 31);
+        }
+
+        [Fact]
+        public void ComputeAdler32_EmptyInput_ReturnsOne()
+        {
+            uint result = ZLibStream.ComputeAdler32(Array.Empty<byte>());
+
+            // For empty input, A=1, B=0, so Adler32 = (0 << 16) | 1 = 1
+            Assert.Equal(1u, result);
+        }
+
+        [Fact]
+        public void ComputeAdler32_KnownInput_ReturnsExpectedChecksum()
+        {
+            // "Wikipedia" Adler-32 is well-known: 0x11E60398
+            byte[] data = Encoding.ASCII.GetBytes("Wikipedia");
+            uint result = ZLibStream.ComputeAdler32(data);
+
+            Assert.Equal(0x11E60398u, result);
+        }
+
+        [Fact]
+        public void ComputeAdler32_WithOffset_ComputesCorrectly()
+        {
+            byte[] data = Encoding.ASCII.GetBytes("XXWikipediaYY");
+            // Offset 2, count 9 = "Wikipedia"
+            uint result = ZLibStream.ComputeAdler32(data, 2, 9);
+
+            Assert.Equal(0x11E60398u, result);
+        }
+
+        [Fact]
+        public void Compress_Fastest_ProducesValidOutput()
+        {
+            byte[] original = Encoding.UTF8.GetBytes("test data for fastest compression level");
+
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Fastest, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            // Verify valid header
+            Assert.Equal(0x78, compressed[0]);
+            int headerCheck = (compressed[0] * 256) + compressed[1];
+            Assert.Equal(0, headerCheck % 31);
+
+            // Verify decompression round-trip
+            byte[] decompressed;
+            using (var compressedStream = new MemoryStream(compressed))
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        zlibStream.CopyTo(resultStream);
+                        decompressed = resultStream.ToArray();
+                    }
+                }
+            }
+
+            Assert.Equal(original, decompressed);
+        }
+
+        [Fact]
+        public void Compress_NoCompression_ProducesValidOutput()
+        {
+            byte[] original = Encoding.UTF8.GetBytes("test data for no compression level");
+
+            byte[] compressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.NoCompression, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                compressed = compressedStream.ToArray();
+            }
+
+            // Verify valid header
+            Assert.Equal(0x78, compressed[0]);
+            int headerCheck = (compressed[0] * 256) + compressed[1];
+            Assert.Equal(0, headerCheck % 31);
+
+            // Verify decompression round-trip
+            byte[] decompressed;
+            using (var compressedStream = new MemoryStream(compressed))
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        zlibStream.CopyTo(resultStream);
+                        decompressed = resultStream.ToArray();
+                    }
+                }
+            }
+
+            Assert.Equal(original, decompressed);
+        }
+
+        /// <summary>
+        /// Simulates the Net iD zlib format: 4-byte Net iD header (0x01, 0x00 magic +
+        /// 2-byte LE uncompressed length) followed by standard zlib-compressed data.
+        /// Verifies the decompression approach used in PivSession.KeyPairs.DecompressNetId.
+        /// </summary>
+        [Fact]
+        public void Decompress_NetIdFormat_WithHeaderStripping_Works()
+        {
+            byte[] original = Encoding.UTF8.GetBytes("Certificate data for Net iD test");
+
+            // Compress with zlib
+            byte[] zlibCompressed;
+            using (var compressedStream = new MemoryStream())
+            {
+                using (var zlibStream = new ZLibStream(compressedStream, CompressionLevel.Optimal, leaveOpen: true))
+                {
+                    zlibStream.Write(original, 0, original.Length);
+                }
+
+                zlibCompressed = compressedStream.ToArray();
+            }
+
+            // Prepend the 4-byte Net iD header: magic (0x01, 0x00) + LE uncompressed length
+            int uncompressedLength = original.Length;
+            byte[] netIdData = new byte[4 + zlibCompressed.Length];
+            netIdData[0] = 0x01;
+            netIdData[1] = 0x00;
+            netIdData[2] = (byte)(uncompressedLength & 0xFF);
+            netIdData[3] = (byte)((uncompressedLength >> 8) & 0xFF);
+            Buffer.BlockCopy(zlibCompressed, 0, netIdData, 4, zlibCompressed.Length);
+
+            // Decompress like PivSession.KeyPairs.DecompressNetId does:
+            // strip 4-byte header, then pass to ZLibStream
+            const int netIdHeaderLength = 4;
+            using (var dataStream = new MemoryStream(netIdData, netIdHeaderLength, netIdData.Length - netIdHeaderLength))
+            {
+                using (var decompressor = new ZLibStream(dataStream, CompressionMode.Decompress))
+                {
+                    using (var resultStream = new MemoryStream())
+                    {
+                        decompressor.CopyTo(resultStream);
+                        byte[] decompressed = resultStream.ToArray();
+
+                        Assert.Equal(original, decompressed);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
@@ -512,10 +512,10 @@ namespace Yubico.YubiKey.Cryptography
             Assert.True(compressed.Length >= 6, "Compressed output too short to contain header + trailer.");
 
             // Parse the 4-byte big-endian Adler-32 trailer
-            uint trailer = ((uint)compressed[compressed.Length - 4] << 24)
-                         | ((uint)compressed[compressed.Length - 3] << 16)
-                         | ((uint)compressed[compressed.Length - 2] << 8)
-                         | compressed[compressed.Length - 1];
+            uint trailer = ((uint)compressed[^4] << 24)
+                         | ((uint)compressed[^3] << 16)
+                         | ((uint)compressed[^2] << 8)
+                         | compressed[^1];
 
             uint expected = ZLibStream.ComputeAdler32(original);
             Assert.Equal(0x11E60398u, expected); // sanity-check known test vector

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
@@ -50,17 +50,17 @@ namespace Yubico.YubiKey.Cryptography
         }
 
         [Fact]
-        public void Decompress_ZlibFormat_StripsHeaderAndDecompresses()
+        public void Decompress_GidsFormat_StripsHeaderAndDecompresses()
         {
-            // Zlib format: 4-byte header (01 00 = magic, 1D 00 = LE uncompressed length 29)
+            // GIDS format: 4-byte header (01 00 = magic, 1D 00 = LE uncompressed length 29)
             // followed by standard zlib (RFC 1950) data.
             string hex = "01001d00789c8b2c4dcaf4ce2c5148cb2f5270cc4b29cacf4c5128492d2e5148492c4904009f2e0aa4";
 
             byte[] data = Convert.FromHexString(hex);
 
-            // Strip 4-byte Zlib header, then decompress the zlib payload
-            const int zlibHeaderLength = 4;
-            using var compressedStream = new MemoryStream(data, zlibHeaderLength, data.Length - zlibHeaderLength);
+            // Strip 4-byte GIDS header, then decompress the zlib payload
+            const int gidsHeaderLength = 4;
+            using var compressedStream = new MemoryStream(data, gidsHeaderLength, data.Length - gidsHeaderLength);
             using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
             using var resultStream = new MemoryStream();
 
@@ -491,14 +491,14 @@ namespace Yubico.YubiKey.Cryptography
         }
 
         /// <summary>
-        /// Simulates the Zlib format: 4-byte Zlib header (0x01, 0x00 magic +
+        /// Simulates the GIDS format: 4-byte GIDS header (0x01, 0x00 magic +
         /// 2-byte LE uncompressed length) followed by standard zlib-compressed data.
-        /// Verifies the decompression approach used in PivSession.KeyPairs.DecompressZlib.
+        /// Verifies the decompression approach used in PivSession.KeyPairs.DecompressGids.
         /// </summary>
         [Fact]
-        public void Decompress_ZlibFormat_WithHeaderStripping_Works()
+        public void Decompress_GidsFormat_WithHeaderStripping_Works()
         {
-            byte[] original = Encoding.UTF8.GetBytes("Certificate data for Zlib test");
+            byte[] original = Encoding.UTF8.GetBytes("Certificate data for GIDS test");
 
             // Compress with zlib
             byte[] zlibCompressed;
@@ -512,19 +512,19 @@ namespace Yubico.YubiKey.Cryptography
                 zlibCompressed = compressedStream.ToArray();
             }
 
-            // Prepend the 4-byte Zlib header: magic (0x01, 0x00) + LE uncompressed length
+            // Prepend the 4-byte GIDS header: magic (0x01, 0x00) + LE uncompressed length
             int uncompressedLength = original.Length;
-            byte[] zlibData = new byte[4 + zlibCompressed.Length];
-            zlibData[0] = 0x01;
-            zlibData[1] = 0x00;
-            zlibData[2] = (byte)(uncompressedLength & 0xFF);
-            zlibData[3] = (byte)((uncompressedLength >> 8) & 0xFF);
-            Buffer.BlockCopy(zlibCompressed, 0, zlibData, 4, zlibCompressed.Length);
+            byte[] gidsData = new byte[4 + zlibCompressed.Length];
+            gidsData[0] = 0x01;
+            gidsData[1] = 0x00;
+            gidsData[2] = (byte)(uncompressedLength & 0xFF);
+            gidsData[3] = (byte)((uncompressedLength >> 8) & 0xFF);
+            Buffer.BlockCopy(zlibCompressed, 0, gidsData, 4, zlibCompressed.Length);
 
-            // Decompress like PivSession.KeyPairs.DecompressZlib does:
+            // Decompress like PivSession.KeyPairs.DecompressGids does:
             // strip 4-byte header, then pass to ZLibStream
-            const int zlibHeaderLength = 4;
-            using (var dataStream = new MemoryStream(zlibData, zlibHeaderLength, zlibData.Length - zlibHeaderLength))
+            const int gidsHeaderLength = 4;
+            using (var dataStream = new MemoryStream(gidsData, gidsHeaderLength, gidsData.Length - gidsHeaderLength))
             {
                 using (var decompressor = new ZLibStream(dataStream, CompressionMode.Decompress))
                 {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Cryptography/ZLibStreamTests.cs
@@ -50,17 +50,17 @@ namespace Yubico.YubiKey.Cryptography
         }
 
         [Fact]
-        public void Decompress_NetIdFormat_StripsHeaderAndDecompresses()
+        public void Decompress_ZlibFormat_StripsHeaderAndDecompresses()
         {
-            // Net iD format: 4-byte header (01 00 = magic, 1D 00 = LE uncompressed length 29)
+            // Zlib format: 4-byte header (01 00 = magic, 1D 00 = LE uncompressed length 29)
             // followed by standard zlib (RFC 1950) data.
             string hex = "01001d00789c8b2c4dcaf4ce2c5148cb2f5270cc4b29cacf4c5128492d2e5148492c4904009f2e0aa4";
 
             byte[] data = Convert.FromHexString(hex);
 
-            // Strip 4-byte Net iD header, then decompress the zlib payload
-            const int netIdHeaderLength = 4;
-            using var compressedStream = new MemoryStream(data, netIdHeaderLength, data.Length - netIdHeaderLength);
+            // Strip 4-byte Zlib header, then decompress the zlib payload
+            const int zlibHeaderLength = 4;
+            using var compressedStream = new MemoryStream(data, zlibHeaderLength, data.Length - zlibHeaderLength);
             using var zlibStream = new ZLibStream(compressedStream, CompressionMode.Decompress);
             using var resultStream = new MemoryStream();
 
@@ -491,14 +491,14 @@ namespace Yubico.YubiKey.Cryptography
         }
 
         /// <summary>
-        /// Simulates the Net iD zlib format: 4-byte Net iD header (0x01, 0x00 magic +
+        /// Simulates the Zlib format: 4-byte Zlib header (0x01, 0x00 magic +
         /// 2-byte LE uncompressed length) followed by standard zlib-compressed data.
-        /// Verifies the decompression approach used in PivSession.KeyPairs.DecompressNetId.
+        /// Verifies the decompression approach used in PivSession.KeyPairs.DecompressZlib.
         /// </summary>
         [Fact]
-        public void Decompress_NetIdFormat_WithHeaderStripping_Works()
+        public void Decompress_ZlibFormat_WithHeaderStripping_Works()
         {
-            byte[] original = Encoding.UTF8.GetBytes("Certificate data for Net iD test");
+            byte[] original = Encoding.UTF8.GetBytes("Certificate data for Zlib test");
 
             // Compress with zlib
             byte[] zlibCompressed;
@@ -512,19 +512,19 @@ namespace Yubico.YubiKey.Cryptography
                 zlibCompressed = compressedStream.ToArray();
             }
 
-            // Prepend the 4-byte Net iD header: magic (0x01, 0x00) + LE uncompressed length
+            // Prepend the 4-byte Zlib header: magic (0x01, 0x00) + LE uncompressed length
             int uncompressedLength = original.Length;
-            byte[] netIdData = new byte[4 + zlibCompressed.Length];
-            netIdData[0] = 0x01;
-            netIdData[1] = 0x00;
-            netIdData[2] = (byte)(uncompressedLength & 0xFF);
-            netIdData[3] = (byte)((uncompressedLength >> 8) & 0xFF);
-            Buffer.BlockCopy(zlibCompressed, 0, netIdData, 4, zlibCompressed.Length);
+            byte[] zlibData = new byte[4 + zlibCompressed.Length];
+            zlibData[0] = 0x01;
+            zlibData[1] = 0x00;
+            zlibData[2] = (byte)(uncompressedLength & 0xFF);
+            zlibData[3] = (byte)((uncompressedLength >> 8) & 0xFF);
+            Buffer.BlockCopy(zlibCompressed, 0, zlibData, 4, zlibCompressed.Length);
 
-            // Decompress like PivSession.KeyPairs.DecompressNetId does:
+            // Decompress like PivSession.KeyPairs.DecompressZlib does:
             // strip 4-byte header, then pass to ZLibStream
-            const int netIdHeaderLength = 4;
-            using (var dataStream = new MemoryStream(netIdData, netIdHeaderLength, netIdData.Length - netIdHeaderLength))
+            const int zlibHeaderLength = 4;
+            using (var dataStream = new MemoryStream(zlibData, zlibHeaderLength, zlibData.Length - zlibHeaderLength))
             {
                 using (var decompressor = new ZLibStream(dataStream, CompressionMode.Decompress))
                 {


### PR DESCRIPTION
# Description
*Certificates compressed with zlib can now be decompressed in the Piv application*

Fixes: # <[link to issue(s)](https://yubico.atlassian.net/jira/software/c/projects/YESDK/boards/1466?issueType=10057%2C10002%2C10001%2C10004%2C10000&selectedIssue=YESDK-1545)>

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## How has this been tested?

Unit tests that test the compression and decompression have been added and run. 

**Test configuration**:
* OS version: *MacOS 15.6*

## Checklist:

- [ ] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
