### PR TITLE
docs: add v1 to v2 migration automation

### DIFF
--- a/.github/prompts/migration-docs-monthly-synthesis.md
+++ b/.github/prompts/migration-docs-monthly-synthesis.md
@@ -1,0 +1,52 @@
+# Migration Documentation Monthly Synthesis Prompt
+
+You are polishing the v1-to-v2 migration documentation for release readiness.
+
+## Purpose
+
+Incremental updates preserve history, but monthly synthesis should turn accumulated notes into a clearer guide. This mode is for organization, deduplication, coverage assessment, and readiness reporting. It must not invent migration mappings.
+
+## Required Inputs
+
+Read:
+
+- `docs/migration/v1-to-v2.md`
+- `docs/migration/v1-to-v2-map.yml`
+- `docs/migration/v1-to-v2-changelog.md`
+- `docs/migration/.state.yml`
+- `.migration-context/context-summary.md`
+- `.migration-context/changed-files.txt`
+- `.migration-context/public-api-candidates.txt`
+- `.migration-context/api-added.txt`
+- `.migration-context/api-removed.txt`
+- `.migration-context/package-changes.txt`
+- `.migration-context/namespace-changes.txt`
+- `.migration-context/session-patterns.txt`
+- `.migration-context/v1-symbol-candidates.txt`
+- `.migration-context/existing-map-hits.txt`
+- `.migration-context/docs-coverage-hits.txt`
+
+## Allowed Work
+
+- Reorganize existing migration guidance into clearer sections.
+- Collapse duplicate changelog-derived guidance into canonical guide text.
+- Add or update a release-readiness section in `docs/migration/v1-to-v2.md`.
+- Add manual-review items when gaps are visible.
+- Improve map entries only when evidence already exists in the map, context files, or source paths.
+
+## Forbidden Work
+
+- Do not create new authoritative mappings without evidence.
+- Do not remove manual-review warnings merely because they are inconvenient.
+- Do not advance `last_analyzed_commit` unless this run also analyzed and handled the supplied range.
+- Do not rewrite the guide into marketing copy; keep it operational for migrating developers.
+
+## Output Expectations
+
+Make documentation-only changes limited to `docs/migration/`. Then summarize:
+
+1. What sections were improved.
+2. What duplicates were collapsed.
+3. Readiness by area: Core/device, PIV, FIDO2, OATH, YubiOTP, OpenPGP, SecurityDomain, YubiHSM, low-level commands.
+4. Remaining manual-review gaps.
+5. Whether this was a synthesis-only change or also advanced analysis state.

--- a/.github/prompts/migration-docs-post-merge.md
+++ b/.github/prompts/migration-docs-post-merge.md
@@ -1,0 +1,80 @@
+# Migration Documentation Post-Merge Prompt
+
+You are updating v1-to-v2 migration documentation after changes landed on the `yubikit` branch.
+
+## Branch and Range Rules
+
+- Treat `develop` as the v1 source of truth.
+- Treat `yubikit` as the authoritative v2 integration branch.
+- Analyze only the supplied post-merge range from `docs/migration/.state.yml` `last_analyzed_commit` to current `HEAD`, normally `last_analyzed_commit..HEAD`.
+- Scheduled reconciliation may compare current `origin/develop` and `origin/yubikit`, but must still distinguish newly documented changes from existing guidance.
+- Do not push directly to `yubikit`. The workflow opens a documentation PR.
+- Advance `docs/migration/.state.yml` `last_analyzed_commit` after successful analysis of the range, even when there is no migration-relevant change. If no guide or map update is needed, add a concise no-impact changelog entry and update only the state file plus changelog.
+
+## Required Inputs
+
+Read the deterministic context files produced under `.migration-context/`:
+
+- `.migration-context/context-summary.md`
+- `.migration-context/changed-files.txt`
+- `.migration-context/diff.patch`
+- `.migration-context/public-api-candidates.txt`
+- `.migration-context/api-added.txt`
+- `.migration-context/api-removed.txt`
+- `.migration-context/package-changes.txt`
+- `.migration-context/namespace-changes.txt`
+- `.migration-context/session-patterns.txt`
+- `.migration-context/v1-symbol-candidates.txt`
+- `.migration-context/existing-map-hits.txt`
+- `.migration-context/docs-coverage-hits.txt`
+- `.migration-context/migration-state.txt`
+
+Read and preserve the existing migration artifacts:
+
+- `docs/migration/v1-to-v2.md`
+- `docs/migration/v1-to-v2-map.yml`
+- `docs/migration/v1-to-v2-changelog.md`
+- `docs/migration/.state.yml`
+
+## Anti-Hallucination Rules
+
+- Update docs only for migration-relevant changes supported by the supplied range or reconciliation evidence.
+- Preserve existing document structure and append rather than rewrite when practical.
+- Prefer appending changelog entries over broad prose rewrites.
+- Do not invent type, member, package, or behavior mappings.
+- Mark uncertain mappings as manual-review with `status: manual` or `status: unknown` and `confidence: low` or `medium`.
+- Never claim automatic migration for lifecycle, transport, security-sensitive, protocol, exception-contract, or behavior-dependent changes unless the evidence is direct and unambiguous.
+- Treat internal-only changes as `none` and leave docs unchanged except for a workflow summary if needed.
+- Keep all generated documentation ASCII-only.
+
+## Confidence and Mapping Requirements
+
+For every new or changed map entry include:
+
+- `status`: `automatic`, `assisted`, `manual`, `removed`, or `unknown`.
+- `confidence`: `high`, `medium`, or `low`.
+- `migration_kind`: package, namespace, type, member, construction, async lifecycle, behavior, transport, command, or removal.
+- `evidence`: source paths or symbols supporting the mapping.
+- `last_reviewed_commit`: the current analyzed `HEAD` commit.
+
+Use `manual` or `unknown` when evidence is incomplete.
+
+## Output Expectations
+
+Make the smallest documentation-only changes needed, limited to:
+
+- `docs/migration/v1-to-v2.md`
+- `docs/migration/v1-to-v2-map.yml`
+- `docs/migration/v1-to-v2-changelog.md`
+- `docs/migration/.state.yml`
+
+Then provide a PR-ready summary with:
+
+1. Analyzed refs and range.
+2. Migration impact classification: `none`, `low`, `medium`, or `high`.
+3. Files changed.
+4. Supported findings and evidence.
+5. Manual-review items that remain.
+6. Whether `last_analyzed_commit` was advanced, and to which commit.
+
+If no migration-relevant changes are present, do not rewrite the migration guide or map. Add a short no-impact changelog entry and advance `docs/migration/.state.yml` to the analyzed `HEAD` so the same range is not analyzed repeatedly.

