### PR TITLE
feat: Add Windows HID transport

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -129,7 +129,10 @@ csharp_style_prefer_readonly_struct = true
 csharp_style_prefer_readonly_struct_member = true
 
 # Code-block preferences
-csharp_prefer_braces = false:when_multiline
+csharp_prefer_braces = when_multiline:none
+csharp_style_prefer_conditional_expression_over_return = true:suggestion
+dotnet_diagnostic.IDE0046.severity = suggestion
+dotnet_diagnostic.IDE0072.severity = suggestion
 csharp_prefer_simple_using_statement = true
 csharp_style_namespace_declarations = file_scoped
 csharp_style_prefer_method_group_conversion = true

--- a/docs/architecture/physical-device-model.md
+++ b/docs/architecture/physical-device-model.md
@@ -7,8 +7,9 @@ by `AvailableConnections`. This document explains the model, how to discover and
 metadata lives, how each applet picks a transport, and how to migrate code written against the old
 per-interface-handle model.
 
-> **Platform note:** HID interface enumeration is implemented on macOS and Linux. On Windows, HID discovery
-> is not yet implemented, so a YubiKey currently surfaces only its PC/SC (CCID) interface there. See
+> **Platform note:** HID interface enumeration is implemented on macOS, Linux, and Windows. On Windows,
+> opening HID report handles can fail with access denied if another process holds the interface or if the
+> environment requires an elevated process. See
 > [Platform Support For HID Discovery](#platform-support-for-hid-discovery).
 
 See also: [event-driven device discovery](./event-driven-device-discovery.md) and the
@@ -71,11 +72,12 @@ distinct keys, so one physical key can surface as more than one row.
 
 ### Platform Support For HID Discovery
 
-HID interface enumeration (HID FIDO, HID OTP) is implemented on **macOS and Linux**. On **Windows** HID
-enumeration is not yet implemented, so today a YubiKey is discovered through its PC/SC (CCID) interface only:
-`AvailableConnections` will not include `HidFido`/`HidOtp`, HID connection filters return no devices, and a
-composite USB key cannot merge HID interfaces it cannot see. The PC/SC SmartCard path works on all
-platforms. This is a known platform residual tracked outside the composite-device model itself.
+HID interface enumeration (HID FIDO, HID OTP) is implemented on **macOS, Linux, and Windows**. On Windows,
+discovery uses ConfigMgr interface metadata and does not need to open report handles just to identify YubiKey
+HID interfaces. Opening a HID report connection can still fail with `UnauthorizedAccessException` when Windows
+denies access to the interface, for example because another process holds it exclusively or because the
+current environment requires the process to run elevated as Administrator. The PC/SC SmartCard path works on
+all platforms and is unaffected by HID report-handle access.
 
 ## Opening A Connection
 

--- a/src/Core/src/Native/SdkPlatformInfo.cs
+++ b/src/Core/src/Native/SdkPlatformInfo.cs
@@ -60,10 +60,8 @@ public static class SdkPlatformInfo
         {
             if (OperatingSystem == SdkPlatform.Windows)
             {
-#pragma warning disable CA1416
                 return new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole
                     .Administrator);
-#pragma warning restore CA1416
             }
 
             return false;

--- a/src/Core/src/Native/Windows/Cfgmgr32/CmDevice.cs
+++ b/src/Core/src/Native/Windows/Cfgmgr32/CmDevice.cs
@@ -194,7 +194,7 @@ public class CmDevice
         }
     }
 
