### PR TITLE
test: SCP03 command chaining regression test (YESDK-1260)

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Scp/ScpConnection.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Scp/ScpConnection.cs
@@ -33,6 +33,7 @@ namespace Yubico.YubiKey.Scp
             : base(smartCardDevice, application, null)
         {
             var scpPipeline = CreateScpPipeline(keyParameters);
+
             var withErrorHandling = CreateParentPipeline(scpPipeline, application);
 
             // Have the base class use the new error augmented pipeline
@@ -61,13 +62,10 @@ namespace Yubico.YubiKey.Scp
 
         private ScpApduTransform CreateScpPipeline(ScpKeyParameters keyParameters)
         {
-            // Get the current pipeline
-            var previousPipeline = GetPipeline();
+            // Use GetPipeline() which includes CommandChaining(255).
+            // Transport-level chaining handles large encrypted APDUs.
+            var scpApduTransform = new ScpApduTransform(GetPipeline(), keyParameters);
 
-            // Wrap the pipeline in ScpApduTransform
-            var scpApduTransform = new ScpApduTransform(previousPipeline, keyParameters);
-
-            // Return both pipeline
             return scpApduTransform;
         }
 

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
@@ -574,13 +574,23 @@ namespace Yubico.YubiKey.Scp
 
                 if (useComplexCreds)
                 {
-                    setupSession.TryChangePin(PivSessionIntegrationTestBase.DefaultPin,
-                        PivSessionIntegrationTestBase.ComplexPin, out _);
-                    setupSession.TryChangePuk(PivSessionIntegrationTestBase.DefaultPuk,
-                        PivSessionIntegrationTestBase.ComplexPuk, out _);
-                    setupSession.TryChangeManagementKey(
-                        PivSessionIntegrationTestBase.DefaultManagementKey,
-                        PivSessionIntegrationTestBase.ComplexManagementKey);
+                    Assert.True(
+                        setupSession.TryChangePin(
+                            PivSessionIntegrationTestBase.DefaultPin,
+                            PivSessionIntegrationTestBase.ComplexPin,
+                            out _),
+                        "Changing the PIN during test setup should succeed.");
+                    Assert.True(
+                        setupSession.TryChangePuk(
+                            PivSessionIntegrationTestBase.DefaultPuk,
+                            PivSessionIntegrationTestBase.ComplexPuk,
+                            out _),
+                        "Changing the PUK during test setup should succeed.");
+                    Assert.True(
+                        setupSession.TryChangeManagementKey(
+                            PivSessionIntegrationTestBase.DefaultManagementKey,
+                            PivSessionIntegrationTestBase.ComplexManagementKey),
+                        "Changing the management key during test setup should succeed.");
                 }
 
                 Assert.True(setupSession.TryAuthenticateManagementKey(mgmtKey));
@@ -608,7 +618,7 @@ namespace Yubico.YubiKey.Scp
             var signature = pivSession.Sign(slotNumber, formattedData);
 
             // Verify signature using the generated public key
-            var rsaPublicKey = (RSAPublicKey)publicKey;
+            var rsaPublicKey = Assert.IsType<RSAPublicKey>(publicKey);
             using var rsa = RSA.Create();
             rsa.ImportParameters(rsaPublicKey.Parameters);
             var isVerified = rsa.VerifyData(

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
@@ -547,6 +547,79 @@ namespace Yubico.YubiKey.Scp
             return pin;
         }
 
+        [SkippableTheory(typeof(DeviceNotFoundException))]
+        [InlineData(StandardTestDevice.Fw5, Transport.UsbSmartCard)]
+        public void Scp03_Piv_RSA2048Sign_WithCommandChaining_Succeeds(
+            StandardTestDevice desiredDeviceType,
+            Transport transport)
+        {
+            // This test validates the fix for YESDK-1260: SCP03 command chaining.
+            // RSA 2048 signing sends 256 bytes of formatted data which exceeds the
+            // 239-byte SCP chunk limit, triggering command chaining.
+
+            var testDevice = GetDevice(desiredDeviceType, transport);
+            Assert.True(testDevice.HasFeature(YubiKeyFeature.Scp03));
+
+            bool useComplexCreds = testDevice.IsFipsSeries || testDevice.IsPinComplexityEnabled;
+            var mgmtKey = useComplexCreds
+                ? (ReadOnlyMemory<byte>)PivSessionIntegrationTestBase.ComplexManagementKey
+                : PivSessionIntegrationTestBase.DefaultManagementKey;
+
+            // Reset PIV and generate key WITHOUT SCP03 (simpler setup)
+            IPublicKey publicKey;
+            const byte slotNumber = PivSlot.Retired12;
+            using (var setupSession = new PivSession(testDevice))
+            {
+                setupSession.ResetApplication();
+
+                if (useComplexCreds)
+                {
+                    setupSession.TryChangePin(PivSessionIntegrationTestBase.DefaultPin,
+                        PivSessionIntegrationTestBase.ComplexPin, out _);
+                    setupSession.TryChangePuk(PivSessionIntegrationTestBase.DefaultPuk,
+                        PivSessionIntegrationTestBase.ComplexPuk, out _);
+                    setupSession.TryChangeManagementKey(
+                        PivSessionIntegrationTestBase.DefaultManagementKey,
+                        PivSessionIntegrationTestBase.ComplexManagementKey);
+                }
+
+                Assert.True(setupSession.TryAuthenticateManagementKey(mgmtKey));
+
+                publicKey = setupSession.GenerateKeyPair(
+                    slotNumber, KeyType.RSA2048, PivPinPolicy.Never, PivTouchPolicy.Never);
+            }
+
+            // Now open a new session WITH SCP03 to perform the sign operation
+            using var pivSession = new PivSession(testDevice, Scp03KeyParameters.DefaultKey);
+
+            // Sign data — 256 bytes of PKCS#1 formatted data triggers command chaining
+            var dataToSign = new byte[128];
+            Random.Shared.NextBytes(dataToSign);
+
+            using var digester = CryptographyProviders.Sha256Creator();
+            _ = digester.TransformFinalBlock(dataToSign, 0, dataToSign.Length);
+
+            var formattedData = RsaFormat.FormatPkcs1Sign(
+                digester.Hash,
+                RsaFormat.Sha256,
+                KeyType.RSA2048.GetKeyDefinition().LengthInBits);
+
+            // This is the critical operation — 256 bytes through SCP03 with command chaining
+            var signature = pivSession.Sign(slotNumber, formattedData);
+
+            // Verify signature using the generated public key
+            var rsaPublicKey = (RSAPublicKey)publicKey;
+            using var rsa = RSA.Create();
+            rsa.ImportParameters(rsaPublicKey.Parameters);
+            var isVerified = rsa.VerifyData(
+                dataToSign,
+                signature,
+                HashAlgorithmName.SHA256,
+                RSASignaturePadding.Pkcs1);
+
+            Assert.True(isVerified, "RSA 2048 signature over SCP03 should be valid");
+        }
+
         #region Helpers
 
         private static StaticKeys RandomStaticKeys() =>

--- a/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
+++ b/Yubico.YubiKey/tests/integration/Yubico/YubiKey/Scp/Scp03Tests.cs
@@ -602,19 +602,21 @@ namespace Yubico.YubiKey.Scp
             // Now open a new session WITH SCP03 to perform the sign operation
             using var pivSession = new PivSession(testDevice, Scp03KeyParameters.DefaultKey);
 
-            // Sign data — 256 bytes of PKCS#1 formatted data triggers command chaining
+            // Raw data to sign (arbitrary size — gets hashed to 32 bytes by SHA-256)
             var dataToSign = new byte[128];
             Random.Shared.NextBytes(dataToSign);
 
             using var digester = CryptographyProviders.Sha256Creator();
             _ = digester.TransformFinalBlock(dataToSign, 0, dataToSign.Length);
 
+            // PKCS#1 pads the 32-byte hash to match the RSA key size: 2048 bits = 256 bytes.
+            // 256 bytes exceeds the SCP03 transport limit (~239 bytes after encryption
+            // overhead), which forces command chaining — the scenario under test.
             var formattedData = RsaFormat.FormatPkcs1Sign(
                 digester.Hash,
                 RsaFormat.Sha256,
                 KeyType.RSA2048.GetKeyDefinition().LengthInBits);
 
-            // This is the critical operation — 256 bytes through SCP03 with command chaining
             var signature = pivSession.Sign(slotNumber, formattedData);
 
             // Verify signature using the generated public key


### PR DESCRIPTION
## Summary

- Adds integration test `Scp03_Piv_RSA2048Sign_WithCommandChaining_Succeeds` covering the scenario reported in YESDK-1260: RSA 2048 signing over an SCP03 channel, which triggers transport-level command chaining
- Cleans up stale comments in `ScpConnection.CreateScpPipeline`
- **No functional code change** — investigation confirmed the original pipeline order (`SCP03 → CommandChaining(255)`) is already correct

## Background

YESDK-1260 reported that `SW 6982` was returned for RSA signing over SCP03 while ECC signing worked fine. ECC doesn't trigger command chaining (small payload); RSA 2048 does (256-byte PKCS#1 block).

The correct pipeline order is:
1. **SCP03 encrypts + MACs the full plaintext APDU** (output can exceed 255 bytes)
2. **CommandChaining(255) splits the encrypted blob** into ≤255-byte transport chunks with `CLA | 0x10`
3. The YubiKey reassembles transport chunks before SCP03 decryption

This matches yubikey-manager's `ScpProcessor` implementation exactly. An earlier attempted fix that inverted this order (chunk first, then encrypt each chunk independently) was incorrect and has been reverted.

## Test plan

- [ ] Run `dotnet test Yubico.YubiKey/tests/integration/Yubico.YubiKey.IntegrationTests.csproj --filter "Scp03_Piv_RSA2048Sign_WithCommandChaining_Succeeds"` on a YubiKey 5 USB (non-FIPS)
- [ ] Confirm all 17 SCP03 integration tests still pass
- [ ] Confirm all unit tests pass (`dotnet test Yubico.YubiKey/tests/unit/Yubico.YubiKey.UnitTests.csproj`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)