### PR TITLE
Fix smart card listener timeout handling and add backoff for immediate failures

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDeviceListener.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDeviceListener.cs
@@ -29,6 +29,13 @@ namespace Yubico.Core.Devices.SmartCard
     /// </summary>
     internal class DesktopSmartCardDeviceListener : SmartCardDeviceListener
     {
+        private enum CheckForUpdatesResult
+        {
+            Continue,
+            Stop,
+            Backoff
+        }
+
         private static readonly string[] readerNames = new[] { "\\\\?\\Pnp\\Notifications" };
         private readonly ILogger _log = Logging.Log.GetLogger<DesktopSmartCardDeviceListener>();
 
@@ -112,16 +119,22 @@ namespace Yubico.Core.Devices.SmartCard
             {
                 try
                 {
-                    bool result = CheckForUpdates(usePnpWorkaround);
-                    if (!result)
+                    CheckForUpdatesResult result = CheckForUpdates(usePnpWorkaround);
+                    if (result == CheckForUpdatesResult.Stop)
                     {
                         break;
-                    }    
+                    }
+
+                    if (result == CheckForUpdatesResult.Backoff)
+                    {
+                        Thread.Sleep(CheckForChangesWaitTime);
+                    }
                 }
                 catch (Exception e)
                 {
                     _log.LogError(e, "Exception occurred while listening for smart card reader changes.");
                     Status = DeviceListenerStatus.Error;
+                    Thread.Sleep(CheckForChangesWaitTime);
                 }
             }
         }
@@ -201,7 +214,19 @@ namespace Yubico.Core.Devices.SmartCard
             _listenerThread = null;
         }
 
-        private bool CheckForUpdates(bool usePnpWorkaround)
+        /// <summary>
+        /// Checks for smart-card reader and card state changes, and determines whether the
+        /// listener should continue normally, stop, or back off before retrying.
+        /// </summary>
+        /// <param name="usePnpWorkaround">
+        /// Use <c>SCardListReaders</c> instead of relying on the <c>\\?\Pnp\Notifications</c> device.
+        /// </param>
+        /// <returns>
+        /// <see cref="CheckForUpdatesResult.Continue"/> if processing should continue normally,
+        /// <see cref="CheckForUpdatesResult.Stop"/> if the listener should stop,
+        /// or <see cref="CheckForUpdatesResult.Backoff"/> if the caller should delay before retrying.
+        /// </returns>
+        private CheckForUpdatesResult CheckForUpdates(bool usePnpWorkaround)
         {
             var arrivedDevices = new List<ISmartCardDevice>();
             var removedDevices = new List<ISmartCardDevice>();
@@ -209,9 +234,21 @@ namespace Yubico.Core.Devices.SmartCard
             var newStates = (SCARD_READER_STATE[])_readerStates.Clone();
 
             uint getStatusChangeResult = SCardGetStatusChange(_context, (int)CheckForChangesWaitTime.TotalMilliseconds, newStates, newStates.Length);
+
+            if (getStatusChangeResult == ErrorCode.SCARD_E_TIMEOUT)
+            {
+                // Timeout is expected behavior in polling - don't log as it occurs every 100ms
+                return CheckForUpdatesResult.Continue;
+            }
+
             if (!HandleSCardGetStatusChangeResult(getStatusChangeResult, newStates))
             {
-                return false;
+                return CheckForUpdatesResult.Stop;
+            }
+
+            if (getStatusChangeResult != ErrorCode.SCARD_S_SUCCESS)
+            {
+                return CheckForUpdatesResult.Backoff;
             }
 
             while (ReaderListChangeDetected(ref newStates, usePnpWorkaround))
@@ -248,9 +285,19 @@ namespace Yubico.Core.Devices.SmartCard
                     _log.LogInformation("Additional smart card readers were found. Calling GetStatusChange for more information.");
                     getStatusChangeResult = SCardGetStatusChange(_context, 0, updatedStates, updatedStates.Length);
 
+                    if (getStatusChangeResult == ErrorCode.SCARD_E_TIMEOUT)
+                    {
+                        return CheckForUpdatesResult.Continue;
+                    }
+
                     if (!HandleSCardGetStatusChangeResult(getStatusChangeResult, updatedStates))
                     {
-                        return false;
+                        return CheckForUpdatesResult.Stop;
+                    }
+
+                    if (getStatusChangeResult != ErrorCode.SCARD_S_SUCCESS)
+                    {
+                        return CheckForUpdatesResult.Backoff;
                     }
                 }
 