--- a/.github/prompts/migration-docs-pr-preview.md
+++ b/.github/prompts/migration-docs-pr-preview.md
@@ -1,0 +1,76 @@
+# Migration Documentation PR Preview Prompt
+
+You are reviewing migration impact for a pull request targeting the `yubikit` branch.
+
+## Branch and Range Rules
+
+- Treat `develop` as the v1 source of truth.
+- Treat `yubikit` as the v2 integration source of truth.
+- Analyze only the supplied pull request range, normally `origin/yubikit...HEAD`.
+- Use `develop` only as the v1 comparison baseline, not as a source of new v2 behavior.
+- Do not infer changes from branch names, commit messages, or intuition when the context files do not support them.
+- Do not edit repository files in preview mode. Produce a PR comment only.
+
+## Required Inputs
+
+Read the deterministic context files produced under `.migration-context/`:
+
+- `.migration-context/context-summary.md`
+- `.migration-context/changed-files.txt`
+- `.migration-context/diff.patch`
+- `.migration-context/public-api-candidates.txt`
+- `.migration-context/api-added.txt`
+- `.migration-context/api-removed.txt`
+- `.migration-context/package-changes.txt`
+- `.migration-context/namespace-changes.txt`
+- `.migration-context/session-patterns.txt`
+- `.migration-context/v1-symbol-candidates.txt`
+- `.migration-context/existing-map-hits.txt`
+- `.migration-context/docs-coverage-hits.txt`
+- `.migration-context/migration-state.txt`
+
+Also read the current migration artifacts if present:
+
+- `docs/migration/v1-to-v2.md`
+- `docs/migration/v1-to-v2-map.yml`
+- `docs/migration/v1-to-v2-changelog.md`
+- `docs/migration/.state.yml`
+
+## Anti-Hallucination Rules
+
+- Document only migration-relevant changes visible in the supplied range.
+- If a mapping is not supported by code or existing migration artifacts, say it needs manual review.
+- Never claim a mechanical migration when lifecycle, transport, security, exception behavior, or protocol bytes are ambiguous.
+- Treat internal-only changes as `none` unless public behavior changes are visible.
+- If the diff is too large or context is incomplete, summarize affected modules and produce a manual-review checklist.
+- Preserve uncertainty. Do not fill gaps with plausible API names.
+
+## Confidence and Manual Review
+
+Use these confidence levels:
+
+- `high`: directly supported by changed files and v1/v2 symbols.
+- `medium`: supported by module structure or existing migration artifacts, but not enough for a mechanical mapping.
+- `low`: plausible migration impact with incomplete evidence; must be manual-review.
+
+Use these mapping statuses when suggesting map changes:
+
+- `automatic`: safe mechanical package, namespace, type, or member mapping.
+- `assisted`: partially mechanical, but requires developer review.
+- `manual`: requires human migration due to behavior, lifecycle, transport, protocol, or security changes.
+- `removed`: v1 API has no v2 equivalent.
+- `unknown`: possible relationship needs review.
+
+## Output Expectations
+
+Post a concise PR comment with this structure:
+
+1. `Migration docs preview`
+2. Analyzed refs and range.
+3. Migration impact classification: `none`, `low`, `medium`, or `high`.
+4. Bullet list of supported findings with evidence paths.
+5. Suggested guide/map/changelog updates, if any.
+6. Manual-review checklist for uncertain items.
+7. Explicit statement that preview mode did not edit files.
+
+If there is no migration impact, say so and cite the evidence that the changes are internal-only or unrelated to public migration behavior.

--- a/.github/workflows/migration-docs-monthly-synthesis.yml
+++ b/.github/workflows/migration-docs-monthly-synthesis.yml
@@ -1,0 +1,70 @@
+name: Migration Docs Monthly Synthesis
+
+on:
+  workflow_dispatch:
+  # GitHub schedule triggers run only from the repository default branch.
+  # Mirror this workflow to the default branch if monthly synthesis should run automatically.
+  schedule:
+    - cron: '41 3 1 * *'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: migration-docs-monthly-synthesis
+  cancel-in-progress: false
+
+jobs:
+  synthesize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out yubikit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: yubikit
+
+      - name: Fetch migration baselines
+        run: |
+          git fetch origin +refs/heads/develop:refs/remotes/origin/develop
+          git fetch origin +refs/heads/yubikit:refs/remotes/origin/yubikit
+
+      - name: Build migration context
+        shell: bash
+        run: |
+          bash ./scripts/migration/build-migration-context.sh \
+            --mode update \
+            --v1-baseline origin/develop \
+            --v2-branch origin/yubikit \
+            --base-range origin/yubikit~1..HEAD \
+            --output-dir .migration-context
+
+      - name: Synthesize migration documentation
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Read and follow `.github/prompts/migration-docs-monthly-synthesis.md`.
+            The generated context is in `.migration-context/`.
+            Improve only migration documentation files.
+          claude_args: >-
+            --allowedTools Read,Grep,Glob,Edit,Write
+
+      - name: Create migration synthesis PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/migration-docs-monthly-synthesis
+          base: yubikit
+          title: Polish v1 to v2 migration documentation
+          commit-message: docs: polish migration documentation
+          body: |
+            Monthly synthesis pass for v1-to-v2 migration documentation.
+
+            Review for clarity, excessive confidence, and remaining manual-review gaps.
+          add-paths: |
+            docs/migration/v1-to-v2.md
+            docs/migration/v1-to-v2-map.yml
+            docs/migration/v1-to-v2-changelog.md
+            docs/migration/.state.yml

--- a/.github/workflows/migration-docs-monthly-synthesis.yml
+++ b/.github/workflows/migration-docs-monthly-synthesis.yml
@@ -41,7 +41,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Synthesize migration documentation
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,12 +53,12 @@ jobs:
             --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration synthesis PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: automation/migration-docs-monthly-synthesis
           base: yubikit
           title: Polish v1 to v2 migration documentation
-          commit-message: docs: polish migration documentation
+          commit-message: "docs: polish migration documentation"
           body: |
             Monthly synthesis pass for v1-to-v2 migration documentation.
 

