### PR TITLE
chore(claude): add /Release skill for SDK release automation

### DIFF
--- a/.claude/skills/Release/SKILL.md
+++ b/.claude/skills/Release/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: Release
+description: Drives the Yubico .NET SDK release end-to-end — version gating, release branch, NativeShims ordering, CI dispatch, tagging, Windows-wizard sign+publish, GitHub release, post-release merge-back, and Slack #ask-tla announcement. USE WHEN release, drop release, ship release, cut release, publish release, release SDK, dotnet release, NuGet release, /Release, /Release resume.
+---
+
+# Release
+
+Project-local skill for shipping a Yubico .NET SDK release. The skill is the operator — Dennis only invokes it, answers gating questions, and (on Windows) plugs in his code-sign YubiKey. Every other step (branch creation, CI dispatch, artifact download, signing, publishing, tagging, GitHub release, Slack draft) is automated or surfaces an explicit decision gate.
+
+The skill works in two modes:
+- **`/Release`** — full flow from phase 1 (pre-flight) onward
+- **`/Release resume <version>`** — picks up at phase 5 (sign+publish) using cached state from `~/Releases/<version>/.state.json`. Used when phases 1–4 ran on macOS/Linux and the operator switches to Windows for signing.
+
+The Windows-only constraint (`build/sign.ps1` + smart-card YubiKey + `signtool.exe`) is enforced at phase 5 — the skill detects platform and either runs the full wizard (Windows) or stops with a handoff (macOS/Linux).
+
+## Workflow Routing
+
+| Request Pattern | Route To |
+|---|---|
+| Drop release, ship release, cut release, publish release, /Release, /Release resume | `Workflows/DropRelease.md` |
+
+## Examples
+
+**Example 1: Full release on Windows**
+```
+User: "/Release"
+→ Skill loads Workflows/DropRelease.md
+→ Phase 1: confirms version 1.16.1, release date, no blocking PRs
+→ Phase 2: detects no Yubico.NativeShims/ changes, skips NativeShims rebuild
+→ Phase 3: creates release/1.16.1 from develop, drafts whats-new.md, opens PR to main
+→ Phase 4: after PR merged, dispatches build.yml with version=1.16.1, polls until green, tags 1.16.1
+→ Phase 5 (Windows): downloads artifacts to ~/Releases/1.16.1/, runs sign.ps1, publishes to NuGet.org
+→ Phase 6: creates draft GitHub release with signed assets, triggers deploy-docs.yml
+→ Phase 7: merges main back to develop, prints Slack #ask-tla announcement ready to copy
+```
+
+**Example 2: Cross-machine release (start macOS, finish Windows)**
+```
+User (on macOS): "/Release"
+→ Phases 1-4 complete (release branch, PR, merge, tag)
+→ Phase 5 detects darwin → STOPS, prints handoff with build.yml run ID and instruction to run `/Release resume 1.16.1` on Windows
+→ State cached to ~/Releases/1.16.1/.state.json (run IDs, version, NativeShims flag)
+
+User (on Windows): "/Release resume 1.16.1"
+→ Loads cached state, skips phases 1-4
+→ Phase 5: downloads artifacts (NativeShims first if rebuilt), runs sign.ps1, publishes
+→ Phases 6-7 complete normally
+```
+
+**Example 3: NativeShims-bearing release**
+```
+User: "/Release"
+→ Phase 2 detects changes in Yubico.NativeShims/ since last tag
+→ AskUserQuestion confirms rebuild + NativeShims version bump
+→ Dispatches build-nativeshims.yml first, polls
+→ HARD GATE: NativeShims must be signed AND published to NuGet.org BEFORE build.yml dispatches
+→ Phase 5 status board shows both NativeShims and main package rows
+```
+
+## Hard Constraints
+
+- **Windows-only sign step**: phase 5 refuses to run on non-Windows
+- **NativeShims ordering**: when rebuilt, NativeShims signs + publishes to NuGet.org *before* main `build.yml` dispatches
+- **Tag only after green CI**: `git tag` runs only after `build.yml` reports success — failed builds mean broken artifacts and a poisoned tag
+- **No Versions.props edits**: version is passed as `build.yml` workflow_dispatch input; `<CommonVersion>0.0.0-dev</CommonVersion>` stays unchanged
+- **Release notes never auto-committed**: skill drafts `docs/users-manual/getting-started/whats-new.md` and shows diff for approval before commit

--- a/.claude/skills/Release/SKILL.md
+++ b/.claude/skills/Release/SKILL.md
@@ -5,7 +5,7 @@ description: Drives the Yubico .NET SDK release end-to-end — version gating, r
 
 # Release
 
-Project-local skill for shipping a Yubico .NET SDK release. The skill is the operator — Dennis only invokes it, answers gating questions, and (on Windows) plugs in his code-sign YubiKey. Every other step (branch creation, CI dispatch, artifact download, signing, publishing, tagging, GitHub release, Slack draft) is automated or surfaces an explicit decision gate.
+Project-local skill for shipping a Yubico .NET SDK release. The operator invokes the skill, answers gating questions, and (on Windows) plugs in the code-sign YubiKey. Every other step (branch creation, CI dispatch, artifact download, signing, publishing, tagging, GitHub release, Slack draft) is automated or surfaces an explicit decision gate.
 
 The skill works in two modes:
 - **`/Release`** — full flow from phase 1 (pre-flight) onward

