### PR TITLE
ci: filter migration docs updates to source impact

### DIFF
--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -65,11 +65,21 @@ jobs:
             exit 0
           fi
 
-          if awk 'index($0, "docs/migration/") != 1 { found=1 } END { exit found ? 0 : 1 }' .migration-context/changed-files.txt; then
-            echo "has_impact=true" >> "$GITHUB_OUTPUT"
+          has_impact=false
+          while IFS= read -r path; do
+            case "$path" in
+              src/*|*.sln|*.slnx|Directory.Build.props|Directory.Build.targets|Directory.Packages.props|NuGet.config|global.json)
+                has_impact=true
+                break
+                ;;
+            esac
+          done < .migration-context/changed-files.txt
+
+          echo "has_impact=$has_impact" >> "$GITHUB_OUTPUT"
+          if [[ "$has_impact" == "true" ]]; then
+            echo "Migration-relevant source or package files changed; running documentation update."
           else
-            echo "has_impact=false" >> "$GITHUB_OUTPUT"
-            echo "Only docs/migration files changed in migration range; skipping self-only documentation update."
+            echo "No migration-relevant source or package files changed; skipping documentation update."
           fi
 
       - name: Install Claude Code


### PR DESCRIPTION
Narrows the migration-docs post-merge update path so it only runs for migration-relevant SDK/package inputs. Docs-only and workflow-only ranges now skip without opening no-impact state PRs.\n\nLocal validation:\n- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/migration-docs-update.yml"); puts "workflow YAML OK"'\n- dotnet toolchain.cs -- docs-qa\n- git diff --check\n- impact predicate smoke test: docs_only=false, workflow_only=false, source=true, packages=true