### PR TITLE
ci: run Claude docs updates from push workflows

### DIFF
--- a/.github/workflows/architecture-docs-update.yml
+++ b/.github/workflows/architecture-docs-update.yml
@@ -76,18 +76,22 @@ jobs:
             echo "No mapped architecture diagram impact; skipping AI update and state-only PR."
           fi
 
+      - name: Install Claude Code
+        if: ${{ steps.impact.outputs.has_affected == 'true' }}
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash -s 2.1.199
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Update architecture documentation
         if: ${{ steps.impact.outputs.has_affected == 'true' }}
-        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: |
-            Read and follow `.github/prompts/architecture-docs-post-merge.md`.
-            The generated context is in `.architecture-context/`.
-            Update only the allowed architecture documentation files.
-          claude_args: >-
-            --allowedTools Read,Grep,Glob,Edit,Write,Bash
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          "$HOME/.local/bin/claude" -p \
+            --allowedTools Read,Grep,Glob,Edit,Write,Bash \
+            "Read and follow \`.github/prompts/architecture-docs-post-merge.md\`.
+          The generated context is in \`.architecture-context/\`.
+          Update only the allowed architecture documentation files."
 
       - name: Enforce architecture-only edits
         if: ${{ steps.impact.outputs.has_affected == 'true' }}

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -55,17 +55,20 @@ jobs:
             --base-range '${{ steps.range.outputs.base_range }}' \
             --output-dir .migration-context
 
+      - name: Install Claude Code
+        run: |
+          curl -fsSL https://claude.ai/install.sh | bash -s 2.1.199
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Update migration documentation
-        uses: anthropics/claude-code-action@769e3bdff9bb7ecfb51bad4c9cba23d6f5fc5ea5 # v1.0.163
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: |
-            Read and follow `.github/prompts/migration-docs-post-merge.md`.
-            The generated context is in `.migration-context/`.
-            Update only the allowed migration documentation files.
-          claude_args: >-
-            --allowedTools Read,Grep,Glob,Edit,Write
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          "$HOME/.local/bin/claude" -p \
+            --allowedTools Read,Grep,Glob,Edit,Write \
+            "Read and follow \`.github/prompts/migration-docs-post-merge.md\`.
+          The generated context is in \`.migration-context/\`.
+          Update only the allowed migration documentation files."
 
       - name: Create migration documentation PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7


### PR DESCRIPTION
## Summary

Keeps PR preview workflows on Claude Code Action v1, but changes the push-triggered docs update workflows to invoke Claude Code CLI directly.

## Root Cause

Claude Code Action v1 supports PR and automation events such as workflow_dispatch, repository_dispatch, schedule, and workflow_run, but it still rejects push events with Unsupported event type: push.

The post-merge Migration Docs Update workflow is push-triggered, so it needs direct CLI invocation instead of the action wrapper.

## Verification

- Ruby YAML parse for docs workflow files
- git diff --check
- Prior PR preview workflows confirmed Claude Code Action v1 plus CLAUDE_CODE_OAUTH_TOKEN works in PR context