--- a/.claude/skills/Release/SKILL.md
+++ b/.claude/skills/Release/SKILL.md
@@ -36,12 +36,12 @@ User: "/Release"
 
 **Example 2: Cross-machine release (start macOS, finish Windows)**
 ```
-User (on macOS): "/Release"
+Operator (on macOS): "/Release"
 → Phases 1-4 complete (release branch, PR, merge, tag)
 → Phase 5 detects darwin → STOPS, prints handoff with build.yml run ID and instruction to run `/Release resume 1.16.1` on Windows
 → State cached to ~/Releases/1.16.1/.state.json (run IDs, version, NativeShims flag)
 
-User (on Windows): "/Release resume 1.16.1"
+Operator (on Windows): "/Release resume 1.16.1"
 → Loads cached state, skips phases 1-4
 → Phase 5: downloads artifacts (NativeShims first if rebuilt), runs sign.ps1, publishes
 → Phases 6-7 complete normally

--- a/.claude/skills/Release/Workflows/DropRelease.md
+++ b/.claude/skills/Release/Workflows/DropRelease.md
@@ -1,6 +1,6 @@
 # DropRelease Workflow
 
-End-to-end Yubico .NET SDK release wizard. Drives 7 phases with explicit gates. Dennis answers AskUserQuestion prompts; everything else is automated.
+End-to-end Yubico .NET SDK release wizard. Drives 7 phases with explicit gates. the operator answers AskUserQuestion prompts; everything else is automated.
 
 ## State file
 
@@ -14,12 +14,17 @@ Location: `~/Releases/<version>/.state.json`. Created in phase 1, updated at eve
   "nativeShimsRebuild": false,
   "nativeShimsVersion": null,
   "nativeShimsRunId": null,
+  "nativeShimsPublished": false,
   "buildRunId": null,
   "tagPushed": false,
   "currentPhase": 4,
-  "categorizedPRs": { "features": [], "bugfixes": [], "docs": [], "deps": [], "security": [] }
+  "categorizedPRs": { "features": [], "bugfixes": [], "docs": [], "deps": [], "security": [], "misc": [] }
 }
 ```
+
+**Date storage convention**: `releaseDate` is always stored as ISO `YYYY-MM-DD`. The Phase 1 prompt collects it in human form (`Month Dth, YYYY`), but the skill normalizes to ISO before writing state. Display formatting is reapplied at write time for `whats-new.md` (long form: `April 29th, 2026`) and the Slack draft (long form). Always derive the display string from the ISO field — never store both.
+
+**Categorization buckets**: All buckets above MUST be present in state (even empty). Phase 3 categorizes "everything else" into `misc`; Phase 7 includes `misc` in both the `whats-new.md` Miscellaneous section and the Slack draft (under a `Miscellaneous 🧰📌` heading) so PRs are never dropped.
 
 The state file is the single source of truth for resume. Update it before any operation that could fail.
 
@@ -76,27 +81,39 @@ git diff <previousTag>..origin/develop -- Yubico.NativeShims/ --stat
    - Get last release date: `gh release view <previousTag> --json publishedAt -q .publishedAt`
    - List merged PRs since: `gh pr list --base develop --state merged --search "merged:>=<lastReleaseISO>" --json number,title,labels,url --limit 100`
    - Categorize by PR title prefix and labels (heuristics):
-     - `feat:` / `feature/` / label `enhancement` → **Features**
-     - `fix:` / `bugfix/` / label `bug` → **Bug Fixes**
-     - `docs:` / `doc:` → **Documentation**
-     - `chore(deps):` / `build(deps):` / dependabot → **Dependencies / Maintenance**
-     - `security:` / `ci:` / `.github/workflows/` touched → **Security / CI**
-     - everything else → **Miscellaneous**
-   - Cache categorization in state for phase 7 Slack reuse
-4. **Insert into `docs/users-manual/getting-started/whats-new.md`**:
+     - `feat:` / `feature/` / label `enhancement` → **Features** (`features` bucket)
+     - `fix:` / `bugfix/` / label `bug` → **Bug Fixes** (`bugfixes` bucket)
+     - `docs:` / `doc:` → **Documentation** (`docs` bucket)
+     - `chore(deps):` / `build(deps):` / dependabot → **Dependencies / Maintenance** (`deps` bucket)
+     - `security:` / `ci:` / `.github/workflows/` touched → **Security / CI** (`security` bucket)
+     - everything else → **Miscellaneous** (`misc` bucket — never dropped)
+   - Cache full categorization (all 6 buckets including `misc`) into `state.categorizedPRs` for phase 7 Slack reuse
+5. **Insert into `docs/users-manual/getting-started/whats-new.md`**:
    - Read current file
    - Insert new `### <version>` block under the appropriate `## 1.16.x Releases` heading (create the heading if needed)
-   - Match the existing format exactly (Release date, Features, Bug Fixes, Documentation, Misc, Dependencies subsections)
+   - Match the existing format exactly (Release date, Features, Bug Fixes, Documentation, Misc, Dependencies subsections — emit Misc subsection whenever `misc` bucket is non-empty)
    - Show diff via `git diff docs/users-manual/getting-started/whats-new.md`
