### PR TITLE
ci: set explicit Claude models for docs automation

### DIFF
--- a/.github/workflows/architecture-docs-monthly-synthesis.yml
+++ b/.github/workflows/architecture-docs-monthly-synthesis.yml
@@ -58,6 +58,7 @@ jobs:
             The generated context is in `.architecture-context/`.
             Improve only architecture documentation files.
           claude_args: >-
+            --model opus
             --allowedTools Read,Grep,Glob,Edit,Write,Bash
 
       - name: Enforce architecture-only edits

--- a/.github/workflows/architecture-docs-preview.yml
+++ b/.github/workflows/architecture-docs-preview.yml
@@ -41,4 +41,5 @@ jobs:
             The generated context is in `.architecture-context/`.
             Preview mode must comment on architecture diagram impact only; do not edit files.
           claude_args: >-
+            --model sonnet
             --allowedTools Read,Grep,Glob

--- a/.github/workflows/architecture-docs-scheduler-wrapper.yml
+++ b/.github/workflows/architecture-docs-scheduler-wrapper.yml
@@ -91,6 +91,7 @@ jobs:
             The generated context is in `.architecture-context/`.
             Update only the allowed architecture documentation files.
           claude_args: >-
+            --model sonnet
             --allowedTools Read,Grep,Glob,Edit,Write,Bash
 
       - name: Enforce architecture-only edits

--- a/.github/workflows/architecture-docs-update.yml
+++ b/.github/workflows/architecture-docs-update.yml
@@ -91,7 +91,7 @@ jobs:
             'Read and follow `.github/prompts/architecture-docs-post-merge.md`.' \
             'The generated context is in `.architecture-context/`.' \
             'Update only the allowed architecture documentation files.' \
-            | "$HOME/.local/bin/claude" -p --allowedTools Read,Grep,Glob,Edit,Write,Bash
+            | "$HOME/.local/bin/claude" -p --model sonnet --allowedTools Read,Grep,Glob,Edit,Write,Bash
 
       - name: Enforce architecture-only edits
         if: ${{ steps.impact.outputs.has_affected == 'true' }}

--- a/.github/workflows/migration-docs-monthly-synthesis.yml
+++ b/.github/workflows/migration-docs-monthly-synthesis.yml
@@ -50,6 +50,7 @@ jobs:
             The generated context is in `.migration-context/`.
             Improve only migration documentation files.
           claude_args: >-
+            --model opus
             --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration synthesis PR

--- a/.github/workflows/migration-docs-preview.yml
+++ b/.github/workflows/migration-docs-preview.yml
@@ -42,4 +42,5 @@ jobs:
             The generated context is in `.migration-context/`.
             Preview mode must comment on migration impact only; do not edit files.
           claude_args: >-
+            --model sonnet
             --allowedTools Read,Grep,Glob

--- a/.github/workflows/migration-docs-scheduler-wrapper.yml
+++ b/.github/workflows/migration-docs-scheduler-wrapper.yml
@@ -59,6 +59,7 @@ jobs:
             The generated context is in `.migration-context/`.
             Update only the allowed migration documentation files.
           claude_args: >-
+            --model sonnet
             --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Create migration documentation PR

--- a/.github/workflows/migration-docs-update.yml
+++ b/.github/workflows/migration-docs-update.yml
@@ -97,7 +97,7 @@ jobs:
             'Read and follow `.github/prompts/migration-docs-post-merge.md`.' \
             'The generated context is in `.migration-context/`.' \
             'Update only the allowed migration documentation files.' \
-            | "$HOME/.local/bin/claude" -p --allowedTools Read,Grep,Glob,Edit,Write
+            | "$HOME/.local/bin/claude" -p --model sonnet --allowedTools Read,Grep,Glob,Edit,Write
 
       - name: Set up .NET SDK
         if: ${{ steps.impact.outputs.has_impact == 'true' }}


### PR DESCRIPTION
Makes Claude model selection explicit for docs automation.

- Routine preview/post-merge/scheduler docs workflows use `--model sonnet`.
- Monthly synthesis workflows use `--model opus`.

Local validation:
- ruby -e 'require "yaml"; Dir[".github/workflows/*docs*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow YAML OK"'
- dotnet toolchain.cs -- docs-qa
- git diff --check