### PR TITLE
Update deploy-docs.yaml to target old and new clusters in parallel

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,13 +3,12 @@ name: Deploy documentation
 on:
   workflow_dispatch:
     inputs:
-      gitops-branch:
+      environment:
         type: choice
         description: Environment to deploy to
         required: true
         options:
           - dev
-          - stage
           - prod
       image-tag:
         type: string
@@ -31,103 +30,24 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Check out current repo
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          path: self
-          persist-credentials: false
-
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           workload_identity_provider: ${{ vars.GLOBAL_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: yubico-docs@prod-github-apps-845651.iam.gserviceaccount.com
+          service_account: yesdk-ci-builder@support-cluster-769001.iam.gserviceaccount.com
+          token_format: access_token
 
-      - name: Generate GitHub App token
-        id: generate_token
-        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
-        with:
-          app-id: 800408 # Yubico Docs
-          owner: Yubico
-          repositories: docs-gitops
-          private-key: ${{ secrets.GH_APP_YUBICO_DOCS_PRIVATE_KEY }}
+      - name: Create Flux-compatible image tag (dev)
+        if: inputs.environment == 'dev'
+        run: |
+          gcloud artifacts docker tags add \
+            "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:${{ inputs.image-tag }}" \
+            "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:$(date +%s)-${{ inputs.image-tag }}"
 
-      - name: Check out docs-gitops repo (${{ inputs.gitops-branch }} branch)
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          repository: Yubico/docs-gitops
-          ref: ${{ inputs.gitops-branch }}
-          token: ${{ steps.generate_token.outputs.token }}
-          path: gitops
-          persist-credentials: true
-
-      - name: Update GitOps resources
-        run: sed -i "s#/yesdk/yesdk-docserver:.*\$#/yesdk/yesdk-docserver:$IMAGE_TAG#" ./k8s/yesdk/kustomization.yaml
-        working-directory: ./gitops
-        env:
-          IMAGE_TAG: "${{ inputs.image-tag }}"
-
-      - name: Set up commit signing
-        run: .github/scripts/configure-git-pgp.sh
-        env:
-          PGP_KEY: ${{ secrets.DOCS_GITOPS_PGP_KEY }}
-        working-directory: ./self
-
-      - name: Push changes to GitOps repo
-        run: ${{ github.workspace }}/self/.github/scripts/commit-and-push.sh
-        working-directory: ./gitops
-        env:
-          GITOPS_BRANCH: ${{ inputs.gitops-branch }}
-          IMAGE_TAG: "${{ inputs.image-tag }}"
-
-  verify:
-    name: Verify deployment completion
-    runs-on: ubuntu-latest
-    needs: deploy
-
-    steps:
-    - name: Harden the runner (Audit all outbound calls)
-      uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
-      with:
-        egress-policy: audit
-
-    - name: Checkout
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      with:
-        persist-credentials: false
-
-    - name: Authenticate to Google Cloud to read commit status
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
-      with:
-        workload_identity_provider: ${{ vars.GLOBAL_GCP_WORKLOAD_IDENTITY_PROVIDER }}
-        service_account: github-commit-status-reader@prod-docs-403900.iam.gserviceaccount.com
-
-    - name: Generate GitHub App token
-      id: generate_token
-      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3  # v3.1.1
-      with:
-        app-id: 260767 # Yubico Commit Status Reader
-        owner: Yubico
-        repositories: docs-gitops
-        private-key: ${{ secrets.GH_APP_YUBICO_COMMIT_STATUS_READER_PRIVATE_KEY }}
-
-    - name: Wait for deployment to complete
-      run: ./.github/scripts/wait-for-commit-status.sh
-      env:
-        GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
-        ORG: yubico
-        REPO: docs-gitops
-        REF: ${{ inputs.gitops-branch }}
-        KUSTOMIZATION_NAME: docs
-
-    - name: Purge Fastly cache
-      run: >-
-        curl
-        -X POST
-        -H "Accept: application/json"
-        -H "Fastly-Key: ${{ secrets.FASTLY_API_KEY }}"
-        "https://api.fastly.com/service/${{ secrets.FASTLY_SERVICE_ID }}/purge_all"
-
-    - name: Wait 30 seconds for Fastly cache to purge
-      run: sleep 30
+      - name: Create Flux-compatible image tag (prod)
+        if: inputs.environment == 'prod'
+        run: |
+          gcloud artifacts docker tags add \
+            "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:${{ inputs.image-tag }}" \
+            "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:yesdk-${{ inputs.image-tag }}"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -131,3 +131,35 @@ jobs:
 
     - name: Wait 30 seconds for Fastly cache to purge
       run: sleep 30
+
+  deploy-us2:
+    name: Deploy docs (US2)
+    runs-on: ubuntu-latest
+    if: inputs.gitops-branch != 'stage'
+
+    steps:
+    - name: Harden the runner (Audit all outbound calls)
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      with:
+        egress-policy: audit
+
+    - id: auth
+      name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+      with:
+        workload_identity_provider: ${{ vars.GLOBAL_GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: yesdk-ci-builder@support-cluster-769001.iam.gserviceaccount.com
+
+    - name: Create Flux-compatible image tag (dev)
+      if: inputs.gitops-branch == 'dev'
+      run: |
+        gcloud artifacts docker tags add \
+          "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:${{ inputs.image-tag }}" \
+          "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:$(date +%s)-${{ inputs.image-tag }}"
+
+    - name: Create Flux-compatible image tag (prod)
+      if: inputs.gitops-branch == 'prod'
+      run: |
+        gcloud artifacts docker tags add \
+          "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:${{ inputs.image-tag }}" \
+          "us-docker.pkg.dev/support-cluster-769001/yesdk/yesdk-docserver:yesdk-$(date +%s)-${{ inputs.image-tag }}"


### PR DESCRIPTION
The publishing process for the doc site is [changing](https://github.com/Yubico/docs/pull/1443), so the yesdk image needs to update to go along with it.

This adds a parallel `deploy-us2` job to the deploy-docs workflow that tags the Docker image for use with Flux image automation. This will make the workflow will deploy to both clusters at the same time. Once we're sure that everything is ready in US2 I'll clean up the old US1 deployment job.