-5. `AskUserQuestion`: "Release notes look correct?" Options: "Yes, commit" / "Let me edit first" / "Regenerate from PRs"
-6. On approval: `git add docs/users-manual/getting-started/whats-new.md && git commit -m "docs: release notes for <version>"`
-7. `git push -u origin release/<version>`
-8. `gh pr create --base main --head release/<version> --title "Release <version>" --body-file <notes-snippet>` — capture PR number to state
-9. Print PR URL, instruct Dennis to get reviewers
+6. `AskUserQuestion`: "Release notes look correct?" Options: "Yes, commit" / "Let me edit first" / "Regenerate from PRs"
+7. On approval: `git add docs/users-manual/getting-started/whats-new.md && git commit -m "docs: release notes for <version>"`
+8. `git push -u origin release/<version>`
+9. **Build the PR-body file** for `gh pr create` — extract just the new `### <version>` block from `whats-new.md` (between the new heading and the next `### ` heading) into a real temp file, then pass it:
+   ```bash
+   notes_file=$(mktemp -t release-notes-<version>.XXXXXX.md)
+   awk -v v="### <version>" '
+     $0 == v {flag=1; print; next}
+     flag && /^### / {exit}
+     flag {print}
+   ' docs/users-manual/getting-started/whats-new.md > "$notes_file"
+   gh pr create --base main --head release/<version> \
+     --title "Release <version>" \
+     --body-file "$notes_file"
+   ```
+   Capture the returned PR number into `state.releasePrNumber`. Keep the temp file path in state too so phase 6 can reuse it.
+10. Print PR URL, instruct the operator to get reviewers
 
 ## Phase 4 — Merge + CI dispatch (cross-platform)
 
-1. **Wait for merge** — poll `gh pr view <prNumber> --json state,mergedAt` every 60s until `state=MERGED`. Print poll updates. If Dennis wants to abort polling and resume later, the state file already has the PR number — `/Release resume <version>` continues from here.
+1. **Wait for merge** — poll `gh pr view <prNumber> --json state,mergedAt` every 60s until `state=MERGED`. Print poll updates. If the operator wants to abort polling and resume later, the state file already has the PR number — `/Release resume <version>` continues from here.
 2. After merge: `git checkout main && git pull origin main`
 3. **Ordering check** — if `nativeShimsRebuild: true` in state AND NativeShims hasn't been signed+published yet (no NuGet 200 on `https://www.nuget.org/packages/Yubico.NativeShims/<nsVersion>`):
    - Print: "⚠ NativeShims must publish to NuGet.org before main build dispatches"
@@ -122,22 +139,37 @@ esac
 
 ### If PLATFORM != windows
 
-STOP. Print handoff:
+STOP. Phase 5 can be reached via two entry paths — render the handoff text from actual state, not assumptions:
+
+- **Entry path A — NativeShims-only** (from Phase 4 step 3 ordering check; `state.buildRunId == null` and `state.tagPushed == false`): main `build.yml` has NOT been dispatched yet. The operator must sign+publish NativeShims first, then resume returns flow to Phase 4 step 4.
+- **Entry path B — full release** (`state.buildRunId != null` and `state.tagPushed == true`): main build is green and tag is pushed; only sign+publish + GitHub release remain.
+
+Pseudocode for the handoff message (skill builds the strings from state):
+
 ```
 ═══ HANDOFF TO WINDOWS ═══
-Release <version> is past CI green and tagged. Sign + publish requires Windows + your code-sign YubiKey.
+Release <version> needs sign+publish on Windows with your code-sign YubiKey.
+
+Current state (from ~/Releases/<version>/.state.json):
+- Entry path: <"NativeShims-only" if buildRunId == null else "full release">
+- NativeShims rebuild: <nativeShimsRebuild>
+- NativeShims run: <nativeShimsRunId or "n/a">
+- NativeShims published: <nativeShimsPublished>
+- Main build run: <buildRunId or "not yet dispatched">
+- Tag pushed: <tagPushed>
+
+What's left after sign+publish:
+<if buildRunId == null:
+   - Resume returns to Phase 4 step 4 (dispatch build.yml against main)
+   - Then re-enter Phase 5 entry path B for the main packages
+ else:
+   - Phase 6 (GitHub release with signed assets)
+   - Phase 7 (merge main back to develop, Slack draft)>
 
 On your Windows machine:
 1. Plug in your code-sign YubiKey
 2. cd <this repo>
 3. Invoke: /Release resume <version>
-
-The skill will resume from this exact point using ~/Releases/<version>/.state.json.
-
-Cached state:
-- build.yml run: <buildRunId>
-- NativeShims run: <nativeShimsRunId or "none">
-- Tag pushed: <tagPushed>
 
 Do not proceed past this point on macOS/Linux.
 ═══
@@ -174,50 +206,93 @@ Release <version> — Sign & Publish
 ```
 (Skip NativeShims rows if `nativeShimsRebuild: false`.)
 
+**Pre-flight for publish (one-time per session)**: `Invoke-NuGetPackagePush` resolves the API key from `-ApiKey` parameter or falls back to `$env:NUGET_API_KEY`. Before phase 5d/5e push steps, assert:
+```powershell
+if ([string]::IsNullOrWhiteSpace($env:NUGET_API_KEY)) {
+  # AskUserQuestion: paste API key (will be set in $env:NUGET_API_KEY for this session only)
+}
+```
+Never echo the API key. Never persist it to the state file.
+
 **5d. NativeShims half** (only if `nativeShimsRebuild: true`):
-1. `gh run download <nativeShimsRunId> --dir $staging\nativeshims` — confirms artifact zip lands
+1. `gh run download <nativeShimsRunId> --dir "$staging\nativeshims"` — confirms artifact zip lands
 2. Identify the zip name (look for `*nativeshims*.zip`)
-3. Invoke sign:
+3. Sign:
    ```powershell
    . ./build/sign.ps1
    Invoke-NuGetPackageSigning `
      -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
      -WorkingDirectory "$staging\nativeshims" `
-     -NativeShimsZip <zipname>
+     -NativeShimsZip "<zipname>"
    ```
