### PR TITLE
docs: corrected info on encidentifier, added relevant info and links

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorInfo.cs
@@ -360,15 +360,21 @@ namespace Yubico.YubiKey.Fido2
         public IReadOnlyList<string> TransportsForReset { get; } = new List<string>();
 
         /// <summary>
-        /// If present, an encrypted identifier that the platform can use to identify the authenticator across resets.
-        /// The platform must use the persistent UV auth token as input to decrypt the identifier.
-        /// If <c>null</c>, the authenticator does not support this feature.
+        /// <para>
+        /// If present, an encrypted identifier that the platform can use to identify the authenticator across various sessions, states, and operations. The identifier is only set to a new random value when the YubiKey's FIDO2 application is reset, as is required by the CTAP 2.3 spec (<see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorReset">section 6.6</see>).
+        /// </para>
+        /// <para>
+        /// The platform must use the Persistent PinUvAuthToken (PPUAT) as input to decrypt the identifier (see <see cref="GetIdentifier"/>).
         /// The encrypted identifier is 32 bytes: the first 16 bytes are the IV,
         /// and the second 16 bytes are the ciphertext.
         /// The encryption algorithm is AES-128-CBC.
-        /// The key is derived from the persistent UV auth token using HKDF-SHA-256
+        /// The key is derived from the PPUAT using HKDF-SHA-256
         /// with the info string "encIdentifier" and a salt of 32 bytes of 0x00.
         /// The plaintext is 16 bytes.
+        /// </para>
+        /// <para>
+        /// EncIdentifier is supported in YubiKey firmware version 5.8 and later. If <c>null</c>, the authenticator does not support this feature.
+        /// </para>
         /// </summary>
         public ReadOnlyMemory<byte>? EncIdentifier { get; }
 
@@ -389,15 +395,21 @@ namespace Yubico.YubiKey.Fido2
         public IReadOnlyList<string> AttestationFormats { get; } = new List<string>();
 
         /// <summary>
-        /// If present, an encrypted credential store state that the platform can use to detect credential store changes across resets.
-        /// The platform must use the persistent UV auth token as input to decrypt the state.
-        /// If <c>null</c>, the authenticator does not support this feature.
+        /// <para>
+        /// If present, an encrypted credential store state that the platform can use to detect credential store changes. The credential store state is only set to a new random value after resetting the FIDO2 application, adding or deleting a discoverable credential, and updating a credential's user information, as required by the CTAP 2.3 spec (see <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorReset">section 6.6</see>, <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#op-makecred-step-rk">section 6.1.2</see>, <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#deleteCredential">section 6.8.5</see>, and <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#updateUserInformation">section 6.8.6</see>)
+        /// </para>
+        /// <para>
+        /// The platform must use the Persistent PinUvAuthToken (PPUAT) as input to decrypt the credential store state (see <see cref="GetCredStoreState"/>).
         /// The encrypted state is 32 bytes: the first 16 bytes are the IV,
         /// and the second 16 bytes are the ciphertext.
         /// The encryption algorithm is AES-128-CBC.
-        /// The key is derived from the persistent UV auth token using HKDF-SHA-256
+        /// The key is derived from the PPUAT using HKDF-SHA-256
         /// with the info string "encCredStoreState" and a salt of 32 bytes of 0x00.
         /// The plaintext is 16 bytes.
+        /// </para>
+        /// <para>
+        /// EncCredStoreState is supported in YubiKey firmware version 5.8 and later. If <c>null</c>, the authenticator does not support this feature.
+        /// </para>
         /// </summary>
         public ReadOnlyMemory<byte>? EncCredStoreState { get; }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
@@ -126,7 +126,7 @@ namespace Yubico.YubiKey.Fido2
         public AuthenticatorInfo AuthenticatorInfo => _authenticatorInfo ??= GetAuthenticatorInfoInternal();
 
         /// <summary>
-        /// Retrieves and decrypts the authenticator's unique 128-bit device identifier.
+        /// Retrieves and decrypts the authenticator's unique 128-bit device identifier. It will call the KeyCollector to retrieve a persistent PIN/UV Authentication Token (PPUAT), which is required to perform the decryption operation.
         /// </summary>
         /// <remarks>
         /// <para>
@@ -135,12 +135,12 @@ namespace Yubico.YubiKey.Fido2
         /// containing a device identifier that is unique to the authenticator.
         /// </para>
         /// <para>