-    private static IList<string> GetDevicePaths(Guid classGuid, string? deviceInstanceId)
+    internal static IList<string> GetDevicePaths(Guid classGuid, string? deviceInstanceId)
     {
         var errorCode = NativeMethods.CM_Get_Device_Interface_List_Size(
             out var bufferLength,
@@ -216,7 +216,7 @@ public class CmDevice
             classGuid,
             deviceInstanceId,
             buffer,
-            bufferLength * 2,
+            bufferLength,
             NativeMethods.CM_GET_DEVICE_LIST.PRESENT
         );
 

--- a/src/Core/src/Native/Windows/HidD/HidD.Interop.cs
+++ b/src/Core/src/Native/Windows/HidD/HidD.Interop.cs
@@ -32,12 +32,12 @@ internal static partial class NativeMethods
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
     internal unsafe struct HIDP_CAPS
     {
-        public fixed short Reserved[17];
         public short Usage;
         public short UsagePage;
         public short InputReportByteLength;
         public short OutputReportByteLength;
         public short FeatureReportByteLength;
+        public fixed short Reserved[17];
         public short NumberLinkCollectionNodes;
 
         public short NumberInputButtonCaps;
@@ -53,7 +53,7 @@ internal static partial class NativeMethods
         public short NumberFeatureDataIndices;
     }
 
-
+    internal const int HidpStatusSuccess = 0x00110000;
 
     [LibraryImport(Libraries.Hid, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
@@ -67,7 +67,7 @@ internal static partial class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     internal static partial bool HidD_GetAttributes(
         SafeFileHandle HidDeviceObject,
-        out HIDD_ATTRIBUTES Attributes
+        ref HIDD_ATTRIBUTES Attributes
     );
 
     [LibraryImport(Libraries.Hid, SetLastError = true)]
@@ -116,8 +116,7 @@ internal static partial class NativeMethods
 
     [LibraryImport(Libraries.Hid, SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    internal static partial bool HidP_GetCaps(
+    internal static partial int HidP_GetCaps(
         IntPtr PreparsedData,
         ref HIDP_CAPS Capabilities
     );

--- a/src/Core/src/Native/Windows/HidD/HidDDevice.cs
+++ b/src/Core/src/Native/Windows/HidD/HidDDevice.cs
@@ -20,6 +20,9 @@ namespace Yubico.YubiKit.Core.Native.Windows.HidD;
 internal sealed class HidDDevice : IHidDDevice
 {
     private const int ErrorAccessDenied = 5;
+    private const string WindowsHidAccessDeniedGuidance =
+        "Windows denied access to the HID interface. The interface may be held exclusively by another process, " +
+        "or this environment may require running the process elevated as Administrator to open YubiKey HID reports.";
     private SafeFileHandle _handle;
     private bool _disposed;
 
@@ -152,7 +155,10 @@ internal sealed class HidDDevice : IHidDDevice
         {
             var error = Marshal.GetLastWin32Error();
             if (error == ErrorAccessDenied)
-                throw new UnauthorizedAccessException($"Access denied opening HID device '{DevicePath}'.");
+            {
+                throw new UnauthorizedAccessException(
+                    $"Access denied opening HID device '{DevicePath}'. {WindowsHidAccessDeniedGuidance}");
+            }
 
             throw new PlatformApiException(nameof(Kernel32.NativeMethods.CreateFile), error,
                 $"Failed to open HID device '{DevicePath}'.");
@@ -211,7 +217,7 @@ internal sealed class HidDDevice : IHidDDevice
     {
         var error = Marshal.GetLastWin32Error();
         if (error == ErrorAccessDenied)
-            throw new UnauthorizedAccessException(message);
+            throw new UnauthorizedAccessException($"{message} {WindowsHidAccessDeniedGuidance}");
 
         throw new PlatformApiException(source, error, message);
     }

--- a/src/Core/src/Native/Windows/HidD/HidDDevice.cs
+++ b/src/Core/src/Native/Windows/HidD/HidDDevice.cs
@@ -77,7 +77,9 @@ internal sealed class HidDDevice : IHidDDevice
 
         if (buffer.Length != FeatureReportByteLength - 1)
         {
-            throw new InvalidOperationException("The HID feature report buffer length is invalid.");
+            throw new ArgumentException(
+                $"The HID feature report buffer length is invalid. Expected {FeatureReportByteLength - 1} bytes, but got {buffer.Length}.",
+                nameof(buffer));
         }
 
         // Windows expects the report ID byte before the report payload.
@@ -114,7 +116,9 @@ internal sealed class HidDDevice : IHidDDevice
 
         if (buffer.Length != OutputReportByteLength - 1)
         {
-            throw new InvalidOperationException("The HID output report buffer length is invalid.");
+            throw new ArgumentException(
+                $"The HID output report buffer length is invalid. Expected {OutputReportByteLength - 1} bytes, but got {buffer.Length}.",
+                nameof(buffer));
         }
 
         // Windows expects the report ID byte before the report payload.

--- a/src/Core/src/Native/Windows/HidD/HidDDevice.cs
+++ b/src/Core/src/Native/Windows/HidD/HidDDevice.cs
@@ -17,16 +17,17 @@ using System.Runtime.InteropServices;
 
 namespace Yubico.YubiKit.Core.Native.Windows.HidD;
 
-internal class HidDDevice : IHidDDevice
+internal sealed class HidDDevice : IHidDDevice
 {
+    private const int ErrorAccessDenied = 5;
     private SafeFileHandle _handle;
+    private bool _disposed;
 
     public HidDDevice(string devicePath)
     {
         DevicePath = devicePath;
 
-        _handle = OpenHandleWithAccess(Kernel32.NativeMethods.DESIRED_ACCESS.NONE);
-        var capabilities = GetCapabilities(_handle);
+        _handle = OpenHandleForMetadata(out var capabilities);
 
         Usage = capabilities.Usage;
         UsagePage = capabilities.UsagePage;
@@ -44,27 +45,21 @@ internal class HidDDevice : IHidDDevice
     public short FeatureReportByteLength { get; }
 
     public void OpenIOConnection()
-    {
-        _handle.Dispose();
-        _handle = OpenHandleWithAccess(Kernel32.NativeMethods.DESIRED_ACCESS.GENERIC_READ |
-                                       Kernel32.NativeMethods.DESIRED_ACCESS.GENERIC_WRITE);
-    }
+        => OpenReportConnection();
 
     public void OpenFeatureConnection()
-    {
-        _handle.Dispose();
-        _handle = OpenHandleWithAccess(Kernel32.NativeMethods.DESIRED_ACCESS.GENERIC_WRITE);
-    }
+        => OpenReportConnection();
 
     public byte[] GetFeatureReport()
     {
-        if (_handle is null) throw new InvalidOperationException("ExceptionMessages.InvalidSafeFileHandle");
+        EnsureOpenHandle();
 
         var buffer = new byte[FeatureReportByteLength];
 
         if (!NativeMethods.HidD_GetFeature(_handle, buffer, buffer.Length))
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
 
+        // Windows includes the report ID byte; the SDK exposes only report payload bytes.
         var returnBuf = new byte[FeatureReportByteLength - 1];
         Array.Copy(buffer, 1, returnBuf, 0, returnBuf.Length);
 
@@ -73,11 +68,12 @@ internal class HidDDevice : IHidDDevice
 
     public void SetFeatureReport(byte[] buffer)
     {
-        if (_handle is null) throw new InvalidOperationException("ExceptionMessages.InvalidSafeFileHandle");
+        EnsureOpenHandle();
 
         if (buffer.Length != FeatureReportByteLength - 1)
-            throw new InvalidOperationException("ExceptionMessages.InvalidReportBufferLength");
+            throw new InvalidOperationException("The HID feature report buffer length is invalid.");
 
+        // Windows expects the report ID byte before the report payload.
         var sendBuf = new byte[buffer.Length + 1];
         Array.Copy(buffer, 0, sendBuf, 1, buffer.Length);
 
@@ -87,13 +83,14 @@ internal class HidDDevice : IHidDDevice
 
     public byte[] GetInputReport()
     {
-        if (_handle is null) throw new InvalidOperationException("ExceptionMessages.InvalidSafeFileHandle");
+        EnsureOpenHandle();
 
         var buffer = new byte[InputReportByteLength];
         if (!Kernel32.NativeMethods.ReadFile(_handle, buffer, buffer.Length, out var bytesRead, IntPtr.Zero)
             || bytesRead != buffer.Length)
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
 
+        // Windows includes the report ID byte; the SDK exposes only report payload bytes.
         var returnBuf = new byte[InputReportByteLength - 1];
         Array.Copy(buffer, 1, returnBuf, 0, returnBuf.Length);
 
@@ -102,10 +99,12 @@ internal class HidDDevice : IHidDDevice
 
     public void SetOutputReport(byte[] buffer)
     {
-        if (_handle is null) throw new InvalidOperationException("ExceptionMessages.InvalidSafeFileHandle");
-        if (buffer.Length != OutputReportByteLength - 1)
-            throw new InvalidOperationException("ExceptionMessages.InvalidReportBufferLength");
+        EnsureOpenHandle();
 
+        if (buffer.Length != OutputReportByteLength - 1)
+            throw new InvalidOperationException("The HID output report buffer length is invalid.");
+
+        // Windows expects the report ID byte before the report payload.
         var sendBuf = new byte[buffer.Length + 1];
         Array.Copy(buffer, 0, sendBuf, 1, buffer.Length);
 
@@ -120,12 +119,14 @@ internal class HidDDevice : IHidDDevice
         NativeMethods.HIDP_CAPS capabilities = new();
 
         if (!NativeMethods.HidD_GetPreparsedData(safeHandle, out var preparsedData))
-            Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            ThrowHidDWin32Failure(nameof(NativeMethods.HidD_GetPreparsedData), "Failed to get HID preparsed data.");
 
         try
         {
-            if (!NativeMethods.HidP_GetCaps(preparsedData, ref capabilities))
-                Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+            var result = NativeMethods.HidP_GetCaps(preparsedData, ref capabilities);
+            if (result != NativeMethods.HidpStatusSuccess)
+                throw new PlatformApiException(nameof(NativeMethods.HidP_GetCaps), result,
+                    "Failed to get HID capabilities.");
 
             return capabilities;
         }
@@ -140,32 +141,96 @@ internal class HidDDevice : IHidDDevice
         var handle = Kernel32.NativeMethods.CreateFile(
             DevicePath,
             desiredAccess,
-            Kernel32.NativeMethods.FILE_SHARE.READWRITE,
+            Kernel32.NativeMethods.FILE_SHARE.ALL,
             IntPtr.Zero,
             Kernel32.NativeMethods.CREATION_DISPOSITION.OPEN_EXISTING,
             Kernel32.NativeMethods.FILE_FLAG.NORMAL,
             IntPtr.Zero
         );
 
-        if (handle.IsInvalid) Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+        if (handle.IsInvalid)
+        {
+            var error = Marshal.GetLastWin32Error();
+            if (error == ErrorAccessDenied)
+                throw new UnauthorizedAccessException($"Access denied opening HID device '{DevicePath}'.");
+
+            throw new PlatformApiException(nameof(Kernel32.NativeMethods.CreateFile), error,
+                $"Failed to open HID device '{DevicePath}'.");
+        }
 
         return handle;
     }
 
-
-    private bool disposedValue; // To detect redundant calls
-
-    protected virtual void Dispose(bool disposing)
+    private SafeFileHandle OpenHandleForMetadata(out NativeMethods.HIDP_CAPS capabilities)
     {
-        if (!disposedValue)
+        try
         {
-            if (disposing) _handle.Dispose();
-
-            disposedValue = true;
+            var handle = OpenHandleWithAccess(Kernel32.NativeMethods.DESIRED_ACCESS.NONE);
+            try
+            {
+                capabilities = GetCapabilities(handle);
+                return handle;
+            }
+            catch
+            {
+                handle.Dispose();
+                throw;
+            }
+        }
+        catch (Exception ex) when (RequiresReadWriteMetadataHandle(ex))
+        {
+            var handle = OpenReadWriteHandle();
+            try
+            {
+                capabilities = GetCapabilities(handle);
+                return handle;
+            }
+            catch
+            {
+                handle.Dispose();
+                throw;
+            }
         }
     }
 
-    // This code added to correctly implement the disposable pattern.
-    public void Dispose() => Dispose(true);
+    private void OpenReportConnection()
+    {
+        var handle = OpenReadWriteHandle();
+        _handle.Dispose();
+        _handle = handle;
+    }
+
+    private SafeFileHandle OpenReadWriteHandle()
+        => OpenHandleWithAccess(Kernel32.NativeMethods.DESIRED_ACCESS.GENERIC_READ |
+                                Kernel32.NativeMethods.DESIRED_ACCESS.GENERIC_WRITE);
+
+    private static bool RequiresReadWriteMetadataHandle(Exception exception)
+        => exception is UnauthorizedAccessException;
+
+    private static void ThrowHidDWin32Failure(string source, string message)
+    {
+        var error = Marshal.GetLastWin32Error();
+        if (error == ErrorAccessDenied)
+            throw new UnauthorizedAccessException(message);
+
+        throw new PlatformApiException(source, error, message);
+    }
+
+    private void EnsureOpenHandle()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        if (_handle.IsInvalid || _handle.IsClosed)
+            throw new InvalidOperationException($"The HID device handle for '{DevicePath}' is not open.");
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _handle.Dispose();
+        _disposed = true;
+    }
 
 }

--- a/src/Core/src/Native/Windows/HidD/HidDDevice.cs
+++ b/src/Core/src/Native/Windows/HidD/HidDDevice.cs
@@ -60,7 +60,9 @@ internal sealed class HidDDevice : IHidDDevice
         var buffer = new byte[FeatureReportByteLength];
 
         if (!NativeMethods.HidD_GetFeature(_handle, buffer, buffer.Length))
+        {
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+        }
 
         // Windows includes the report ID byte; the SDK exposes only report payload bytes.
         var returnBuf = new byte[FeatureReportByteLength - 1];
@@ -74,14 +76,18 @@ internal sealed class HidDDevice : IHidDDevice
         EnsureOpenHandle();
 
         if (buffer.Length != FeatureReportByteLength - 1)
+        {
             throw new InvalidOperationException("The HID feature report buffer length is invalid.");
+        }
 
         // Windows expects the report ID byte before the report payload.
         var sendBuf = new byte[buffer.Length + 1];
         Array.Copy(buffer, 0, sendBuf, 1, buffer.Length);
 
         if (!NativeMethods.HidD_SetFeature(_handle, sendBuf, sendBuf.Length))
+        {
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+        }
     }
 
     public byte[] GetInputReport()
@@ -91,7 +97,9 @@ internal sealed class HidDDevice : IHidDDevice
         var buffer = new byte[InputReportByteLength];
         if (!Kernel32.NativeMethods.ReadFile(_handle, buffer, buffer.Length, out var bytesRead, IntPtr.Zero)
             || bytesRead != buffer.Length)
+        {
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+        }
 
         // Windows includes the report ID byte; the SDK exposes only report payload bytes.
         var returnBuf = new byte[InputReportByteLength - 1];
@@ -105,7 +113,9 @@ internal sealed class HidDDevice : IHidDDevice
         EnsureOpenHandle();
 
         if (buffer.Length != OutputReportByteLength - 1)
+        {
             throw new InvalidOperationException("The HID output report buffer length is invalid.");
+        }
 
         // Windows expects the report ID byte before the report payload.
         var sendBuf = new byte[buffer.Length + 1];
@@ -113,7 +123,9 @@ internal sealed class HidDDevice : IHidDDevice
 
         if (!Kernel32.NativeMethods.WriteFile(_handle, sendBuf, sendBuf.Length, out var bytesWritten, IntPtr.Zero)
             || bytesWritten != sendBuf.Length)
+        {
             Marshal.ThrowExceptionForHR(Marshal.GetHRForLastWin32Error());
+        }
     }
 
 
@@ -122,16 +134,17 @@ internal sealed class HidDDevice : IHidDDevice
         NativeMethods.HIDP_CAPS capabilities = new();
 
         if (!NativeMethods.HidD_GetPreparsedData(safeHandle, out var preparsedData))
+        {
             ThrowHidDWin32Failure(nameof(NativeMethods.HidD_GetPreparsedData), "Failed to get HID preparsed data.");
+        }
 
         try
         {
             var result = NativeMethods.HidP_GetCaps(preparsedData, ref capabilities);
-            if (result != NativeMethods.HidpStatusSuccess)
-                throw new PlatformApiException(nameof(NativeMethods.HidP_GetCaps), result,
+            return result == NativeMethods.HidpStatusSuccess
+                ? capabilities
+                : throw new PlatformApiException(nameof(NativeMethods.HidP_GetCaps), result,
                     "Failed to get HID capabilities.");
-
-            return capabilities;
         }
         finally
         {
@@ -217,7 +230,9 @@ internal sealed class HidDDevice : IHidDDevice
     {
         var error = Marshal.GetLastWin32Error();
         if (error == ErrorAccessDenied)
+        {
             throw new UnauthorizedAccessException($"{message} {WindowsHidAccessDeniedGuidance}");
+        }
 
         throw new PlatformApiException(source, error, message);
     }
@@ -227,13 +242,17 @@ internal sealed class HidDDevice : IHidDDevice
         ObjectDisposedException.ThrowIf(_disposed, this);
 
         if (_handle.IsInvalid || _handle.IsClosed)
+        {
             throw new InvalidOperationException($"The HID device handle for '{DevicePath}' is not open.");
+        }
     }
 
     public void Dispose()
     {
         if (_disposed)
+        {
             return;
+        }
 
         _handle.Dispose();
         _disposed = true;

--- a/src/Core/src/Native/Windows/Kernel32/Kernel32.Interop.cs
+++ b/src/Core/src/Native/Windows/Kernel32/Kernel32.Interop.cs
@@ -153,7 +153,7 @@ internal static partial class NativeMethods
 
 
     [LibraryImport(Libraries.Kernel32, EntryPoint = "CreateFileW", SetLastError = true,
-        StringMarshalling = StringMarshalling.Utf8)]
+        StringMarshalling = StringMarshalling.Utf16)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     internal static partial SafeFileHandle CreateFile(
         string lpFileName,

--- a/src/Core/src/Transports/Hid/FindHidDevices.cs
+++ b/src/Core/src/Transports/Hid/FindHidDevices.cs
@@ -15,6 +15,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Runtime.Versioning;
+using Yubico.YubiKit.Core.Native;
 using Yubico.YubiKit.Core.Transports.Hid.Linux;
 using Yubico.YubiKit.Core.Transports.Hid.MacOS;
 using Yubico.YubiKit.Core.Transports.Hid.Windows;
@@ -46,25 +47,15 @@ public class FindHidDevices(ILogger<FindHidDevices> logger) : IFindHidDevices
         return yubicoDevices;
     }
 
-    private IReadOnlyList<IHidDevice> GetPlatformDevices()
-    {
-        if (OperatingSystem.IsMacOS())
+    private IReadOnlyList<IHidDevice> GetPlatformDevices() =>
+        SdkPlatformInfo.OperatingSystem switch
         {
-            return FindAllMacOS();
-        }
-
-        if (OperatingSystem.IsLinux())
-        {
-            return FindAllLinux();
-        }
-
-        if (OperatingSystem.IsWindows())
-        {
-            return FindAllWindows();
-        }
-
-        return [];
-    }
+            SdkPlatform.MacOS => FindAllMacOS(),
+            SdkPlatform.Linux => FindAllLinux(),
+            SdkPlatform.Windows => FindAllWindows(),
+            SdkPlatform.Unknown => [],
+            _ => []
+        };
 
     [SupportedOSPlatform("macos")]
     private static IReadOnlyList<IHidDevice> FindAllMacOS() =>

--- a/src/Core/src/Transports/Hid/FindHidDevices.cs
+++ b/src/Core/src/Transports/Hid/FindHidDevices.cs
@@ -15,9 +15,9 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Runtime.Versioning;
-using Yubico.YubiKit.Core.Transports.Hid;
 using Yubico.YubiKit.Core.Transports.Hid.Linux;
 using Yubico.YubiKit.Core.Transports.Hid.MacOS;
+using Yubico.YubiKit.Core.Transports.Hid.Windows;
 
 namespace Yubico.YubiKit.Core.Transports.Hid;
 
@@ -28,8 +28,6 @@ public interface IFindHidDevices
 
 public class FindHidDevices(ILogger<FindHidDevices> logger) : IFindHidDevices
 {
-    private const short YubicoVendorId = 0x1050;
-
     public async Task<IReadOnlyList<IHidDevice>> FindAllAsync(CancellationToken cancellationToken = default) =>
         await Task.Run(FindAll, cancellationToken).ConfigureAwait(false);
 
@@ -40,7 +38,7 @@ public class FindHidDevices(ILogger<FindHidDevices> logger) : IFindHidDevices
         var allDevices = GetPlatformDevices();
 
         var yubicoDevices = allDevices
-            .Where(d => d.DescriptorInfo.VendorId == YubicoVendorId)
+            .Where(d => d.DescriptorInfo.VendorId == HidConstants.YubicoVendorId)
             .ToList();
 
         logger.LogDebug("Found {Count} Yubico HID devices", yubicoDevices.Count);
@@ -60,7 +58,11 @@ public class FindHidDevices(ILogger<FindHidDevices> logger) : IFindHidDevices
             return FindAllLinux();
         }
 
-        // Windows not yet implemented, return empty list
+        if (OperatingSystem.IsWindows())
+        {
+            return FindAllWindows();
+        }
+
         return [];
     }
 
@@ -81,6 +83,10 @@ public class FindHidDevices(ILogger<FindHidDevices> logger) : IFindHidDevices
             return [];
         }
     }
+
+    [SupportedOSPlatform("windows")]
+    private static IReadOnlyList<IHidDevice> FindAllWindows() =>
+        WindowsHidDevice.GetList();
 
     public static FindHidDevices Create(ILogger<FindHidDevices>? logger = null) =>
         new(logger ?? NullLogger<FindHidDevices>.Instance);

--- a/src/Core/src/Transports/Hid/HidConstants.cs
+++ b/src/Core/src/Transports/Hid/HidConstants.cs
@@ -1,0 +1,20 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.YubiKit.Core.Transports.Hid;
+
+internal static class HidConstants
+{
+    public const short YubicoVendorId = 0x1050;
+}

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
@@ -17,7 +17,6 @@ using System.Runtime.Versioning;
 using Yubico.YubiKit.Core.Native;
 using Yubico.YubiKit.Core.Native.Linux.Libc;
 using Yubico.YubiKit.Core.Native.Linux.Udev;
-using Yubico.YubiKit.Core.Transports.Hid;
 using LibcNativeMethods = Yubico.YubiKit.Core.Native.Linux.Libc.NativeMethods;
 using UdevNativeMethods = Yubico.YubiKit.Core.Native.Linux.Udev.NativeMethods;
 
@@ -110,7 +109,7 @@ internal sealed class LinuxHidDevice : IHidDevice
                     var descriptorInfo = ParseHidDescriptor(device);
 
                     // Only include Yubico devices with supported interface types
-                    if (descriptorInfo.VendorId == 0x1050 &&
+                    if (descriptorInfo.VendorId == HidConstants.YubicoVendorId &&
                         HidInterfaceClassifier.IsSupported(descriptorInfo))
                     {
                         devices.Add(new LinuxHidDevice(descriptorInfo));

--- a/src/Core/src/Transports/Hid/MacOS/MacOSHidDevice.cs
+++ b/src/Core/src/Transports/Hid/MacOS/MacOSHidDevice.cs
@@ -16,7 +16,6 @@ using System.Globalization;
 using System.Runtime.Versioning;
 using Yubico.YubiKit.Core.Native;
 using Yubico.YubiKit.Core.Native.MacOS.IOKitFramework;
-using Yubico.YubiKit.Core.Transports.Hid;
 using CFNativeMethods = Yubico.YubiKit.Core.Native.MacOS.CoreFoundation.NativeMethods;
 using IOKitNativeMethods = Yubico.YubiKit.Core.Native.MacOS.IOKitFramework.NativeMethods;
 
@@ -85,7 +84,7 @@ internal sealed class MacOSHidDevice : IHidDevice
                 };
 
                 // Only include Yubico devices with supported interface types
-                if (descriptorInfo.VendorId == 0x1050 &&
+                if (descriptorInfo.VendorId == HidConstants.YubicoVendorId &&
                     HidInterfaceClassifier.IsSupported(descriptorInfo))
                 {
                     result.Add(new MacOSHidDevice(GetEntryId(device), descriptorInfo));

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidDevice.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidDevice.cs
@@ -1,0 +1,107 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System.Runtime.Versioning;
+using Yubico.YubiKit.Core.Native;
+using Yubico.YubiKit.Core.Native.Windows.Cfgmgr32;
+using Cfgmgr32NativeMethods = Yubico.YubiKit.Core.Native.Windows.Cfgmgr32.NativeMethods;
+
+namespace Yubico.YubiKit.Core.Transports.Hid.Windows;
+
+/// <summary>
+/// Windows implementation of a Human Interface Device (HID).
+/// </summary>
+[SupportedOSPlatform("windows")]
+internal sealed class WindowsHidDevice : IHidDevice
+{
+    private static readonly ILogger<WindowsHidDevice> Logger = YubiKitLogging.CreateLogger<WindowsHidDevice>();
+
+    private readonly string _devicePath;
+
+    private WindowsHidDevice(HidDescriptorInfo descriptorInfo)
+    {
+        DescriptorInfo = descriptorInfo;
+        InterfaceType = HidInterfaceClassifier.Classify(descriptorInfo);
+        _devicePath = descriptorInfo.DevicePath;
+    }
+
+    public string ReaderName => _devicePath;
+
+    public HidDescriptorInfo DescriptorInfo { get; }
+
+    public HidInterfaceType InterfaceType { get; }
+
+    public static IReadOnlyList<IHidDevice> GetList()
+    {
+        var devices = new List<IHidDevice>();
+
+        foreach (var interfacePath in CmDevice.GetDevicePaths(CmInterfaceGuid.Hid, null))
+        {
+            if (string.IsNullOrEmpty(interfacePath))
+                continue;
+
+            try
+            {
+                var descriptorInfo = GetDescriptorInfo(interfacePath);
+
+                if (descriptorInfo.VendorId == HidConstants.YubicoVendorId &&
+                    HidInterfaceClassifier.IsSupported(descriptorInfo))
+                {
+                    devices.Add(new WindowsHidDevice(descriptorInfo));
+                }
+            }
+            catch (PlatformApiException ex)
+            {
+                Logger.LogDebug(ex, "Skipping HID interface {InterfacePath}: ConfigMgr property read failed", interfacePath);
+                // Ignore inaccessible or transient HID interfaces; one bad device must not abort discovery.
+            }
+            catch (NotSupportedException ex)
+            {
+                Logger.LogDebug(ex, "Skipping HID interface {InterfacePath}: unsupported or malformed ConfigMgr HID properties", interfacePath);
+                // Ignore HID interfaces with unsupported/malformed ConfigMgr properties.
+            }
+        }
+
+        return devices;
+    }
+
+    private static HidDescriptorInfo GetDescriptorInfo(string interfacePath) =>
+        new()
+        {
+            UsagePage = GetInterfaceProperty<ushort>(interfacePath, Cfgmgr32NativeMethods.DEVPKEY_DeviceInterface_HID_UsagePage),
+            Usage = GetInterfaceProperty<ushort>(interfacePath, Cfgmgr32NativeMethods.DEVPKEY_DeviceInterface_HID_UsageId),
+            DevicePath = interfacePath,
+            VendorId = unchecked((short)GetInterfaceProperty<ushort>(interfacePath, Cfgmgr32NativeMethods.DEVPKEY_DeviceInterface_HID_VendorId)),
+            ProductId = unchecked((short)GetInterfaceProperty<ushort>(interfacePath, Cfgmgr32NativeMethods.DEVPKEY_DeviceInterface_HID_ProductId))
+        };
+
+    private static T GetInterfaceProperty<T>(string interfacePath, Cfgmgr32NativeMethods.DEVPROPKEY propertyKey)
+    {
+        var value = CmPropertyAccessHelper.TryGetProperty(
+            Cfgmgr32NativeMethods.CM_Get_Device_Interface_Property,
+            interfacePath,
+            propertyKey);
+
+        return value is T typed
+            ? typed
+            : throw new NotSupportedException($"Missing or invalid HID interface property {propertyKey}.");
+    }
+
+    public IHidConnection ConnectToFeatureReports() =>
+        new WindowsHidFeatureReportConnection(_devicePath);
+
+    public IHidConnection ConnectToIOReports() =>
+        new WindowsHidIOReportConnection(_devicePath);
+}

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidFeatureReportConnection.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidFeatureReportConnection.cs
@@ -1,87 +1,66 @@
-﻿// // Copyright 2025 Yubico AB
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License").
-// // You may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// //     http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
+﻿// Copyright 2025 Yubico AB
 //
-// using Yubico.YubiKit.Core.Native.Windows.HidD;
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// namespace Yubico.YubiKit.Core.Core.Devices.Hid
-// {
-//     internal sealed class WindowsHidFeatureReportConnection : IHidConnection
-//     {
-//         // The SDK device instance that created this connection instance.
-//         // private readonly WindowsHidDevice _device;
-//         // The underlying Windows HID device used for communication.
-//         private IHidDDevice HidDDevice { get; set; }
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//         public int InputReportSize { get; private set; }
-//         public int OutputReportSize { get; private set; }
-//
-//         internal WindowsHidFeatureReportConnection(WindowsHidDevice device, string path)
-//         {
-//             _device = device;
-//             HidDDevice = new HidDDevice(path);
-//             SetupConnection();
-//         }
-//
-//         private void SetupConnection()
-//         {
-//             HidDDevice.OpenFeatureConnection();
-//             InputReportSize = HidDDevice.FeatureReportByteLength;
-//             OutputReportSize = HidDDevice.FeatureReportByteLength;
-//         }
-//
-//         public byte[] GetReport()
-//         {
-//             byte[] data = HidDDevice.GetFeatureReport();
-//
-//             _device.LogDeviceAccessTime();
-//
-//             return data;
-//         }
-//
-//         public void SetReport(byte[] report)
-//         {
-//             HidDDevice.SetFeatureReport(report);
-//             _device.LogDeviceAccessTime();
-//         }
-//
-//         private bool disposedValue; // To detect redundant calls
-//
-//         private void Dispose(bool disposing)
-//         {
-//             if (!disposedValue)
-//             {
-//                 if (disposing)
-//                 {
-//                     HidDDevice.Dispose();
-//                 }
-//
-//                 disposedValue = true;
-//             }
-//         }
-//
-//         ~WindowsHidFeatureReportConnection()
-//         {
-//             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-//             Dispose(false);
-//         }
-//
-//         // This code added to correctly implement the disposable pattern.
-//         public void Dispose()
-//         {
-//             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-//             Dispose(true);
-//             GC.SuppressFinalize(this);
-//         }
-//     }
-// }
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Native.Windows.HidD;
+
+namespace Yubico.YubiKit.Core.Transports.Hid.Windows;
+
+internal sealed class WindowsHidFeatureReportConnection : IHidConnection
+{
+    private readonly IHidDDevice _hidDDevice;
+    private bool _disposed;
+
+    internal WindowsHidFeatureReportConnection(string path)
+    {
+        _hidDDevice = new HidDDevice(path);
+        _hidDDevice.OpenFeatureConnection();
+
+        // HidD report lengths include the report ID byte; IHidConnection sizes are payload-only.
+        InputReportSize = _hidDDevice.FeatureReportByteLength - 1;
+        OutputReportSize = _hidDDevice.FeatureReportByteLength - 1;
+    }
+
+    public int InputReportSize { get; }
+    public int OutputReportSize { get; }
+    public ConnectionType Type => ConnectionType.Hid;
+
+    public byte[] GetReport()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _hidDDevice.GetFeatureReport();
+    }
+
+    public void SetReport(byte[] report)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(report);
+        _hidDDevice.SetFeatureReport(report);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _hidDDevice.Dispose();
+        _disposed = true;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidIOReportConnection.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidIOReportConnection.cs
@@ -1,87 +1,66 @@
-﻿// // Copyright 2025 Yubico AB
-// //
-// // Licensed under the Apache License, Version 2.0 (the "License").
-// // You may not use this file except in compliance with the License.
-// // You may obtain a copy of the License at
-// //
-// //     http://www.apache.org/licenses/LICENSE-2.0
-// //
-// // Unless required by applicable law or agreed to in writing, software
-// // distributed under the License is distributed on an "AS IS" BASIS,
-// // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// // See the License for the specific language governing permissions and
-// // limitations under the License.
+﻿// Copyright 2025 Yubico AB
 //
-// using Yubico.YubiKit.Core.Native.Windows.HidD;
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// namespace Yubico.YubiKit.Core.Core.Devices.Hid
-// {
-//     internal class WindowsHidIOReportConnection : IHidConnection
-//     {
-//         // The SDK device instance that created this connection instance.
-//         private readonly WindowsHidDevice _device;
-//         // The underlying Windows HID device used for communication.
-//         private IHidDDevice HidDDevice { get; set; }
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-//         public int InputReportSize { get; private set; }
-//         public int OutputReportSize { get; private set; }
-//
-//         internal WindowsHidIOReportConnection(WindowsHidDevice device, string path)
-//         {
-//             _device = device;
-//             HidDDevice = new HidDDevice(path);
-//             SetupConnection();
-//         }
-//
-//         private void SetupConnection()
-//         {
-//             HidDDevice.OpenIOConnection();
-//             InputReportSize = HidDDevice.InputReportByteLength;
-//             OutputReportSize = HidDDevice.OutputReportByteLength;
-//         }
-//
-//         public byte[] GetReport()
-//         {
-//             byte[] data = HidDDevice.GetInputReport();
-//
-//             _device.LogDeviceAccessTime();
-//
-//             return data;
-//         }
-//
-//         public void SetReport(byte[] report)
-//         {
-//             HidDDevice.SetOutputReport(report);
-//             _device.LogDeviceAccessTime();
-//         }
-//
-//         private bool disposedValue; // To detect redundant calls
-//
-//         protected virtual void Dispose(bool disposing)
-//         {
-//             if (!disposedValue)
-//             {
-//                 if (disposing)
-//                 {
-//                     HidDDevice.Dispose();
-//                 }
-//
-//                 disposedValue = true;
-//             }
-//         }
-//
-//         ~WindowsHidIOReportConnection()
-//         {
-//             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-//             Dispose(false);
-//         }
-//
-//         // This code added to correctly implement the disposable pattern.
-//         public void Dispose()
-//         {
-//             // Do not change this code. Put cleanup code in Dispose(bool disposing) above.
-//             Dispose(true);
-//             GC.SuppressFinalize(this);
-//         }
-//     }
-// }
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Native.Windows.HidD;
+
+namespace Yubico.YubiKit.Core.Transports.Hid.Windows;
+
+internal sealed class WindowsHidIOReportConnection : IHidConnection
+{
+    private readonly IHidDDevice _hidDDevice;
+    private bool _disposed;
+
+    internal WindowsHidIOReportConnection(string path)
+    {
+        _hidDDevice = new HidDDevice(path);
+        _hidDDevice.OpenIOConnection();
+
+        // HidD report lengths include the report ID byte; IHidConnection sizes are payload-only.
+        InputReportSize = _hidDDevice.InputReportByteLength - 1;
+        OutputReportSize = _hidDDevice.OutputReportByteLength - 1;
+    }
+
+    public int InputReportSize { get; }
+    public int OutputReportSize { get; }
+    public ConnectionType Type => ConnectionType.Hid;
+
+    public byte[] GetReport()
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        return _hidDDevice.GetInputReport();
+    }
+
+    public void SetReport(byte[] report)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        ArgumentNullException.ThrowIfNull(report);
+        _hidDDevice.SetOutputReport(report);
+    }
+
+    public void Dispose()
+    {
+        if (_disposed)
+            return;
+
+        _hidDDevice.Dispose();
+        _disposed = true;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidDeviceListenerIntegrationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidDeviceListenerIntegrationTests.cs
@@ -46,11 +46,6 @@ public class HidDeviceListenerIntegrationTests
             _output.WriteLine($"Test skipped: {ex.Message}");
             return;
         }
-        catch (Exception ex)
-        {
-            _output.WriteLine($"HID listener creation failed: {ex.Message}");
-            return;
-        }
 
         try
         {
@@ -78,39 +73,7 @@ public class HidDeviceListenerIntegrationTests
     }
 
     [Fact]
-    public void Create_StatusIsStarted()
-    {
-        // Arrange & Act
-        HidDeviceListener? listener = null;
-        try
-        {
-            listener = HidDeviceListener.Create();
-        }
-        catch (PlatformNotSupportedException ex)
-        {
-            _output.WriteLine($"Test skipped: {ex.Message}");
-            return;
-        }
-        catch (Exception ex)
-        {
-            _output.WriteLine($"Test skipped: {ex.Message}");
-            return;
-        }
-
-        try
-        {
-            // Assert
-            Assert.Equal(DeviceListenerStatus.Started, listener.Status);
-            _output.WriteLine("HID listener created with Started status");
-        }
-        finally
-        {
-            listener?.Dispose();
-        }
-    }
-
-    [Fact]
-    public void EventSubscription_NoDeviceChange_NoEventsFired()
+    public void Start_TransitionsToStartedStatus()
     {
         // Arrange
         HidDeviceListener? listener = null;
@@ -123,7 +86,34 @@ public class HidDeviceListenerIntegrationTests
             _output.WriteLine($"Test skipped: {ex.Message}");
             return;
         }
-        catch (Exception ex)
+
+        try
+        {
+            // Act
+            listener.Start();
+
+            // Assert - Error is acceptable when CM_Register_Notification is blocked (CI/sandbox)
+            Assert.True(
+                listener.Status is DeviceListenerStatus.Started or DeviceListenerStatus.Error,
+                $"Expected Started or Error, but got {listener.Status}");
+            _output.WriteLine($"HID listener status after Start(): {listener.Status}");
+        }
+        finally
+        {
+            listener?.Dispose();
+        }
+    }
+
+    [Fact]
+    public void StartedListener_NoDeviceChange_NoSpuriousEvents()
+    {
+        // Arrange
+        HidDeviceListener? listener = null;
+        try
+        {
+            listener = HidDeviceListener.Create();
+        }
+        catch (PlatformNotSupportedException ex)
         {
             _output.WriteLine($"Test skipped: {ex.Message}");
             return;
@@ -134,13 +124,14 @@ public class HidDeviceListenerIntegrationTests
         try
         {
             listener.DeviceEvent = () => Interlocked.Increment(ref eventCount);
+            listener.Start();
 
-            // Act - wait briefly
+            // Act - wait briefly with listener running
             Thread.Sleep(500);
 
-            // Assert - no spurious events
+            // Assert - no spurious events while running
             Assert.Equal(0, eventCount);
-            _output.WriteLine("No spurious events fired during quiet period");
+            _output.WriteLine("No spurious events fired during quiet period with listener running");
         }
         finally
         {
@@ -149,20 +140,16 @@ public class HidDeviceListenerIntegrationTests
     }
 
     [Fact]
-    public async Task Dispose_CompletesCleanly()
+    public async Task Dispose_AfterStart_CompletesCleanly()
     {
         // Arrange
         HidDeviceListener? listener = null;
         try
         {
             listener = HidDeviceListener.Create();
+            listener.Start();
         }
         catch (PlatformNotSupportedException ex)
-        {
-            _output.WriteLine($"Test skipped: {ex.Message}");
-            return;
-        }
-        catch (Exception ex)
         {
             _output.WriteLine($"Test skipped: {ex.Message}");
             return;
@@ -175,38 +162,6 @@ public class HidDeviceListenerIntegrationTests
         // Assert
         Assert.True(completedTask == disposeTask, "Dispose should complete within 5 seconds");
         Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
-        _output.WriteLine("Dispose completed cleanly within timeout");
-    }
-
-    [Fact]
-    public void Dispose_MultipleTimes_NoException()
-    {
-        // Arrange
-        HidDeviceListener? listener = null;
-        try
-        {
-            listener = HidDeviceListener.Create();
-        }
-        catch (PlatformNotSupportedException ex)
-        {
-            _output.WriteLine($"Test skipped: {ex.Message}");
-            return;
-        }
-        catch (Exception ex)
-        {
-            _output.WriteLine($"Test skipped: {ex.Message}");
-            return;
-        }
-
-        // Act & Assert
-        var exception = Record.Exception(() =>
-        {
-            listener.Dispose();
-            listener.Dispose();
-            listener.Dispose();
-        });
-
-        Assert.Null(exception);
-        _output.WriteLine("Multiple dispose calls succeeded without exception");
+        _output.WriteLine("Dispose after Start() completed cleanly within timeout");
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
@@ -13,14 +13,12 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
-using System.Runtime.Versioning;
 using Xunit.Abstractions;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Transports.Hid;
 
 namespace Yubico.YubiKit.Core.IntegrationTests.Transports.Hid;
 
-[SupportedOSPlatform("macos")]
 public class HidEnumerationTests
 {
     private readonly ITestOutputHelper _output;
@@ -35,12 +33,6 @@ public class HidEnumerationTests
     [Trait("RequiresHardware", "false")]
     public async Task FindHidDevices_EnumeratesYubicoDevices()
     {
-        if (!OperatingSystem.IsMacOS())
-        {
-            _output.WriteLine("Test skipped: not running on macOS");
-            return;
-        }
-
         var loggerFactory = LoggerFactory.Create(builder =>
             builder.AddConsole().SetMinimumLevel(LogLevel.Debug));
 
@@ -53,7 +45,7 @@ public class HidEnumerationTests
         foreach (var device in devices)
         {
             _output.WriteLine($"  VID={device.DescriptorInfo.VendorId:X4} PID={device.DescriptorInfo.ProductId:X4} " +
-                            $"Usage={device.DescriptorInfo.Usage:X4} UsagePage={device.DescriptorInfo.UsagePage}");
+                            $"Usage={device.DescriptorInfo.Usage:X4} UsagePage={device.DescriptorInfo.UsagePage:X4}");
         }
 
         Assert.True(devices.Count >= 0, "Should not fail even if no devices present");
@@ -64,12 +56,6 @@ public class HidEnumerationTests
     [Trait("RequiresHardware", "true")]
     public async Task FindYubiKeys_IncludesHidDevices()
     {
-        if (!OperatingSystem.IsMacOS())
-        {
-            _output.WriteLine("Test skipped: not running on macOS");
-            return;
-        }
-
         var finder = FindYubiKeys.Create();
 
         var yubiKeys = await finder.FindAllAsync();

--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
@@ -48,6 +48,14 @@ public class HidEnumerationTests
                             $"Usage={device.DescriptorInfo.Usage:X4} UsagePage={device.DescriptorInfo.UsagePage:X4}");
         }
 
+        if (OperatingSystem.IsWindows())
+        {
+            _output.WriteLine(
+                "Windows HID enumeration reads interface metadata without opening report handles. " +
+                "Access denied failures while opening HID reports usually mean the test host must run elevated as Administrator, " +
+                "or another process is holding the HID interface exclusively.");
+        }
+
         Assert.True(devices.Count >= 0, "Should not fail even if no devices present");
     }
 

--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidEnumerationTests.cs
@@ -30,7 +30,7 @@ public class HidEnumerationTests
 
     [Fact]
     [Trait("Category", "Integration")]
-    [Trait("RequiresHardware", "false")]
+    [Trait("RequiresHardware", "true")]
     public async Task FindHidDevices_EnumeratesYubicoDevices()
     {
         var loggerFactory = LoggerFactory.Create(builder =>
@@ -48,7 +48,7 @@ public class HidEnumerationTests
                             $"Usage={device.DescriptorInfo.Usage:X4} UsagePage={device.DescriptorInfo.UsagePage:X4}");
         }
 
-        if (OperatingSystem.IsWindows())
+        if (devices.Count == 0 && OperatingSystem.IsWindows())
         {
             _output.WriteLine(
                 "Windows HID enumeration reads interface metadata without opening report handles. " +
@@ -56,7 +56,7 @@ public class HidEnumerationTests
                 "or another process is holding the HID interface exclusively.");
         }
 
-        Assert.True(devices.Count >= 0, "Should not fail even if no devices present");
+        Assert.True(devices.Count > 0, "Expected at least one Yubico HID device with hardware present");
     }
 
     [Fact]
@@ -75,9 +75,10 @@ public class HidEnumerationTests
             _output.WriteLine($"  DeviceId={yubiKey.DeviceId}");
         }
 
-        var hidYubiKeys = yubiKeys.Where(yk => yk.DeviceId.StartsWith("hid:")).ToList();
+        var hidYubiKeys = yubiKeys.Where(yk => yk.SupportsConnection(ConnectionType.Hid)).ToList();
         _output.WriteLine($"Found {hidYubiKeys.Count} HID YubiKeys");
 
-        Assert.True(yubiKeys.Count >= 0, "Should not fail even if no devices present");
+        Assert.True(yubiKeys.Count > 0, "Expected at least one YubiKey with hardware present");
+        Assert.True(hidYubiKeys.Count > 0, "Expected at least one YubiKey with HID interfaces");
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/SmartCard/Apdu/Fakes/FakeSmartCardConnection.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/SmartCard/Apdu/Fakes/FakeSmartCardConnection.cs
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 using Yubico.YubiKit.Core.Devices;
-using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
+
 using Yubico.YubiKit.Core.Transports.SmartCard;
 
 namespace Yubico.YubiKit.Core.UnitTests.Protocols.SmartCard.Apdu.Fakes;
@@ -46,16 +46,17 @@ internal sealed class FakeSmartCardConnection : ISmartCardConnection
         CancellationToken cancellationToken = default)
     {
         if (_disposed)
+        {
             throw new ObjectDisposedException(nameof(FakeSmartCardConnection));
+        }
 
         cancellationToken.ThrowIfCancellationRequested();
 
         TransmittedCommands.Add(command.ToArray());
 
-        if (_responses.Count == 0)
-            throw new InvalidOperationException("No response enqueued for transmission");
-
-        return await Task.FromResult(_responses.Dequeue());
+        return _responses.Count == 0
+            ? throw new InvalidOperationException("No response enqueued for transmission")
+            : await Task.FromResult(_responses.Dequeue());
     }
 
     public void Dispose()
@@ -64,9 +65,8 @@ internal sealed class FakeSmartCardConnection : ISmartCardConnection
         _disposed = true;
     }
 
-    public async ValueTask DisposeAsync()
-    {
+    public ValueTask DisposeAsync() =>
         // TODO release managed resources here
-    }
+        ValueTask.CompletedTask;
 
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidDeviceListenerDisposalTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidDeviceListenerDisposalTests.cs
@@ -41,10 +41,6 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         try
         {
@@ -73,17 +69,13 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         try
         {
             // Act
             listener.Start();
 
-            // Assert - either Started or Error (if HID subsystem unavailable)
+            // Assert - either Started or Error (if HID subsystem unavailable in sandboxed/CI environments)
             Assert.True(
                 listener.Status is DeviceListenerStatus.Started or DeviceListenerStatus.Error,
                 $"Expected Started or Error, but got {listener.Status}");
@@ -107,10 +99,6 @@ public class HidDeviceListenerDisposalTests
             listener = HidDeviceListener.Create();
         }
         catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (Exception)
         {
             return;
         }
@@ -147,10 +135,6 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         try
         {
@@ -164,6 +148,9 @@ public class HidDeviceListenerDisposalTests
 
             // Assert
             Assert.Null(exception);
+            Assert.True(
+                listener.Status is DeviceListenerStatus.Started or DeviceListenerStatus.Error,
+                $"Expected Started or Error after multiple Start() calls, but got {listener.Status}");
         }
         finally
         {
@@ -187,10 +174,6 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         try
         {
@@ -204,6 +187,7 @@ public class HidDeviceListenerDisposalTests
 
             // Assert
             Assert.Null(exception);
+            Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
         }
         finally
         {
@@ -227,10 +211,6 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         try
         {
@@ -249,44 +229,6 @@ public class HidDeviceListenerDisposalTests
         }
     }
 
-
-
-    /// <summary>
-    /// Verifies that the factory returns the correct platform-specific implementation.
-    /// </summary>
-    [Fact]
-    public void Create_ReturnsPlatformSpecificImplementation()
-    {
-        // Arrange & Act
-        HidDeviceListener? listener = null;
-        try
-        {
-            listener = HidDeviceListener.Create();
-        }
-        catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (Exception)
-        {
-            return;
-        }
-
-        try
-        {
-            // Assert - Type should match current platform
-            var typeName = listener.GetType().Name;
-            var expectedNames = new[] { "WindowsHidDeviceListener", "MacOSHidDeviceListener", "LinuxHidDeviceListener" };
-            Assert.Contains(typeName, expectedNames);
-        }
-        finally
-        {
-            listener?.Dispose();
-        }
-    }
-
-
-
     /// <summary>
     /// Verifies that Dispose completes within a reasonable timeout when listener is running.
     /// If this test hangs, the cancellation logic is broken.
@@ -302,10 +244,6 @@ public class HidDeviceListenerDisposalTests
             listener.Start(); // Start the listener
         }
         catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (Exception)
         {
             return;
         }
@@ -334,10 +272,6 @@ public class HidDeviceListenerDisposalTests
         {
             return;
         }
-        catch (Exception)
-        {
-            return;
-        }
 
         // Act & Assert - should complete very quickly
         var disposeTask = Task.Run(() => listener.Dispose(), TestContext.Current.CancellationToken);
@@ -360,10 +294,6 @@ public class HidDeviceListenerDisposalTests
             listener.Start();
         }
         catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (Exception)
         {
             return;
         }
@@ -393,10 +323,6 @@ public class HidDeviceListenerDisposalTests
             listener.Start();
         }
         catch (PlatformNotSupportedException)
-        {
-            return;
-        }
-        catch (Exception)
         {
             return;
         }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidInterfaceClassifierTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidInterfaceClassifierTests.cs
@@ -1,0 +1,72 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Transports.Hid;
+
+namespace Yubico.YubiKit.Core.UnitTests.Transports.Hid;
+
+public class HidInterfaceClassifierTests
+{
+    private static HidDescriptorInfo MakeDescriptor(ushort usagePage, ushort usage) =>
+        new()
+        {
+            UsagePage = usagePage,
+            Usage = usage,
+            DevicePath = "test",
+            VendorId = HidConstants.YubicoVendorId,
+            ProductId = 0x0407
+        };
+
+    [Fact]
+    public void Classify_FidoDescriptor_ReturnsFido() =>
+        Assert.Equal(
+            HidInterfaceType.Fido,
+            HidInterfaceClassifier.Classify(MakeDescriptor(0xF1D0, 0x0001)));
+
+    [Fact]
+    public void Classify_OtpDescriptor_ReturnsOtp() =>
+        Assert.Equal(
+            HidInterfaceType.Otp,
+            HidInterfaceClassifier.Classify(MakeDescriptor(0x0001, 0x0006)));
+
+    [Fact]
+    public void Classify_UnknownDescriptor_ReturnsUnknown() =>
+        Assert.Equal(
+            HidInterfaceType.Unknown,
+            HidInterfaceClassifier.Classify(MakeDescriptor(0x0001, 0x0001)));
+
+    [Fact]
+    public void IsSupported_FidoDescriptor_ReturnsTrue() =>
+        Assert.True(HidInterfaceClassifier.IsSupported(MakeDescriptor(0xF1D0, 0x0001)));
+
+    [Fact]
+    public void IsSupported_OtpDescriptor_ReturnsTrue() =>
+        Assert.True(HidInterfaceClassifier.IsSupported(MakeDescriptor(0x0001, 0x0006)));
+
+    [Fact]
+    public void IsSupported_UnknownDescriptor_ReturnsFalse() =>
+        Assert.False(HidInterfaceClassifier.IsSupported(MakeDescriptor(0x0001, 0x0001)));
+
+    [Fact]
+    public void GetReportType_Fido_ReturnsInputOutput() =>
+        Assert.Equal(HidReportType.InputOutput, HidInterfaceClassifier.GetReportType(HidInterfaceType.Fido));
+
+    [Fact]
+    public void GetReportType_Otp_ReturnsFeature() =>
+        Assert.Equal(HidReportType.Feature, HidInterfaceClassifier.GetReportType(HidInterfaceType.Otp));
+
+    [Fact]
+    public void GetReportType_Unknown_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() => HidInterfaceClassifier.GetReportType(HidInterfaceType.Unknown));
+}

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.IntegrationTests/TestExtensions/FidoTestStateExtensions.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.IntegrationTests/TestExtensions/FidoTestStateExtensions.cs
@@ -16,7 +16,6 @@ using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
-using Yubico.YubiKit.Core.Transports.SmartCard;
 using Yubico.YubiKit.Fido2.Ctap;
 using Yubico.YubiKit.Fido2.Pin;
 using Yubico.YubiKit.Tests.Shared;
@@ -138,6 +137,10 @@ public static class FidoTestStateExtensions
         }
     }
 
+    private static string GetWindowsHidAccessDeniedTestMessage(ConnectionType? preferredConnection) =>
+        $"Windows denied access while opening a FIDO2 session over {preferredConnection ?? ConnectionType.HidFido}. " +
+        "If this test targets HID FIDO, run the test host elevated as Administrator or close software that may hold the HID interface exclusively.";
+
     extension(YubiKeyTestState state)
     {
         /// <summary>
@@ -166,17 +169,28 @@ public static class FidoTestStateExtensions
             ConnectionType? preferredConnection = null,
             CancellationToken cancellationToken = default)
         {
-            await using var session = await state.Device
-                .CreateFidoSessionAsync(scpKeyParams, configuration, preferredConnection, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (normalizePin)
+            FidoSession session;
+            try
             {
-                await NormalizePinAsync(session, cancellationToken)
+                session = await state.Device
+                    .CreateFidoSessionAsync(scpKeyParams, configuration, preferredConnection, cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (UnauthorizedAccessException ex) when (OperatingSystem.IsWindows())
+            {
+                throw new UnauthorizedAccessException(GetWindowsHidAccessDeniedTestMessage(preferredConnection), ex);
+            }
 
-            await action(session).ConfigureAwait(false);
+            await using (session.ConfigureAwait(false))
+            {
+                if (normalizePin)
+                {
+                    await NormalizePinAsync(session, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                await action(session).ConfigureAwait(false);
+            }
         }
 
         /// <summary>
@@ -205,18 +219,29 @@ public static class FidoTestStateExtensions
             ConnectionType? preferredConnection = null,
             CancellationToken cancellationToken = default)
         {
-            await using var session = await state.Device
-                .CreateFidoSessionAsync(scpKeyParams, configuration, preferredConnection, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (normalizePin)
+            FidoSession session;
+            try
             {
-                await NormalizePinAsync(session, cancellationToken)
+                session = await state.Device
+                    .CreateFidoSessionAsync(scpKeyParams, configuration, preferredConnection, cancellationToken)
                     .ConfigureAwait(false);
             }
+            catch (UnauthorizedAccessException ex) when (OperatingSystem.IsWindows())
+            {
+                throw new UnauthorizedAccessException(GetWindowsHidAccessDeniedTestMessage(preferredConnection), ex);
+            }
 
-            var info = await session.GetInfoAsync(cancellationToken).ConfigureAwait(false);
-            await action(session, info).ConfigureAwait(false);
+            await using (session.ConfigureAwait(false))
+            {
+                if (normalizePin)
+                {
+                    await NormalizePinAsync(session, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+
+                var info = await session.GetInfoAsync(cancellationToken).ConfigureAwait(false);
+                await action(session, info).ConfigureAwait(false);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Windows HID discovery and report connections for YubiKey HID FIDO/OTP interfaces.
- Use ConfigMgr metadata for Windows HID enumeration and actionable access-denied guidance for report-handle opens.
- Update HID documentation and integration-test diagnostics for Windows access/elevation failures.

## Verification
- `dotnet format --verify-no-changes` on touched C# files
- `dotnet toolchain.cs /p:TreatWarningsAsErrors=false -- build --project Core`
- `dotnet toolchain.cs -- test --integration --project Core --filter "FullyQualifiedName~HidEnumerationTests"`
- `dotnet toolchain.cs -- test --integration --project Management --smoke --filter "FullyQualifiedName~ManagementSessionSimpleTests"`
- `dotnet toolchain.cs -- test --integration --project Fido2 --smoke --filter "FullyQualifiedName~FidoSessionSimpleTests"`
- `dotnet toolchain.cs -- resilience --fast`