-   YubiKey PIN prompt will surface; tell Dennis to enter it
-4. Verify: `Get-ChildItem "$staging\nativeshims\signed\packages\*.nupkg"` non-empty
-5. Publish: `Invoke-NuGetPackagePush -WorkingDirectory "$staging\nativeshims"` (function call signature per `build/sign.ps1` — read script before invoking to confirm exact param names)
-6. Verify live: poll `https://www.nuget.org/packages/Yubico.NativeShims/<nsVersion>` until 200 (NuGet indexing latency: 1-5 min). Update status board.
-7. **Loop back to phase 4 step 4** to dispatch `build.yml` if not yet done
+   YubiKey PIN prompt will surface; tell the operator to enter it.
+4. Verify: `Get-ChildItem "$staging\nativeshims\signed\packages\*.nupkg"` non-empty.
+5. Publish (per `build/sign.ps1` — `Invoke-NuGetPackagePush` requires `-PackagePath`, optional `-ApiKey`/`$env:NUGET_API_KEY`, optional `-Source`/`-SkipDuplicate`):
+   ```powershell
+   Invoke-NuGetPackagePush `
+     -PackagePath "$staging\nativeshims\signed\packages" `
+     -SkipDuplicate
+   ```
+   `-SkipDuplicate` is defensive against re-runs; the source defaults to `https://api.nuget.org/v3/index.json`.
+6. Verify live: poll `https://www.nuget.org/packages/Yubico.NativeShims/<nsVersion>` until 200 (NuGet indexing latency: 1–5 min). Update status board. Set `state.nativeShimsPublished: true`.
+7. **Loop back to phase 4 step 4** to dispatch `build.yml` if not yet done.
 
 **5e. Main half**:
-1. `gh run download <buildRunId> --dir $staging\core`
-2. Identify zips (`*Nuget*.zip`, `*Symbols*.zip` — confirm by listing artifacts: `gh run view <buildRunId> --json artifacts`)
-3. Invoke sign:
+1. `gh run download <buildRunId> --dir "$staging\core"`
+2. Identify zips by listing artifacts: `gh run view <buildRunId> --json artifacts -q '.artifacts[].name'` — typically `Nuget Packages` and `Symbols Packages` (confirm exact names per CI run; spaces in artifact names are quoted by `gh`).
+3. Sign:
    ```powershell
    Invoke-NuGetPackageSigning `
      -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
      -WorkingDirectory "$staging\core" `
-     -NuGetPackagesZip <name> `
-     -SymbolsPackagesZip <name>
+     -NuGetPackagesZip "<nuget-zip-name>" `
+     -SymbolsPackagesZip "<symbols-zip-name>"
    ```
-4. Verify signed packages exist
-5. Publish: `Invoke-NuGetPackagePush ...`
-6. Verify live: poll `https://www.nuget.org/packages/Yubico.YubiKey/<version>` AND `https://www.nuget.org/packages/Yubico.Core/<version>` until both 200
-7. Update final status board rows
+4. Verify: `Get-ChildItem "$staging\core\signed\packages\*.nupkg","$staging\core\signed\packages\*.snupkg"` non-empty.
+5. Publish:
+   ```powershell
+   Invoke-NuGetPackagePush `
+     -PackagePath "$staging\core\signed\packages" `
+     -SkipDuplicate
+   ```
+6. Verify live: poll `https://www.nuget.org/packages/Yubico.YubiKey/<version>` AND `https://www.nuget.org/packages/Yubico.Core/<version>` until both 200.
+7. Update final status board rows.
 
 ## Phase 6 — GitHub release (cross-platform; can run on Windows continuation or back on dev machine)
 
-1. **Create draft release**:
+1. **Create draft release** — extract the new `### <version>` section from `whats-new.md` to a real temp file (no bash process substitution; works on Windows PowerShell, macOS, and Linux). Reuse the temp file already produced in Phase 3 step 9 if its path is still in `state.notesFile` and the file exists; otherwise regenerate:
+
+   **bash / zsh**:
    ```bash
+   notes_file="${state_notes_file:-$(mktemp -t release-notes-<version>.XXXXXX.md)}"
+   if [ ! -s "$notes_file" ]; then
+     awk -v v="### <version>" '
+       $0 == v {flag=1; print; next}
+       flag && /^### / {exit}
+       flag {print}
+     ' docs/users-manual/getting-started/whats-new.md > "$notes_file"
+   fi
    gh release create <version> \
      --draft \
      --title "<version>" \
-     --notes-file <(extract <version> section from whats-new.md) \
+     --notes-file "$notes_file" \
      --generate-notes
    ```