--- a/.github/workflows/migration-docs-preview.yml
+++ b/.github/workflows/migration-docs-preview.yml
@@ -33,7 +33,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Comment with migration documentation preview
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-preview.yml
+++ b/.github/workflows/migration-docs-preview.yml
@@ -1,0 +1,45 @@
+name: Migration Docs Preview
+
+on:
+  pull_request:
+    branches: [ yubikit ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch migration baselines
+        run: |
+          git fetch origin +refs/heads/develop:refs/remotes/origin/develop
+          git fetch origin +refs/heads/yubikit:refs/remotes/origin/yubikit
+
+      - name: Build migration context
+        shell: bash
+        run: |
+          bash ./scripts/migration/build-migration-context.sh \
+            --mode preview \
+            --v1-baseline origin/develop \
+            --v2-branch origin/yubikit \
+            --base-range origin/yubikit...HEAD \
+            --output-dir .migration-context
+
+      - name: Comment with migration documentation preview
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Read and follow `.github/prompts/migration-docs-pr-preview.md`.
+            The generated context is in `.migration-context/`.
+            Preview mode must comment on migration impact only; do not edit files.
+          claude_args: >-
+            --allowedTools Read,Grep,Glob

--- a/.github/workflows/migration-docs-scheduler-wrapper.yml
+++ b/.github/workflows/migration-docs-scheduler-wrapper.yml
@@ -13,7 +13,7 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: migration-docs-scheduler-wrapper
+  group: migration-docs-weekly-yubikit
   cancel-in-progress: false
 
 jobs:
@@ -31,22 +31,11 @@ jobs:
           git fetch origin +refs/heads/develop:refs/remotes/origin/develop
           git fetch origin +refs/heads/yubikit:refs/remotes/origin/yubikit
 
-      - name: Resolve migration range
+      - name: Resolve reconciliation range
         id: range
         shell: bash
         run: |
-          state_path='docs/migration/.state.yml'
-          if [[ -f "$state_path" ]]; then
-            last=$(sed -n 's/^last_analyzed_commit:[[:space:]]*//p' "$state_path" | head -n 1)
-          else
-            last=''
-          fi
-
-          if [[ -z "$last" ]]; then
-            last='origin/yubikit^'
-          fi
-
-          echo "base_range=$last..HEAD" >> "$GITHUB_OUTPUT"
+          echo "base_range=origin/develop..HEAD" >> "$GITHUB_OUTPUT"
 
       - name: Build migration context
         shell: bash
@@ -59,25 +48,26 @@ jobs:
             --output-dir .migration-context
 
       - name: Reconcile migration documentation
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/migration-docs-post-merge.md`.
             This is a scheduled reconciliation run from the default-branch wrapper.
+            Analyze the full v1-to-v2 tree delta so this can catch gaps missed by incremental runs.
             The generated context is in `.migration-context/`.
             Update only the allowed migration documentation files.
           claude_args: >-
             --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration documentation PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: automation/migration-docs-weekly-reconciliation
           base: yubikit
           title: Reconcile v1 to v2 migration documentation
-          commit-message: docs: reconcile migration documentation
+          commit-message: "docs: reconcile migration documentation"
           body: |
             Weekly migration documentation reconciliation for `${{ steps.range.outputs.base_range }}`.
 

--- a/.github/workflows/migration-docs-scheduler-wrapper.yml
+++ b/.github/workflows/migration-docs-scheduler-wrapper.yml
@@ -1,0 +1,89 @@
+name: Migration Docs Scheduler Wrapper
+
+on:
+  # GitHub schedule triggers run only from the repository default branch.
+  # Keep this wrapper on the default branch. It checks out yubikit and opens
+  # migration documentation PRs back into yubikit.
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: migration-docs-scheduler-wrapper
+  cancel-in-progress: false
+
+jobs:
+  reconcile-yubikit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out yubikit
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: yubikit
+
+      - name: Fetch migration baselines
+        run: |
+          git fetch origin +refs/heads/develop:refs/remotes/origin/develop
+          git fetch origin +refs/heads/yubikit:refs/remotes/origin/yubikit
+
+      - name: Resolve migration range
+        id: range
+        shell: bash
+        run: |
+          state_path='docs/migration/.state.yml'
+          if [[ -f "$state_path" ]]; then
+            last=$(sed -n 's/^last_analyzed_commit:[[:space:]]*//p' "$state_path" | head -n 1)
+          else
+            last=''
+          fi
+
+          if [[ -z "$last" ]]; then
+            last='origin/yubikit^'
+          fi
+
+          echo "base_range=$last..HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Build migration context
+        shell: bash
+        run: |
+          bash ./scripts/migration/build-migration-context.sh \
+            --mode update \
+            --v1-baseline origin/develop \
+            --v2-branch origin/yubikit \
+            --base-range '${{ steps.range.outputs.base_range }}' \
+            --output-dir .migration-context
+
+      - name: Reconcile migration documentation
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Read and follow `.github/prompts/migration-docs-post-merge.md`.
+            This is a scheduled reconciliation run from the default-branch wrapper.
+            The generated context is in `.migration-context/`.
+            Update only the allowed migration documentation files.
+          claude_args: >-
+            --allowedTools Read,Grep,Glob,Edit,Write
+
+      - name: Create migration documentation PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/migration-docs-weekly-reconciliation
+          base: yubikit
+          title: Reconcile v1 to v2 migration documentation
+          commit-message: docs: reconcile migration documentation
+          body: |
+            Weekly migration documentation reconciliation for `${{ steps.range.outputs.base_range }}`.
+
+            This workflow is intended to live on the repository default branch and update docs on `yubikit`.
+          add-paths: |
+            docs/migration/v1-to-v2.md
+            docs/migration/v1-to-v2-map.yml
+            docs/migration/v1-to-v2-changelog.md
+            docs/migration/.state.yml

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches: [ yubikit ]
   workflow_dispatch:
-  # GitHub only runs scheduled workflows from the repository default branch.
-  # Keep this trigger here for when the workflow is mirrored to the default branch
-  # or the repository default branch changes to yubikit.
-  schedule:
-    - cron: '17 3 * * 1'
 
 permissions:
   contents: write
@@ -61,7 +56,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Update migration documentation
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -73,12 +68,12 @@ jobs:
             --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration documentation PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch: automation/migration-docs-update
           base: yubikit
           title: Update v1 to v2 migration documentation
-          commit-message: docs: update migration documentation
+          commit-message: "docs: update migration documentation"
           body: |
             Automated migration documentation update for `${{ steps.range.outputs.base_range }}`.
 

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -1,0 +1,90 @@
+name: Migration Docs Update
+
+on:
+  push:
+    branches: [ yubikit ]
+  workflow_dispatch:
+  # GitHub only runs scheduled workflows from the repository default branch.
+  # Keep this trigger here for when the workflow is mirrored to the default branch
+  # or the repository default branch changes to yubikit.
+  schedule:
+    - cron: '17 3 * * 1'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: migration-docs-update-yubikit
+  cancel-in-progress: false
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          ref: yubikit
+
+      - name: Fetch migration baselines
+        run: |
+          git fetch origin +refs/heads/develop:refs/remotes/origin/develop
+          git fetch origin +refs/heads/yubikit:refs/remotes/origin/yubikit
+
+      - name: Resolve migration range
+        id: range
+        shell: bash
+        run: |
+          state_path='docs/migration/.state.yml'
+          if [[ -f "$state_path" ]]; then
+            last=$(sed -n 's/^last_analyzed_commit:[[:space:]]*//p' "$state_path" | head -n 1)
+          else
+            last=''
+          fi
+
+          if [[ -z "$last" ]]; then
+            last='origin/yubikit^'
+          fi
+
+          echo "base_range=$last..HEAD" >> "$GITHUB_OUTPUT"
+
+      - name: Build migration context
+        shell: bash
+        run: |
+          bash ./scripts/migration/build-migration-context.sh \
+            --mode update \
+            --v1-baseline origin/develop \
+            --v2-branch origin/yubikit \
+            --base-range '${{ steps.range.outputs.base_range }}' \
+            --output-dir .migration-context
+
+      - name: Update migration documentation
+        uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          prompt: |
+            Read and follow `.github/prompts/migration-docs-post-merge.md`.
+            The generated context is in `.migration-context/`.
+            Update only the allowed migration documentation files.
+          claude_args: >-
+            --allowedTools Read,Grep,Glob,Edit,Write
+
+      - name: Create migration documentation PR
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: automation/migration-docs-update
+          base: yubikit
+          title: Update v1 to v2 migration documentation
+          commit-message: docs: update migration documentation
+          body: |
+            Automated migration documentation update for `${{ steps.range.outputs.base_range }}`.
+
+            Review the generated guide, map, changelog, and state changes before merging.
+          add-paths: |
+            docs/migration/v1-to-v2.md
+            docs/migration/v1-to-v2-map.yml
+            docs/migration/v1-to-v2-changelog.md
+            docs/migration/.state.yml

--- a/docs/migration/.state.yml
+++ b/docs/migration/.state.yml
@@ -1,0 +1,4 @@
+format_version: 1
+v1_baseline: develop
+v2_branch: yubikit
+last_analyzed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5

--- a/docs/migration/v1-to-v2-changelog.md
+++ b/docs/migration/v1-to-v2-changelog.md
@@ -1,0 +1,8 @@
+# V1 to V2 Migration Documentation Changelog
+
+## 2026-06-30 - Initial baseline snapshot
+
+- Created the initial migration guide, mapping seed, and automation state for branch `yubikit` at commit `e348013685d92a6a665cd0b8bd7e8b05850fddd5`.
+- Recorded high-confidence package and namespace split guidance from `Yubico.YubiKey.*` and `Yubico.Core` to `Yubico.YubiKit.*` packages.
+- Added manual-review guidance for device discovery, transport selection, applet session lifecycle, and raw APDU or low-level command migrations.
+- Established automation expectations: PR preview comments for pull requests targeting `yubikit`, post-merge documentation PRs for pushes to `yubikit`, and weekly reconciliation.

--- a/docs/migration/v1-to-v2-map.yml
+++ b/docs/migration/v1-to-v2-map.yml
@@ -1,0 +1,195 @@
+format_version: 1
+generated_from:
+  v1_baseline: develop
+  v2_branch: yubikit
+  initial_snapshot_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+mapping_status_values:
+  - automatic
+  - assisted
+  - manual
+  - removed
+  - unknown
+mappings:
+  - id: package-core
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: Yubico.Core
+    v2: Yubico.YubiKit.Core
+    evidence:
+      - develop:Yubico.Core/
+      - yubikit:src/Core/
+    notes: Core infrastructure moved into the YubiKit package family; verify specific type mappings before mechanical replacement.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: package-yubikey-to-yubikit
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: Yubico.YubiKey.*
+    v2: Yubico.YubiKit.*
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/
+      - yubikit:src/Core/
+      - yubikit:src/Management/
+      - yubikit:src/Piv/
+      - yubikit:src/Fido2/
+      - yubikit:src/Oath/
+      - yubikit:src/YubiOtp/
+      - yubikit:src/OpenPgp/
+      - yubikit:src/SecurityDomain/
+      - yubikit:src/YubiHsm/
+    notes: V2 is split by core infrastructure, management, and applet packages.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: namespace-core
+    status: assisted
+    confidence: high
+    migration_kind: namespace
+    v1: Yubico.Core
+    v2: Yubico.YubiKit.Core
+    evidence:
+      - develop:Yubico.Core/
+      - yubikit:src/Core/
+    notes: Namespace replacement is not guaranteed to be one-to-one for every type.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: namespace-applications
+    status: assisted
+    confidence: high
+    migration_kind: namespace
+    v1: Yubico.YubiKey.*
+    v2: Yubico.YubiKit.{Management,Piv,Fido2,Oath,YubiOtp,OpenPgp,SecurityDomain,YubiHsm}
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/
+      - yubikit:src/Management/
+      - yubikit:src/Piv/
+      - yubikit:src/Fido2/
+      - yubikit:src/Oath/
+      - yubikit:src/YubiOtp/
+      - yubikit:src/OpenPgp/
+      - yubikit:src/SecurityDomain/
+      - yubikit:src/YubiHsm/
+    notes: Select the v2 package by applet or infrastructure area rather than applying one namespace substitution globally.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: device-discovery-model
+    status: manual
+    confidence: medium
+    migration_kind: behavior
+    v1: v1 device discovery and device access APIs
+    v2: Yubico.YubiKit.Core device repository, device, connection, and protocol abstractions
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/IYubiKeyDevice.cs
+      - yubikit:src/Core/
+    notes: Discovery, transport selection, and connection ownership must be reviewed at call sites.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: session-lifecycle
+    status: manual
+    confidence: medium
+    migration_kind: async lifecycle
+    v1: v1 applet session construction and disposal
+    v2: applet-specific Yubico.YubiKit sessions
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/ApplicationSession.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
+      - yubikit:src/Core/src/Sessions/ApplicationSession.cs
+      - yubikit:src/Piv/src/PivSession.cs
+      - yubikit:src/Fido2/src/FidoSession.cs
+    notes: Check construction, async disposal, transport, authentication, and connection reuse semantics before migrating mechanically.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-piv
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: v1 PIV APIs
+    v2: Yubico.YubiKit.Piv
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Piv/PivSession.cs
+      - yubikit:src/Piv/
+    notes: Security-sensitive operations still require manual behavior review.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-fido2
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: v1 FIDO2 APIs
+    v2: Yubico.YubiKit.Fido2
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Fido2Session.cs
+      - yubikit:src/Fido2/
+    notes: Review PIN/UV and transport behavior manually.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-oath
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: v1 OATH APIs
+    v2: Yubico.YubiKit.Oath
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Oath/OathSession.cs
+      - yubikit:src/Oath/
+    notes: Review secret and password handling manually.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-yubiotp
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: v1 OTP APIs
+    v2: Yubico.YubiKit.YubiOtp
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Otp/OtpSession.cs
+      - yubikit:src/YubiOtp/
+    notes: Review slot configuration behavior manually.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-openpgp
+    status: assisted
+    confidence: high
+    migration_kind: package
+    v1: v1 OpenPGP APIs
+    v2: Yubico.YubiKit.OpenPgp
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/OpenPgp/
+      - yubikit:src/OpenPgp/
+    notes: Review PIN, key slot, and card state behavior manually.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-security-domain
+    status: manual
+    confidence: high
+    migration_kind: package
+    v1: v1 secure channel or security domain APIs
+    v2: Yubico.YubiKit.SecurityDomain
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/Scp/SecurityDomainSession.cs
+      - yubikit:src/SecurityDomain/
+    notes: Cryptographic key and secure channel migrations require manual review.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: applet-yubihsm
+    status: manual
+    confidence: high
+    migration_kind: package
+    v1: v1 YubiHSM or HSM Auth APIs
+    v2: Yubico.YubiKit.YubiHsm
+    evidence:
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/YubiHsmAuth/YubiHsmAuthSession.cs
+      - yubikit:src/YubiHsm/
+    notes: Authentication, connector, object, and command behavior require manual review.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: low-level-commands
+    status: manual
+    confidence: high
+    migration_kind: command
+    v1: raw APDU or low-level command usage
+    v2: v2 command, APDU, protocol, or applet session abstractions
+    evidence:
+      - develop:Yubico.Core/
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/InterIndustry/
+      - yubikit:src/Core/
+    notes: Verify byte-level behavior, status words, and response parsing before migration.
+    last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+manual_review:
+  - device discovery call sites
+  - transport selection assumptions
+  - session construction and disposal
+  - authentication, PIN, PUK, password, and key material handling
+  - raw APDU and low-level command usage
+  - behavior-dependent tests and exception contracts

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -1,0 +1,100 @@
+# YubiKey SDK v1 to YubiKit v2 Migration Guide
+
+This document reflects the v2 SDK state on branch `yubikit` as of commit `e348013685d92a6a665cd0b8bd7e8b05850fddd5`. Later pull requests targeting `yubikit` update this guide incrementally.
+
+This is an initial migration snapshot. It records high-confidence migration areas and marks low-level or behavior-sensitive cases for manual review.
+
+## Package and Namespace Split
+
+The v2 SDK uses `Yubico.YubiKit.*` packages and namespaces instead of the v1 `Yubico.YubiKey.*` and `Yubico.Core` shape.
+
+High-level package guidance:
+
+- Core device, transport, connection, APDU, logging, and platform infrastructure move to `Yubico.YubiKit.Core`.
+- Management interfaces move to `Yubico.YubiKit.Management`.
+- Application features are split by applet: `Yubico.YubiKit.Piv`, `Yubico.YubiKit.Fido2`, `Yubico.YubiKit.Oath`, `Yubico.YubiKit.YubiOtp`, `Yubico.YubiKit.OpenPgp`, `Yubico.YubiKit.SecurityDomain`, and `Yubico.YubiKit.YubiHsm`.
+
+Treat package and namespace changes as assisted migrations until the specific v1 type or member mapping is present in `v1-to-v2-map.yml`.
+
+## Device Discovery and Connections
+
+V2 separates device discovery, device identity, connection factories, and protocol handling more explicitly than v1. Migration work usually starts by replacing direct v1 device enumeration or static discovery calls with the v2 device repository and connection abstractions in `Yubico.YubiKit.Core`.
+
+Review code that assumes:
+
+- One global device discovery entry point.
+- A fixed transport for all operations.
+- A device object that directly owns all applet operations.
+- Synchronous connection setup for operations that are async in v2.
+
+## Session Lifecycle
+
+V2 application sessions are applet-specific and commonly own connection/protocol state. Prefer the v2 session factory or constructor pattern documented by each applet package rather than carrying v1 session setup forward mechanically.
+
+Migration review is required for code that:
+
+- Constructs sessions directly from v1 device objects.
+- Relies on synchronous disposal where v2 uses async cleanup.
+- Reuses one connection across multiple applet sessions.
+- Depends on implicit transport selection.
+
+## Application Sections
+
+### PIV
+
+Use `Yubico.YubiKit.Piv` for PIV operations. Review authentication, PIN/PUK handling, key import/generation, certificate management, and APDU-level customization manually because lifecycle and security-sensitive buffer handling can differ between v1 and v2.
+
+### FIDO2
+
+Use `Yubico.YubiKit.Fido2` for FIDO2/WebAuthn operations. Review transport selection, PIN/UV flows, credential management, and authenticator state assumptions manually.
+
+### OATH
+
+Use `Yubico.YubiKit.Oath` for TOTP/HOTP credential management and code calculation. Review credential naming, secret handling, password flows, and time-source assumptions manually.
+
+### YubiOTP
+
+Use `Yubico.YubiKit.YubiOtp` for Yubico OTP configuration and slot operations. Review slot numbering, configuration flags, and write/update behavior manually.
+
+### OpenPGP
+
+Use `Yubico.YubiKit.OpenPgp` for OpenPGP card operations. Review key slots, PIN policy, management key behavior, and command-level assumptions manually.
+
+### Security Domain
+
+Use `Yubico.YubiKit.SecurityDomain` for SCP03 and security domain key management. Treat all secure channel, cryptographic key, and diversification migrations as manual until a specific high-confidence mapping exists.
+
+### YubiHSM
+
+Use `Yubico.YubiKit.YubiHsm` for YubiHSM 2 workflows. Review connector/session creation, authentication, object identifiers, capabilities, and command behavior manually.
+
+## Manual Low-Level Command Cases
+
+Manual migration is required for code that builds APDUs, parses raw responses, relies on status-word behavior, preserves unknown protocol fields, or sends vendor-specific commands directly. These cases should be migrated against v2 command/session abstractions where possible. If direct command access remains necessary, verify byte-level behavior against both v1 and v2 sources.
+
+## Automation Note
+
+Migration documentation is maintained by automation on the `yubikit` branch. Pull requests targeting `yubikit` receive migration-impact preview comments. Pushes to `yubikit` open documentation update pull requests and advance `docs/migration/.state.yml` only after migration artifacts are updated.
+
+Weekly scheduled reconciliation requires a wrapper workflow on the repository default branch, because GitHub only runs scheduled workflows from the default branch. The wrapper checks out `yubikit`, runs the same reconciliation logic, and opens documentation pull requests back into `yubikit`.
+
+## How This Document Grows
+
+This guide is intended to mature over the v2 development cycle rather than be written in one final pass.
+
+1. Pull requests targeting `yubikit` get preview comments that identify migration impact without editing files.
+2. Merges into `yubikit` trigger documentation update pull requests for the newly analyzed commit range.
+3. Weekly reconciliation catches missed or stale migration guidance.
+4. Monthly synthesis reorganizes accumulated notes into clearer release-ready sections.
+
+The human review responsibility is intentionally narrow: review the generated migration documentation pull requests for truthfulness, confidence level, and usefulness. The automation should preserve uncertainty as manual-review items instead of inventing mappings.
+
+## Release Readiness Tracker
+
+This initial snapshot is not release-complete. Future automated updates should improve these areas:
+
+- Core/device discovery: package, namespace, physical device, and transport model guidance.
+- Session lifecycle: direct v1 constructors to v2 async factories and async disposal.
+- Applet recipes: before/after examples for common PIV, FIDO2, OATH, YubiOTP, OpenPGP, Security Domain, and YubiHSM tasks.
+- Manual migration cases: raw APDU, custom command classes, exception behavior, and security-sensitive credential flows.
+- Tooling foundation: structured map entries precise enough to support a future scanner or analyzer.

--- a/docs/plans/migration-docs-automation-handoff.md
+++ b/docs/plans/migration-docs-automation-handoff.md
@@ -1,0 +1,197 @@
+# Migration Documentation Automation Handoff
+
+## Status
+
+Implemented on branch `yubikit-migration-docs-automation` and opened as PR #513:
+
+https://github.com/Yubico/Yubico.NET.SDK/pull/513
+
+The work seeds v1-to-v2 migration documentation and adds automation intended to keep that documentation current as v2 evolves on `yubikit`.
+
+## Goal
+
+Reduce the lead developer's documentation burden to reviewing generated migration-documentation PRs. The system should accumulate migration guidance over the next several months so that, near v2 finalization, the migration guide is already close to release-ready.
+
+## Added Files
+
+Migration documentation:
+
+- `docs/migration/v1-to-v2.md`
+- `docs/migration/v1-to-v2-map.yml`
+- `docs/migration/v1-to-v2-changelog.md`
+- `docs/migration/.state.yml`
+
+Planning and handoff:
+
+- `docs/plans/migration-docs-automation-plan.md`
+- `docs/plans/migration-docs-automation-handoff.md`
+
+Claude prompts:
+
+- `.github/prompts/migration-docs-pr-preview.md`
+- `.github/prompts/migration-docs-post-merge.md`
+- `.github/prompts/migration-docs-monthly-synthesis.md`
+
+GitHub workflows:
+
+- `.github/workflows/migration-docs-preview.yml`
+- `.github/workflows/migration-docs-update.yml`
+- `.github/workflows/migration-docs-scheduler-wrapper.yml`
+- `.github/workflows/migration-docs-monthly-synthesis.yml`
+
+Context builder:
+
+- `scripts/migration/build-migration-context.sh`
+
+PowerShell was intentionally removed from this automation path; Bash is the canonical scripting language for portability across macOS, Linux, and GitHub-hosted Ubuntu runners.
+
+## How It Works
+
+### PR Preview
+
+When a PR targets `yubikit`, `.github/workflows/migration-docs-preview.yml` runs.
+
+It:
+
+1. Checks out the PR with full history.
+2. Fetches `origin/develop` and `origin/yubikit`.
+3. Builds `.migration-context/` using `scripts/migration/build-migration-context.sh`.
+4. Invokes `anthropics/claude-code-action@beta` with `.github/prompts/migration-docs-pr-preview.md`.
+5. Comments on migration impact only; it should not edit files.
+
+### Post-Merge Update
+
+When changes land on `yubikit`, `.github/workflows/migration-docs-update.yml` runs.
+
+It:
+
+1. Checks out `yubikit`.
+2. Reads `docs/migration/.state.yml`.
+3. Analyzes `last_analyzed_commit..HEAD`.
+4. Invokes Claude with `.github/prompts/migration-docs-post-merge.md`.
+5. Opens a migration-doc update PR back into `yubikit` using `peter-evans/create-pull-request@v7`.
+
+The prompt tells Claude to advance `.state.yml` after successful analysis, even for no-impact ranges, so old commits do not get reanalyzed forever.
+
+### Weekly Reconciliation
+
+GitHub cron only runs workflows from the repository default branch. The repository default branch is currently `develop`, while the migration docs live on `yubikit`.
+
+`.github/workflows/migration-docs-scheduler-wrapper.yml` is therefore a wrapper intended to exist on the default branch. It checks out `yubikit`, runs reconciliation there, and opens PRs back into `yubikit`.
+
+Until this wrapper is present on the default branch, weekly reconciliation will not run automatically. Push-triggered and manually dispatched runs on `yubikit` still work.
+
+### Monthly Synthesis
+
+`.github/workflows/migration-docs-monthly-synthesis.yml` is intended to keep the guide from becoming a pile of chronological updates.
+
+It asks Claude to:
+
+- collapse duplicate guidance,
+- improve structure,
+- preserve uncertainty,
+- report readiness by applet/area,
+- avoid inventing mappings.
+
+Like weekly scheduling, automatic monthly cron requires the workflow to exist on the default branch. Manual dispatch can be used from `yubikit`.
+
+## Deterministic Context Bundle
+
+`scripts/migration/build-migration-context.sh` produces these files under `.migration-context/`:
+
+- `context-summary.md`
+- `changed-files.txt`
+- `diff.patch`
+- `public-api-candidates.txt`
+- `api-added.txt`
+- `api-removed.txt`
+- `package-changes.txt`
+- `namespace-changes.txt`
+- `session-patterns.txt`
+- `existing-map-hits.txt`
+- `docs-coverage-hits.txt`
+- `v1-symbol-candidates.txt`
+- `migration-state.txt`
+
+This is meant to keep AI inference grounded in deterministic evidence. The model should classify and write from these files, not guess from branch names or broad context.
+
+## Dry Run Performed
+
+The Bash context builder was dry-run locally against:
+
+```text
+origin/yubikit...HEAD
+```
+
+Result:
+
+- Context generation succeeded.
+- 13 changed files were detected.
+- Diff size was 54,726 bytes.
+- Diff was not truncated.
+- No C# public API candidates were found, as expected for a docs/workflow PR.
+- The repo remained clean after the dry run.
+
+Local WSL required a temporary `safe.directory` override due Windows-owned repo paths. No global Git config was changed.
+
+## Verification Performed
+
+- `bash -n ./scripts/migration/build-migration-context.sh`
+- Local deterministic dry run of the Bash context builder.
+- DevTeam reviewer pass after implementation.
+- DevTeam reviewer re-review after fixes: no blockers remained.
+
+## Cato / Opus Audit Status
+
+Cato was attempted multiple times but did not produce an audit result:
+
+- `CatoRun.ts` returned `status: error` with an empty Claude audit failure.
+- Direct `claude -p --bare --model claude-opus-4-8` fallback was blocked by Vertex quota (`429 RESOURCE_EXHAUSTED`).
+
+The implementation proceeded with DevTeam review instead.
+
+## Important Dependencies
+
+- `ANTHROPIC_API_KEY` repository secret, unless the workflows are changed to Vertex/Bedrock/OIDC auth.
+- GitHub Actions must allow workflows to create pull requests.
+- `peter-evans/create-pull-request@v7` must be permitted to push automation branches and open PRs.
+- `anthropics/claude-code-action@beta` behavior should be validated on the first real workflow run.
+- Scheduler/monthly cron automation requires wrapper workflows on the repository default branch.
+
+## Expected First Behavior After Merge To `yubikit`
+
+After PR #513 merges into `yubikit`, the push workflow may open a first migration-doc PR analyzing the automation merge itself. That first PR may be meta/noisy. It should either:
+
+- record a no-impact or automation-added changelog entry and advance `.state.yml`, or
+- make small automation-note adjustments.
+
+After that state advancement, later SDK feature merges should produce more useful migration-specific documentation PRs.
+
+## Next Steps
+
+1. Merge PR #513 into `yubikit`.
+2. Watch the first `Migration Docs Update` workflow run.
+3. Verify the Claude action receives context and can either comment or modify docs as intended.
+4. Verify `peter-evans/create-pull-request` opens PRs with only `docs/migration/**` changes.
+5. If PR creation fails, check repository Actions settings and token permissions.
+6. Mirror `.github/workflows/migration-docs-scheduler-wrapper.yml` to the default branch (`develop`) if automatic weekly reconciliation is required immediately.
+7. Optionally mirror `.github/workflows/migration-docs-monthly-synthesis.yml` to the default branch if automatic monthly synthesis is required immediately.
+8. After a few real runs, tune prompts for noise level and confidence calibration.
+
+## What To Watch For
+
+- Claude action input compatibility with `prompt` and `claude_args`.
+- Excessively noisy PR comments.
+- State file not advancing.
+- Generated docs claiming more confidence than evidence supports.
+- Scheduler not running because it exists only on `yubikit`.
+- Automation PRs piling up unmerged, causing docs to lag.
+
+## Operating Principle
+
+The system should be boring where correctness matters and intelligent where prose helps:
+
+- deterministic scripts find changed evidence,
+- AI classifies migration impact and writes documentation,
+- uncertainty becomes manual-review guidance,
+- humans only review generated documentation PRs.

--- a/docs/plans/migration-docs-automation-handoff.md
+++ b/docs/plans/migration-docs-automation-handoff.md
@@ -132,7 +132,7 @@ Result:
 - No C# public API candidates were found, as expected for a docs/workflow PR.
 - The repo remained clean after the dry run.
 
-Local WSL required a temporary `safe.directory` override due Windows-owned repo paths. No global Git config was changed.
+Local WSL required a temporary `safe.directory` override due to Windows-owned repo paths. No global Git config was changed.
 
 ## Verification Performed
 

--- a/docs/plans/migration-docs-automation-handoff.md
+++ b/docs/plans/migration-docs-automation-handoff.md
@@ -56,7 +56,7 @@ It:
 1. Checks out the PR with full history.
 2. Fetches `origin/develop` and `origin/yubikit`.
 3. Builds `.migration-context/` using `scripts/migration/build-migration-context.sh`.
-4. Invokes `anthropics/claude-code-action@beta` with `.github/prompts/migration-docs-pr-preview.md`.
+4. Invokes `anthropics/claude-code-action` pinned to the commit behind `beta` with `.github/prompts/migration-docs-pr-preview.md`.
 5. Comments on migration impact only; it should not edit files.
 
 ### Post-Merge Update
@@ -69,7 +69,7 @@ It:
 2. Reads `docs/migration/.state.yml`.
 3. Analyzes `last_analyzed_commit..HEAD`.
 4. Invokes Claude with `.github/prompts/migration-docs-post-merge.md`.
-5. Opens a migration-doc update PR back into `yubikit` using `peter-evans/create-pull-request@v7`.
+5. Opens a migration-doc update PR back into `yubikit` using `peter-evans/create-pull-request` pinned to the `v7` commit.
 
 The prompt tells Claude to advance `.state.yml` after successful analysis, even for no-impact ranges, so old commits do not get reanalyzed forever.
 
@@ -77,7 +77,7 @@ The prompt tells Claude to advance `.state.yml` after successful analysis, even 
 
 GitHub cron only runs workflows from the repository default branch. The repository default branch is currently `develop`, while the migration docs live on `yubikit`.
 
-`.github/workflows/migration-docs-scheduler-wrapper.yml` is therefore a wrapper intended to exist on the default branch. It checks out `yubikit`, runs reconciliation there, and opens PRs back into `yubikit`.
+`.github/workflows/migration-docs-scheduler-wrapper.yml` is therefore a wrapper intended to exist on the default branch. It checks out `yubikit`, scans the full `origin/develop..HEAD` v1-to-v2 tree delta for reconciliation, and opens PRs back into `yubikit`.
 
 Until this wrapper is present on the default branch, weekly reconciliation will not run automatically. Push-triggered and manually dispatched runs on `yubikit` still work.
 
@@ -154,8 +154,8 @@ The implementation proceeded with DevTeam review instead.
 
 - `ANTHROPIC_API_KEY` repository secret, unless the workflows are changed to Vertex/Bedrock/OIDC auth.
 - GitHub Actions must allow workflows to create pull requests.
-- `peter-evans/create-pull-request@v7` must be permitted to push automation branches and open PRs.
-- `anthropics/claude-code-action@beta` behavior should be validated on the first real workflow run.
+- `peter-evans/create-pull-request` must be permitted to push automation branches and open PRs.
+- `anthropics/claude-code-action` behavior should be validated on the first real workflow run.
 - Scheduler/monthly cron automation requires wrapper workflows on the repository default branch.
 
 ## Expected First Behavior After Merge To `yubikit`

--- a/docs/plans/migration-docs-automation-plan.md
+++ b/docs/plans/migration-docs-automation-plan.md
@@ -1,0 +1,190 @@
+# V1 to V2 Migration Documentation Automation Plan
+
+## Problem
+
+The v2 SDK will continue evolving for roughly six months before migration guidance must be ready for external developers. The lead developer does not want to manually write, maintain, or remember migration documentation while feature work is ongoing. Without automation, migration guidance will drift, important API deltas will be forgotten, and the final documentation push will require reconstructing months of context.
+
+## Goal
+
+Make v1-to-v2 migration documentation mostly self-maintaining as v2 changes land in the `yubikit` integration branch. By release readiness, developers migrating from v1 should have accurate, current, practical migration documentation and enough structured mapping data to support future migration tooling.
+
+## Branch Model
+
+- `develop` is the v1 baseline.
+- `yubikit` is the authoritative v2 integration branch.
+- `yubikit-*` branches are feature branches or stacked feature branches.
+- Migration docs are authoritative only on `yubikit`.
+- Feature branches do not directly maintain migration docs.
+- Pull requests targeting `yubikit` get migration-impact preview comments.
+- Pushes to `yubikit` produce chronological migration documentation updates.
+
+## Artifacts
+
+- `docs/migration/v1-to-v2.md`: human-readable migration guide.
+- `docs/migration/v1-to-v2-map.yml`: structured v1-to-v2 package, namespace, type, member, and behavior mapping.
+- `docs/migration/v1-to-v2-changelog.md`: chronological migration-impact ledger.
+- `docs/migration/.state.yml`: migration automation state containing `v1_baseline`, `v2_branch`, and `last_analyzed_commit`.
+
+## Initial Snapshot
+
+Create the first migration snapshot on a branch based on `origin/yubikit`. The snapshot explicitly records its scope:
+
+> This document reflects the v2 SDK state on branch `yubikit` as of commit `<sha>`. Later pull requests targeting `yubikit` update this guide incrementally.
+
+The initial snapshot covers the high-confidence migration areas already known:
+
+- Package and namespace split from `Yubico.YubiKey.*` / `Yubico.Core` to `Yubico.YubiKit.*` packages.
+- Device discovery model changes.
+- Connection and transport selection changes.
+- Session construction and async disposal changes.
+- Application-specific migration sections for PIV, FIDO2, OATH, OTP, Security Domain, and HSM Auth.
+- Manual migration guidance for low-level command/APDU users.
+
+## PR Preview Workflow
+
+For pull requests targeting `yubikit`:
+
+- Fetch `origin/develop` and `origin/yubikit`.
+- Analyze only `origin/yubikit...HEAD`.
+- Cross-reference changed v2 public surface against v1 source on `origin/develop`.
+- Read the existing migration guide and mapping file.
+- Comment on the PR with migration impact and suggested documentation changes.
+- Do not edit files.
+- If the diff is too large, produce only an affected-module summary and manual-review checklist.
+
+## Post-Merge Documentation Workflow
+
+On push to `yubikit`:
+
+- Fetch `origin/develop`.
+- Read `docs/migration/.state.yml`.
+- Analyze only `last_analyzed_commit..HEAD`.
+- Cross-reference changed v2 public surface against v1 source on `origin/develop`.
+- Update migration artifacts conservatively.
+- Open a documentation PR back into `yubikit`; do not push directly to `yubikit`.
+- Advance `last_analyzed_commit` only in the documentation PR and only after the analyzed range has been handled. If the range has no migration-relevant changes, add a short no-impact changelog entry and advance the state file so the same commits are not analyzed repeatedly.
+
+## Scheduled Reconciliation Workflow
+
+Run weekly on `yubikit`:
+
+- Compare the current migration guide and map against the current `develop` and `yubikit` trees.
+- Detect migration-relevant public API changes missed by incremental runs.
+- Detect stale mappings and unresolved manual-review items.
+- Open a documentation PR if reconciliation finds gaps.
+
+GitHub scheduled workflows run from the repository default branch. Because this repository currently uses `develop` as the remote default branch, weekly reconciliation requires either mirroring the update workflow onto the default branch or changing the repository default branch to `yubikit`. Push and manual dispatch runs on `yubikit` remain the reliable initial automation path.
+
+The preferred no-manual-work model is a small default-branch scheduler wrapper. The wrapper lives on the default branch, checks out `yubikit`, builds migration context from `develop` and `yubikit`, and opens documentation pull requests back into `yubikit`. This preserves `yubikit` as the authoritative documentation branch without requiring the repository default branch to change.
+
+## Monthly Synthesis Workflow
+
+Run monthly or manually:
+
+- Read accumulated guide, map, changelog, and context evidence.
+- Collapse duplicate incremental notes into canonical guide sections.
+- Improve release-readiness structure without inventing mappings.
+- Produce or update readiness guidance by area: Core/device, PIV, FIDO2, OATH, YubiOTP, OpenPGP, Security Domain, YubiHSM, and low-level commands.
+- Open a documentation PR back into `yubikit`.
+
+Monthly synthesis is the quality ratchet that prevents the guide from becoming a chronological pile of small updates.
+
+## AI Context Contract
+
+Each AI run receives deterministic context before inference:
+
+- V1 baseline ref: `origin/develop`.
+- V2 integration ref: `origin/yubikit`.
+- Current analyzed range: either `origin/yubikit...HEAD` for PR preview or `last_analyzed_commit..HEAD` for post-merge updates.
+- Changed files.
+- Changed public API candidates.
+- Added and removed public/protected API candidates.
+- Package, namespace, session, device, connection, and transport evidence files.
+- Existing migration guide.
+- Existing migration mapping file.
+- Existing chronological changelog.
+- Existing map and documentation coverage hits for diff-derived symbols.
+- Relevant v1 source snippets discovered by targeted symbol searches.
+- Relevant v2 source snippets from the changed range.
+
+The AI must not infer what changed from branch names or intuition. It classifies only the supplied changed range and uses `develop` only as the v1 reference baseline.
+
+The context builder is implemented in Bash for portability across macOS, Linux, and GitHub-hosted Ubuntu runners. A PowerShell implementation may remain temporarily as a fallback while the Bash path is validated, but workflows should prefer Bash.
+
+## AI Prompt Rules
+
+The AI must:
+
+- Document only migration-relevant changes introduced in the analyzed range.
+- Use `develop` as the v1 source of truth.
+- Use `yubikit` as the v2 source of truth.
+- Preserve existing document structure.
+- Prefer appending changelog entries over broad rewrites.
+- Avoid inventing mappings.
+- Mark uncertain mappings as `manual-review`.
+- Assign confidence levels to mappings.
+- Treat internal-only changes as `none`.
+- Never advance `last_analyzed_commit` unless migration artifacts were updated successfully.
+- Never claim an automatic migration when behavior or intent is ambiguous.
+
+## Structured Mapping States
+
+Mappings in `v1-to-v2-map.yml` use these statuses:
+
+- `automatic`: safe mechanical package, namespace, type, or member mapping.
+- `assisted`: partially mechanical, but requires developer review.
+- `manual`: requires human migration due to behavior, lifecycle, transport, or protocol changes.
+- `removed`: v1 API has no v2 equivalent.
+- `unknown`: possible relationship needs review.
+
+Mappings also include:
+
+- `confidence`: `high`, `medium`, or `low`.
+- `migration_kind`: package, namespace, type, member, construction, async lifecycle, behavior, transport, command, or removal.
+- `evidence`: source paths or symbols supporting the mapping.
+- `last_reviewed_commit`.
+
+## Guardrails
+
+- PR mode comments only; it does not edit files.
+- Post-merge mode opens PRs; it does not directly push to `yubikit`.
+- The workflow reports the analyzed refs and range in every comment or documentation PR.
+- Large diffs degrade to summary mode instead of attempting exhaustive prose.
+- Diff context is size-bounded before it reaches the model; oversized ranges include truncation metadata and must be handled as summary/manual-review cases.
+- Low-confidence findings become manual-review entries.
+- Weekly reconciliation catches missed incremental changes.
+- Mapping and changelog are append-friendly to reduce merge conflicts and AI rewrite churn.
+- The guide remains human-readable; the map remains machine-readable.
+
+## Success Criteria
+
+At month six:
+
+- The migration guide reflects current `yubikit` behavior.
+- The mapping file covers major v1 package, namespace, applet, session, and device APIs.
+- The changelog explains migration-impacting changes chronologically.
+- PR comments surfaced migration impact during development.
+- The lead developer did not need to manually remember or author most migration documentation.
+- External developers can identify required v2 packages, namespaces, session creation patterns, device discovery changes, transport changes, async lifecycle changes, and manual migration cases.
+
+## Desired Developer Experience
+
+The system should feel like a memory assistant for the lead developer. Each migration-doc PR should include a short summary such as:
+
+> Migration impact since last update:
+> - PIV session creation now uses async factory methods.
+> - FIDO2 transport selection defaults changed.
+> - Direct v1 `IYubiKeyDevice` usage maps to v2 `IYubiKey`.
+
+This summary should make it easy to review migration documentation without rereading the full guide.
+
+## Cato Audit Questions
+
+Audit this plan for:
+
+- What did we miss?
+- What could make this fail over six months?
+- How do we make this successful for a lead developer who does not want to manually write or remember migration docs?
+- How do we make the outcome exceed expectations for developers migrating from v1 to v2?
+- Are the branch model, state tracking, PR workflow, and AI prompt contract sufficient?
+- What guardrails are needed to prevent stale, misleading, or hallucinated migration docs?

--- a/scripts/migration/build-migration-context.sh
+++ b/scripts/migration/build-migration-context.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: build-migration-context.sh --mode preview|update --v1-baseline REF --v2-branch REF --base-range RANGE --output-dir DIR
+
+Build deterministic context files for the v1-to-v2 migration documentation assistant.
+USAGE
+}
+
+mode=""
+v1_baseline=""
+v2_branch=""
+base_range=""
+output_dir=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      mode="${2:-}"
+      shift 2
+      ;;
+    --v1-baseline)
+      v1_baseline="${2:-}"
+      shift 2
+      ;;
+    --v2-branch)
+      v2_branch="${2:-}"
+      shift 2
+      ;;
+    --base-range)
+      base_range="${2:-}"
+      shift 2
+      ;;
+    --output-dir)
+      output_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$mode" != "preview" && "$mode" != "update" ]]; then
+  echo "--mode must be preview or update" >&2
+  exit 2
+fi
+
+if [[ -z "$v1_baseline" || -z "$v2_branch" || -z "$base_range" || -z "$output_dir" ]]; then
+  echo "Missing required argument" >&2
+  usage >&2
+  exit 2
+fi
+
+mkdir -p "$output_dir"
+max_diff_bytes="${MIGRATION_CONTEXT_MAX_DIFF_BYTES:-250000}"
+
+state_path="docs/migration/.state.yml"
+if [[ -f "$state_path" ]]; then
+  state_content="$(cat "$state_path")"
+else
+  state_content="format_version: unknown
+v1_baseline: $v1_baseline
+v2_branch: $v2_branch
+last_analyzed_commit: unavailable
+state_file: absent"
+fi
+
+head_sha="$(git rev-parse HEAD)"
+git diff --name-only "$base_range" > "$output_dir/changed-files.txt"
+full_diff="$output_dir/.diff.full.tmp"
+git diff --no-ext-diff "$base_range" > "$full_diff"
+diff_bytes="$(wc -c < "$full_diff" | tr -d ' ')"
+diff_truncated="false"
+if [[ "$diff_bytes" -gt "$max_diff_bytes" ]]; then
+  head -c "$max_diff_bytes" "$full_diff" > "$output_dir/diff.patch"
+  {
+    printf '\n\n'
+    printf '[migration-context truncated diff: original_bytes=%s max_bytes=%s]\n' "$diff_bytes" "$max_diff_bytes"
+  } >> "$output_dir/diff.patch"
+  diff_truncated="true"
+else
+  mv "$full_diff" "$output_dir/diff.patch"
+fi
+rm -f "$full_diff"
+
+awk '
+  /^[+-]/ && !/^\+\+\+/ && !/^---/ {
+    marker = substr($0, 1, 1)
+    line = substr($0, 2)
+    if (line ~ /^[[:space:]]*(public|protected)[[:space:]]+/) {
+      if (line ~ /[[:space:]](class|struct|record|interface|enum)[[:space:]]+/ || line ~ /[A-Za-z0-9_<>,\[\]\?]+[[:space:]]+[A-Za-z_][A-Za-z0-9_]*[[:space:]]*(\(|\{|=>)/) {
+        print marker line
+      }
+    }
+  }
+' "$output_dir/diff.patch" > "$output_dir/public-api-candidates.txt"
+
+awk '
+  /^\+/ && !/^\+\+\+/ {
+    line = substr($0, 2)
+    if (line ~ /^[[:space:]]*(public|protected)[[:space:]]+/) print line
+  }
+' "$output_dir/diff.patch" > "$output_dir/api-added.txt"
+
+awk '
+  /^-/ && !/^---/ {
+    line = substr($0, 2)
+    if (line ~ /^[[:space:]]*(public|protected)[[:space:]]+/) print line
+  }
+' "$output_dir/diff.patch" > "$output_dir/api-removed.txt"
+
+grep -E '^[+-].*<PackageReference|^[+-].*<ProjectReference|^[+-].*<PackageId>|^[+-].*<RootNamespace>|^[+-].*<AssemblyName>' "$output_dir/diff.patch" \
+  | grep -Ev '^(\+\+\+|---)' > "$output_dir/package-changes.txt" || true
+
+grep -E '^[+-][[:space:]]*(namespace|using)[[:space:]]+Yubico\.' "$output_dir/diff.patch" \
+  | grep -Ev '^(\+\+\+|---)' > "$output_dir/namespace-changes.txt" || true
+
+grep -Ei 'ApplicationSession|Create[A-Za-z0-9]+SessionAsync|Session\.CreateAsync|IApplicationSession|IYubiKeyExtensions|ConnectAsync|AvailableConnections|SupportsConnection' "$output_dir/diff.patch" \
+  > "$output_dir/session-patterns.txt" || true
+
+tmp_symbols="$output_dir/.symbols.tmp"
+grep -Eo '\b[A-Za-z_][A-Za-z0-9_]{2,}\b' "$output_dir/diff.patch" \
+  | grep -Ev '^(abstract|async|await|class|const|enum|event|false|get|init|interface|internal|namespace|new|null|override|private|protected|public|readonly|record|return|sealed|set|static|struct|this|true|using|virtual|void)$' \
+  | sort -u \
+  | head -n 200 > "$tmp_symbols" || true
+
+grep -Ff "$tmp_symbols" docs/migration/v1-to-v2-map.yml 2>/dev/null \
+  | head -n 200 > "$output_dir/existing-map-hits.txt" || true
+
+grep -Ff "$tmp_symbols" docs/migration/v1-to-v2.md docs/migration/v1-to-v2-changelog.md 2>/dev/null \
+  | head -n 200 > "$output_dir/docs-coverage-hits.txt" || true
+
+: > "$output_dir/v1-symbol-candidates.txt"
+while IFS= read -r symbol; do
+  [[ -z "$symbol" ]] && continue
+  if [[ "$(wc -l < "$output_dir/v1-symbol-candidates.txt")" -ge 300 ]]; then
+    break
+  fi
+
+  matches="$(git grep -n --no-color -F -- "$symbol" "$v1_baseline" -- 'Yubico.Core' 'Yubico.YubiKey' 2>/dev/null | head -n 3 || true)"
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches" >> "$output_dir/v1-symbol-candidates.txt"
+  fi
+done < "$tmp_symbols"
+
+sort -u "$output_dir/v1-symbol-candidates.txt" -o "$output_dir/v1-symbol-candidates.txt"
+rm -f "$tmp_symbols"
+
+last_analyzed="$(printf '%s\n' "$state_content" | sed -n 's/^last_analyzed_commit:[[:space:]]*//p' | head -n 1)"
+changed_file_count="$(wc -l < "$output_dir/changed-files.txt" | tr -d ' ')"
+if [[ ! -s "$output_dir/changed-files.txt" ]]; then
+  changed_file_count="0"
+fi
+
+cat > "$output_dir/migration-state.txt" <<EOF
+mode: $mode
+v1_baseline: $v1_baseline
+v2_branch: $v2_branch
+base_range: $base_range
+head_sha: $head_sha
+state_last_analyzed_commit: $last_analyzed
+
+--- docs/migration/.state.yml ---
+$state_content
+EOF
+
+cat > "$output_dir/context-summary.md" <<EOF
+# Migration Context Summary
+
+- Mode: $mode
+- V1 baseline: $v1_baseline
+- V2 branch: $v2_branch
+- Analyzed range: $base_range
+- HEAD: $head_sha
+- Changed file count: $changed_file_count
+- State last analyzed commit: $last_analyzed
+- Diff bytes before truncation: $diff_bytes
+- Diff truncated: $diff_truncated
+- Max diff bytes: $max_diff_bytes
+
+## Files
+
+- changed-files.txt: files changed in the analyzed range.
+- diff.patch: deterministic git diff for the analyzed range, truncated when it exceeds the configured size limit.
+- public-api-candidates.txt: added or removed public/protected C# declarations found in the diff.
+- api-added.txt: added public/protected declarations.
+- api-removed.txt: removed public/protected declarations.
+- package-changes.txt: package, project, namespace, and assembly metadata changes.
+- namespace-changes.txt: Yubico namespace import/declaration changes.
+- session-patterns.txt: session, device, connection, and transport related diff lines.
+- existing-map-hits.txt: current migration map lines matching diff-derived symbols.
+- docs-coverage-hits.txt: current migration guide/changelog lines matching diff-derived symbols.
+- v1-symbol-candidates.txt: bounded v1 baseline grep matches for symbols found in the diff.
+- migration-state.txt: workflow mode, refs, range, HEAD, and migration state content.
+
+Use this context only for the requested migration documentation task. If evidence is incomplete, mark findings manual-review instead of inventing mappings.
+EOF

--- a/scripts/migration/build-migration-context.sh
+++ b/scripts/migration/build-migration-context.sh
@@ -141,15 +141,18 @@ grep -Ff "$tmp_symbols" docs/migration/v1-to-v2.md docs/migration/v1-to-v2-chang
   | head -n 200 > "$output_dir/docs-coverage-hits.txt" || true
 
 : > "$output_dir/v1-symbol-candidates.txt"
+candidate_lines=0
 while IFS= read -r symbol; do
   [[ -z "$symbol" ]] && continue
-  if [[ "$(wc -l < "$output_dir/v1-symbol-candidates.txt")" -ge 300 ]]; then
+  if [[ "$candidate_lines" -ge 300 ]]; then
     break
   fi
 
   matches="$(git grep -n --no-color -F -- "$symbol" "$v1_baseline" -- 'Yubico.Core' 'Yubico.YubiKey' 2>/dev/null | head -n 3 || true)"
   if [[ -n "$matches" ]]; then
     printf '%s\n' "$matches" >> "$output_dir/v1-symbol-candidates.txt"
+    added_lines="$(printf '%s\n' "$matches" | wc -l | tr -d ' ')"
+    candidate_lines=$((candidate_lines + added_lines))
   fi
 done < "$tmp_symbols"
 

--- a/scripts/migration/build-migration-context.sh
+++ b/scripts/migration/build-migration-context.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
+export LC_ALL=C
 
 usage() {
   cat <<'USAGE'


### PR DESCRIPTION
## Summary
- add initial v1-to-v2 migration guide, map, changelog, and automation state
- add Claude prompt files and GitHub workflows for PR preview, post-merge updates, scheduler wrapper, and monthly synthesis
- add Bash context builder for deterministic migration evidence bundles

## Verification
- bash -n ./scripts/migration/build-migration-context.sh
- DevTeam reviewer pass: no remaining blockers

## Notes
- Direct Opus/Cato audit was attempted but blocked by Vertex quota/runner error.
- Scheduled workflows only run from the repository default branch; the scheduler wrapper is included so it can be mirrored to the default branch while still updating yubikit.