### PR TITLE
fix(logging): downgrade HID/SmartCard transport events from Info to Debug

### DIFF
--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/HidLoggerExtensions.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/HidLoggerExtensions.cs
@@ -23,7 +23,7 @@ namespace Yubico.Core.Devices.Hid
         {
             if (result == kern_return_t.KERN_SUCCESS)
             {
-                logger.LogInformation("{APIName} called successfully.", apiName);
+                logger.LogDebug("{APIName} called successfully.", apiName);
             }
             else
             {

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/LinuxHidDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/LinuxHidDevice.cs
@@ -330,7 +330,7 @@ namespace Yubico.Core.Devices.Hid
         public void LogDeviceAccessTime()
         {
             LastAccessed = DateTime.Now;
-            _log.LogInformation("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
+            _log.LogDebug("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/LinuxHidIOReportConnection.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/LinuxHidIOReportConnection.cs
@@ -60,7 +60,7 @@ namespace Yubico.Core.Devices.Hid
         // exactly 64 bytes long.
         public void SetReport(byte[] report)
         {
-            _log.SensitiveLogInformation("Sending IO report> {report}, Length = {length}", Hex.BytesToHex(report), report.Length);
+            _log.SensitiveLogDebug("Sending IO report> {report}, Length = {length}", Hex.BytesToHex(report), report.Length);
             if (report.Length != YubiKeyIOReportSize)
             {
                 throw new InvalidOperationException(
@@ -105,7 +105,7 @@ namespace Yubico.Core.Devices.Hid
 
             if (bytesRead >= 0)
             {
-                _log.SensitiveLogInformation("Receiving IO report< {report}", Hex.BytesToHex(outputBuffer));
+                _log.SensitiveLogDebug("Receiving IO report< {report}", Hex.BytesToHex(outputBuffer));
                 return outputBuffer;
             }
 

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidDevice.cs
@@ -136,7 +136,7 @@ namespace Yubico.Core.Devices.Hid
         public void LogDeviceAccessTime()
         {
             LastAccessed = DateTime.Now;
-            _log.LogInformation("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
+            _log.LogDebug("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidFeatureReportConnection.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidFeatureReportConnection.cs
@@ -147,7 +147,7 @@ namespace Yubico.Core.Devices.Hid
                     ExceptionMessages.IOKitOperationFailed);
             }
 
-            _log.SensitiveLogInformation(
+            _log.SensitiveLogDebug(
                 "GetReport returned buffer: {Report}",
                 Hex.BytesToHex(buffer));
 
@@ -165,7 +165,7 @@ namespace Yubico.Core.Devices.Hid
         /// </exception>
         public void SetReport(byte[] report)
         {
-            _log.SensitiveLogInformation(
+            _log.SensitiveLogDebug(
                 "Calling SetReport with data: {Report}",
                 Hex.BytesToHex(report));
 

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidIOReportConnection.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/MacOSHidIOReportConnection.cs
@@ -172,7 +172,7 @@ namespace Yubico.Core.Devices.Hid
             {
                 // If there's already a report in the queue (i.e. the callback beat us to calling GetReport) return
                 // that one immediately.
-                _log.SensitiveLogInformation(
+                _log.SensitiveLogDebug(
                     "GetReport returned buffer: {Report}",
                     Hex.BytesToHex(report));
 
@@ -207,7 +207,7 @@ namespace Yubico.Core.Devices.Hid
             // and the PlatformApiException above would have been thrown.
             _ = _reportsQueue.TryDequeue(out report);
 
-            _log.SensitiveLogInformation(
+            _log.SensitiveLogDebug(
                 "GetReport returned buffer: {Report}",
                 Hex.BytesToHex(report));
 
@@ -249,7 +249,7 @@ namespace Yubico.Core.Devices.Hid
         {
             ILogger logger = Logging.Log.GetLogger(typeof(MacOSHidIOReportConnection).FullName!);
 
-            logger.LogInformation("MacOSHidIOReportConnection.ReportCallback has been called.");
+            logger.LogDebug("MacOSHidIOReportConnection.ReportCallback has been called.");
 
             if (result != 0 || type != IOKitHidConstants.kIOHidReportTypeInput || reportId != 0 || reportLength < 0)
             {
@@ -298,7 +298,7 @@ namespace Yubico.Core.Devices.Hid
                 throw new ArgumentNullException(nameof(report));
             }
 
-            _log.SensitiveLogInformation(
+            _log.SensitiveLogDebug(
                 "Calling SetReport with data: {Report}",
                 Hex.BytesToHex(report));
 

--- a/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/Hid/WindowsHidDevice.cs
@@ -117,7 +117,7 @@ namespace Yubico.Core.Devices.Hid
         public void LogDeviceAccessTime()
         {
             LastAccessed = DateTime.Now;
-            _log.LogInformation("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
+            _log.LogDebug("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
         }
     }
 }

--- a/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDevice.cs
+++ b/Yubico.Core/src/Yubico/Core/Devices/SmartCard/DesktopSmartCardDevice.cs
@@ -196,7 +196,7 @@ namespace Yubico.Core.Devices.SmartCard
         public void LogDeviceAccessTime()
         {
             LastAccessed = DateTime.Now;
-            _log.LogInformation("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
+            _log.LogDebug("Updating last used for {Device} to {LastAccessed:hh:mm:ss.fffffff}", this, LastAccessed);
         }
 
     }

--- a/Yubico.YubiKey/tests/integration/appsettings.json
+++ b/Yubico.YubiKey/tests/integration/appsettings.json
@@ -2,7 +2,7 @@
   "AppName": "Integration",
   "Logging": {
     "LogLevel": {
-      "Yubico": "Debug"
+      "Yubico": "Information"
     },
     "Console": {
       "IncludeScopes": true

--- a/Yubico.YubiKey/tests/sandbox/appsettings.json
+++ b/Yubico.YubiKey/tests/sandbox/appsettings.json
@@ -2,7 +2,7 @@
   "AppName": "Sandbox",
   "Logging": {
     "LogLevel": {
-      "Yubico": "Debug"
+      "Yubico": "Information"
     },
     "Console": {
       "IncludeScopes": true


### PR DESCRIPTION
Rebased from #469 (which was auto-closed when its previous base `feature/webauthn-preview-sign` was force-pushed). This PR contains only the single logging fix, targeted directly at `develop`.

## Summary
Wire-level events (per-packet timestamps, I/O callbacks, raw buffer hex, API call success confirmations) were emitting at Information level, flooding integration test output with hundreds of lines per ceremony.

**Source changes (8 files, 13 call sites):**
- `LogDeviceAccessTime` / `UpdateLastUsed` on macOS, Windows, Linux HID + SmartCard
- `IOKitApiCall` success in `HidLoggerExtensions`
- `MacOSHidIOReportConnection.ReportCallback`
- `SensitiveLogInformation` → `SensitiveLogDebug` for raw buffer hex in macOS IO/Feature and Linux IO report connections

**Config changes (2 files):**
- `integration/appsettings.json` and `sandbox/appsettings.json`: `"Yubico": "Debug"` → `"Yubico": "Information"`, establishing Information as the default floor

Result: three-tier system — Information (milestones), Debug (per-packet events), Debug + `ENABLE_SENSITIVE_LOG` (raw byte hex).

## Test plan
- [ ] Run unit tests on macOS/Windows/Linux
- [x] Spot-check integration test log output to confirm reduced verbosity at Information level

🤖 Generated with [Claude Code](https://claude.com/claude-code)