-        /// A valid and active persistent PIN/UV Authentication Token is automatically obtained if needed.
+        /// A valid and active PPUAT is automatically obtained.
         /// The authenticator must support and return the `encIdentifier` in its `getInfo` response (YubiKeys v5.8.0 and later).
         /// </para>
         /// <para>
-        /// The identifier remains constant across PIN changes and resets, allowing platforms to track
-        /// the same physical authenticator across different sessions and states.
+        /// The identifier remains constant across PIN changes and other FIDO2 operations, allowing platforms to track
+        /// the same physical authenticator across different sessions and states. The identifier is only set to a new random value when the YubiKey's FIDO2 application is reset, as is required by the CTAP 2.3 spec (<see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorReset">section 6.6</see>).
         /// </para>
         /// </remarks>
         /// <returns>
@@ -149,9 +149,9 @@ namespace Yubico.YubiKey.Fido2
         /// </para>
         /// <para>
         /// Returns <c>null</c> if:
-        /// - The YubiKey firmware does not support this feature (firmware &lt; 5.8.0)
-        /// - The persistent PIN/UV auth token could not be obtained
-        /// - The user cancels PIN entry when prompted
+        /// <br/> - The YubiKey firmware does not support this feature (firmware &lt; 5.8.0).
+        /// <br/> - The PPUAT could not be obtained.
+        /// <br/> - The user cancels PIN entry when prompted.
         /// </para>
         /// <para>
         /// Always check <c>result.HasValue</c> before accessing <c>result.Value</c>.
@@ -170,22 +170,21 @@ namespace Yubico.YubiKey.Fido2
         }
 
         /// <summary>
-        /// Retrieves and decrypts the authenticator's credential store state.
+        /// Retrieves and decrypts the authenticator's credential store state. It will call the KeyCollector to retrieve a persistent PIN/UV Authentication Token (PPUAT), which is required to perform the decryption operation.
         /// </summary>
         /// <remarks>
         /// <para>
         /// This property leverages the <c>encCredStoreState</c> value obtained from the authenticator's
         /// <c>authenticatorGetInfo</c> response. The <c>encCredStoreState</c> is an encrypted byte string
-        /// that platforms can use to detect credential store changes across resets.
+        /// that platforms can use to detect credential store changes. The credential store state is only set to a new random value after resetting the FIDO2 application, adding or deleting a discoverable credential, and updating a credential's user information, as required by the CTAP 2.3 spec (see <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#authenticatorReset">section 6.6</see>, <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#op-makecred-step-rk">section 6.1.2</see>, <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#deleteCredential">section 6.8.5</see>, and <see href="https://fidoalliance.org/specs/fido-v2.3-ps-20260226/fido-client-to-authenticator-protocol-v2.3-ps-20260226.html#updateUserInformation">section 6.8.6</see>)
         /// </para>
         /// <para>
-        /// A valid and active persistent PIN/UV Authentication Token is automatically obtained if needed.
+        /// A valid and active PPUAT is automatically obtained.
         /// The authenticator must support and return the `encCredStoreState` in its `getInfo` response (YubiKeys v5.8.0 and later).
         /// </para>
         /// <para>
         /// By comparing the credential store state before and after operations (or across sessions), platforms can detect
-        /// when credentials have been added, removed, or when the authenticator has been reset. The state changes
-        /// whenever the credential store is modified.
+        /// when important authenticator operations have taken place and react accordingly (e.g. remove a deleted credential from a list of credentials displayed in an application window).
         /// </para>
         /// </remarks>
         /// <returns>
@@ -194,9 +193,9 @@ namespace Yubico.YubiKey.Fido2
         /// </para>
         /// <para>
         /// Returns <c>null</c> if:
-        /// - The YubiKey firmware does not support this feature (firmware &lt; 5.8.0)
-        /// - The persistent PIN/UV auth token could not be obtained
-        /// - The user cancels PIN entry when prompted
+        /// <br/> - The YubiKey firmware does not support this feature (firmware &lt; 5.8.0).
+        /// <br/> - The PPUAT could not be obtained.
+        /// <br/> - The user cancels PIN entry when prompted.
         /// </para>
         /// <para>
         /// Always check <c>result.HasValue</c> before accessing <c>result.Value</c>.


### PR DESCRIPTION
# Description

Corrected information on EncIdentifier behavior, added new info on EncIdentifier and EncCredStoreState with relevant links, fixed formatting.

Fixes: [RFE-3843](https://yubico.atlassian.net/browse/RFE-3843)

## How has this been tested?

Local docs build. Validated YubiKey behavior with 5.8 beta key and SDK version 1.16.0.