@@ -260,9 +307,20 @@ namespace Yubico.Core.Devices.SmartCard
             if (RelevantChangesDetected(newStates))
             {
                 getStatusChangeResult = SCardGetStatusChange(_context, 0, newStates, newStates.Length);
+
+                if (getStatusChangeResult == ErrorCode.SCARD_E_TIMEOUT)
+                {
+                    return CheckForUpdatesResult.Continue;
+                }
+
                 if (!HandleSCardGetStatusChangeResult(getStatusChangeResult, newStates))
                 {
-                    return false;
+                    return CheckForUpdatesResult.Stop;
+                }
+
+                if (getStatusChangeResult != ErrorCode.SCARD_S_SUCCESS)
+                {
+                    return CheckForUpdatesResult.Backoff;
                 }
             }
 
@@ -277,7 +335,7 @@ namespace Yubico.Core.Devices.SmartCard
 
             FireEvents(arrivedDevices, removedDevices);
 
-            return true;
+            return CheckForUpdatesResult.Continue;
         }
 
         // So apparently not all platforms implement the virtual pnp reader semantics the same. They will still wait on
@@ -449,7 +507,7 @@ namespace Yubico.Core.Devices.SmartCard
         }
 
         /// <summary>
-        /// Handles common SCardGetStatusChange result codes including cancellation, timeouts, and non-critical errors.
+        /// Handles common SCardGetStatusChange result codes including cancellation and non-critical errors.
         /// Logs appropriately based on the result code.
         /// </summary>
         /// <param name="result">The result code from SCardGetStatusChange</param>
@@ -461,12 +519,6 @@ namespace Yubico.Core.Devices.SmartCard
             {
                 _log.LogInformation("GetStatusChange indicated SCARD_E_CANCELLED.");
                 return false;
-            }
-
-            // Timeout is expected behavior in polling - don't log as it occurs every 100ms
-            if (result == ErrorCode.SCARD_E_TIMEOUT)
-            {
-                return true;
             }
 
             // Non-critical errors that need context update


### PR DESCRIPTION
# Description
This change fixes two smart-card listener issues in the .NET SDK. 
First, it treats SCARD_E_TIMEOUT as a normal polling outcome and exits the current update cycle without continuing into change detection or firing events. 
Second, it adds a backoff path for immediate non-timeout failures, so the listener does not hot-loop and flood logs when SCardGetStatusChange returns immediately with errors such as Result = 6.

The idea is to only slows the bad failure path
it preserves fast success handling and it preserves normal timeout behavior

timeout → Continue
cancelled → Stop
immediate failure → Backoff
success → keep processing normally.

**Issue fixed & Motivation and context:**
Fixes the smart-card listener log flooding issue where SCardGetStatusChange failures could be logged at sub-millisecond intervals instead of following the intended 100 ms polling cadence. (a simpler fix of just adding Thread.Sleep(CheckForChangesWaitTime) after the immediate failure path. That would likely reduce the log flooding with a small code change, but it felt more like a mitigation than a clean fix. The richer return approach seemed better because it makes the control flow explicit: CheckForUpdates() can tell the caller whether to continue, stop, or back off, and ListenForReaderChanges() can handle each case appropriately.)

**Dependencies:**
No external dependencies. PCS will need to update to the fixed .NET SDK package once the new NuGet release is published.

Fixes: # <[PROD-5297](https://yubico.atlassian.net/browse/PROD-5297)>

## Type of change

- [ ] Refactor (non-breaking change which improves code quality or performance)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How has this been tested?

Tested by running PCS and comparing the logs.

## Checklist:

- [x] My code follows the [style guidelines](https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/CONTRIBUTING.md) of this project 
- [x] I have performed a self-review of my own code
- [x] I have run `dotnet format` to format my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

[^1]: See [Yubikey models](https://www.yubico.com/products/) (Multi-protocol, Security Key, FIPS, Bio, YubiHSM, YubiHSM FIPS)
