### PR TITLE
ci: pipe Claude docs update prompts via stdin

### DIFF
--- a/.github/workflows/architecture-docs-update.yml
+++ b/.github/workflows/architecture-docs-update.yml
@@ -87,11 +87,11 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          "$HOME/.local/bin/claude" -p \
-            --allowedTools Read,Grep,Glob,Edit,Write,Bash \
-            "Read and follow \`.github/prompts/architecture-docs-post-merge.md\`.
-          The generated context is in \`.architecture-context/\`.
-          Update only the allowed architecture documentation files."
+          printf '%s\n' \
+            'Read and follow `.github/prompts/architecture-docs-post-merge.md`.' \
+            'The generated context is in `.architecture-context/`.' \
+            'Update only the allowed architecture documentation files.' \
+            | "$HOME/.local/bin/claude" -p --allowedTools Read,Grep,Glob,Edit,Write,Bash
 
       - name: Enforce architecture-only edits
         if: ${{ steps.impact.outputs.has_affected == 'true' }}

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -64,11 +64,11 @@ jobs:
         env:
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          "$HOME/.local/bin/claude" -p \
-            --allowedTools Read,Grep,Glob,Edit,Write \
-            "Read and follow \`.github/prompts/migration-docs-post-merge.md\`.
-          The generated context is in \`.migration-context/\`.
-          Update only the allowed migration documentation files."
+          printf '%s\n' \
+            'Read and follow `.github/prompts/migration-docs-post-merge.md`.' \
+            'The generated context is in `.migration-context/`.' \
+            'Update only the allowed migration documentation files.' \
+            | "$HOME/.local/bin/claude" -p --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration documentation PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7


### PR DESCRIPTION
## Summary

Fixes the direct Claude Code CLI invocation in push-triggered docs update workflows by piping the automation prompt through stdin.

## Root Cause

The previous CLI command passed flags after `-p` in a way that left Claude Code without a prompt, producing: Input must be provided either through stdin or as a prompt argument when using --print.

## Verification

- Ruby YAML parse for docs workflow files
- git diff --check
- Post-merge failure log confirmed Claude Code installed and OAuth token was present before the prompt-input error