### PR TITLE
ci: migrate source-url to explicit nuget source registration

### DIFF
--- a/.github/workflows/build-pull-requests.yml
+++ b/.github/workflows/build-pull-requests.yml
@@ -64,9 +64,10 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           global-json-file: global.json
-          source-url: https://nuget.pkg.github.com/Yubico/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register GitHub Packages NuGet source
+        run: |
+          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
       - name: Build Yubico.NET.SDK.sln
         run: dotnet build --configuration Release --nologo --verbosity minimal Yubico.NET.SDK.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,10 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           global-json-file: "./global.json"
-          source-url: https://nuget.pkg.github.com/Yubico/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register GitHub Packages NuGet source
+        run: |
+          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
       - name: Set build version
         if: ${{ github.event.inputs.version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -67,10 +67,10 @@ jobs:
       # Setup .NET with authenticated NuGet source
       - name: Setup .NET
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
-        with:
-          source-url: https://nuget.pkg.github.com/Yubico/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register GitHub Packages NuGet source
+        run: |
+          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -48,10 +48,6 @@ jobs:
         with:
           global-json-file: "./global.json"
 
-      - name: Register GitHub Packages NuGet source
-        run: |
-          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
-
       #- name: Build Yubico.NET.SDK.sln
       #  run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
       - name: "Add DOTNET to path explicitly to address bug where it cannot be found"

--- a/.github/workflows/verify-code-style.yml
+++ b/.github/workflows/verify-code-style.yml
@@ -47,9 +47,11 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7  # v5.2.0
         with:
           global-json-file: "./global.json"
-          source-url: https://nuget.pkg.github.com/Yubico/index.json
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Register GitHub Packages NuGet source
+        run: |
+          dotnet nuget add source --username ${{ github.actor }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/Yubico/index.json"
+
       #- name: Build Yubico.NET.SDK.sln
       #  run: dotnet build --nologo --verbosity normal Yubico.NET.SDK.sln
       - name: "Add DOTNET to path explicitly to address bug where it cannot be found"


### PR DESCRIPTION
## Summary

Migrates 3 `actions/setup-dotnet@v5` callsites from the fragile `source-url:` parameter to explicit `dotnet nuget add source --name github` registration. Also removes an unnecessary GitHub Packages NuGet source registration from `verify-code-style.yml` which uses `--no-restore`.

## Context

`actions/setup-dotnet@v5.2.0` (commit `2aa9c062`) silently dropped named-source registration from the `source-url:` parameter. While the affected workflows technically still work via v5's implicit `nuget.config` creation for restore operations, this behavior is undocumented and fragile.

This PR applies the same explicit registration pattern already used in `build-nativeshims.yml` (lines 517-519) to ensure durable, documented behavior across all workflows that actually need the internal NuGet feed.

## Files Changed

### Migrated to Explicit Registration (3 workflows)

These workflows transitively restore `Yubico.NativeShims` from the internal GitHub Packages feed via `Yubico.Core.csproj:132`, so they need the explicit source registration:

1. `.github/workflows/build.yml` (build-artifacts job) — runs `dotnet pack`
2. `.github/workflows/build-pull-requests.yml` — runs `dotnet build`
3. `.github/workflows/codeql-analysis.yml` — CodeQL build trace with restore

Pattern: Remove `source-url:` and `env: NUGET_AUTH_TOKEN:` from `setup-dotnet`, add explicit `- name: Register GitHub Packages NuGet source` step.

### Cleaned Up (1 workflow)

4. `.github/workflows/verify-code-style.yml` — **removed** the GitHub Packages source registration added in the first commit because this workflow runs `dotnet format --verify-no-changes --no-restore` (line 77), which explicitly skips package restore and doesn't need any internal NuGet feed access.

## Companion Work

This is a companion to the fix in PR #460 commit `eb5438ae`, which addressed the same v5 regression for the **named-source-push** case (publish-internal job in build.yml). That fix enabled `dotnet nuget push --source "github"` by registering the source with an explicit name.

This PR completes the migration by cleaning up the 3 **restore-with-internal-packages** sites that still used `source-url:`.

## Test Plan

- [x] Two atomic commits created and pushed
- [ ] CI build-pull-requests.yml passes (exercises the changed code path)
- [ ] verify-code-style.yml passes (with no NuGet source — uses --no-restore)
- [ ] codeql-analysis.yml passes
- [ ] No functional change expected — this is a registration pattern migration + cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)