### PR TITLE
docs: added ZeroMemory operations to additional OTP configuration examples

### DIFF
--- a/docs/users-manual/application-otp/how-to-program-a-challenge-response-credential.md
+++ b/docs/users-manual/application-otp/how-to-program-a-challenge-response-credential.md
@@ -107,12 +107,22 @@ the button during a challenge-response operation.
 ```C#
 using (OtpSession otp = new OtpSession(yubiKey))
 {
-  // The secret key, hmacKey, was set elsewhere.
-  otp.ConfigureChallengeResponse(Slot.ShortPress)
-    .UseHmacSha1()
-    .UseKey(hmacKey)
-    .UseButton()
-    .Execute();
+  try
+  {
+    // The secret key, hmacKey, was set elsewhere.
+    otp.ConfigureChallengeResponse(Slot.ShortPress)
+      .UseHmacSha1()
+      .UseKey(hmacKey)
+      .UseButton()
+      .Execute();
+
+    // Share the secret key with the validation server (if you haven't already) 
+    // before clearing.
+  }
+  finally
+  {
+    CryptographicOperations.ZeroMemory(hmacKey.Span);
+  }
 }
 ```
 

--- a/docs/users-manual/application-otp/how-to-program-a-yubico-otp-credential.md
+++ b/docs/users-manual/application-otp/how-to-program-a-yubico-otp-credential.md
@@ -51,12 +51,22 @@ credential as follows:
 ```C#
 using (OtpSession otp = new OtpSession(yKey))
 {
-  // privateId and aesKey are Memory<byte> references.
-  otp.ConfigureYubicoOtp(Slot.ShortPress)
-    .UseSerialNumberAsPublicId()
-    .UsePrivateId(privateId)
-    .UseKey(aesKey)
-    .Execute();
+  try
+  {
+    // privateId and aesKey are Memory<byte> references.
+    otp.ConfigureYubicoOtp(Slot.ShortPress)
+      .UseSerialNumberAsPublicId()
+      .UsePrivateId(privateId)
+      .UseKey(aesKey)
+      .Execute();
+
+    // Do whatever is needed with privateId and aesKey before clearing them from memory.
+  }
+  finally
+  {
+    CryptographicOperations.ZeroMemory(privateId.Span);
+    CryptographicOperations.ZeroMemory(aesKey.Span);
+  }
 }
 ```
 

--- a/docs/users-manual/application-otp/how-to-program-an-hotp-credential.md
+++ b/docs/users-manual/application-otp/how-to-program-an-hotp-credential.md
@@ -57,9 +57,18 @@ using (OtpSession otp = new OtpSession(yubiKey))
 {
     ReadOnlyMemory<byte> hmacKey = new byte[ConfigureHotp.HmacKeySize] {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, };
 
-    otp.ConfigureHotp(Slot.LongPress)
-       .UseKey(hmacKey)
-       .Execute();
+    try
+    {
+        otp.ConfigureHotp(Slot.LongPress)
+           .UseKey(hmacKey)
+           .Execute();
+
+        // Share hmacKey with the validation server before clearing.
+    }
+    finally
+    {
+        CryptographicOperations.ZeroMemory(hmacKey.Span);
+    }
 }    
 ```
 
@@ -76,7 +85,7 @@ using (OtpSession otp = new OtpSession(yubiKey))
            .GenerateKey(hmacKey)
            .Execute();
 
-        // Share with validation server before clearing.
+        // Share hmacKey with the validation server before clearing.
     }
     finally
     {
@@ -119,7 +128,7 @@ using (OtpSession otp = new OtpSession(yubiKey))
            .Use8Digits()
            .Execute();
 
-        // Share with validation server before clearing.
+        // Share hmacKey with the validation server before clearing.
     }
     finally
     {


### PR DESCRIPTION
# Description

Added ZeroMemory operations to the OTP configuration how-to examples with predefined secret keys/values.

## How has this been tested?

Local docs build