### PR TITLE
fix(fido2): parse thirdPartyPayment in credential management response

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementData.cs
@@ -59,6 +59,7 @@ namespace Yubico.YubiKey.Fido2.Commands
         private const int KeyTotalRpCredentials = 9;
         private const int KeyCredProtectPolicy = 10;
         private const int KeyLargeBlobKey = 11;
+        private const int KeyThirdPartyPayment = 12;
 
         /// <summary>
         /// The number of discoverable credentials on the YubiKey. This is not
@@ -166,6 +167,12 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// </remarks>
         public ReadOnlyMemory<byte>? LargeBlobKey { get; private set; }
 
+        /// <summary>
+        /// Whether this credential is third-party payment enabled.
+        /// Null if the credential was not created with the thirdPartyPayment extension.
+        /// </summary>
+        public bool? ThirdPartyPayment { get; private set; }
+
         // The default constructor explicitly defined. We don't want it to be
         // used.
         private CredentialManagementData()
@@ -246,6 +253,10 @@ namespace Yubico.YubiKey.Fido2.Commands
 
                     case KeyLargeBlobKey:
                         LargeBlobKey = cborReader.ReadByteString();
+                        break;
+
+                    case KeyThirdPartyPayment:
+                        ThirdPartyPayment = cborReader.ReadBoolean();
                         break;
                 }
                 count--;

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsBeginResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsBeginResponse.cs
@@ -84,7 +84,8 @@ namespace Yubico.YubiKey.Fido2.Commands
                     credentialManagementData.CredentialId,
                     credentialManagementData.CredentialPublicKey,
                     credentialManagementData.CredProtectPolicy.Value,
-                    credentialManagementData.LargeBlobKey);
+                    credentialManagementData.LargeBlobKey,
+                    credentialManagementData.ThirdPartyPayment);
 
                 return (credentialManagementData.TotalCredentialsForRelyingParty.Value, userInfo);
             }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextResponse.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsGetNextResponse.cs
@@ -54,7 +54,8 @@ namespace Yubico.YubiKey.Fido2.Commands
                     credentialManagementData.CredentialId,
                     credentialManagementData.CredentialPublicKey,
                     credentialManagementData.CredProtectPolicy.Value,
-                    credentialManagementData.LargeBlobKey);
+                    credentialManagementData.LargeBlobKey,
+                    credentialManagementData.ThirdPartyPayment);
             }
 
             throw new Ctap2DataException(ExceptionMessages.InvalidFido2Info);

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialUserInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialUserInfo.cs
@@ -52,6 +52,12 @@ namespace Yubico.YubiKey.Fido2
         /// </summary>
         public ReadOnlyMemory<byte>? LargeBlobKey { get; private set; }
 
+        /// <summary>
+        /// Whether this credential is third-party payment enabled.
+        /// Null if the credential was not created with the thirdPartyPayment extension.
+        /// </summary>
+        public bool? ThirdPartyPayment { get; private set; }
+
         // The default constructor explicitly defined. We don't want it to be
         // used.
         private CredentialUserInfo()
@@ -80,12 +86,17 @@ namespace Yubico.YubiKey.Fido2
         /// that can be used to encrypt or decrypt large blob data for the
         /// credential.
         /// </param>
+        /// <param name="thirdPartyPayment">
+        /// Whether the credential was created as payment-enabled. If null, the
+        /// authenticator did not return the thirdPartyPayment element.
+        /// </param>
         public CredentialUserInfo(
             UserEntity user,
             CredentialId credentialId,
             CoseKey credentialPublicKey,
             int credProtectPolicy,
-            ReadOnlyMemory<byte>? largeBlobKey = null
+            ReadOnlyMemory<byte>? largeBlobKey = null,
+            bool? thirdPartyPayment = null
             )
         {
             User = user;
@@ -93,6 +104,7 @@ namespace Yubico.YubiKey.Fido2
             CredentialPublicKey = credentialPublicKey;
             CredProtectPolicy = (CredProtectPolicy)credProtectPolicy;
             LargeBlobKey = largeBlobKey;
+            ThirdPartyPayment = thirdPartyPayment;
         }
     }
 }

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.CredMgmt.cs
@@ -273,7 +273,8 @@ namespace Yubico.YubiKey.Fido2
         /// <see cref="CredentialUserInfo.CredentialId"/>,
         /// <see cref="CredentialUserInfo.CredentialPublicKey"/>,
         /// <see cref="CredentialUserInfo.CredProtectPolicy"/>, and possibly