-   `--generate-notes` adds the auto "what's new" + full changelog appendix
+
+   **PowerShell** (when phase 6 runs on Windows after sign+publish):
+   ```powershell
+   $notesFile = if ($state.notesFile -and (Test-Path $state.notesFile)) { $state.notesFile } else { New-TemporaryFile }
+   if ((Get-Item $notesFile).Length -eq 0) {
+     $whatsNew = Get-Content docs/users-manual/getting-started/whats-new.md
+     $start = ($whatsNew | Select-String -Pattern "^### <version>$" | Select-Object -First 1).LineNumber
+     $end = ($whatsNew[$start..($whatsNew.Length - 1)] | Select-String -Pattern "^### " | Select-Object -First 1).LineNumber
+     $section = if ($end) { $whatsNew[($start - 1)..($start + $end - 2)] } else { $whatsNew[($start - 1)..($whatsNew.Length - 1)] }
+     $section | Set-Content $notesFile
+   }
+   gh release create <version> --draft --title "<version>" --notes-file $notesFile --generate-notes
+   ```
+
+   `--generate-notes` adds the auto "what's new" + full changelog appendix on top of the section pulled from `whats-new.md`.
 2. **Upload signed assets**: for each signed `.nupkg` and `.snupkg` in `~/Releases/<version>/{nativeshims,core}/signed/packages/`:
    ```bash
    gh release upload <version> <file>
@@ -247,7 +322,7 @@ NuGet:
 GitHub: https://github.com/Yubico/Yubico.NET.SDK/releases/tag/<version> 🐙
 Latest release: https://github.com/Yubico/Yubico.NET.SDK/releases/latest ✨
 ---
-<for each non-empty category, in order Features → Bug Fixes → Documentation → Dependencies / Maintenance → Security / CI:>
+<for each non-empty category, in this fixed order: Features → Bug Fixes → Documentation → Dependencies / Maintenance → Security / CI → Miscellaneous:>
 <Category Name> <category emoji>
 - <PR title> (#<num>)
   https://github.com/Yubico/Yubico.NET.SDK/pull/<num>
@@ -257,12 +332,13 @@ https://github.com/Yubico/Yubico.NET.SDK/compare/<previousTag>...<version>
 Track the progress: https://nugettrends.com/packages?months=36&ids=Yubico.YubiKey 📈🔥
 ```
 
-Category emojis (match prior 1.15.1 announcement exactly):
+Category emojis (Features → Security/CI match prior 1.15.1 announcement exactly; Miscellaneous added so `misc` PRs are never dropped):
 - Features: ✨🎁
 - Bug Fixes: 🛠️✅
 - Documentation: 📚✍️
 - Dependencies / Maintenance: 🔧🧼
 - Security / CI: 🔒🤖
+- Miscellaneous: 🧰📌
 
 4. **Print closing checklist** (manual — skill cannot automate):
    - [ ] Post drafted message in Slack #ask-tla

