### PR TITLE
ci: update Claude docs automation actions

### DIFF
--- a/.github/workflows/architecture-docs-monthly-synthesis.yml
+++ b/.github/workflows/architecture-docs-monthly-synthesis.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Synthesize architecture documentation
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/architecture-docs-monthly-synthesis.md`.

--- a/.github/workflows/architecture-docs-monthly-synthesis.yml
+++ b/.github/workflows/architecture-docs-monthly-synthesis.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yubikit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -49,7 +49,7 @@ jobs:
             --output-dir .architecture-context
 
       - name: Synthesize architecture documentation
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/architecture-docs-preview.yml
+++ b/.github/workflows/architecture-docs-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -32,7 +32,7 @@ jobs:
 
       - name: Comment with architecture documentation preview
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/architecture-docs-preview.yml
+++ b/.github/workflows/architecture-docs-preview.yml
@@ -34,7 +34,7 @@ jobs:
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/architecture-docs-pr-preview.md`.

--- a/.github/workflows/architecture-docs-scheduler-wrapper.yml
+++ b/.github/workflows/architecture-docs-scheduler-wrapper.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yubikit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -81,7 +81,7 @@ jobs:
 
       - name: Reconcile architecture documentation
         if: ${{ steps.impact.outputs.has_affected == 'true' }}
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/architecture-docs-scheduler-wrapper.yml
+++ b/.github/workflows/architecture-docs-scheduler-wrapper.yml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ steps.impact.outputs.has_affected == 'true' }}
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/architecture-docs-post-merge.md`.

--- a/.github/workflows/architecture-docs-update.yml
+++ b/.github/workflows/architecture-docs-update.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ steps.impact.outputs.has_affected == 'true' }}
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/architecture-docs-post-merge.md`.

--- a/.github/workflows/architecture-docs-update.yml
+++ b/.github/workflows/architecture-docs-update.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yubikit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -78,7 +78,7 @@ jobs:
 
       - name: Update architecture documentation
         if: ${{ steps.impact.outputs.has_affected == 'true' }}
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-monthly-synthesis.yml
+++ b/.github/workflows/migration-docs-monthly-synthesis.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yubikit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -41,7 +41,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Synthesize migration documentation
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-monthly-synthesis.yml
+++ b/.github/workflows/migration-docs-monthly-synthesis.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Synthesize migration documentation
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/migration-docs-monthly-synthesis.md`.

--- a/.github/workflows/migration-docs-preview.yml
+++ b/.github/workflows/migration-docs-preview.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Comment with migration documentation preview
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/migration-docs-pr-preview.md`.

--- a/.github/workflows/migration-docs-preview.yml
+++ b/.github/workflows/migration-docs-preview.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
 
@@ -33,7 +33,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Comment with migration documentation preview
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-scheduler-wrapper.yml
+++ b/.github/workflows/migration-docs-scheduler-wrapper.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Reconcile migration documentation
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/migration-docs-post-merge.md`.

--- a/.github/workflows/migration-docs-scheduler-wrapper.yml
+++ b/.github/workflows/migration-docs-scheduler-wrapper.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out yubikit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -48,7 +48,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Reconcile migration documentation
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
           ref: yubikit
@@ -56,7 +56,7 @@ jobs:
             --output-dir .migration-context
 
       - name: Update migration documentation
-        uses: anthropics/claude-code-action@28f83620103c48a57093dcc2837eec89e036bb9f # beta (v0.0.63)
+        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Update migration documentation
         uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
         with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: |
             Read and follow `.github/prompts/migration-docs-post-merge.md`.


### PR DESCRIPTION
## Summary

Updates documentation automation workflows to use Claude Code Action v1 with the v1-style inputs already present in the workflows.

Also updates checkout in those docs automation workflows to v5 to avoid Node 20 deprecation warnings from checkout v4.

## Root Cause

The workflows used v1 inputs while pinned to an older beta Claude Code Action SHA. The old action ignored those inputs, fell back to tag mode, and failed on push events with Unsupported event type: push.

## Verification

- Ruby YAML parse for docs workflow files
- git diff --check
- Branch push dependency submission check passed