-        /// <see cref="CredentialUserInfo.LargeBlobKey"/>,
+        /// <see cref="CredentialUserInfo.LargeBlobKey"/> and
+        /// <see cref="CredentialUserInfo.ThirdPartyPayment"/>.
         /// </para>
         /// </remarks>
         /// <param name="relyingParty">

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtDataTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtDataTests.cs
@@ -41,6 +41,7 @@ namespace Yubico.YubiKey.Fido2.Commands
         private const int TotalCount = 9;
         private const int CredProtect = 10;
         private const int BlobKey = 11;
+        private const int ThirdPartyPmt = 12;
 
         [Fact]
         public void CredMgm_Decode_CorrectNumCredentials()
@@ -342,12 +343,23 @@ namespace Yubico.YubiKey.Fido2.Commands
             Assert.True(isCorrect);
         }
 
+        [Fact]
+        public void CredMgm_Decode_CorrectThirdPartyPayment()
+        {
+            CredentialManagementData mgmtData = GetFullCredMgmtData(out Dictionary<int, object> expectedValues);
+            object expected = expectedValues[ThirdPartyPmt];
+
+            Assert.True(mgmtData.ThirdPartyPayment.HasValue);
+            Assert.True(expected is bool);
+            Assert.Equal((bool)expected, mgmtData.ThirdPartyPayment!.Value);
+        }
+
         private CredentialManagementData GetFullCredMgmtData(out Dictionary<int, object> expectedValues)
         {
             expectedValues = new Dictionary<int, object>(20);
 
             byte[] encodedData = new byte[] {
-                0xAB,
+                0xAC,
                   0x01, 0x02,
                   0x02, 0x17,
                   0x03, 0xA2,
@@ -390,6 +402,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                  0x0B, 0x58, 0x20,
                        0xBC, 0x29, 0xFC, 0xE7, 0xAC, 0x3E, 0x44, 0xCC, 0xC4, 0x21, 0xFA, 0xCB, 0xAA, 0x98, 0x47, 0x5F,
                        0x8A, 0x98, 0xF1, 0x10, 0xD3, 0x49, 0x7B, 0x02, 0x21, 0x00, 0xB7, 0x74, 0xDF, 0x0E, 0xF9, 0x9B,
+                 0x0C, 0xF5,
             };
 
             expectedValues.Add(NumCredentials, (int)2);
@@ -424,6 +437,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                                                      0xC4, 0x21, 0xFA, 0xCB, 0xAA, 0x98, 0x47, 0x5F,
                                                      0x8A, 0x98, 0xF1, 0x10, 0xD3, 0x49, 0x7B, 0x02,
                                                      0x21, 0x00, 0xB7, 0x74, 0xDF, 0x0E, 0xF9, 0x9B });
+            expectedValues.Add(ThirdPartyPmt, true);
 
             return new CredentialManagementData(encodedData);
         }


### PR DESCRIPTION
## Summary

`EnumerateCredentialsForRelyingParty` throws `Ctap2DataException` ("An unexpected
key was encountered in a CBOR map") on YubiKey firmware 5.8 when any credential
was created with the `thirdPartyPayment` extension.

`CredentialManagementData` only handled response map keys `0x01`–`0x0B` (CTAP 2.1).
The `thirdPartyPayment` extension (CTAP 2.2) stores a per-credential boolean at key
`0x0C`, which firmware 5.8 is the first YubiKey to return. The parser hit the
`default: throw` case.

- Add `KeyThirdPartyPayment = 12` and parse key `0x0C` as `bool?` in
  `CredentialManagementData`.
- Surface through the call stack: `CredentialUserInfo` gains `bool? ThirdPartyPayment`;
  both `EnumerateCredentialsBeginResponse` and `EnumerateCredentialsGetNextResponse`
  pass it through.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

- Added `CredMgm_Decode_CorrectThirdPartyPayment` to `CredMgmtDataTests`, extending
  the full-response test vector with key `0x0C`. All 21 tests pass.
- Verified end-to-end against a firmware 5.8 key
  `EnumerateCredentialsForRelyingParty` now returns payment credentials correctly
  instead of throwing.

**Test configuration:**
- OS: Windows 11
- Firmware: 5.8 beta
- YubiKey model: YubiKey 5C NFC