--- a/.claude/skills/Release/Workflows/DropRelease.md
+++ b/.claude/skills/Release/Workflows/DropRelease.md
@@ -1,0 +1,279 @@
+# DropRelease Workflow
+
+End-to-end Yubico .NET SDK release wizard. Drives 7 phases with explicit gates. Dennis answers AskUserQuestion prompts; everything else is automated.
+
+## State file
+
+Location: `~/Releases/<version>/.state.json`. Created in phase 1, updated at every phase boundary, read by `/Release resume`.
+
+```json
+{
+  "version": "1.16.1",
+  "previousTag": "1.16.0",
+  "releaseDate": "2026-04-29",
+  "nativeShimsRebuild": false,
+  "nativeShimsVersion": null,
+  "nativeShimsRunId": null,
+  "buildRunId": null,
+  "tagPushed": false,
+  "currentPhase": 4,
+  "categorizedPRs": { "features": [], "bugfixes": [], "docs": [], "deps": [], "security": [] }
+}
+```
+
+The state file is the single source of truth for resume. Update it before any operation that could fail.
+
+## Phase 1 — Pre-flight (cross-platform)
+
+**Prerequisites**:
+- `gh auth status` — must be authenticated
+- `git remote -v` — confirm `origin` points to `Yubico/Yubico.NET.SDK`
+
+**Steps**:
+1. `git fetch --tags origin`
+2. `git tag --sort=-v:refname | head -5` → show recent tags, parse latest as `previousTag`
+3. `gh pr list --base develop --state open --json number,title,author --limit 20` → display, then `AskUserQuestion`: "Any of these need to merge before release?" Options: "All clear, proceed" / "Wait — I'll merge manually" / "Specific PRs blocking"
+4. `AskUserQuestion`: "Confirm release version" — default option is `+1 patch` of `previousTag` (e.g., `1.16.0` → `1.16.1`); also offer `+1 minor`, `+1 major`, custom
+5. `AskUserQuestion`: "Release date" — default today (in `Month Dth, YYYY` format matching whats-new.md style)
+6. **Hardware test reminder** — print: "Before continuing, confirm you've tested PIV + SCP on real YubiKey hardware. The skill cannot do this for you." Gate with `AskUserQuestion`: "Hardware tests pass?" / "Skip (not recommended)"
+7. Create `~/Releases/<version>/` and write initial `.state.json`
+
+## Phase 2 — NativeShims gate (cross-platform, conditional)
+
+**Detection**:
+```bash
+git diff <previousTag>..origin/develop -- Yubico.NativeShims/ --stat
+```
+
+**If output is empty** → set `nativeShimsRebuild: false` in state, print "✓ No NativeShims changes since <previousTag>, skipping rebuild", continue to phase 3.
+
+**If output non-empty** →
+1. Print the file list
+2. `AskUserQuestion`: "NativeShims changed in N files. Rebuild and publish new NativeShims package?" Options: "Yes — rebuild and bump" / "No — current published NativeShims is sufficient" / "Show me the diff first" (in which case loop back after `git diff`)
+3. If yes:
+   - `AskUserQuestion`: "NativeShims version" — fetch latest from NuGet (`gh api /repos/Yubico/Yubico.NET.SDK/contents/Yubico.NativeShims/version.txt` or query NuGet API), default +1 patch
+   - `gh workflow run build-nativeshims.yml --ref develop -f version=<nsVersion>` — capture run ID
+   - Poll: `gh run list --workflow=build-nativeshims.yml --limit 1 --json databaseId,status,conclusion` until status=`completed`. Print poll progress every 30s
+   - On `failure`: STOP, print logs URL, do not proceed
+   - On `success`: update state with `nativeShimsRebuild: true`, `nativeShimsVersion`, `nativeShimsRunId`
+   - **HARD GATE**: NativeShims MUST be signed (phase 5 wizard) AND published to NuGet.org BEFORE phase 4 dispatches `build.yml`. The skill enforces this by deferring `build.yml` dispatch in phase 4 until phase 5's NativeShims half completes — see phase 4 ordering note.
+
+## Phase 3 — Release branch (cross-platform)
+
+1. `git checkout develop && git pull origin develop`
+2. `git checkout -b release/<version>` (per gitflow + project CLAUDE.md)
+3. **NativeShims lockfile repin** (only if `nativeShimsRebuild: true` in state and NativeShims published as stable):
+   - Per project CLAUDE.md (NuGet floating version + lockfile pattern): `Yubico.Core/src/Yubico.Core.csproj` uses `Version="1.*-*"` and resolves via `Yubico.Core/src/packages.lock.json`
+   - `enforce-branch-policy` job in `.github/workflows/build.yml` HARD-FAILS on main if lockfile pins a `-prerelease` Yubico.NativeShims
+   - Repin against nuget.org-only environment (so the local internal feed doesn't shadow the just-published stable):
+     ```bash
+     dotnet restore Yubico.Core/src/Yubico.Core.csproj --force-evaluate --source https://api.nuget.org/v3/index.json
+     ```
+   - `git diff Yubico.Core/src/packages.lock.json` — confirm one-line change to stable Yubico.NativeShims `<nsVersion>`
+   - DO NOT edit `Yubico.Core.csproj` itself
+   - Commit: `git add Yubico.Core/src/packages.lock.json && git commit -m "build: repin NativeShims to <nsVersion> stable"`
+4. **Generate release notes draft**:
+   - Get last release date: `gh release view <previousTag> --json publishedAt -q .publishedAt`
+   - List merged PRs since: `gh pr list --base develop --state merged --search "merged:>=<lastReleaseISO>" --json number,title,labels,url --limit 100`
+   - Categorize by PR title prefix and labels (heuristics):
+     - `feat:` / `feature/` / label `enhancement` → **Features**
+     - `fix:` / `bugfix/` / label `bug` → **Bug Fixes**
+     - `docs:` / `doc:` → **Documentation**
+     - `chore(deps):` / `build(deps):` / dependabot → **Dependencies / Maintenance**
+     - `security:` / `ci:` / `.github/workflows/` touched → **Security / CI**
+     - everything else → **Miscellaneous**
+   - Cache categorization in state for phase 7 Slack reuse
+4. **Insert into `docs/users-manual/getting-started/whats-new.md`**:
+   - Read current file
+   - Insert new `### <version>` block under the appropriate `## 1.16.x Releases` heading (create the heading if needed)
+   - Match the existing format exactly (Release date, Features, Bug Fixes, Documentation, Misc, Dependencies subsections)
+   - Show diff via `git diff docs/users-manual/getting-started/whats-new.md`
+5. `AskUserQuestion`: "Release notes look correct?" Options: "Yes, commit" / "Let me edit first" / "Regenerate from PRs"
+6. On approval: `git add docs/users-manual/getting-started/whats-new.md && git commit -m "docs: release notes for <version>"`
+7. `git push -u origin release/<version>`
+8. `gh pr create --base main --head release/<version> --title "Release <version>" --body-file <notes-snippet>` — capture PR number to state
+9. Print PR URL, instruct Dennis to get reviewers
+
+## Phase 4 — Merge + CI dispatch (cross-platform)
+
+1. **Wait for merge** — poll `gh pr view <prNumber> --json state,mergedAt` every 60s until `state=MERGED`. Print poll updates. If Dennis wants to abort polling and resume later, the state file already has the PR number — `/Release resume <version>` continues from here.
+2. After merge: `git checkout main && git pull origin main`
+3. **Ordering check** — if `nativeShimsRebuild: true` in state AND NativeShims hasn't been signed+published yet (no NuGet 200 on `https://www.nuget.org/packages/Yubico.NativeShims/<nsVersion>`):
+   - Print: "⚠ NativeShims must publish to NuGet.org before main build dispatches"
+   - Jump to phase 5 NativeShims half (Windows-only); after that completes and NuGet shows live, return here
+4. `gh workflow run build.yml --ref main -f version=<version>` — capture run ID to state as `buildRunId`
+5. Poll until `completed`. On failure: STOP, print logs URL.
+6. On success: tag the release
+   - **Branch sanity check** (per memory `check-branch-before-amend.md`-adjacent caution): `git branch --show-current` must equal `main`; `git log -1 --oneline` should be the merge commit
+   - `git tag -a <version> -m "Release <version>"`
+   - `git push origin <version>`
+   - Update state: `tagPushed: true`
+
+## Phase 5 — Sign + publish (Windows wizard, or hard-stop)
+
+**Platform detection**:
+```bash
+# In bash:
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) PLATFORM=windows ;;
+  *) PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]') ;;
+esac
+```
+
+### If PLATFORM != windows
+
+STOP. Print handoff:
+```
+═══ HANDOFF TO WINDOWS ═══
+Release <version> is past CI green and tagged. Sign + publish requires Windows + your code-sign YubiKey.
+
+On your Windows machine:
+1. Plug in your code-sign YubiKey
+2. cd <this repo>
+3. Invoke: /Release resume <version>
+
+The skill will resume from this exact point using ~/Releases/<version>/.state.json.
+
+Cached state:
+- build.yml run: <buildRunId>
+- NativeShims run: <nativeShimsRunId or "none">
+- Tag pushed: <tagPushed>
+
+Do not proceed past this point on macOS/Linux.
+═══
+```
+Exit cleanly. Do NOT mark phase 5 complete.
+
+### If PLATFORM == windows
+
+**5a. Pre-flight asserts** (each is a hard gate; on failure print fix instructions and stop):
+- `gh auth status` — authenticated with `repo` + `workflow` scope
+- `Get-Command signtool.exe` (PowerShell) — resolvable
+- `Get-Command nuget.exe` — resolvable
+- `$env:YUBICO_SIGNING_THUMBPRINT` — set; if not, AskUserQuestion to provide and persist for session
+- YubiKey presence — best-effort: `Get-PnpDevice -Class SmartCard | Where-Object Status -eq 'OK'`. If empty, prompt: "No smart card detected — is YubiKey plugged in?"
+
+**5b. Staging**:
+```powershell
+$staging = "$HOME\Releases\<version>"
+New-Item -ItemType Directory -Force -Path "$staging\nativeshims","$staging\core"
+```
+
+**5c. Status board** — initialize and print after each step:
+```
+Release <version> — Sign & Publish
+
+[ ] NativeShims build.yml         (run <id>)
+[ ] NativeShims download
+[ ] NativeShims signed
+[ ] NativeShims published to NuGet
+[ ] Main build.yml                (run <id>)
+[ ] Main download
+[ ] Main signed
+[ ] Main published to NuGet
+```
+(Skip NativeShims rows if `nativeShimsRebuild: false`.)
+
+**5d. NativeShims half** (only if `nativeShimsRebuild: true`):
+1. `gh run download <nativeShimsRunId> --dir $staging\nativeshims` — confirms artifact zip lands
+2. Identify the zip name (look for `*nativeshims*.zip`)
+3. Invoke sign:
+   ```powershell
+   . ./build/sign.ps1
+   Invoke-NuGetPackageSigning `
+     -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
+     -WorkingDirectory "$staging\nativeshims" `
+     -NativeShimsZip <zipname>
+   ```
+   YubiKey PIN prompt will surface; tell Dennis to enter it
+4. Verify: `Get-ChildItem "$staging\nativeshims\signed\packages\*.nupkg"` non-empty
+5. Publish: `Invoke-NuGetPackagePush -WorkingDirectory "$staging\nativeshims"` (function call signature per `build/sign.ps1` — read script before invoking to confirm exact param names)
+6. Verify live: poll `https://www.nuget.org/packages/Yubico.NativeShims/<nsVersion>` until 200 (NuGet indexing latency: 1-5 min). Update status board.
+7. **Loop back to phase 4 step 4** to dispatch `build.yml` if not yet done
+
+**5e. Main half**:
+1. `gh run download <buildRunId> --dir $staging\core`
+2. Identify zips (`*Nuget*.zip`, `*Symbols*.zip` — confirm by listing artifacts: `gh run view <buildRunId> --json artifacts`)
+3. Invoke sign:
+   ```powershell
+   Invoke-NuGetPackageSigning `
+     -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
+     -WorkingDirectory "$staging\core" `
+     -NuGetPackagesZip <name> `
+     -SymbolsPackagesZip <name>
+   ```
+4. Verify signed packages exist
+5. Publish: `Invoke-NuGetPackagePush ...`
+6. Verify live: poll `https://www.nuget.org/packages/Yubico.YubiKey/<version>` AND `https://www.nuget.org/packages/Yubico.Core/<version>` until both 200
+7. Update final status board rows
+
+## Phase 6 — GitHub release (cross-platform; can run on Windows continuation or back on dev machine)
+
+1. **Create draft release**:
+   ```bash
+   gh release create <version> \
+     --draft \
+     --title "<version>" \
+     --notes-file <(extract <version> section from whats-new.md) \
+     --generate-notes
+   ```
+   `--generate-notes` adds the auto "what's new" + full changelog appendix
+2. **Upload signed assets**: for each signed `.nupkg` and `.snupkg` in `~/Releases/<version>/{nativeshims,core}/signed/packages/`:
+   ```bash
+   gh release upload <version> <file>
+   ```
+3. **Trigger docs deploy**: `gh workflow run deploy-docs.yml --ref main` — read workflow first to confirm input names; if it has `environment` input, set to `prod`
+4. `AskUserQuestion`: "Draft release ready at <URL>. Publish now?" Options: "Publish" / "Leave as draft" / "Open in browser first"
+5. If "Publish": `gh release edit <version> --draft=false`
+
+## Phase 7 — Closing (cross-platform)
+
+1. **Merge main back to develop** (gitflow):
+   ```bash
+   git checkout develop && git pull
+   git merge main --no-ff -m "Merge main back into develop after <version> release"
+   git push origin develop
+   ```
+2. **Assert** `build/Versions.props:43` is still `<CommonVersion>0.0.0-dev</CommonVersion>` — print warning if drifted (we never edit it; if drifted, something else changed it)
+3. **Generate Slack #ask-tla announcement** — print as fenced code block ready to copy. Use cached `categorizedPRs` from state. Exact format:
+
+```
+NET SDK <version> Release Announcement! 🎉🚀
+Release: <Month Dth, YYYY> 📅
+Distribution: 📦
+NuGet:
+- https://www.nuget.org/packages/Yubico.YubiKey/<version> 🔑
+- https://www.nuget.org/packages/Yubico.Core/<version> 🧩
+GitHub: https://github.com/Yubico/Yubico.NET.SDK/releases/tag/<version> 🐙
+Latest release: https://github.com/Yubico/Yubico.NET.SDK/releases/latest ✨
+---
+<for each non-empty category, in order Features → Bug Fixes → Documentation → Dependencies / Maintenance → Security / CI:>
+<Category Name> <category emoji>
+- <PR title> (#<num>)
+  https://github.com/Yubico/Yubico.NET.SDK/pull/<num>
+---
+Full Changelog: <previousTag>...<version> 🧾🔍
+https://github.com/Yubico/Yubico.NET.SDK/compare/<previousTag>...<version>
+Track the progress: https://nugettrends.com/packages?months=36&ids=Yubico.YubiKey 📈🔥
+```
+
+Category emojis (match prior 1.15.1 announcement exactly):
+- Features: ✨🎁
+- Bug Fixes: 🛠️✅
+- Documentation: 📚✍️
+- Dependencies / Maintenance: 🔧🧼
+- Security / CI: 🔒🤖
+
+4. **Print closing checklist** (manual — skill cannot automate):
+   - [ ] Post drafted message in Slack #ask-tla
+   - [ ] Post on GitHub Discussions (link to release)
+   - [ ] Close release in Jira
+5. Mark `~/Releases/<version>/.state.json` as `currentPhase: 7, complete: true`
+
+## Failure modes & recovery
+
+- **CI build fails** → STOP, do not tag, do not proceed. Re-dispatch after fix.
+- **Sign fails** → leave artifacts in staging; do not delete. Inspect, retry. State preserved.
+- **NuGet publish 409 (already exists)** → version conflict; abort entire release, never overwrite published packages.
+- **Tag push fails** (e.g., already exists) → STOP, investigate. Never force-push tags.
+- **Resume on different machine** → `/Release resume <version>` reads `~/Releases/<version>/.state.json` and skips completed phases. Phase boundaries are the resume points.

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ mono_crash.*
 [Dd]ebugPublic/
 [Rr]elease/
 [Rr]eleases/
+# Exception: project-local Claude skill at .claude/skills/Release/ collides with
+# the [Rr]elease/ pattern above (intended for .NET bin/Release output). Re-include it.
+!.claude/skills/Release/
+!.claude/skills/Release/**
 x64/
 x86/
 [Aa][Rr][Mm]/


### PR DESCRIPTION
## Summary

Adds a project-local Claude Code skill at \`.claude/skills/Release/\` that drives the full Yubico .NET SDK release end-to-end. Same pattern as the existing \`.claude/skills/DocsAudit/\` skill in the repo.

## What it does

The \`/Release\` skill walks through 7 phases with explicit gates:

| Phase | Cross-platform? | What it does |
|---|---|---|
| 1. Pre-flight | ✓ | gh auth check, recent tags, open PR scan, version + date + HW-test gates |
| 2. NativeShims gate | ✓ | Auto-detects \`Yubico.NativeShims/\` changes since previous tag; dispatches \`build-nativeshims.yml\` when needed |
| 3. Release branch | ✓ | \`release/<ver>\` from develop + lockfile repin (\`--force-evaluate --source nuget.org\`) when NativeShims rebuilt + release notes draft from merged PRs + PR to main |
| 4. Merge + CI | ✓ | Wait for merge, dispatch \`build.yml\` with \`version\` input, tag only after CI green |
| 5. Sign + publish | **Windows only** | Downloads artifacts to \`~/Releases/<ver>/\`, runs \`build/sign.ps1\`, publishes to NuGet.org with live status board. NativeShims signs+publishes BEFORE main packages. |
| 6. GitHub release | ✓ | Draft release with signed assets, \`deploy-docs.yml\` trigger |
| 7. Closing | ✓ | Merge main → develop, generate Slack #ask-tla announcement in canonical emoji format from prior 1.15.1 precedent |

## Hard constraints encoded

- Windows-only sign step (refuses to run \`sign.ps1\` on macOS/Linux — prints handoff with cached run IDs instead)
- NativeShims must publish to NuGet.org BEFORE main \`build.yml\` dispatches (hard ordering)
- Tag only after green CI (failed builds = poisoned tag)
- \`build/Versions.props\` never edited — version is set via \`build.yml\` workflow_dispatch input
- Release notes never auto-committed — drafted, diff shown, approved before commit
- When NativeShims rebuilt as stable: \`Yubico.Core/src/packages.lock.json\` is repinned via \`--force-evaluate --source nuget.org\` on the release branch, so \`enforce-branch-policy\` doesn't hard-fail on main

## Cross-machine resume

State cached to \`~/Releases/<version>/.state.json\` at every phase boundary. Start phases 1–4 on macOS/Linux, finish phase 5+ with \`/Release resume <version>\` on Windows.

## Note on \`git add -f\`

\`.gitignore\` line 55 has \`[Rr]elease/\` (intended for .NET build output \`bin/Release/\`) which collaterally matches the skill's \`Release/\` directory name. Files were force-added. Two alternatives if reviewers prefer:
1. Rename skill directory to \`SdkRelease\` (changes invocation to \`/SdkRelease\`)
2. Add \`!.claude/skills/Release/\` exception to .gitignore

## Test plan

- [ ] Pull this branch on Windows machine with code-sign YubiKey + \`signtool.exe\` + \`nuget.exe\` available
- [ ] Run \`/Release\` from inside the repo
- [ ] Verify Phase 1 prompts appear (version, date, HW tests)
- [ ] Verify Phase 2 detects \`Yubico.NativeShims/\` changes since 1.16.0
- [ ] Confirm phase 5 wizard runs sign.ps1 + publishes packages without manual intervention beyond YubiKey PIN
- [ ] Confirm Slack #ask-tla draft appears at end with correct emoji format

## Followup

PR #474 (floating NativeShims version + lockfile pattern) should merge before the skill is used for the 1.16.1 release — the skill's phase 3 lockfile-repin step assumes that pattern is in place.