### PR TITLE
feat: yubikit-hid-hardening

### DIFF
--- a/docs/architecture/event-driven-device-discovery.md
+++ b/docs/architecture/event-driven-device-discovery.md
@@ -1,4 +1,4 @@
-@arh# Event-Driven Device Discovery Architecture
+# Event-Driven Device Discovery Architecture
 
 ## Before vs After
 
@@ -6,57 +6,21 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────┐
-│                         DeviceMonitorService                                 │
-│                         (BackgroundService)                                  │
+│                       Legacy timer-based polling                             │
 ├─────────────────────────────────────────────────────────────────────────────┤
-│                                                                              │
-│    ┌──────────────────┐                                                      │
-│    │  PeriodicTimer   │◄─── 500ms interval                                   │
-│    │    (polling)     │                                                      │
-│    └────────┬─────────┘                                                      │
-│             │                                                                │
-│             ▼ Every 500ms                                                    │
-│    ┌────────────────────────────────────────────────────────────┐            │
-│    │              Task.Run() - Async-over-sync 😞               │            │
-│    ├────────────────────┬───────────────────────────────────────┤            │
-│    │                    │                                       │            │
-│    ▼                    ▼                                       │            │
-│ ┌─────────────────┐  ┌─────────────────┐                        │            │
-│ │ FindPcscDevices │  │  FindHidDevices │                        │            │
-│ │                 │  │                 │                        │            │
-│ │ SCardGetStatus  │  │ Full platform   │                        │            │
-│ │ Change(0)       │  │ enumeration     │                        │            │
-│ │ ▲               │  │ every cycle     │                        │            │
-│ │ │ timeout=0     │  │                 │                        │            │
-│ │ │ (immediate)   │  │ • udev_enum     │                        │            │
-│ │ └───────────────┤  │ • IOHIDManager  │                        │            │
-│ └─────────────────┘  │   CopyDevices   │                        │            │
-│                      │ • Windows: N/A  │                        │            │
-│                      └─────────────────┘                        │            │
-│    └────────────────────────────────────────────────────────────┘            │
-│             │                                                                │
-│             ▼                                                                │
-│    ┌─────────────────┐                                                       │
-│    │  DeviceChannel  │◄─── Push all devices found                            │
-│    │   (Channel<T>)  │                                                       │
-│    └────────┬────────┘                                                       │
-│             │                                                                │
-└─────────────┼────────────────────────────────────────────────────────────────┘
-              │
-              ▼
-     ┌─────────────────────┐
-     │ DeviceListenerService│
-     │  (consumes channel)  │
-     └──────────┬──────────┘
-                │
-                ▼
-     ┌─────────────────────┐
-     │DeviceRepositoryCached│
-     │   (IObservable<>)    │
-     └──────────┬──────────┘
-                │
-                ▼
-         Application
+│  PeriodicTimer (500ms)                                                       │
+│      │                                                                       │
+│      ▼                                                                       │
+│  Task.Run() async-over-sync scan                                             │
+│      ├─ PC/SC scan: SCardGetStatusChange(timeout=0)                           │
+│      └─ HID scan: full platform enumeration every cycle                        │
+│      │                                                                       │
+│      ▼                                                                       │
+│  Cache update + observable device notifications                              │
+│      │                                                                       │
+│      ▼                                                                       │
+│  Application                                                                 │
+└─────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **Problems:**
@@ -72,86 +36,36 @@
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────────────────┐
-│                              DeviceMonitorService                                    │
-│                              (BackgroundService)                                     │
+│                         YubiKeyDeviceMonitorService                                  │
+│                         (plain async service)                                         │
 ├─────────────────────────────────────────────────────────────────────────────────────┤
-│                                                                                      │
-│  ┌──────────────────────────────────────────────────────────────────────────────┐   │
-│  │                         Platform Event Listeners                              │   │
-│  │                         (Dedicated Background Threads)                        │   │
-│  ├──────────────────────────┬──────────────────────────────────────────────────┤   │
-│  │                          │                                                   │   │
-│  │  ┌────────────────────┐  │  ┌─────────────────────────────────────────────┐ │   │
-│  │  │DesktopSmartCard    │  │  │            HidDeviceListener                │ │   │
-│  │  │DeviceListener      │  │  │            (abstract base)                  │ │   │
-│  │  │                    │  │  │                                             │ │   │
-│  │  │ ISmartCardDevice   │  │  │  ┌─────────────┬─────────────┬───────────┐ │ │   │
-│  │  │ Listener (interface)│  │  │  │  Windows   │   macOS     │   Linux   │ │ │   │
-│  │  │                    │  │  │  │            │             │           │ │ │   │
-│  │  │ SCardGetStatus     │  │  │  │ CM_Register│ IOHIDManager│ udev_     │ │ │   │
-│  │  │ Change(1000ms)     │  │  │  │ Notification│ + CFRunLoop │ monitor   │ │ │   │
-│  │  │      │             │  │  │  │   ▲        │   ▲         │ + poll()  │ │ │   │
-│  │  │      │ Blocks up   │  │  │  │   │callback│   │callback │   ▲       │ │ │   │
-│  │  │      │ to 1000ms   │  │  │  │   │        │   │         │   │eventfd│ │ │   │
-│  │  │      ▼             │  │  │  └───┼────────┴───┼─────────┴───┼───────┘ │ │   │
-│  │  │ Checks _isListening│  │  │      │            │             │         │ │   │
-│  │  │ flag, loops        │  │  │      │ OS notifies│ OS notifies │ fd ready│ │   │
-│  │  └────────┬───────────┘  │  └──────┴────────────┴─────────────┴─────────┘ │   │
-│  │           │              │                        │                       │   │
-│  └───────────┼──────────────┴────────────────────────┼───────────────────────┘   │
-│              │                                       │                           │
-│              │  Rescan trigger                       │  Rescan hint              │
-│              │  callback                             │  callback                 │
-│              ▼                                       ▼                           │
-│         ┌─────────────────────────────────────────────────┐                      │
-│         │              Channel write                       │                      │
-│         │         single-reader debounce queue             │                      │
-│         └───────────────────────┬─────────────────────────┘                      │
-│                                 │                                                │
-│                                 ▼                                                │
-│         ┌─────────────────────────────────────────────────┐                      │
-│         │           Event Coalescing Loop                  │                      │
-│         │                                                  │                      │
-│         │  await channel.Reader.WaitToReadAsync()          │                      │
-│         │  await Task.Delay(200ms) ◄── Coalesce rapid      │                      │
-│         │  drain queued triggers      events               │                      │
-│         │  PerformDeviceScan()                             │                      │
-│         └───────────────────────┬─────────────────────────┘                      │
-│                                 │                                                │
-│                                 ▼                                                │
-│    ┌────────────────────────────────────────────────────────────┐                │
-│    │              Enumeration (only after event)                │                │
-│    ├────────────────────┬───────────────────────────────────────┤                │
-│    │                    │                                       │                │
-│    ▼                    ▼                                       │                │
-│ ┌─────────────────┐  ┌─────────────────┐                        │                │
-│ │ FindPcscDevices │  │  FindHidDevices │  ◄── Only runs when    │                │
-│ │   (snapshot)    │  │   (snapshot)    │      event received    │                │
-│ └─────────────────┘  └─────────────────┘                        │                │
-│    └────────────────────────────────────────────────────────────┘                │
-│                                 │                                                │
-│                                 ▼                                                │
-│                     ┌─────────────────┐                                          │
-│                     │  DeviceChannel  │                                          │
-│                     │   (Channel<T>)  │                                          │
-│                     └────────┬────────┘                                          │
-│                              │                                                   │
-└──────────────────────────────┼───────────────────────────────────────────────────┘
-                               │
-                               ▼
-                    ┌─────────────────────┐
-                    │ DeviceListenerService│
-                    │  (consumes channel)  │
-                    └──────────┬──────────┘
-                               │
-                               ▼
-                    ┌─────────────────────┐
-                    │DeviceRepositoryCached│
-                    │   (IObservable<>)    │
-                    └──────────┬──────────┘
-                               │
-                               ▼
-                        Application
+│  Platform listeners                                                                  │
+│    ├─ DesktopSmartCardDeviceListener: SCardGetStatusChange(1000ms)                   │
+│    └─ HidDeviceListener: Windows/macOS/Linux OS notifications                        │
+│             │                                                                        │
+│             ▼                                                                        │
+│  Channel<DeviceMonitorRescanRequest> (single reader)                                 │
+│             │                                                                        │
+│             ▼                                                                        │
+│  Event coalescing loop                                                               │
+│    ├─ initial RescanCoreAsync() at monitor startup                                   │
+│    ├─ listener hints wait for a 200ms quiet period                                   │
+│    ├─ each new hint re-arms the quiet period                                         │
+│    ├─ MaxCoalesceInterval = 5 × ThrottleInterval caps a hint storm                   │
+│    └─ periodic interval fallback triggers a rescan when no listener hint arrives     │
+│             │                                                                        │
+│             ▼                                                                        │
+│  RescanCoreAsync()                                                                   │
+│    ├─ IFindYubiKeys.FindAllAsync(ConnectionType.All, ...)                            │
+│    └─ YubiKeyDeviceRepository.UpdateCache(discoveredDevices)                         │
+│             │                                                                        │
+│             ▼                                                                        │
+│  YubiKeyDeviceRepository.DeviceChanges                                               │
+│    └─ repository-diffed DeviceEvent Added/Removed notifications                      │
+│             │                                                                        │
+│             ▼                                                                        │
+│  Application                                                                         │
+└─────────────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -168,10 +82,9 @@
 │ ISmartCardDeviceListener│         │   HidDeviceListener     │
 │      (interface)        │         │    (abstract class)     │
 ├─────────────────────────┤         ├─────────────────────────┤
-│ + DeviceEvent callback  │         │ + DeviceEvent callback  │
+│ + DeviceEvent callback  │         │ + DeviceEvent : Action<HidDeviceRescanHint> │
 │ + Status { get; }       │         │ + Status { get; set; }  │
 └────────────┬────────────┘         │ # OnDeviceEvent(hint)   │
-             │                      │ + HidDeviceRescanHint   │
              │                      │ + Create() : static     │
              ▼                      └────────────┬────────────┘
 ┌─────────────────────────┐                      │
@@ -228,36 +141,14 @@ Why different patterns?
 ## Event Flow Sequence
 
 ```
-         YubiKey              OS                  Listener            Service           App
-           │                  │                      │                   │               │
-           │ Insert device    │                      │                   │               │
-           ├─────────────────►│                      │                   │               │
-           │                  │                      │                   │               │
-           │                  │ Device notification  │                   │               │
-           │                  ├─────────────────────►│                   │               │
-           │                  │                      │                   │               │
-           │                  │                      │ Rescan hint       │               │
-           │                  │                      ├──────────────────►│               │
-           │                  │                      │                   │               │
-           │                  │                      │                   │ Channel write │
-           │                  │                      │                   │ (single read) │
-           │                  │                      │                   │               │
-           │                  │                      │                   │◄──────────────┤
-           │                  │                      │                   │ Wait 200ms    │
-           │                  │                      │                   │ (coalesce)    │
-           │                  │                      │                   │               │
-           │                  │                      │                   │ Drain queue   │
-           │                  │                      │                   │               │
-           │                  │                      │                   │ FindAll()     │
-           │                  │                      │                   ├───────────────┤
-           │                  │                      │                   │               │
-           │                  │                      │                   │ DeviceChannel │
-           │                  │                      │                   │ .Write()      │
-           │                  │                      │                   ├──────────────►│
-           │                  │                      │                   │               │
-           │                  │                      │                   │               │ DeviceChanges
-           │                  │                      │                   │               │ (Added)
-           │                  │                      │                   │               ├──────────►
+YubiKey/OS ──device notification──► Platform listener
+Platform listener ──rescan callback/hint──► YubiKeyDeviceMonitorService
+YubiKeyDeviceMonitorService ──TryWrite──► Channel<DeviceMonitorRescanRequest>
+Single reader ──drain queued requests──► 200ms quiet period (re-arms on new hints)
+Single reader ──cap reached or quiet period elapsed──► RescanCoreAsync()
+RescanCoreAsync() ──FindAllAsync snapshot──► YubiKeyDeviceRepository.UpdateCache()
+YubiKeyDeviceRepository ──diff──► DeviceChanges (DeviceAction.Added/Removed)
+Application subscription ◄──DeviceEvent── YubiKeyManager.DeviceChanges
 ```
 
 ---
@@ -272,7 +163,7 @@ Why different patterns?
 | **HID Windows** | ❌ Not implemented | ✅ CM_Register_Notification |
 | **HID macOS** | Full enumeration | ✅ IOHIDManager callbacks |
 | **HID Linux** | udev_enumerate | ✅ udev_monitor + poll() |
-| **Event Coalescing** | None | Single-reader queue + 200ms debounce |
+| **Event Coalescing** | None | Single-reader queue + 200ms quiet period capped at `MaxCoalesceInterval` |
 | **Cancellation** | Unreliable | Responsive (eventfd/run-loop stop/PCSC timeout) |
 
 ---
@@ -313,24 +204,21 @@ HID: macOS stops its run loop directly; Linux polls the udev monitor and an expl
 ## Files Created/Modified
 
 ```
-Yubico.YubiKit.Core/
-├── src/
-│   ├── DeviceMonitorService.cs              ◄── MODIFIED: Event-driven loop
-│   ├── SmartCard/
-│   │   ├── ISmartCardDeviceListener.cs      ◄── NEW: Interface
-│   │   └── DesktopSmartCardDeviceListener.cs◄── NEW: Implementation
-│   ├── Hid/
-│   │   ├── HidDeviceListener.cs             ◄── NEW: Abstract base
-│   │   ├── NullDevice.cs                    ◄── NEW: Placeholder for removals
-│   │   ├── Windows/
-│   │   │   └── WindowsHidDeviceListener.cs  ◄── NEW
-│   │   ├── MacOS/
-│   │   │   └── MacOSHidDeviceListener.cs    ◄── NEW
-│   │   └── Linux/
-│   │       └── LinuxHidDeviceListener.cs    ◄── NEW
-│   ├── PlatformInterop/
-│   │   └── Linux/Libc/
-│   │       └── Libc.Interop.cs              ◄── MODIFIED: Added poll()
-│   └── YubiKey/
-│       └── YubiKeyManagerOptions.cs         ◄── MODIFIED: EventCoalescingDelay
+src/Core/src/
+├── Devices/
+│   ├── YubiKeyDeviceMonitorService.cs        ◄── Event-driven monitor loop
+│   ├── YubiKeyDeviceRepository.cs            ◄── Repository-diffed DeviceChanges
+│   ├── IYubiKeyDeviceMonitorService.cs       ◄── Monitor contract
+│   ├── IYubiKeyDeviceRepository.cs           ◄── Cache contract
+│   └── YubiKeyManager.cs                     ◄── Static public entry point
+└── Transports/
+    ├── SmartCard/
+    │   ├── ISmartCardDeviceListener.cs       ◄── Listener interface
+    │   └── DesktopSmartCardDeviceListener.cs ◄── PC/SC implementation
+    └── Hid/
+        ├── HidDeviceListener.cs              ◄── Abstract listener base
+        ├── HidDeviceRescanHint.cs            ◄── Diagnostic rescan hint
+        ├── Windows/WindowsHidDeviceListener.cs
+        ├── MacOS/MacOSHidDeviceListener.cs
+        └── Linux/LinuxHidDeviceListener.cs
 ```

--- a/docs/architecture/event-driven-device-discovery.md
+++ b/docs/architecture/event-driven-device-discovery.md
@@ -92,7 +92,7 @@
 │  │  │ Change(1000ms)     │  │  │  │ Notification│ + CFRunLoop │ monitor   │ │ │   │
 │  │  │      │             │  │  │  │   ▲        │   ▲         │ + poll()  │ │ │   │
 │  │  │      │ Blocks up   │  │  │  │   │callback│   │callback │   ▲       │ │ │   │
-│  │  │      │ to 1000ms   │  │  │  │   │        │   │         │   │100ms  │ │ │   │
+│  │  │      │ to 1000ms   │  │  │  │   │        │   │         │   │eventfd│ │ │   │
 │  │  │      ▼             │  │  │  └───┼────────┴───┼─────────┴───┼───────┘ │ │   │
 │  │  │ Checks _isListening│  │  │      │            │             │         │ │   │
 │  │  │ flag, loops        │  │  │      │ OS notifies│ OS notifies │ fd ready│ │   │
@@ -100,21 +100,21 @@
 │  │           │              │                        │                       │   │
 │  └───────────┼──────────────┴────────────────────────┼───────────────────────┘   │
 │              │                                       │                           │
-│              │  Arrived/Removed                      │  Arrived/Removed          │
-│              │  events                               │  events                   │
+│              │  Rescan trigger                       │  Rescan hint              │
+│              │  callback                             │  callback                 │
 │              ▼                                       ▼                           │
 │         ┌─────────────────────────────────────────────────┐                      │
-│         │              SignalEvent()                       │                      │
-│         │         _eventSemaphore.Release()                │                      │
+│         │              Channel write                       │                      │
+│         │         single-reader debounce queue             │                      │
 │         └───────────────────────┬─────────────────────────┘                      │
 │                                 │                                                │
 │                                 ▼                                                │
 │         ┌─────────────────────────────────────────────────┐                      │
 │         │           Event Coalescing Loop                  │                      │
 │         │                                                  │                      │
-│         │  await _eventSemaphore.WaitAsync()               │                      │
+│         │  await channel.Reader.WaitToReadAsync()          │                      │
 │         │  await Task.Delay(200ms) ◄── Coalesce rapid      │                      │
-│         │  drain remaining signals    events               │                      │
+│         │  drain queued triggers      events               │                      │
 │         │  PerformDeviceScan()                             │                      │
 │         └───────────────────────┬─────────────────────────┘                      │
 │                                 │                                                │
@@ -168,11 +168,10 @@
 │ ISmartCardDeviceListener│         │   HidDeviceListener     │
 │      (interface)        │         │    (abstract class)     │
 ├─────────────────────────┤         ├─────────────────────────┤
-│ + Arrived event         │         │ + Arrived event         │
-│ + Removed event         │         │ + Removed event         │
+│ + DeviceEvent callback  │         │ + DeviceEvent callback  │
 │ + Status { get; }       │         │ + Status { get; set; }  │
-└────────────┬────────────┘         │ # OnArrived(device)     │
-             │                      │ # OnRemoved(device)     │
+└────────────┬────────────┘         │ # OnDeviceEvent(hint)   │
+             │                      │ + HidDeviceRescanHint   │
              │                      │ + Create() : static     │
              ▼                      └────────────┬────────────┘
 ┌─────────────────────────┐                      │
@@ -211,16 +210,16 @@ Why different patterns?
 │ Notification     │  │ Create()         │  │ new_from_netlink │
 │     │            │  │     │            │  │     │            │
 │     ▼            │  │     ▼            │  │     ▼            │
-│ Callback from OS │  │ CFRunLoop        │  │ poll(fd, 100ms)  │
+│ Callback from OS │  │ CFRunLoop        │  │ poll(monitor+fd) │
 │ on device change │  │ RunInMode(100ms) │  │     │            │
 │     │            │  │     │            │  │     ▼            │
 │     ▼            │  │     ▼            │  │ udev_monitor_    │
-│ OnArrived() or   │  │ Matching/Removal │  │ receive_device   │
-│ OnRemoved()      │  │ callbacks fire   │  │     │            │
+│ Rescan hint      │  │ Matching/Removal │  │ receive_device   │
+│ callback         │  │ callbacks fire   │  │     │            │
 │                  │  │     │            │  │     ▼            │
 │ GCHandle pins    │  │     ▼            │  │ Check action:    │
-│ callback delegate│  │ OnArrived() or   │  │ add → OnArrived  │
-│                  │  │ OnRemoved()      │  │ remove→OnRemoved │
+│ callback delegate│  │ Rescan hint      │  │ add/remove hint  │
+│                  │  │ callback         │  │ stable identity  │
 └──────────────────┘  └──────────────────┘  └──────────────────┘
 ```
 
@@ -237,17 +236,17 @@ Why different patterns?
            │                  │ Device notification  │                   │               │
            │                  ├─────────────────────►│                   │               │
            │                  │                      │                   │               │
-           │                  │                      │ Arrived event     │               │
+           │                  │                      │ Rescan hint       │               │
            │                  │                      ├──────────────────►│               │
            │                  │                      │                   │               │
-           │                  │                      │                   │ SignalEvent() │
-           │                  │                      │                   │ semaphore++   │
+           │                  │                      │                   │ Channel write │
+           │                  │                      │                   │ (single read) │
            │                  │                      │                   │               │
            │                  │                      │                   │◄──────────────┤
            │                  │                      │                   │ Wait 200ms    │
            │                  │                      │                   │ (coalesce)    │
            │                  │                      │                   │               │
-           │                  │                      │                   │ Drain sema    │
+           │                  │                      │                   │ Drain queue   │
            │                  │                      │                   │               │
            │                  │                      │                   │ FindAll()     │
            │                  │                      │                   ├───────────────┤
@@ -256,8 +255,8 @@ Why different patterns?
            │                  │                      │                   │ .Write()      │
            │                  │                      │                   ├──────────────►│
            │                  │                      │                   │               │
-           │                  │                      │                   │               │ DeviceEvent
-           │                  │                      │                   │               │ (Arrived)
+           │                  │                      │                   │               │ DeviceChanges
+           │                  │                      │                   │               │ (Added)
            │                  │                      │                   │               ├──────────►
 ```
 
@@ -273,8 +272,8 @@ Why different patterns?
 | **HID Windows** | ❌ Not implemented | ✅ CM_Register_Notification |
 | **HID macOS** | Full enumeration | ✅ IOHIDManager callbacks |
 | **HID Linux** | udev_enumerate | ✅ udev_monitor + poll() |
-| **Event Coalescing** | None | 200ms debounce |
-| **Cancellation** | Unreliable | Responsive (100-1000ms) |
+| **Event Coalescing** | None | Single-reader queue + 200ms debounce |
+| **Cancellation** | Unreliable | Responsive (eventfd/run-loop stop/PCSC timeout) |
 
 ---
 
@@ -306,7 +305,7 @@ INFINITE timeout (0xFFFFFFFF):
 │ }                                                            │
 └──────────────────────────────────────────────────────────────┘
 
-HID: 100ms poll/CFRunLoop timeout for same reason
+HID: macOS stops its run loop directly; Linux polls the udev monitor and an explicit shutdown event fd.
 ```
 
 ---

--- a/docs/migration/v1-to-v2-changelog.md
+++ b/docs/migration/v1-to-v2-changelog.md
@@ -16,5 +16,5 @@
 
 ## 2026-07-06 - HID listener rescan hint migration note
 
-- Added `hid-listener-rescan-hints` migration guidance for the 2.0 break where low-level HID listener callbacks now carry `HidDeviceRescanHint` diagnostics.
-- Clarified that listener hints are rescan triggers only; public `YubiKeyManager.DeviceChanges` remains repository-diffed Added/Removed truth.
+- Added `hid-listener-rescan-hints` migration guidance for the change from v1 `Yubico.Core.Devices.Hid.HidDeviceListener.Arrived`/`Removed` events (`EventHandler<HidDeviceEventArgs>`) to the v2 low-level `HidDeviceListener.DeviceEvent` callback carrying `HidDeviceRescanHint` diagnostics.
+- Clarified that v2 HID listener hints are rescan triggers only; public `YubiKeyManager.DeviceChanges` remains repository-diffed Added/Removed truth.

--- a/docs/migration/v1-to-v2-changelog.md
+++ b/docs/migration/v1-to-v2-changelog.md
@@ -13,3 +13,8 @@
 - Added an assisted, high-confidence mapping (`session-creation-extension-methods`) documenting that every v2 applet package now exposes an `IYubiKey.Create{Applet}SessionAsync(...)` extension method as the standard v2 session-construction entry point, and referenced it from the Session Lifecycle section of the migration guide.
 - The bulk of the analyzed range is v2-internal: device discovery/composite-device internals, APDU/CTAPHID protocol fixes, WebAuthn Swift/Rust exploration and documentation, previewSign/ARKG experimental API notes, and documentation/CI automation tooling. None of this required new v1-to-v2 mapping guidance beyond the session-construction update above; existing manual-review guidance for device discovery, transport selection, and security-sensitive flows still applies.
 - Advanced `docs/migration/.state.yml` `last_analyzed_commit` to `5a82db9bce05addc0385162e9f085adbc2366c5b`.
+
+## 2026-07-06 - HID listener rescan hint migration note
+
+- Added `hid-listener-rescan-hints` migration guidance for the 2.0 break where low-level HID listener callbacks now carry `HidDeviceRescanHint` diagnostics.
+- Clarified that listener hints are rescan triggers only; public `YubiKeyManager.DeviceChanges` remains repository-diffed Added/Removed truth.

--- a/docs/migration/v1-to-v2-map.yml
+++ b/docs/migration/v1-to-v2-map.yml
@@ -81,6 +81,18 @@ mappings:
       - yubikit:src/Core/
     notes: Discovery, transport selection, and connection ownership must be reviewed at call sites.
     last_reviewed_commit: e348013685d92a6a665cd0b8bd7e8b05850fddd5
+  - id: hid-listener-rescan-hints
+    status: manual
+    confidence: high
+    migration_kind: behavior
+    v1: Low-level HID listener DeviceEvent parameterless callbacks
+    v2: HidDeviceListener.DeviceEvent callbacks carrying HidDeviceRescanHint diagnostics
+    evidence:
+      - yubikit:src/Core/src/Transports/Hid/HidDeviceListener.cs
+      - yubikit:src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
+      - yubikit:src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
+    notes: Direct HID listener consumers must update callback signatures and must not treat listener hints as public physical-device truth. Use YubiKeyManager.DeviceChanges for repository-diffed Added/Removed events.
+    last_reviewed_commit: pending
   - id: session-lifecycle
     status: manual
     confidence: medium
@@ -206,6 +218,7 @@ mappings:
     last_reviewed_commit: 5a82db9bce05addc0385162e9f085adbc2366c5b
 manual_review:
   - device discovery call sites
+  - low-level HID listener DeviceEvent callback signatures
   - transport selection assumptions
   - session construction and disposal
   - authentication, PIN, PUK, password, and key material handling

--- a/docs/migration/v1-to-v2-map.yml
+++ b/docs/migration/v1-to-v2-map.yml
@@ -85,14 +85,20 @@ mappings:
     status: manual
     confidence: high
     migration_kind: behavior
-    v1: Low-level HID listener DeviceEvent parameterless callbacks
-    v2: HidDeviceListener.DeviceEvent callbacks carrying HidDeviceRescanHint diagnostics
+    v1: Yubico.Core.Devices.Hid.HidDeviceListener Arrived/Removed events (EventHandler<HidDeviceEventArgs>) carrying IHidDevice payloads
+    v2: Yubico.YubiKit.Core.Transports.Hid.HidDeviceListener.DeviceEvent callback (Action<HidDeviceRescanHint>?) carrying diagnostic rescan hints
     evidence:
+      - develop:Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceListener.cs
+      - develop:Yubico.Core/src/Yubico/Core/Devices/Hid/HidDeviceEventArgs.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDeviceListener.cs
+      - develop:Yubico.YubiKey/src/Yubico/YubiKey/YubiKeyDevice.Static.cs
       - yubikit:src/Core/src/Transports/Hid/HidDeviceListener.cs
       - yubikit:src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
       - yubikit:src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
-    notes: Direct HID listener consumers must update callback signatures and must not treat listener hints as public physical-device truth. Use YubiKeyManager.DeviceChanges for repository-diffed Added/Removed events.
-    last_reviewed_commit: pending
+      - yubikit:src/Core/src/Devices/YubiKeyDeviceRepository.cs
+      - yubikit:src/Core/src/Devices/YubiKeyManager.cs
+    notes: V1 low-level HID consumers handled Arrived/Removed EventHandler<HidDeviceEventArgs> events with per-HID-device payloads, while v1 device-level consumers used YubiKeyDeviceListener.Arrived/Removed and YubiKeyDevice.FindAll() over the listener cache. V2 low-level HID DeviceEvent is only a diagnostic rescan hint (HidDeviceChangeKind plus optional platform id/path), not public physical-device truth. Use YubiKeyManager.DeviceChanges for repository-diffed Added/Removed events after YubiKeyDeviceRepository.UpdateCache.
+    last_reviewed_commit: b1744cb36974ba8885fc7d9c007fe9fc5012b225
   - id: session-lifecycle
     status: manual
     confidence: medium

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -27,6 +27,10 @@ Review code that assumes:
 - A device object that directly owns all applet operations.
 - Synchronous connection setup for operations that are async in v2.
 
+### HID Listener Callbacks
+
+The low-level `HidDeviceListener.DeviceEvent` callback now receives a `HidDeviceRescanHint` instead of a parameterless `Action`. This is a 2.0 breaking change for direct HID listener consumers. Treat the hint as diagnostic input for triggering discovery only; it is not authoritative physical-device state. Applications that need real YubiKey arrivals and removals should use `YubiKeyManager.DeviceChanges`, which is emitted after the device repository rescans and diffs the discovered device set.
+
 ## Session Lifecycle
 
 V2 application sessions are applet-specific and commonly own connection/protocol state. Prefer the v2 session factory or constructor pattern documented by each applet package rather than carrying v1 session setup forward mechanically.

--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -29,7 +29,7 @@ Review code that assumes:
 
 ### HID Listener Callbacks
 
-The low-level `HidDeviceListener.DeviceEvent` callback now receives a `HidDeviceRescanHint` instead of a parameterless `Action`. This is a 2.0 breaking change for direct HID listener consumers. Treat the hint as diagnostic input for triggering discovery only; it is not authoritative physical-device state. Applications that need real YubiKey arrivals and removals should use `YubiKeyManager.DeviceChanges`, which is emitted after the device repository rescans and diffs the discovered device set.
+V1 low-level HID listeners used `Yubico.Core.Devices.Hid.HidDeviceListener.Arrived` and `Removed` events (`EventHandler<HidDeviceEventArgs>`) carrying the affected `IHidDevice`. V1 YubiKey-level monitoring used `YubiKeyDeviceListener.Arrived`/`Removed` and the `YubiKeyDevice.FindAll()` cache. In v2, the low-level `Yubico.YubiKit.Core.Transports.Hid.HidDeviceListener.DeviceEvent` callback is `Action<HidDeviceRescanHint>?`: a diagnostic rescan hint with `HidDeviceChangeKind` plus optional platform identifier/path. It is not authoritative physical-device state. Applications that need real YubiKey arrivals and removals should use `YubiKeyManager.DeviceChanges`, which is emitted after the device repository rescans and diffs the discovered device set.
 
 ## Session Lifecycle
 

--- a/docs/usage/device-discovery.md
+++ b/docs/usage/device-discovery.md
@@ -34,7 +34,7 @@ The `YubiKeyManager` class is a **static-only API** - no dependency injection or
 | `StartMonitoring(TimeSpan)` | Start monitoring with custom interval |
 | `StopMonitoring()` | Stop monitoring |
 | `IsMonitoring` | Check if monitoring is active |
-| `DeviceChanges` | Observable sequence of device events |
+| `DeviceChanges` | Observable sequence of repository-diffed device events |
 
 ### Lifecycle Methods
 
@@ -69,7 +69,7 @@ using var subscription = YubiKeyManager.DeviceChanges.Subscribe(e =>
 {
     switch (e.Action)
     {
-        case DeviceAction.Arrived:
+        case DeviceAction.Added:
             Console.WriteLine($"Device connected: {e.Device.SerialNumber}");
             break;
         case DeviceAction.Removed:
@@ -86,6 +86,11 @@ YubiKeyManager.StartMonitoring();
 // Clean up
 await YubiKeyManager.ShutdownAsync();
 ```
+
+`StartMonitoring()` performs an initial repository rescan. Native SmartCard and HID listener notifications are
+treated as rescan triggers only. Public `DeviceChanges` events are emitted from repository diffs after discovery,
+so a raw HID listener notification is not itself authoritative evidence that a YubiKey physical device was added
+or removed.
 
 ### Custom Monitoring Interval
 
@@ -202,4 +207,5 @@ Key changes:
 All `YubiKeyManager` methods are thread-safe:
 - `FindAllAsync()` can be called from multiple threads concurrently
 - `StartMonitoring()` and `StopMonitoring()` are idempotent
+- Listener notifications are serialized through a single-reader debounce queue before rescans
 - `DeviceChanges` events may be delivered on any thread

--- a/docs/usage/device-discovery.md
+++ b/docs/usage/device-discovery.md
@@ -5,13 +5,14 @@ This guide covers how to discover and monitor YubiKey devices using the static `
 ## Quick Start
 
 ```csharp
+using System;
 using Yubico.YubiKit.Core.Devices;
 
 // Find all connected YubiKeys
 var devices = await YubiKeyManager.FindAllAsync();
 foreach (var device in devices)
 {
-    Console.WriteLine($"Found YubiKey: {device.SerialNumber}");
+    Console.WriteLine($"Found YubiKey: {device.DeviceId} ({device.AvailableConnections})");
 }
 ```
 
@@ -61,21 +62,22 @@ var hidDevices = await YubiKeyManager.FindAllAsync(ConnectionType.Hid);
 For applications that need to react to device connections/disconnections:
 
 ```csharp
+using System;
 using System.Reactive.Linq;
+using Yubico.YubiKit.Core;
 using Yubico.YubiKit.Core.Devices;
 
 // Subscribe to device events
 using var subscription = YubiKeyManager.DeviceChanges.Subscribe(e =>
 {
-    switch (e.Action)
+    var message = e.Action switch
     {
-        case DeviceAction.Added:
-            Console.WriteLine($"Device connected: {e.Device.SerialNumber}");
-            break;
-        case DeviceAction.Removed:
-            Console.WriteLine($"Device removed: {e.Device.SerialNumber}");
-            break;
-    }
+        DeviceAction.Added => "connected",
+        DeviceAction.Removed => "removed",
+        _ => "changed"
+    };
+
+    Console.WriteLine($"Device {message}: {e.Device.DeviceId} ({e.Device.AvailableConnections})");
 });
 
 // Start monitoring (events won't flow until this is called)

--- a/src/Core/CLAUDE.md
+++ b/src/Core/CLAUDE.md
@@ -208,6 +208,10 @@ Management. Applet session extensions choose a transport via a documented defaul
 
 `ConnectionType` is a `[Flags]` enum with explicit values. `HidFido`, `HidOtp`, and `SmartCard` represent concrete discovered device interfaces. `Hid` is a group filter that includes both HID FIDO and HID OTP interfaces when used with discovery/cache filtering APIs. `Unknown` matches no devices.
 
+### Listener Event Semantics
+
+HID listeners expose typed `HidDeviceRescanHint` callbacks. These hints are diagnostic only and are never public physical-device truth. `YubiKeyManager.DeviceChanges` must remain repository-diffed output after a rescan. Unknown HID removals still trigger a rescan fallback rather than being suppressed, because the removed interface may be the only native signal for a physical-device diff.
+
 ## Session Base Class
 
 `ApplicationSession` centralizes shared session state:

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -52,6 +52,13 @@ var hidDevices = await YubiKeyManager.FindAllAsync(ConnectionType.Hid);
 var fidoDevices = await YubiKeyManager.FindAllAsync(ConnectionType.HidFido);
 ```
 
+### Device Monitoring
+
+`YubiKeyManager.StartMonitoring()` starts platform listeners and performs an initial repository rescan. Listener
+notifications are only rescan hints; public `YubiKeyManager.DeviceChanges` events are emitted after discovery
+updates the repository and computes an `Added` or `Removed` diff. This means an OS-level HID notification does
+not by itself mean a public YubiKey device was added or removed.
+
 ### Opening a Connection
 
 Open a specific interface with the typed overload. The parameterless `ConnectAsync()` is only for

--- a/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
+++ b/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
@@ -13,9 +13,8 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Threading.Channels;
-using Yubico.YubiKit.Core.Devices;
-using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Transports.Hid;
 using Yubico.YubiKit.Core.Transports.SmartCard;
 
@@ -32,18 +31,30 @@ namespace Yubico.YubiKit.Core.Devices;
 internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 {
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger<YubiKeyDeviceMonitorService>();
-    private static readonly TimeSpan ThrottleInterval = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// Quiet period after the last listener hint before a coalesced repository rescan runs.
+    /// </summary>
+    internal static readonly TimeSpan ThrottleInterval = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// Maximum time listener hints may be coalesced before forcing a repository rescan.
+    /// </summary>
+    internal static readonly TimeSpan MaxCoalesceInterval = 5 * ThrottleInterval;
 
     private readonly IYubiKeyDeviceRepository _repository;
     private readonly IFindYubiKeys _findYubiKeys;
     private readonly Lock _monitorLock = new();
+    private readonly SemaphoreSlim _rescanGate = new(1, 1);
 
     // Device listeners for event-driven discovery
     private HidDeviceListener? _hidListener;
     private ISmartCardDeviceListener? _smartCardListener;
 
-    // Channel-based event coalescing. Native listener callbacks may be concurrent;
-    // the single reader is the only place that performs repository rescans.
+    // Channel-based event coalescing. Native listener callbacks may be concurrent,
+    // so a single reader serializes hint ingress and debounce. All repository
+    // rescans, including manual RescanAsync calls, are serialized through
+    // _rescanGate before updating the repository cache.
     private Channel<DeviceMonitorRescanRequest>? _rescanRequests;
 
     // Monitoring lifecycle fields
@@ -107,10 +118,18 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
     private async Task RescanCoreAsync(CancellationToken cancellationToken)
     {
-        Logger.LogDebug("Rescanning devices...");
-        var devices = await _findYubiKeys.FindAllAsync(ConnectionType.All, cancellationToken)
-            .ConfigureAwait(false);
-        _repository.UpdateCache(devices);
+        await _rescanGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            Logger.LogDebug("Rescanning devices...");
+            var devices = await _findYubiKeys.FindAllAsync(ConnectionType.All, cancellationToken)
+                .ConfigureAwait(false);
+            _repository.UpdateCache(devices);
+        }
+        finally
+        {
+            _rescanGate.Release();
+        }
     }
 
     /// <inheritdoc/>
@@ -121,6 +140,8 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
         lock (_monitorLock)
         {
+            ThrowIfDisposed();
+
             if (_monitoringTask is not null)
             {
                 return; // Already monitoring, idempotent
@@ -147,18 +168,43 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     /// <inheritdoc/>
     public void StopMonitoring()
     {
-        Task? taskToAwait;
-        CancellationTokenSource? ctsToDispose;
+        var (taskToAwait, ctsToDispose) = StopMonitoringCore(teardownWhenNotMonitoring: false);
+        if (taskToAwait is null)
+        {
+            return;
+        }
 
+        // Wait for monitoring loop to complete (outside lock to avoid deadlock)
+        try
+        {
+            taskToAwait.Wait(TimeSpan.FromSeconds(10));
+        }
+        catch (AggregateException)
+        {
+            // Ignore exceptions from the monitoring task - it's being stopped
+        }
+
+        ctsToDispose?.Dispose();
+
+        Logger.LogInformation("Device monitoring stopped");
+    }
+
+    private (Task? TaskToAwait, CancellationTokenSource? CtsToDispose) StopMonitoringCore(bool teardownWhenNotMonitoring)
+    {
         lock (_monitorLock)
         {
             if (_monitoringTask is null)
             {
-                return; // Not monitoring, idempotent
+                if (teardownWhenNotMonitoring)
+                {
+                    TeardownListeners();
+                }
+
+                return (null, null); // Not monitoring, idempotent
             }
 
-            taskToAwait = _monitoringTask;
-            ctsToDispose = _monitoringCts;
+            var taskToAwait = _monitoringTask;
+            var ctsToDispose = _monitoringCts;
 
             // Signal cancellation
             _monitoringCts?.Cancel();
@@ -170,29 +216,15 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
             // Teardown listeners under lock
             TeardownListeners();
+
+            return (taskToAwait, ctsToDispose);
         }
-
-        // Wait for monitoring loop to complete (outside lock to avoid deadlock)
-        if (taskToAwait is not null)
-        {
-            try
-            {
-                taskToAwait.Wait(TimeSpan.FromSeconds(10));
-            }
-            catch (AggregateException)
-            {
-                // Ignore exceptions from the monitoring task - it's being stopped
-            }
-        }
-
-        // Dispose the CancellationTokenSource
-        ctsToDispose?.Dispose();
-
-        Logger.LogInformation("Device monitoring stopped");
     }
 
     /// <summary>
-    /// Internal monitoring loop that processes debounced listener events and interval fallback scans.
+    /// Internal monitoring loop that processes listener events using a
+    /// <see cref="ThrottleInterval"/> quiet period capped by
+    /// <see cref="MaxCoalesceInterval"/>, plus interval fallback scans.
     /// </summary>
     private async Task MonitoringLoopAsync(
         TimeSpan interval,
@@ -231,6 +263,10 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         {
             // Expected during shutdown
         }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex, "monitoring loop terminated unexpectedly");
+        }
     }
 
     private async Task RescanSafelyAsync(string reason, CancellationToken cancellationToken)
@@ -257,13 +293,31 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         }
     }
 
+    /// <summary>
+    /// Waits for listener hints to stay quiet for <see cref="ThrottleInterval"/>,
+    /// forcing a rescan once the coalescing round reaches
+    /// <see cref="MaxCoalesceInterval"/>.
+    /// </summary>
     private static async Task<bool> WaitForDebounceQuietPeriodAsync(
         ChannelReader<DeviceMonitorRescanRequest> reader,
         CancellationToken cancellationToken)
     {
+        var coalesceStarted = Stopwatch.GetTimestamp();
+
         while (true)
         {
-            var trigger = await WaitForTriggerAsync(reader, ThrottleInterval, cancellationToken).ConfigureAwait(false);
+            var elapsed = Stopwatch.GetElapsedTime(coalesceStarted);
+            if (elapsed >= MaxCoalesceInterval)
+            {
+                return true;
+            }
+
+            var remainingCoalesce = MaxCoalesceInterval - elapsed;
+            var waitInterval = remainingCoalesce < ThrottleInterval
+                ? remainingCoalesce
+                : ThrottleInterval;
+
+            var trigger = await WaitForTriggerAsync(reader, waitInterval, cancellationToken).ConfigureAwait(false);
             if (trigger == DeviceMonitorWaitResult.Timeout)
             {
                 return true;
@@ -321,7 +375,8 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     {
         try
         {
-            if (_rescanRequests is null || !_rescanRequests.Writer.TryWrite(request))
+            var rescanRequests = _rescanRequests;
+            if (rescanRequests is null || !rescanRequests.Writer.TryWrite(request))
             {
                 Logger.LogTrace("Ignored device rescan request from {Source}; monitoring is stopping", request.Source);
                 return;
@@ -428,16 +483,13 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
             return;
         }
 
-        // 1. Signal cancellation
-        _monitoringCts?.Cancel();
-        _rescanRequests?.Writer.TryComplete();
+        var (taskToAwait, ctsToDispose) = StopMonitoringCore(teardownWhenNotMonitoring: true);
 
-        // 2. Wait for monitoring loop to exit (with timeout)
-        if (_monitoringTask is not null)
+        if (taskToAwait is not null)
         {
             try
             {
-                await _monitoringTask.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+                await taskToAwait.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
             }
             catch
             {
@@ -445,30 +497,12 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
             }
         }
 
-        // 3. Stop listeners
-        _hidListener?.Stop();
-        _smartCardListener?.Stop();
+        ctsToDispose?.Dispose();
 
-        // 4. Clear callbacks (prevent events during disposal)
-        if (_hidListener is not null)
-        {
-            _hidListener.DeviceEvent = null;
-        }
-        if (_smartCardListener is not null)
-        {
-            _smartCardListener.DeviceEvent = null;
-        }
+        await _rescanGate.WaitAsync().ConfigureAwait(false);
+        _rescanGate.Release();
 
-        // 5. Dispose listeners
-        _hidListener?.Dispose();
-        _smartCardListener?.Dispose();
-
-        // 6. Complete channel resources
-        _rescanRequests?.Writer.TryComplete();
-        _rescanRequests = null;
-
-        // 7. Dispose primitives
-        _monitoringCts?.Dispose();
+        _rescanGate.Dispose();
 
         Logger.LogDebug("YubiKeyDeviceMonitorService disposed");
     }

--- a/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
+++ b/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
@@ -13,9 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
-using System.Reactive;
-using System.Reactive.Linq;
-using System.Reactive.Subjects;
+using System.Threading.Channels;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Transports.Hid;
@@ -29,7 +27,7 @@ namespace Yubico.YubiKit.Core.Devices;
 /// <remarks>
 /// This service owns the device listeners (HID and SmartCard) and coordinates
 /// with <see cref="IYubiKeyDeviceRepository"/> to update the device cache.
-/// Uses Rx-based event coalescing via Throttle to minimize redundant scans.
+/// Uses a single-reader channel to serialize listener ingress and debounce redundant scans.
 /// </remarks>
 internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 {
@@ -44,9 +42,9 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     private HidDeviceListener? _hidListener;
     private ISmartCardDeviceListener? _smartCardListener;
 
-    // Rx-based event coalescing
-    private Subject<Unit>? _rescanTrigger;
-    private IDisposable? _throttleSubscription;
+    // Channel-based event coalescing. Native listener callbacks may be concurrent;
+    // the single reader is the only place that performs repository rescans.
+    private Channel<DeviceMonitorRescanRequest>? _rescanRequests;
 
     // Monitoring lifecycle fields
     private CancellationTokenSource? _monitoringCts;
@@ -62,13 +60,30 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     public YubiKeyDeviceMonitorService(
         IYubiKeyDeviceRepository repository,
         IFindYubiKeys findYubiKeys)
+        : this(repository, findYubiKeys, HidDeviceListener.Create, () => new DesktopSmartCardDeviceListener())
+    {
+    }
+
+    internal YubiKeyDeviceMonitorService(
+        IYubiKeyDeviceRepository repository,
+        IFindYubiKeys findYubiKeys,
+        Func<HidDeviceListener> hidListenerFactory,
+        Func<ISmartCardDeviceListener> smartCardListenerFactory)
     {
         ArgumentNullException.ThrowIfNull(repository);
         ArgumentNullException.ThrowIfNull(findYubiKeys);
+        ArgumentNullException.ThrowIfNull(hidListenerFactory);
+        ArgumentNullException.ThrowIfNull(smartCardListenerFactory);
 
         _repository = repository;
         _findYubiKeys = findYubiKeys;
+        HidListenerFactory = hidListenerFactory;
+        SmartCardListenerFactory = smartCardListenerFactory;
     }
+
+    private Func<HidDeviceListener> HidListenerFactory { get; }
+
+    private Func<ISmartCardDeviceListener> SmartCardListenerFactory { get; }
 
     /// <inheritdoc/>
     public bool IsMonitoring
@@ -87,6 +102,11 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     {
         ThrowIfDisposed();
 
+        await RescanCoreAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task RescanCoreAsync(CancellationToken cancellationToken)
+    {
         Logger.LogDebug("Rescanning devices...");
         var devices = await _findYubiKeys.FindAllAsync(ConnectionType.All, cancellationToken)
             .ConfigureAwait(false);
@@ -106,14 +126,19 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
                 return; // Already monitoring, idempotent
             }
 
-            // Setup Rx subject for event coalescing
-            _rescanTrigger = new Subject<Unit>();
+            _rescanRequests = Channel.CreateUnbounded<DeviceMonitorRescanRequest>(
+                new UnboundedChannelOptions
+                {
+                    SingleReader = true,
+                    SingleWriter = false,
+                    AllowSynchronousContinuations = false
+                });
 
             // Setup listeners BEFORE starting them
             SetupListeners();
 
             _monitoringCts = new CancellationTokenSource();
-            _monitoringTask = Task.Run(() => MonitoringLoopAsync(_monitoringCts.Token));
+            _monitoringTask = Task.Run(() => MonitoringLoopAsync(interval, _rescanRequests.Reader, _monitoringCts.Token));
 
             Logger.LogInformation("Device monitoring started with interval {Interval}", interval);
         }
@@ -137,6 +162,7 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
             // Signal cancellation
             _monitoringCts?.Cancel();
+            _rescanRequests?.Writer.TryComplete();
 
             // Clear fields under lock
             _monitoringTask = null;
@@ -166,41 +192,40 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     }
 
     /// <summary>
-    /// Internal monitoring loop that processes throttled device events.
+    /// Internal monitoring loop that processes debounced listener events and interval fallback scans.
     /// </summary>
-    private async Task MonitoringLoopAsync(CancellationToken cancellationToken)
+    private async Task MonitoringLoopAsync(
+        TimeSpan interval,
+        ChannelReader<DeviceMonitorRescanRequest> reader,
+        CancellationToken cancellationToken)
     {
-        if (_rescanTrigger is null)
-        {
-            return;
-        }
-
         try
         {
-            // Subscribe to throttled events - this coalesces rapid device events
-            await _rescanTrigger
-                .Throttle(ThrottleInterval)
-                .ForEachAsync(async _ =>
-                {
-                    if (cancellationToken.IsCancellationRequested)
-                    {
-                        return;
-                    }
+            await RescanSafelyAsync("initial monitor startup", cancellationToken).ConfigureAwait(false);
 
-                    try
-                    {
-                        await RescanAsync(cancellationToken).ConfigureAwait(false);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        // Expected during shutdown
-                    }
-                    catch (Exception ex)
-                    {
-                        Logger.LogWarning(ex, "Background device scan failed, continuing monitoring");
-                    }
-                }, cancellationToken)
-                .ConfigureAwait(false);
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var trigger = await WaitForTriggerAsync(reader, interval, cancellationToken).ConfigureAwait(false);
+                if (trigger == DeviceMonitorWaitResult.Timeout)
+                {
+                    await RescanSafelyAsync("interval fallback", cancellationToken).ConfigureAwait(false);
+                    continue;
+                }
+
+                if (trigger == DeviceMonitorWaitResult.Completed)
+                {
+                    break;
+                }
+
+                DrainQueuedRequests(reader);
+
+                if (!await WaitForDebounceQuietPeriodAsync(reader, cancellationToken).ConfigureAwait(false))
+                {
+                    break;
+                }
+
+                await RescanSafelyAsync("listener event", cancellationToken).ConfigureAwait(false);
+            }
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
@@ -208,17 +233,145 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         }
     }
 
+    private async Task RescanSafelyAsync(string reason, CancellationToken cancellationToken)
+    {
+        try
+        {
+            Logger.LogDebug("Starting device rescan after {Reason}", reason);
+            await RescanCoreAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            // Expected during shutdown
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Background device scan after {Reason} failed, continuing monitoring", reason);
+        }
+    }
+
+    private static void DrainQueuedRequests(ChannelReader<DeviceMonitorRescanRequest> reader)
+    {
+        while (reader.TryRead(out _))
+        {
+        }
+    }
+
+    private static async Task<bool> WaitForDebounceQuietPeriodAsync(
+        ChannelReader<DeviceMonitorRescanRequest> reader,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            var trigger = await WaitForTriggerAsync(reader, ThrottleInterval, cancellationToken).ConfigureAwait(false);
+            if (trigger == DeviceMonitorWaitResult.Timeout)
+            {
+                return true;
+            }
+
+            if (trigger == DeviceMonitorWaitResult.Completed)
+            {
+                return false;
+            }
+
+            DrainQueuedRequests(reader);
+        }
+    }
+
+    private static async Task<DeviceMonitorWaitResult> WaitForTriggerAsync(
+        ChannelReader<DeviceMonitorRescanRequest> reader,
+        TimeSpan timeout,
+        CancellationToken cancellationToken)
+    {
+        using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        using var readCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+
+        var timeoutTask = Task.Delay(timeout, timeoutCts.Token);
+        var readTask = reader.WaitToReadAsync(readCts.Token).AsTask();
+        var completedTask = await Task.WhenAny(timeoutTask, readTask).ConfigureAwait(false);
+
+        if (completedTask == timeoutTask)
+        {
+            readCts.Cancel();
+            await ObserveCancellationAsync(readTask).ConfigureAwait(false);
+            await timeoutTask.ConfigureAwait(false);
+            return DeviceMonitorWaitResult.Timeout;
+        }
+
+        timeoutCts.Cancel();
+        await ObserveCancellationAsync(timeoutTask).ConfigureAwait(false);
+        return await readTask.ConfigureAwait(false)
+            ? DeviceMonitorWaitResult.Signal
+            : DeviceMonitorWaitResult.Completed;
+    }
+
+    private static async Task ObserveCancellationAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected for the loser of a timeout/channel-read race.
+        }
+    }
+
+    private void QueueRescan(DeviceMonitorRescanRequest request)
+    {
+        try
+        {
+            if (_rescanRequests is null || !_rescanRequests.Writer.TryWrite(request))
+            {
+                Logger.LogTrace("Ignored device rescan request from {Source}; monitoring is stopping", request.Source);
+                return;
+            }
+
+            if (request.HidHint is not null)
+            {
+                Logger.LogTrace(
+                    "Queued HID rescan hint: {Kind}, {PlatformDeviceId}, {DevicePath}",
+                    request.HidHint.ChangeKind,
+                    request.HidHint.PlatformDeviceId,
+                    request.HidHint.DevicePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogTrace(ex, "Ignored device rescan request from {Source}", request.Source);
+        }
+    }
+
+    private void SignalHidEvent(HidDeviceRescanHint hint)
+    {
+        QueueRescan(new DeviceMonitorRescanRequest("HID", hint));
+    }
+
+    private void SignalSmartCardEvent()
+    {
+        QueueRescan(new DeviceMonitorRescanRequest("SmartCard", null));
+    }
+
+    private readonly record struct DeviceMonitorRescanRequest(string Source, HidDeviceRescanHint? HidHint);
+
+    private enum DeviceMonitorWaitResult
+    {
+        Signal,
+        Timeout,
+        Completed
+    }
+
     /// <summary>
     /// Sets up device listeners for event-driven discovery.
     /// </summary>
     private void SetupListeners()
     {
-        _hidListener = HidDeviceListener.Create();
-        _smartCardListener = new DesktopSmartCardDeviceListener();
+        _hidListener = HidListenerFactory();
+        _smartCardListener = SmartCardListenerFactory();
 
-        // Wire event callbacks to signal Rx subject
-        _hidListener.DeviceEvent = SignalEvent;
-        _smartCardListener.DeviceEvent = SignalEvent;
+        // Wire event callbacks before starting listeners.
+        _hidListener.DeviceEvent = SignalHidEvent;
+        _smartCardListener.DeviceEvent = SignalSmartCardEvent;
 
         // Start listeners AFTER wiring callbacks (explicit lifecycle)
         _hidListener.Start();
@@ -253,29 +406,10 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         _smartCardListener?.Dispose();
         _smartCardListener = null;
 
-        // Dispose Rx resources
-        _throttleSubscription?.Dispose();
-        _throttleSubscription = null;
-
-        _rescanTrigger?.Dispose();
-        _rescanTrigger = null;
+        _rescanRequests?.Writer.TryComplete();
+        _rescanRequests = null;
 
         Logger.LogDebug("Device listeners torn down");
-    }
-
-    /// <summary>
-    /// Signals the Rx subject when a device event occurs.
-    /// </summary>
-    private void SignalEvent()
-    {
-        try
-        {
-            _rescanTrigger?.OnNext(Unit.Default);
-        }
-        catch (ObjectDisposedException)
-        {
-            // Subject was disposed, ignore
-        }
     }
 
     private void ThrowIfDisposed()
@@ -296,6 +430,7 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
         // 1. Signal cancellation
         _monitoringCts?.Cancel();
+        _rescanRequests?.Writer.TryComplete();
 
         // 2. Wait for monitoring loop to exit (with timeout)
         if (_monitoringTask is not null)
@@ -328,9 +463,9 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         _hidListener?.Dispose();
         _smartCardListener?.Dispose();
 
-        // 6. Dispose Rx resources
-        _throttleSubscription?.Dispose();
-        _rescanTrigger?.Dispose();
+        // 6. Complete channel resources
+        _rescanRequests?.Writer.TryComplete();
+        _rescanRequests = null;
 
         // 7. Dispose primitives
         _monitoringCts?.Dispose();

--- a/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
+++ b/src/Core/src/Devices/YubiKeyDeviceMonitorService.cs
@@ -42,10 +42,17 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
     /// </summary>
     internal static readonly TimeSpan MaxCoalesceInterval = 5 * ThrottleInterval;
 
+    /// <summary>
+    /// Default maximum time <see cref="StopMonitoring"/> and <see cref="DisposeAsync"/>
+    /// wait for the monitoring loop and in-flight rescans before abandoning them.
+    /// </summary>
+    internal static readonly TimeSpan DefaultShutdownTimeout = TimeSpan.FromSeconds(10);
+
     private readonly IYubiKeyDeviceRepository _repository;
     private readonly IFindYubiKeys _findYubiKeys;
     private readonly Lock _monitorLock = new();
     private readonly SemaphoreSlim _rescanGate = new(1, 1);
+    private readonly TimeSpan _shutdownTimeout;
 
     // Device listeners for event-driven discovery
     private HidDeviceListener? _hidListener;
@@ -79,7 +86,8 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         IYubiKeyDeviceRepository repository,
         IFindYubiKeys findYubiKeys,
         Func<HidDeviceListener> hidListenerFactory,
-        Func<ISmartCardDeviceListener> smartCardListenerFactory)
+        Func<ISmartCardDeviceListener> smartCardListenerFactory,
+        TimeSpan? shutdownTimeout = null)
     {
         ArgumentNullException.ThrowIfNull(repository);
         ArgumentNullException.ThrowIfNull(findYubiKeys);
@@ -88,6 +96,7 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
         _repository = repository;
         _findYubiKeys = findYubiKeys;
+        _shutdownTimeout = shutdownTimeout ?? DefaultShutdownTimeout;
         HidListenerFactory = hidListenerFactory;
         SmartCardListenerFactory = smartCardListenerFactory;
     }
@@ -144,7 +153,20 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
             if (_monitoringTask is not null)
             {
-                return; // Already monitoring, idempotent
+                if (!_monitoringTask.IsCompleted)
+                {
+                    return; // Already monitoring, idempotent
+                }
+
+                // The monitoring loop only completes through StopMonitoring or
+                // DisposeAsync, which also clear this field. A completed task here
+                // means the loop terminated unexpectedly; tear down the stale
+                // session state so monitoring can restart cleanly.
+                Logger.LogWarning("Previous monitoring loop terminated unexpectedly; restarting device monitoring");
+                TeardownListeners();
+                _monitoringCts?.Dispose();
+                _monitoringCts = null;
+                _monitoringTask = null;
             }
 
             _rescanRequests = Channel.CreateUnbounded<DeviceMonitorRescanRequest>(
@@ -175,13 +197,25 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
         }
 
         // Wait for monitoring loop to complete (outside lock to avoid deadlock)
+        var loopStopped = false;
         try
         {
-            taskToAwait.Wait(TimeSpan.FromSeconds(10));
+            loopStopped = taskToAwait.Wait(_shutdownTimeout);
         }
         catch (AggregateException)
         {
-            // Ignore exceptions from the monitoring task - it's being stopped
+            // The monitoring task faulted, which means it has completed.
+            loopStopped = true;
+        }
+
+        if (!loopStopped)
+        {
+            // Abandon the stuck loop (e.g. a rescan blocked in native I/O) rather
+            // than dispose the CTS out from under it while it may still run.
+            Logger.LogWarning(
+                "Device monitoring loop did not stop within {Timeout}; abandoning it",
+                _shutdownTimeout);
+            return;
         }
 
         ctsToDispose?.Dispose();
@@ -485,24 +519,46 @@ internal sealed class YubiKeyDeviceMonitorService : IYubiKeyDeviceMonitorService
 
         var (taskToAwait, ctsToDispose) = StopMonitoringCore(teardownWhenNotMonitoring: true);
 
+        var loopStopped = true;
         if (taskToAwait is not null)
         {
             try
             {
-                await taskToAwait.WaitAsync(TimeSpan.FromSeconds(10)).ConfigureAwait(false);
+                await taskToAwait.WaitAsync(_shutdownTimeout).ConfigureAwait(false);
+            }
+            catch (TimeoutException)
+            {
+                loopStopped = false;
+                Logger.LogWarning(
+                    "Device monitoring loop did not stop within {Timeout} during dispose; abandoning it",
+                    _shutdownTimeout);
             }
             catch
             {
-                // Ignore timeout/cancellation
+                // Faulted or canceled means the loop has completed.
             }
         }
 
-        ctsToDispose?.Dispose();
+        if (loopStopped)
+        {
+            ctsToDispose?.Dispose();
+        }
 
-        await _rescanGate.WaitAsync().ConfigureAwait(false);
-        _rescanGate.Release();
-
-        _rescanGate.Dispose();
+        // Drain any in-flight rescan before disposing the gate, bounded so a hung
+        // discovery scan cannot hang disposal. On timeout the semaphore is
+        // abandoned rather than disposed so the stuck rescan's Release() does not
+        // hit a disposed handle.
+        if (await _rescanGate.WaitAsync(_shutdownTimeout).ConfigureAwait(false))
+        {
+            _rescanGate.Release();
+            _rescanGate.Dispose();
+        }
+        else
+        {
+            Logger.LogWarning(
+                "In-flight device rescan did not finish within {Timeout} during dispose; abandoning rescan gate",
+                _shutdownTimeout);
+        }
 
         Logger.LogDebug("YubiKeyDeviceMonitorService disposed");
     }

--- a/src/Core/src/Devices/YubiKeyManager.cs
+++ b/src/Core/src/Devices/YubiKeyManager.cs
@@ -23,10 +23,15 @@ namespace Yubico.YubiKit.Core.Devices;
 /// <example>
 /// <para><strong>Simple Device Discovery:</strong></para>
 /// <code>
+/// using System;
+/// using System.Reactive.Linq;
+/// using Yubico.YubiKit.Core;
+/// using Yubico.YubiKit.Core.Devices;
+///
 /// var devices = await YubiKeyManager.FindAllAsync();
 /// foreach (var device in devices)
 /// {
-///     Console.WriteLine($"Found: {device.SerialNumber}");
+///     Console.WriteLine($"Found: {device.DeviceId} ({device.AvailableConnections})");
 /// }
 /// </code>
 /// <para><strong>Force Fresh Scan:</strong></para>
@@ -37,7 +42,7 @@ namespace Yubico.YubiKit.Core.Devices;
 /// <code>
 /// using var subscription = YubiKeyManager.DeviceChanges.Subscribe(e =>
 /// {
-///     Console.WriteLine($"{e.Action}: {e.Device.SerialNumber}");
+///     Console.WriteLine($"{e.Action}: {e.Device.DeviceId} ({e.Device.AvailableConnections})");
 /// });
 /// YubiKeyManager.StartMonitoring();
 /// // ... application runs ...

--- a/src/Core/src/Native/Linux/Libc/Libc.Interop.cs
+++ b/src/Core/src/Native/Linux/Libc/Libc.Interop.cs
@@ -61,6 +61,18 @@ internal static class NativeMethods
     /// <summary>Invalid request: fd not open (only returned in revents; ignored in events).</summary>
     public const short POLLNVAL = 0x0020;
 
+    /// <summary>Close the descriptor on exec.</summary>
+    public const int EFD_CLOEXEC = 0x80000;
+
+    /// <summary>Open the event fd in non-blocking mode.</summary>
+    public const int EFD_NONBLOCK = 0x800;
+
+    /// <summary>EINTR: interrupted system call.</summary>
+    public const int EINTR = 4;
+
+    /// <summary>EAGAIN/EWOULDBLOCK: no data available on a non-blocking descriptor.</summary>
+    public const int EAGAIN = 11;
+
     /// <summary>
     /// Wait for events on the specified file descriptors.
     /// </summary>
@@ -71,6 +83,10 @@ internal static class NativeMethods
     [DllImport(Libraries.LinuxKernelLib, EntryPoint = "poll", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
     public static extern int poll([In, Out] PollFd[] fds, int nfds, int timeout);
+
+    [DllImport(Libraries.LinuxKernelLib, EntryPoint = "eventfd", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    public static extern LinuxEventFdSafeHandle eventfd(uint initval, int flags);
 
 
     public const long HIDIOCGRAWINFO = 0x0000000080084803;
@@ -143,10 +159,25 @@ internal static class NativeMethods
         byte[] outputBuffer,
         int count);
 
+    // Read count bytes from an event fd. Place them into outputBuffer.
+    [DllImport(Libraries.LinuxKernelLib, CharSet = CharSet.Ansi, EntryPoint = "read", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    public static extern int read(LinuxEventFdSafeHandle handle,
+        [MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)]
+        byte[] outputBuffer,
+        int count);
+
     // Write the count bytes in inputBuffer.
     [DllImport(Libraries.LinuxKernelLib, CharSet = CharSet.Ansi, EntryPoint = "write", SetLastError = true)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
     public static extern int write(LinuxFileSafeHandle handle,
+        [MarshalAs(UnmanagedType.LPArray)] byte[] inputBuffer,
+        int count);
+
+    // Write count bytes to an event fd.
+    [DllImport(Libraries.LinuxKernelLib, CharSet = CharSet.Ansi, EntryPoint = "write", SetLastError = true)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    public static extern int write(LinuxEventFdSafeHandle handle,
         [MarshalAs(UnmanagedType.LPArray)] byte[] inputBuffer,
         int count);
 

--- a/src/Core/src/Native/Linux/Libc/LinuxEventFdSafeHandle.cs
+++ b/src/Core/src/Native/Linux/Libc/LinuxEventFdSafeHandle.cs
@@ -1,0 +1,29 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.InteropServices;
+
+namespace Yubico.YubiKit.Core.Native.Linux.Libc;
+
+internal sealed class LinuxEventFdSafeHandle : SafeHandle
+{
+    public LinuxEventFdSafeHandle()
+        : base(new IntPtr(-1), true)
+    {
+    }
+
+    public override bool IsInvalid => handle == new IntPtr(-1);
+
+    protected override bool ReleaseHandle() => NativeMethods.close(handle) == 0;
+}

--- a/src/Core/src/Native/Linux/Libc/LinuxEventFdSafeHandle.cs
+++ b/src/Core/src/Native/Linux/Libc/LinuxEventFdSafeHandle.cs
@@ -1,7 +1,7 @@
 // Copyright 2026 Yubico AB
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/src/Core/src/Native/MacOS/CoreFoundation/CoreFoundation.Interop.cs
+++ b/src/Core/src/Native/MacOS/CoreFoundation/CoreFoundation.Interop.cs
@@ -77,6 +77,10 @@ internal static class NativeMethods
 
     [DllImport(Libraries.CoreFoundation)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    public static extern IntPtr CFRetain(IntPtr theObject);
+
+    [DllImport(Libraries.CoreFoundation)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
     public static extern IntPtr CFRunLoopGetCurrent();
 
     [DllImport(Libraries.CoreFoundation)]

--- a/src/Core/src/Native/MacOS/IOKitFramework/IOKitHid.Interop.cs
+++ b/src/Core/src/Native/MacOS/IOKitFramework/IOKitHid.Interop.cs
@@ -59,29 +59,6 @@ internal static partial class NativeMethods
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
     internal static extern IntPtr IOHIDManagerCreate(IntPtr allocator, int options); /* OS >= 10.5 */
 
-    /*! @function   IOHIDManagerOpen
-        @abstract   Opens the HID manager.
-        @discussion Opening the manager establishes communication with currently matched
-                    devices and allows callbacks for matched devices to be delivered.
-        @param      manager Reference to an IOHIDManager.
-        @param      options Option bits to be sent down to the manager.
-        @result     Returns kIOReturnSuccess if successful.
-    */
-    [DllImport(Libraries.IOKitFramework)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-    internal static extern int IOHIDManagerOpen(IntPtr manager, int options); /* OS >= 10.5 */
-
-    /*! @function   IOHIDManagerClose
-        @abstract   Closes the HID manager.
-        @discussion Closes communication established by IOHIDManagerOpen.
-        @param      manager Reference to an IOHIDManager.
-        @param      options Option bits to be sent down to the manager.
-        @result     Returns kIOReturnSuccess if successful.
-    */
-    [DllImport(Libraries.IOKitFramework)]
-    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
-    internal static extern int IOHIDManagerClose(IntPtr manager, int options); /* OS >= 10.5 */
-
     /*! @function   IOHIDManagerSetDeviceMatching
         @abstract   Sets matching criteria for device enumeration.
         @discussion Matching keys are prefixed by kIOHIDDevice and declared in

--- a/src/Core/src/Native/MacOS/IOKitFramework/IOKitHid.Interop.cs
+++ b/src/Core/src/Native/MacOS/IOKitFramework/IOKitHid.Interop.cs
@@ -59,6 +59,29 @@ internal static partial class NativeMethods
     [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
     internal static extern IntPtr IOHIDManagerCreate(IntPtr allocator, int options); /* OS >= 10.5 */
 
+    /*! @function   IOHIDManagerOpen
+        @abstract   Opens the HID manager.
+        @discussion Opening the manager establishes communication with currently matched
+                    devices and allows callbacks for matched devices to be delivered.
+        @param      manager Reference to an IOHIDManager.
+        @param      options Option bits to be sent down to the manager.
+        @result     Returns kIOReturnSuccess if successful.
+    */
+    [DllImport(Libraries.IOKitFramework)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    internal static extern int IOHIDManagerOpen(IntPtr manager, int options); /* OS >= 10.5 */
+
+    /*! @function   IOHIDManagerClose
+        @abstract   Closes the HID manager.
+        @discussion Closes communication established by IOHIDManagerOpen.
+        @param      manager Reference to an IOHIDManager.
+        @param      options Option bits to be sent down to the manager.
+        @result     Returns kIOReturnSuccess if successful.
+    */
+    [DllImport(Libraries.IOKitFramework)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)]
+    internal static extern int IOHIDManagerClose(IntPtr manager, int options); /* OS >= 10.5 */
+
     /*! @function   IOHIDManagerSetDeviceMatching
         @abstract   Sets matching criteria for device enumeration.
         @discussion Matching keys are prefixed by kIOHIDDevice and declared in

--- a/src/Core/src/Native/Windows/Cfgmgr32/Cfgmgr32.Interop.cs
+++ b/src/Core/src/Native/Windows/Cfgmgr32/Cfgmgr32.Interop.cs
@@ -179,7 +179,7 @@ internal static partial class NativeMethods
     internal const int OffsetGuidData4 = 24;
     internal const int LengthGuidData4 = 8;
 
-    [StructLayout(LayoutKind.Sequential)]
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode, Size = CmNotifyFilterSize)]
     internal struct CM_NOTIFY_FILTER
     {
         internal int cbSize;

--- a/src/Core/src/Transports/Hid/HidDeviceChangeKind.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceChangeKind.cs
@@ -1,0 +1,36 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.YubiKit.Core.Transports.Hid;
+
+/// <summary>
+/// Describes the type of HID topology change reported by a platform listener.
+/// </summary>
+public enum HidDeviceChangeKind
+{
+    /// <summary>
+    /// The listener could not classify the HID topology change.
+    /// </summary>
+    Unknown = 0,
+
+    /// <summary>
+    /// A HID interface was added.
+    /// </summary>
+    Added = 1,
+
+    /// <summary>
+    /// A HID interface was removed.
+    /// </summary>
+    Removed = 2
+}

--- a/src/Core/src/Transports/Hid/HidDeviceChangeKind.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceChangeKind.cs
@@ -1,7 +1,7 @@
 // Copyright 2026 Yubico AB
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/src/Core/src/Transports/Hid/HidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceListener.cs
@@ -33,9 +33,13 @@ public abstract class HidDeviceListener : IDisposable
     private bool _disposed;
 
     /// <summary>
-    /// Callback invoked when any HID device event (arrival or removal) occurs.
+    /// Callback invoked when a HID listener observes a topology change.
     /// </summary>
-    public Action? DeviceEvent { get; set; }
+    /// <remarks>
+    /// The callback receives a diagnostic rescan hint only. It must not be treated as
+    /// authoritative YubiKey arrival or removal state.
+    /// </remarks>
+    public Action<HidDeviceRescanHint>? DeviceEvent { get; set; }
 
     /// <summary>
     /// Gets the current status of the listener.
@@ -81,11 +85,14 @@ public abstract class HidDeviceListener : IDisposable
     /// <summary>
     /// Signals that a device event has occurred.
     /// </summary>
-    protected void OnDeviceEvent()
+    /// <param name="hint">The diagnostic rescan hint to pass to subscribers.</param>
+    protected void OnDeviceEvent(HidDeviceRescanHint hint)
     {
+        ArgumentNullException.ThrowIfNull(hint);
+
         try
         {
-            DeviceEvent?.Invoke();
+            DeviceEvent?.Invoke(hint);
         }
         catch (Exception ex)
         {

--- a/src/Core/src/Transports/Hid/HidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceListener.cs
@@ -31,6 +31,7 @@ public abstract class HidDeviceListener : IDisposable
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger<HidDeviceListener>();
 
     private bool _disposed;
+    private volatile DeviceListenerStatus _status = DeviceListenerStatus.Stopped;
 
     /// <summary>
     /// Callback invoked when a HID listener observes a topology change.
@@ -44,7 +45,16 @@ public abstract class HidDeviceListener : IDisposable
     /// <summary>
     /// Gets the current status of the listener.
     /// </summary>
-    public DeviceListenerStatus Status { get; protected set; } = DeviceListenerStatus.Stopped;
+    /// <remarks>
+    /// The status is written by platform listener threads and may be read from any thread;
+    /// reads and writes use volatile semantics. It is diagnostic state, not a synchronization
+    /// primitive.
+    /// </remarks>
+    public DeviceListenerStatus Status
+    {
+        get => _status;
+        protected set => _status = value;
+    }
 
     /// <summary>
     /// Starts the listener. Establishes baseline of currently connected devices,
@@ -60,8 +70,16 @@ public abstract class HidDeviceListener : IDisposable
     /// Stops the listener and releases monitoring resources.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// After calling Stop(), the listener can be restarted by calling <see cref="Start"/> again.
     /// Calling Stop() on an already stopped listener has no effect.
+    /// </para>
+    /// <para>
+    /// Do not call <see cref="Stop"/> or <see cref="Dispose()"/> from within the
+    /// <see cref="DeviceEvent"/> callback. Platform implementations wait for their native
+    /// registration or listener thread to drain before returning, so stopping from inside the
+    /// callback can deadlock or stall for the full disposal timeout.
+    /// </para>
     /// </remarks>
     public abstract void Stop();
 
@@ -121,6 +139,9 @@ public abstract class HidDeviceListener : IDisposable
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Do not call from within the <see cref="DeviceEvent"/> callback; see <see cref="Stop"/>.
+    /// </remarks>
     public void Dispose()
     {
         Dispose(disposing: true);

--- a/src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
@@ -1,0 +1,37 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.YubiKit.Core.Transports.Hid;
+
+/// <summary>
+/// Diagnostic information from a HID listener indicating that device discovery should be rescanned.
+/// </summary>
+/// <remarks>
+/// HID listener hints are not authoritative physical-device state. Consumers that need YubiKey
+/// arrivals and removals should use <c>YubiKeyManager.DeviceChanges</c>, which is emitted only
+/// after a repository rescan and diff.
+/// </remarks>
+/// <param name="ChangeKind">The platform-reported HID topology change.</param>
+/// <param name="PlatformDeviceId">A platform-specific diagnostic identifier when available.</param>
+/// <param name="DevicePath">A platform-specific path when available.</param>
+public sealed record HidDeviceRescanHint(
+    HidDeviceChangeKind ChangeKind,
+    string? PlatformDeviceId = null,
+    string? DevicePath = null)
+{
+    /// <summary>
+    /// Gets a generic rescan hint for a HID topology change whose details are unknown.
+    /// </summary>
+    public static HidDeviceRescanHint Unknown { get; } = new(HidDeviceChangeKind.Unknown);
+}

--- a/src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
+++ b/src/Core/src/Transports/Hid/HidDeviceRescanHint.cs
@@ -1,7 +1,7 @@
 // Copyright 2026 Yubico AB
 //
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
 //     http://www.apache.org/licenses/LICENSE-2.0

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidDeviceListener.cs
@@ -30,14 +30,16 @@ namespace Yubico.YubiKit.Core.Transports.Hid.Linux;
 /// </remarks>
 internal sealed class LinuxHidDeviceListener : HidDeviceListener
 {
-    private static readonly TimeSpan CheckForChangesWaitTime = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan HidrawReadinessFallbackDelay = TimeSpan.FromMilliseconds(250);
     private static readonly TimeSpan MaxDisposalWaitTime = TimeSpan.FromSeconds(8);
 
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger<LinuxHidDeviceListener>();
 
     private readonly Lock _syncLock = new();
+    private readonly HashSet<string> _knownDeviceIds = new(StringComparer.Ordinal);
     private LinuxUdevSafeHandle? _udevHandle;
     private LinuxUdevMonitorSafeHandle? _monitorHandle;
+    private LinuxEventFdSafeHandle? _shutdownEventHandle;
     private Thread? _listenerThread;
     private volatile bool _shouldStop;
     private bool _disposed;
@@ -69,6 +71,7 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 {
                     Logger.LogWarning("Failed to create udev context");
                     Status = DeviceListenerStatus.Error;
+                    ReleaseNativeHandles();
                     return;
                 }
 
@@ -78,6 +81,7 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 {
                     Logger.LogWarning("Failed to create udev monitor");
                     Status = DeviceListenerStatus.Error;
+                    ReleaseNativeHandles();
                     return;
                 }
 
@@ -91,6 +95,7 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 {
                     Logger.LogWarning("Failed to add udev filter: {Result}", filterResult);
                     Status = DeviceListenerStatus.Error;
+                    ReleaseNativeHandles();
                     return;
                 }
 
@@ -100,10 +105,23 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 {
                     Logger.LogWarning("Failed to enable udev receiving: {Result}", enableResult);
                     Status = DeviceListenerStatus.Error;
+                    ReleaseNativeHandles();
+                    return;
+                }
+
+                _shutdownEventHandle = LibcNativeMethods.eventfd(
+                    0,
+                    LibcNativeMethods.EFD_CLOEXEC | LibcNativeMethods.EFD_NONBLOCK);
+                if (_shutdownEventHandle.IsInvalid)
+                {
+                    Logger.LogWarning("Failed to create Linux HID listener shutdown event fd: {Error}", Marshal.GetLastWin32Error());
+                    Status = DeviceListenerStatus.Error;
+                    ReleaseNativeHandles();
                     return;
                 }
 
                 _shouldStop = false;
+                Status = DeviceListenerStatus.Started;
 
                 // Start the listener thread
                 _listenerThread = new Thread(ListenerThreadProc)
@@ -112,13 +130,12 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                     IsBackground = true
                 };
                 _listenerThread.Start();
-
-                Status = DeviceListenerStatus.Started;
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Failed to start Linux HID listener");
                 Status = DeviceListenerStatus.Error;
+                ReleaseNativeHandles();
             }
         }
     }
@@ -134,6 +151,7 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
             }
 
             _shouldStop = true;
+            SignalShutdownEvent();
 
             // Wait for the listener thread to exit
             if (_listenerThread is not null && _listenerThread.IsAlive)
@@ -146,12 +164,8 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
 
             _listenerThread = null;
 
-            // Cleanup udev resources
-            _monitorHandle?.Dispose();
-            _monitorHandle = null;
-
-            _udevHandle?.Dispose();
-            _udevHandle = null;
+            ReleaseNativeHandles();
+            _knownDeviceIds.Clear();
 
             Status = DeviceListenerStatus.Stopped;
         }
@@ -159,8 +173,13 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
 
     private void ListenerThreadProc()
     {
-        if (_monitorHandle is null || _monitorHandle.IsInvalid)
+        if (_monitorHandle is null || _monitorHandle.IsInvalid || _shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
         {
+            if (!_shouldStop)
+            {
+                Status = DeviceListenerStatus.Error;
+            }
+
             return;
         }
 
@@ -175,14 +194,23 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 return;
             }
 
-            var pollFds = new LibcNativeMethods.PollFd[1];
+            var shutdownFd = _shutdownEventHandle.DangerousGetHandle().ToInt32();
+            if (shutdownFd < 0)
+            {
+                Logger.LogWarning("Invalid Linux HID listener shutdown fd");
+                Status = DeviceListenerStatus.Error;
+                return;
+            }
+
+            var pollFds = new LibcNativeMethods.PollFd[2];
             pollFds[0].fd = fd.ToInt32();
             pollFds[0].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
+            pollFds[1].fd = shutdownFd;
+            pollFds[1].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
 
             while (!_shouldStop)
             {
-                // Poll with timeout
-                var pollResult = LibcNativeMethods.poll(pollFds, 1, (int)CheckForChangesWaitTime.TotalMilliseconds);
+                var pollResult = LibcNativeMethods.poll(pollFds, pollFds.Length, -1);
 
                 if (_shouldStop)
                 {
@@ -192,32 +220,47 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 if (pollResult < 0)
                 {
                     var error = Marshal.GetLastWin32Error();
-                    // EINTR (4) is normal for interrupted system calls
-                    if (error == 4)
+                    if (error == LibcNativeMethods.EINTR)
                     {
                         continue;
                     }
 
                     Logger.LogWarning("poll() failed with error: {Error}", error);
-                    continue;
+                    Status = DeviceListenerStatus.Error;
+                    break;
                 }
 
                 if (pollResult == 0)
                 {
-                    // Timeout, continue polling
                     continue;
                 }
 
-                // Check if there's data to read
+                if ((pollFds[1].revents & LibcNativeMethods.POLLIN) != 0)
+                {
+                    DrainShutdownEvent();
+                    break;
+                }
+
+                if ((pollFds[1].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
+                {
+                    Logger.LogWarning("Linux HID listener shutdown fd reported error: {Revents}", pollFds[1].revents);
+                    if (!_shouldStop)
+                    {
+                        Status = DeviceListenerStatus.Error;
+                    }
+
+                    break;
+                }
+
                 if ((pollFds[0].revents & LibcNativeMethods.POLLIN) != 0)
                 {
                     ProcessUdevEvent();
                 }
 
-                // Check for errors
-                if ((pollFds[0].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP)) != 0)
+                if ((pollFds[0].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
                 {
-                    Logger.LogWarning("poll() reported error or hangup");
+                    Logger.LogWarning("udev monitor fd reported error: {Revents}", pollFds[0].revents);
+                    Status = DeviceListenerStatus.Error;
                     break;
                 }
             }
@@ -257,17 +300,174 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
         switch (action)
         {
             case "add":
-                HandleDeviceAdd();
+                HandleDeviceAdd(device);
                 break;
             case "remove":
-                OnDeviceEvent();
+                HandleDeviceRemove(device);
                 break;
         }
     }
 
-    private void HandleDeviceAdd()
+    private void HandleDeviceAdd(LinuxUdevDeviceSafeHandle device)
     {
-        OnDeviceEvent();
+        var hint = CreateHint(HidDeviceChangeKind.Added, device);
+        if (hint.PlatformDeviceId is not null)
+        {
+            _knownDeviceIds.Add(hint.PlatformDeviceId);
+        }
+
+        OnDeviceEvent(hint);
+
+        if (!IsHidrawReady(hint.DevicePath))
+        {
+            QueueReadinessFallback(hint);
+        }
+    }
+
+    private void HandleDeviceRemove(LinuxUdevDeviceSafeHandle device)
+    {
+        var hint = CreateHint(HidDeviceChangeKind.Removed, device);
+        if (hint.PlatformDeviceId is not null)
+        {
+            _knownDeviceIds.Remove(hint.PlatformDeviceId);
+        }
+
+        OnDeviceEvent(hint);
+    }
+
+    private HidDeviceRescanHint CreateHint(HidDeviceChangeKind changeKind, LinuxUdevDeviceSafeHandle device)
+    {
+        var stableIdentity = GetStableUdevIdentity(device);
+        var devNode = GetDevNode(device);
+        return new HidDeviceRescanHint(changeKind, stableIdentity, devNode);
+    }
+
+    private void QueueReadinessFallback(HidDeviceRescanHint hint)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await Task.Delay(HidrawReadinessFallbackDelay).ConfigureAwait(false);
+
+                if (_shouldStop || Status != DeviceListenerStatus.Started)
+                {
+                    return;
+                }
+
+                OnDeviceEvent(hint);
+            }
+            catch (Exception ex)
+            {
+                Logger.LogTrace(ex, "Ignored delayed hidraw readiness rescan hint");
+            }
+        });
+    }
+
+    private static bool IsHidrawReady(string? devNode)
+    {
+        if (string.IsNullOrEmpty(devNode) || !File.Exists(devNode))
+        {
+            return false;
+        }
+
+        using var handle = LibcNativeMethods.open(
+            devNode,
+            LibcNativeMethods.OpenFlags.O_RDONLY | LibcNativeMethods.OpenFlags.O_NONBLOCK);
+        return !handle.IsInvalid;
+    }
+
+    private static string? GetStableUdevIdentity(LinuxUdevDeviceSafeHandle device)
+    {
+        var parent = UdevNativeMethods.udev_device_get_parent(device);
+        var syspath = parent == IntPtr.Zero
+            ? PtrToString(UdevNativeMethods.udev_device_get_syspath(device))
+            : PtrToString(UdevNativeMethods.udev_device_get_syspath(parent));
+
+        if (string.IsNullOrEmpty(syspath))
+        {
+            return null;
+        }
+
+        const string hidrawSegment = "/hidraw/";
+        var hidrawIndex = syspath.LastIndexOf(hidrawSegment, StringComparison.Ordinal);
+        if (hidrawIndex >= 0)
+        {
+            return syspath[..hidrawIndex];
+        }
+
+        const string hidrawDirectorySuffix = "/hidraw";
+        return syspath.EndsWith(hidrawDirectorySuffix, StringComparison.Ordinal)
+            ? syspath[..^hidrawDirectorySuffix.Length]
+            : syspath;
+    }
+
+    private static string? GetDevNode(LinuxUdevDeviceSafeHandle device) =>
+        PtrToString(UdevNativeMethods.udev_device_get_devnode(device));
+
+    private static string? PtrToString(IntPtr value) =>
+        value == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(value);
+
+    private void SignalShutdownEvent()
+    {
+        if (_shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
+        {
+            return;
+        }
+
+        var signal = BitConverter.GetBytes(1UL);
+        var result = LibcNativeMethods.write(_shutdownEventHandle, signal, signal.Length);
+        if (result < 0)
+        {
+            var error = Marshal.GetLastWin32Error();
+            if (error != LibcNativeMethods.EAGAIN)
+            {
+                Logger.LogDebug("Failed to signal Linux HID listener shutdown fd: {Error}", error);
+            }
+        }
+    }
+
+    private void DrainShutdownEvent()
+    {
+        if (_shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
+        {
+            return;
+        }
+
+        var buffer = new byte[sizeof(ulong)];
+        while (true)
+        {
+            var result = LibcNativeMethods.read(_shutdownEventHandle, buffer, buffer.Length);
+            if (result > 0)
+            {
+                continue;
+            }
+
+            if (result == 0)
+            {
+                return;
+            }
+
+            var error = Marshal.GetLastWin32Error();
+            if (error != LibcNativeMethods.EAGAIN && error != LibcNativeMethods.EINTR)
+            {
+                Logger.LogDebug("Failed to drain Linux HID listener shutdown fd: {Error}", error);
+            }
+
+            return;
+        }
+    }
+
+    private void ReleaseNativeHandles()
+    {
+        _shutdownEventHandle?.Dispose();
+        _shutdownEventHandle = null;
+
+        _monitorHandle?.Dispose();
+        _monitorHandle = null;
+
+        _udevHandle?.Dispose();
+        _udevHandle = null;
     }
 
     protected override void Dispose(bool disposing)
@@ -288,8 +488,8 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
         {
             // Finalizer path - minimal cleanup
             _shouldStop = true;
-            _monitorHandle?.Dispose();
-            _udevHandle?.Dispose();
+            SignalShutdownEvent();
+            ReleaseNativeHandles();
         }
 
         base.Dispose(disposing);

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidDeviceListener.cs
@@ -13,11 +13,6 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
-using System.Runtime.InteropServices;
-using Yubico.YubiKit.Core.Native.Linux.Libc;
-using Yubico.YubiKit.Core.Native.Linux.Udev;
-using LibcNativeMethods = Yubico.YubiKit.Core.Native.Linux.Libc.NativeMethods;
-using UdevNativeMethods = Yubico.YubiKit.Core.Native.Linux.Udev.NativeMethods;
 
 namespace Yubico.YubiKit.Core.Transports.Hid.Linux;
 
@@ -25,8 +20,17 @@ namespace Yubico.YubiKit.Core.Transports.Hid.Linux;
 /// Linux implementation of HID device listener using udev_monitor with poll().
 /// </summary>
 /// <remarks>
-/// The listener does not auto-start. Call <see cref="Start"/> after setting up <see cref="DeviceEvent"/>
-/// callback.
+/// <para>
+/// The listener does not auto-start. Call <see cref="Start"/> after setting up
+/// <see cref="HidDeviceListener.DeviceEvent"/> callback.
+/// </para>
+/// <para>
+/// Each <see cref="Start"/> creates an independent session that owns its native resources
+/// (udev context, monitor, shutdown event fd). The session's listener thread disposes those
+/// resources when its loop exits. If <see cref="Stop"/> times out waiting for a wedged thread,
+/// the cancelled session is abandoned rather than torn down, so a late-exiting thread can never
+/// touch recycled file descriptors or state belonging to a newer session.
+/// </para>
 /// </remarks>
 internal sealed class LinuxHidDeviceListener : HidDeviceListener
 {
@@ -36,21 +40,30 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger<LinuxHidDeviceListener>();
 
     private readonly Lock _syncLock = new();
-    private readonly HashSet<string> _knownDeviceIds = new(StringComparer.Ordinal);
-    private LinuxUdevSafeHandle? _udevHandle;
-    private LinuxUdevMonitorSafeHandle? _monitorHandle;
-    private LinuxEventFdSafeHandle? _shutdownEventHandle;
-    private Thread? _listenerThread;
-    private volatile bool _shouldStop;
+    private readonly Func<ILinuxHidEventSource> _eventSourceFactory;
+    private ListenerSession? _session;
     private bool _disposed;
 
     /// <summary>
     /// Creates a new instance. The listener does not start automatically - call <see cref="Start"/>
-    /// after setting up the <see cref="DeviceEvent"/> callback.
+    /// after setting up the <see cref="HidDeviceListener.DeviceEvent"/> callback.
     /// </summary>
     public LinuxHidDeviceListener()
+        : this(null)
     {
-        // Lazy start - do nothing in constructor
+    }
+
+    /// <summary>
+    /// Creates a new instance with a custom event source factory. Used by tests to inject a
+    /// fake <see cref="ILinuxHidEventSource"/> for no-hardware fault injection.
+    /// </summary>
+    /// <param name="eventSourceFactory">
+    /// Factory invoked once per <see cref="Start"/> to create the session's event source,
+    /// or null to use the udev-backed production source.
+    /// </param>
+    internal LinuxHidDeviceListener(Func<ILinuxHidEventSource>? eventSourceFactory)
+    {
+        _eventSourceFactory = eventSourceFactory ?? (static () => new LinuxUdevHidEventSource());
     }
 
     /// <inheritdoc />
@@ -63,79 +76,41 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 return;
             }
 
+            // A previous session's thread may still be exiting after a Stop() join timeout.
+            // It is cancelled and owns its own cleanup; start a fresh, independent session.
+            if (_session?.Thread is { IsAlive: true })
+            {
+                Logger.LogWarning("Previous Linux HID listener thread is still exiting; starting a new session");
+            }
+
+            var source = _eventSourceFactory();
             try
             {
-                // Create udev context
-                _udevHandle = UdevNativeMethods.udev_new();
-                if (_udevHandle.IsInvalid)
+                if (!source.Initialize())
                 {
-                    Logger.LogWarning("Failed to create udev context");
                     Status = DeviceListenerStatus.Error;
-                    ReleaseNativeHandles();
+                    source.Dispose();
                     return;
                 }
 
-                // Create monitor for netlink events
-                _monitorHandle = UdevNativeMethods.udev_monitor_new_from_netlink(_udevHandle, UdevNativeMethods.UdevMonitorName);
-                if (_monitorHandle.IsInvalid)
-                {
-                    Logger.LogWarning("Failed to create udev monitor");
-                    Status = DeviceListenerStatus.Error;
-                    ReleaseNativeHandles();
-                    return;
-                }
-
-                // Filter for hidraw subsystem
-                var filterResult = UdevNativeMethods.udev_monitor_filter_add_match_subsystem_devtype(
-                    _monitorHandle,
-                    UdevNativeMethods.UdevSubsystemName,
-                    null);
-
-                if (filterResult < 0)
-                {
-                    Logger.LogWarning("Failed to add udev filter: {Result}", filterResult);
-                    Status = DeviceListenerStatus.Error;
-                    ReleaseNativeHandles();
-                    return;
-                }
-
-                // Enable receiving
-                var enableResult = UdevNativeMethods.udev_monitor_enable_receiving(_monitorHandle);
-                if (enableResult < 0)
-                {
-                    Logger.LogWarning("Failed to enable udev receiving: {Result}", enableResult);
-                    Status = DeviceListenerStatus.Error;
-                    ReleaseNativeHandles();
-                    return;
-                }
-
-                _shutdownEventHandle = LibcNativeMethods.eventfd(
-                    0,
-                    LibcNativeMethods.EFD_CLOEXEC | LibcNativeMethods.EFD_NONBLOCK);
-                if (_shutdownEventHandle.IsInvalid)
-                {
-                    Logger.LogWarning("Failed to create Linux HID listener shutdown event fd: {Error}", Marshal.GetLastWin32Error());
-                    Status = DeviceListenerStatus.Error;
-                    ReleaseNativeHandles();
-                    return;
-                }
-
-                _shouldStop = false;
-                Status = DeviceListenerStatus.Started;
-
-                // Start the listener thread
-                _listenerThread = new Thread(ListenerThreadProc)
+                var session = new ListenerSession(source);
+                var thread = new Thread(() => ListenerThreadProc(session))
                 {
                     Name = "LinuxHidDeviceListener",
                     IsBackground = true
                 };
-                _listenerThread.Start();
+                session.Thread = thread;
+
+                _session = session;
+                Status = DeviceListenerStatus.Started;
+                thread.Start();
             }
             catch (Exception ex)
             {
                 Logger.LogError(ex, "Failed to start Linux HID listener");
                 Status = DeviceListenerStatus.Error;
-                ReleaseNativeHandles();
+                _session = null;
+                source.Dispose();
             }
         }
     }
@@ -150,199 +125,162 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 return;
             }
 
-            _shouldStop = true;
-            SignalShutdownEvent();
-
-            // Wait for the listener thread to exit
-            if (_listenerThread is not null && _listenerThread.IsAlive)
+            var session = _session;
+            if (session is not null)
             {
-                if (!_listenerThread.Join(MaxDisposalWaitTime))
+                session.Cancel();
+                session.Source.SignalShutdown();
+
+                if (session.Thread is { IsAlive: true } thread && !thread.Join(MaxDisposalWaitTime))
                 {
-                    Logger.LogWarning("Linux HID listener thread did not exit within timeout");
+                    // Abandon rather than tear down: the cancelled session owns its handles and
+                    // disposes them when its thread finally unblocks. Freeing them here would let
+                    // a still-running thread poll recycled file descriptors.
+                    Logger.LogError(
+                        "Linux HID listener thread did not exit within {Timeout}; abandoning its session resources",
+                        MaxDisposalWaitTime);
                 }
+
+                _session = null;
             }
-
-            _listenerThread = null;
-
-            ReleaseNativeHandles();
-            _knownDeviceIds.Clear();
 
             Status = DeviceListenerStatus.Stopped;
         }
     }
 
-    private void ListenerThreadProc()
+    private void ListenerThreadProc(ListenerSession session)
     {
-        if (_monitorHandle is null || _monitorHandle.IsInvalid || _shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
-        {
-            if (!_shouldStop)
-            {
-                Status = DeviceListenerStatus.Error;
-            }
-
-            return;
-        }
-
         try
         {
-            // Get the file descriptor for the monitor
-            var fd = UdevNativeMethods.udev_monitor_get_fd(_monitorHandle);
-            if (fd == IntPtr.Zero || fd.ToInt32() < 0)
+            RunEventLoop(session);
+        }
+        catch (Exception ex)
+        {
+            if (!session.Cancelled)
             {
-                Logger.LogWarning("Failed to get udev monitor fd");
-                Status = DeviceListenerStatus.Error;
+                Logger.LogError(ex, "Linux HID listener thread encountered an error");
+                SetErrorStatus(session);
+            }
+        }
+        finally
+        {
+            session.Source.Dispose();
+        }
+    }
+
+    private void RunEventLoop(ListenerSession session)
+    {
+        while (!session.Cancelled)
+        {
+            var outcome = session.Source.WaitForEvent();
+
+            if (session.Cancelled)
+            {
                 return;
             }
 
-            var shutdownFd = _shutdownEventHandle.DangerousGetHandle().ToInt32();
-            if (shutdownFd < 0)
+            switch (outcome)
             {
-                Logger.LogWarning("Invalid Linux HID listener shutdown fd");
-                Status = DeviceListenerStatus.Error;
+                case LinuxHidPollOutcome.Event:
+                    ProcessUdevEvent(session);
+                    break;
+
+                case LinuxHidPollOutcome.Retry:
+                    break;
+
+                case LinuxHidPollOutcome.ShutdownSignaled:
+                    return;
+
+                case LinuxHidPollOutcome.ShutdownFdError:
+                case LinuxHidPollOutcome.MonitorFdError:
+                case LinuxHidPollOutcome.PollFailed:
+                    SetErrorStatus(session);
+                    return;
+
+                default:
+                    Logger.LogWarning("Unexpected Linux HID poll outcome: {Outcome}", outcome);
+                    SetErrorStatus(session);
+                    return;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Transitions the listener to <see cref="DeviceListenerStatus.Error"/> unless the session
+    /// was cancelled, so an abandoned (zombie) session can never stamp Error onto a newer session.
+    /// </summary>
+    private void SetErrorStatus(ListenerSession session)
+    {
+        if (!session.Cancelled)
+        {
+            Status = DeviceListenerStatus.Error;
+        }
+    }
+
+    private void ProcessUdevEvent(ListenerSession session)
+    {
+        try
+        {
+            var udevEvent = session.Source.ReceiveEvent();
+            if (udevEvent is null)
+            {
+                // Receive failures matter most during event storms (e.g. ENOBUFS after the kernel
+                // dropped notifications) — exactly when a removal may have been lost. Never
+                // suppress: hint a rescan so discovery re-syncs with reality.
+                Logger.LogWarning("Failed to receive udev event; emitting unknown-change rescan hint");
+                OnDeviceEvent(HidDeviceRescanHint.Unknown);
                 return;
             }
 
-            var pollFds = new LibcNativeMethods.PollFd[2];
-            pollFds[0].fd = fd.ToInt32();
-            pollFds[0].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
-            pollFds[1].fd = shutdownFd;
-            pollFds[1].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
-
-            while (!_shouldStop)
+            switch (udevEvent.Action)
             {
-                var pollResult = LibcNativeMethods.poll(pollFds, pollFds.Length, -1);
-
-                if (_shouldStop)
-                {
+                case "add":
+                    HandleDeviceAdd(session, udevEvent);
                     break;
-                }
 
-                if (pollResult < 0)
-                {
-                    var error = Marshal.GetLastWin32Error();
-                    if (error == LibcNativeMethods.EINTR)
-                    {
-                        continue;
-                    }
-
-                    Logger.LogWarning("poll() failed with error: {Error}", error);
-                    Status = DeviceListenerStatus.Error;
+                case "remove":
+                    HandleDeviceRemove(udevEvent);
                     break;
-                }
 
-                if (pollResult == 0)
-                {
-                    continue;
-                }
-
-                if ((pollFds[1].revents & LibcNativeMethods.POLLIN) != 0)
-                {
-                    DrainShutdownEvent();
+                case null:
+                    Logger.LogDebug("udev event missing action; emitting unknown-change rescan hint");
+                    OnDeviceEvent(HidDeviceRescanHint.Unknown);
                     break;
-                }
 
-                if ((pollFds[1].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
-                {
-                    Logger.LogWarning("Linux HID listener shutdown fd reported error: {Revents}", pollFds[1].revents);
-                    if (!_shouldStop)
-                    {
-                        Status = DeviceListenerStatus.Error;
-                    }
-
+                default:
+                    // Recognized non-topology actions ("change", "bind", ...) do not affect discovery.
+                    Logger.LogTrace(
+                        "Ignoring udev action '{Action}' for {Identity}",
+                        udevEvent.Action,
+                        udevEvent.StableIdentity);
                     break;
-                }
-
-                if ((pollFds[0].revents & LibcNativeMethods.POLLIN) != 0)
-                {
-                    ProcessUdevEvent();
-                }
-
-                if ((pollFds[0].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
-                {
-                    Logger.LogWarning("udev monitor fd reported error: {Revents}", pollFds[0].revents);
-                    Status = DeviceListenerStatus.Error;
-                    break;
-                }
             }
         }
         catch (Exception ex)
         {
-            if (!_shouldStop)
-            {
-                Logger.LogError(ex, "Linux HID listener thread encountered an error");
-                Status = DeviceListenerStatus.Error;
-            }
+            Logger.LogWarning(ex, "Failed to process udev event; emitting unknown-change rescan hint");
+            OnDeviceEvent(HidDeviceRescanHint.Unknown);
         }
     }
 
-    private void ProcessUdevEvent()
+    private void HandleDeviceAdd(ListenerSession session, LinuxHidUdevEvent udevEvent)
     {
-        if (_monitorHandle is null || _monitorHandle.IsInvalid)
-        {
-            return;
-        }
-
-        using var device = UdevNativeMethods.udev_monitor_receive_device(_monitorHandle);
-        if (device.IsInvalid)
-        {
-            return;
-        }
-
-        // Get the action
-        var actionPtr = UdevNativeMethods.udev_device_get_action(device);
-        if (actionPtr == IntPtr.Zero)
-        {
-            return;
-        }
-
-        var action = Marshal.PtrToStringAnsi(actionPtr);
-
-        switch (action)
-        {
-            case "add":
-                HandleDeviceAdd(device);
-                break;
-            case "remove":
-                HandleDeviceRemove(device);
-                break;
-        }
-    }
-
-    private void HandleDeviceAdd(LinuxUdevDeviceSafeHandle device)
-    {
-        var hint = CreateHint(HidDeviceChangeKind.Added, device);
-        if (hint.PlatformDeviceId is not null)
-        {
-            _knownDeviceIds.Add(hint.PlatformDeviceId);
-        }
-
+        var hint = new HidDeviceRescanHint(HidDeviceChangeKind.Added, udevEvent.StableIdentity, udevEvent.DevNode);
         OnDeviceEvent(hint);
 
-        if (!IsHidrawReady(hint.DevicePath))
+        if (!session.Source.IsHidrawReady(hint.DevicePath))
         {
-            QueueReadinessFallback(hint);
+            QueueReadinessFallback(session, hint);
         }
     }
 
-    private void HandleDeviceRemove(LinuxUdevDeviceSafeHandle device)
+    private void HandleDeviceRemove(LinuxHidUdevEvent udevEvent)
     {
-        var hint = CreateHint(HidDeviceChangeKind.Removed, device);
-        if (hint.PlatformDeviceId is not null)
-        {
-            _knownDeviceIds.Remove(hint.PlatformDeviceId);
-        }
-
+        var hint = new HidDeviceRescanHint(HidDeviceChangeKind.Removed, udevEvent.StableIdentity, udevEvent.DevNode);
         OnDeviceEvent(hint);
     }
 
-    private HidDeviceRescanHint CreateHint(HidDeviceChangeKind changeKind, LinuxUdevDeviceSafeHandle device)
-    {
-        var stableIdentity = GetStableUdevIdentity(device);
-        var devNode = GetDevNode(device);
-        return new HidDeviceRescanHint(changeKind, stableIdentity, devNode);
-    }
-
-    private void QueueReadinessFallback(HidDeviceRescanHint hint)
+    private void QueueReadinessFallback(ListenerSession session, HidDeviceRescanHint hint)
     {
         _ = Task.Run(async () =>
         {
@@ -350,7 +288,7 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
             {
                 await Task.Delay(HidrawReadinessFallbackDelay).ConfigureAwait(false);
 
-                if (_shouldStop || Status != DeviceListenerStatus.Started)
+                if (session.Cancelled || Status != DeviceListenerStatus.Started)
                 {
                     return;
                 }
@@ -362,112 +300,6 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
                 Logger.LogTrace(ex, "Ignored delayed hidraw readiness rescan hint");
             }
         });
-    }
-
-    private static bool IsHidrawReady(string? devNode)
-    {
-        if (string.IsNullOrEmpty(devNode) || !File.Exists(devNode))
-        {
-            return false;
-        }
-
-        using var handle = LibcNativeMethods.open(
-            devNode,
-            LibcNativeMethods.OpenFlags.O_RDONLY | LibcNativeMethods.OpenFlags.O_NONBLOCK);
-        return !handle.IsInvalid;
-    }
-
-    private static string? GetStableUdevIdentity(LinuxUdevDeviceSafeHandle device)
-    {
-        var parent = UdevNativeMethods.udev_device_get_parent(device);
-        var syspath = parent == IntPtr.Zero
-            ? PtrToString(UdevNativeMethods.udev_device_get_syspath(device))
-            : PtrToString(UdevNativeMethods.udev_device_get_syspath(parent));
-
-        if (string.IsNullOrEmpty(syspath))
-        {
-            return null;
-        }
-
-        const string hidrawSegment = "/hidraw/";
-        var hidrawIndex = syspath.LastIndexOf(hidrawSegment, StringComparison.Ordinal);
-        if (hidrawIndex >= 0)
-        {
-            return syspath[..hidrawIndex];
-        }
-
-        const string hidrawDirectorySuffix = "/hidraw";
-        return syspath.EndsWith(hidrawDirectorySuffix, StringComparison.Ordinal)
-            ? syspath[..^hidrawDirectorySuffix.Length]
-            : syspath;
-    }
-
-    private static string? GetDevNode(LinuxUdevDeviceSafeHandle device) =>
-        PtrToString(UdevNativeMethods.udev_device_get_devnode(device));
-
-    private static string? PtrToString(IntPtr value) =>
-        value == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(value);
-
-    private void SignalShutdownEvent()
-    {
-        if (_shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
-        {
-            return;
-        }
-
-        var signal = BitConverter.GetBytes(1UL);
-        var result = LibcNativeMethods.write(_shutdownEventHandle, signal, signal.Length);
-        if (result < 0)
-        {
-            var error = Marshal.GetLastWin32Error();
-            if (error != LibcNativeMethods.EAGAIN)
-            {
-                Logger.LogDebug("Failed to signal Linux HID listener shutdown fd: {Error}", error);
-            }
-        }
-    }
-
-    private void DrainShutdownEvent()
-    {
-        if (_shutdownEventHandle is null || _shutdownEventHandle.IsInvalid)
-        {
-            return;
-        }
-
-        var buffer = new byte[sizeof(ulong)];
-        while (true)
-        {
-            var result = LibcNativeMethods.read(_shutdownEventHandle, buffer, buffer.Length);
-            if (result > 0)
-            {
-                continue;
-            }
-
-            if (result == 0)
-            {
-                return;
-            }
-
-            var error = Marshal.GetLastWin32Error();
-            if (error != LibcNativeMethods.EAGAIN && error != LibcNativeMethods.EINTR)
-            {
-                Logger.LogDebug("Failed to drain Linux HID listener shutdown fd: {Error}", error);
-            }
-
-            return;
-        }
-    }
-
-    private void ReleaseNativeHandles()
-    {
-        _shutdownEventHandle?.Dispose();
-        _shutdownEventHandle = null;
-
-        _monitorHandle?.Dispose();
-        _monitorHandle = null;
-
-        _udevHandle?.Dispose();
-        _udevHandle = null;
     }
 
     protected override void Dispose(bool disposing)
@@ -486,10 +318,13 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
         }
         else
         {
-            // Finalizer path - minimal cleanup
-            _shouldStop = true;
-            SignalShutdownEvent();
-            ReleaseNativeHandles();
+            // Finalizer path: cancel and wake the session; its thread owns handle cleanup.
+            var session = _session;
+            if (session is not null)
+            {
+                session.Cancel();
+                session.Source.SignalShutdown();
+            }
         }
 
         base.Dispose(disposing);
@@ -498,5 +333,28 @@ internal sealed class LinuxHidDeviceListener : HidDeviceListener
     ~LinuxHidDeviceListener()
     {
         Dispose(disposing: false);
+    }
+
+    /// <summary>
+    /// Per-<see cref="Start"/> state: the event source, its listener thread, and the
+    /// cancellation flag. Sessions are never reused; a session's thread is the sole owner of
+    /// its source's disposal.
+    /// </summary>
+    private sealed class ListenerSession
+    {
+        private volatile bool _cancelled;
+
+        public ListenerSession(ILinuxHidEventSource source)
+        {
+            Source = source;
+        }
+
+        public ILinuxHidEventSource Source { get; }
+
+        public Thread? Thread { get; set; }
+
+        public bool Cancelled => _cancelled;
+
+        public void Cancel() => _cancelled = true;
     }
 }

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidEventSource.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidEventSource.cs
@@ -1,0 +1,374 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
+using Yubico.YubiKit.Core.Native.Linux.Libc;
+using Yubico.YubiKit.Core.Native.Linux.Udev;
+using LibcNativeMethods = Yubico.YubiKit.Core.Native.Linux.Libc.NativeMethods;
+using UdevNativeMethods = Yubico.YubiKit.Core.Native.Linux.Udev.NativeMethods;
+
+namespace Yubico.YubiKit.Core.Transports.Hid.Linux;
+
+/// <summary>
+/// Outcome of a single blocking wait on the Linux HID event source.
+/// </summary>
+internal enum LinuxHidPollOutcome
+{
+    /// <summary>No actionable outcome (EINTR or spurious wake); poll again.</summary>
+    Retry = 0,
+
+    /// <summary>The udev monitor has at least one event ready to receive.</summary>
+    Event,
+
+    /// <summary>The shutdown event fd was signaled; exit the loop cleanly.</summary>
+    ShutdownSignaled,
+
+    /// <summary>The shutdown event fd reported an error condition; the loop cannot be woken reliably.</summary>
+    ShutdownFdError,
+
+    /// <summary>The udev monitor fd reported an error condition; events can no longer be received.</summary>
+    MonitorFdError,
+
+    /// <summary>poll() failed with a non-EINTR error.</summary>
+    PollFailed
+}
+
+/// <summary>
+/// A udev event received from the Linux HID event source, reduced to the fields the
+/// listener needs to construct a <see cref="HidDeviceRescanHint"/>.
+/// </summary>
+/// <param name="Action">The udev action string ("add", "remove", ...), or null when unavailable.</param>
+/// <param name="StableIdentity">The stable udev/sysfs identity (parent HID device syspath), or null.</param>
+/// <param name="DevNode">The /dev/hidrawN node path, diagnostic only, or null.</param>
+internal sealed record LinuxHidUdevEvent(string? Action, string? StableIdentity, string? DevNode);
+
+/// <summary>
+/// Abstraction over the native udev monitor, poll(), and shutdown eventfd used by
+/// <see cref="LinuxHidDeviceListener"/>. Enables no-hardware fault-injection tests of the
+/// listener's loop policy (bounded exit, error transitions, hint emission).
+/// </summary>
+/// <remarks>
+/// Ownership: the listener session's thread owns the source and disposes it when the loop
+/// exits. <see cref="SignalShutdown"/> may be called concurrently from other threads and
+/// must tolerate a source that is concurrently disposing.
+/// </remarks>
+internal interface ILinuxHidEventSource : IDisposable
+{
+    /// <summary>
+    /// Creates the udev context, monitor (hidraw subsystem filter, receiving enabled), and
+    /// shutdown event fd. Returns false when any native step fails; the caller disposes the
+    /// source in that case.
+    /// </summary>
+    bool Initialize();
+
+    /// <summary>
+    /// Blocks until the monitor has an event, the shutdown fd is signaled, or an error occurs.
+    /// </summary>
+    LinuxHidPollOutcome WaitForEvent();
+
+    /// <summary>
+    /// Receives one pending udev event. Returns null when the receive fails — which is most
+    /// likely during event storms (for example ENOBUFS after the kernel dropped notifications),
+    /// exactly when a removal may have been lost.
+    /// </summary>
+    LinuxHidUdevEvent? ReceiveEvent();
+
+    /// <summary>
+    /// Wakes a thread blocked in <see cref="WaitForEvent"/> so it can observe cancellation.
+    /// Safe to call from any thread, including concurrently with <see cref="IDisposable.Dispose"/>.
+    /// </summary>
+    void SignalShutdown();
+
+    /// <summary>
+    /// Returns true when the hidraw device node exists and can be opened, indicating the node
+    /// is ready for enumeration by discovery rescans.
+    /// </summary>
+    bool IsHidrawReady(string? devNode);
+}
+
+/// <summary>
+/// Production <see cref="ILinuxHidEventSource"/> backed by libudev and libc P/Invoke.
+/// </summary>
+internal sealed class LinuxUdevHidEventSource : ILinuxHidEventSource
+{
+    private static readonly ILogger Logger = YubiKitLogging.CreateLogger<LinuxUdevHidEventSource>();
+
+    private LinuxUdevSafeHandle? _udevHandle;
+    private LinuxUdevMonitorSafeHandle? _monitorHandle;
+    private LinuxEventFdSafeHandle? _shutdownEventHandle;
+    private LibcNativeMethods.PollFd[]? _pollFds;
+    private bool _disposed;
+
+    /// <inheritdoc />
+    public bool Initialize()
+    {
+        _udevHandle = UdevNativeMethods.udev_new();
+        if (_udevHandle.IsInvalid)
+        {
+            Logger.LogWarning("Failed to create udev context");
+            return false;
+        }
+
+        _monitorHandle = UdevNativeMethods.udev_monitor_new_from_netlink(_udevHandle, UdevNativeMethods.UdevMonitorName);
+        if (_monitorHandle.IsInvalid)
+        {
+            Logger.LogWarning("Failed to create udev monitor");
+            return false;
+        }
+
+        var filterResult = UdevNativeMethods.udev_monitor_filter_add_match_subsystem_devtype(
+            _monitorHandle,
+            UdevNativeMethods.UdevSubsystemName,
+            null);
+        if (filterResult < 0)
+        {
+            Logger.LogWarning("Failed to add udev filter: {Result}", filterResult);
+            return false;
+        }
+
+        var enableResult = UdevNativeMethods.udev_monitor_enable_receiving(_monitorHandle);
+        if (enableResult < 0)
+        {
+            Logger.LogWarning("Failed to enable udev receiving: {Result}", enableResult);
+            return false;
+        }
+
+        _shutdownEventHandle = LibcNativeMethods.eventfd(
+            0,
+            LibcNativeMethods.EFD_CLOEXEC | LibcNativeMethods.EFD_NONBLOCK);
+        if (_shutdownEventHandle.IsInvalid)
+        {
+            Logger.LogWarning(
+                "Failed to create Linux HID listener shutdown event fd: {Error}",
+                Marshal.GetLastWin32Error());
+            return false;
+        }
+
+        var monitorFd = UdevNativeMethods.udev_monitor_get_fd(_monitorHandle);
+        if (monitorFd == IntPtr.Zero || monitorFd.ToInt32() < 0)
+        {
+            Logger.LogWarning("Failed to get udev monitor fd");
+            return false;
+        }
+
+        var shutdownFd = _shutdownEventHandle.DangerousGetHandle().ToInt32();
+        if (shutdownFd < 0)
+        {
+            Logger.LogWarning("Invalid Linux HID listener shutdown fd");
+            return false;
+        }
+
+        var pollFds = new LibcNativeMethods.PollFd[2];
+        pollFds[0].fd = monitorFd.ToInt32();
+        pollFds[0].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
+        pollFds[1].fd = shutdownFd;
+        pollFds[1].events = (short)(LibcNativeMethods.POLLIN | LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP);
+        _pollFds = pollFds;
+
+        return true;
+    }
+
+    /// <inheritdoc />
+    public LinuxHidPollOutcome WaitForEvent()
+    {
+        var pollFds = _pollFds ?? throw new InvalidOperationException("The event source is not initialized.");
+
+        var pollResult = LibcNativeMethods.poll(pollFds, pollFds.Length, -1);
+        if (pollResult < 0)
+        {
+            var error = Marshal.GetLastWin32Error();
+            if (error == LibcNativeMethods.EINTR)
+            {
+                return LinuxHidPollOutcome.Retry;
+            }
+
+            Logger.LogWarning("poll() failed with error: {Error}", error);
+            return LinuxHidPollOutcome.PollFailed;
+        }
+
+        if ((pollFds[1].revents & LibcNativeMethods.POLLIN) != 0)
+        {
+            DrainShutdownEvent();
+            return LinuxHidPollOutcome.ShutdownSignaled;
+        }
+
+        if ((pollFds[1].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
+        {
+            Logger.LogWarning("Linux HID listener shutdown fd reported error: {Revents}", pollFds[1].revents);
+            return LinuxHidPollOutcome.ShutdownFdError;
+        }
+
+        if ((pollFds[0].revents & LibcNativeMethods.POLLIN) != 0)
+        {
+            return LinuxHidPollOutcome.Event;
+        }
+
+        if ((pollFds[0].revents & (LibcNativeMethods.POLLERR | LibcNativeMethods.POLLHUP | LibcNativeMethods.POLLNVAL)) != 0)
+        {
+            Logger.LogWarning("udev monitor fd reported error: {Revents}", pollFds[0].revents);
+            return LinuxHidPollOutcome.MonitorFdError;
+        }
+
+        return LinuxHidPollOutcome.Retry;
+    }
+
+    /// <inheritdoc />
+    public LinuxHidUdevEvent? ReceiveEvent()
+    {
+        if (_monitorHandle is null || _monitorHandle.IsInvalid)
+        {
+            return null;
+        }
+
+        using var device = UdevNativeMethods.udev_monitor_receive_device(_monitorHandle);
+        if (device.IsInvalid)
+        {
+            return null;
+        }
+
+        var action = PtrToString(UdevNativeMethods.udev_device_get_action(device));
+        var stableIdentity = GetStableUdevIdentity(device);
+        var devNode = PtrToString(UdevNativeMethods.udev_device_get_devnode(device));
+
+        return new LinuxHidUdevEvent(action, stableIdentity, devNode);
+    }
+
+    /// <inheritdoc />
+    public void SignalShutdown()
+    {
+        var handle = _shutdownEventHandle;
+        if (handle is null || handle.IsInvalid)
+        {
+            return;
+        }
+
+        try
+        {
+            var signal = BitConverter.GetBytes(1UL);
+            var result = LibcNativeMethods.write(handle, signal, signal.Length);
+            if (result < 0)
+            {
+                var error = Marshal.GetLastWin32Error();
+                if (error != LibcNativeMethods.EAGAIN)
+                {
+                    Logger.LogDebug("Failed to signal Linux HID listener shutdown fd: {Error}", error);
+                }
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The owning thread disposed the source while exiting — nothing left to wake.
+        }
+    }
+
+    /// <inheritdoc />
+    public bool IsHidrawReady(string? devNode)
+    {
+        if (string.IsNullOrEmpty(devNode) || !File.Exists(devNode))
+        {
+            return false;
+        }
+
+        using var handle = LibcNativeMethods.open(
+            devNode,
+            LibcNativeMethods.OpenFlags.O_RDONLY | LibcNativeMethods.OpenFlags.O_NONBLOCK);
+        return !handle.IsInvalid;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (_disposed)
+        {
+            return;
+        }
+
+        _disposed = true;
+        _pollFds = null;
+
+        _shutdownEventHandle?.Dispose();
+        _shutdownEventHandle = null;
+
+        _monitorHandle?.Dispose();
+        _monitorHandle = null;
+
+        _udevHandle?.Dispose();
+        _udevHandle = null;
+    }
+
+    /// <summary>
+    /// Trims the hidraw-specific suffix from a hidraw syspath so the remaining prefix
+    /// identifies the parent HID device stably across hidraw node renumbering.
+    /// </summary>
+    internal static string TrimHidrawSyspath(string syspath)
+    {
+        const string hidrawSegment = "/hidraw/";
+        var hidrawIndex = syspath.LastIndexOf(hidrawSegment, StringComparison.Ordinal);
+        if (hidrawIndex >= 0)
+        {
+            return syspath[..hidrawIndex];
+        }
+
+        const string hidrawDirectorySuffix = "/hidraw";
+        return syspath.EndsWith(hidrawDirectorySuffix, StringComparison.Ordinal)
+            ? syspath[..^hidrawDirectorySuffix.Length]
+            : syspath;
+    }
+
+    private void DrainShutdownEvent()
+    {
+        var handle = _shutdownEventHandle;
+        if (handle is null || handle.IsInvalid)
+        {
+            return;
+        }
+
+        var buffer = new byte[sizeof(ulong)];
+        while (true)
+        {
+            var result = LibcNativeMethods.read(handle, buffer, buffer.Length);
+            if (result > 0)
+            {
+                continue;
+            }
+
+            if (result == 0)
+            {
+                return;
+            }
+
+            var error = Marshal.GetLastWin32Error();
+            if (error != LibcNativeMethods.EAGAIN && error != LibcNativeMethods.EINTR)
+            {
+                Logger.LogDebug("Failed to drain Linux HID listener shutdown fd: {Error}", error);
+            }
+
+            return;
+        }
+    }
+
+    private static string? GetStableUdevIdentity(LinuxUdevDeviceSafeHandle device)
+    {
+        var parent = UdevNativeMethods.udev_device_get_parent(device);
+        var syspath = parent == IntPtr.Zero
+            ? PtrToString(UdevNativeMethods.udev_device_get_syspath(device))
+            : PtrToString(UdevNativeMethods.udev_device_get_syspath(parent));
+
+        return string.IsNullOrEmpty(syspath) ? null : TrimHidrawSyspath(syspath);
+    }
+
+    private static string? PtrToString(IntPtr value) =>
+        value == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(value);
+}

--- a/src/Core/src/Transports/Hid/MacOS/MacOSHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/MacOS/MacOSHidDeviceListener.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
+using System.Globalization;
 using System.Text;
 using Yubico.YubiKit.Core.Native.MacOS.CoreFoundation;
 using CFNativeMethods = Yubico.YubiKit.Core.Native.MacOS.CoreFoundation.NativeMethods;
@@ -35,11 +36,14 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger<MacOSHidDeviceListener>();
 
     private readonly Lock _syncLock = new();
+    private readonly Lock _cacheLock = new();
+    private readonly HashSet<long> _knownEntryIds = [];
     private IntPtr _hidManager;
     private IntPtr _runLoop;
     private IntPtr _runLoopMode;
     private Thread? _listenerThread;
     private volatile bool _shouldStop;
+    private volatile bool _managerOpened;
     private bool _disposed;
 
     // Keep callback delegates alive to prevent GC
@@ -78,6 +82,7 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
 
                 // Set device matching to all HID devices
                 IOKitNativeMethods.IOHIDManagerSetDeviceMatching(_hidManager, IntPtr.Zero);
+                PopulateInitialKnownEntryIds();
 
                 // Keep callback delegates alive
                 _arrivedCallbackDelegate = DeviceArrivedCallback;
@@ -95,6 +100,7 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
                     IntPtr.Zero);
 
                 _shouldStop = false;
+                Status = DeviceListenerStatus.Started;
 
                 // Start the listener thread
                 _listenerThread = new Thread(ListenerThreadProc)
@@ -103,8 +109,6 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
                     IsBackground = true
                 };
                 _listenerThread.Start();
-
-                Status = DeviceListenerStatus.Started;
             }
             catch (Exception ex)
             {
@@ -159,6 +163,10 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
 
             _arrivedCallbackDelegate = null;
             _removedCallbackDelegate = null;
+            lock (_cacheLock)
+            {
+                _knownEntryIds.Clear();
+            }
 
             Status = DeviceListenerStatus.Stopped;
         }
@@ -183,6 +191,16 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
                 _hidManager,
                 _runLoop,
                 _runLoopMode);
+
+            var openResult = IOKitNativeMethods.IOHIDManagerOpen(_hidManager, 0);
+            if (openResult != 0)
+            {
+                Logger.LogWarning("IOHIDManagerOpen failed: 0x{Result:X8}", openResult);
+                Status = DeviceListenerStatus.Error;
+                return;
+            }
+
+            _managerOpened = true;
 
             // Run the loop until stopped
             while (!_shouldStop)
@@ -217,6 +235,17 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
         }
         finally
         {
+            if (_managerOpened && _hidManager != IntPtr.Zero)
+            {
+                var closeResult = IOKitNativeMethods.IOHIDManagerClose(_hidManager, 0);
+                if (!_shouldStop && closeResult != 0)
+                {
+                    Logger.LogWarning("IOHIDManagerClose failed: 0x{Result:X8}", closeResult);
+                }
+
+                _managerOpened = false;
+            }
+
             // Cleanup run loop resources
             if (_hidManager != IntPtr.Zero && _runLoop != IntPtr.Zero && _runLoopMode != IntPtr.Zero)
             {
@@ -237,11 +266,22 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
                 return;
             }
 
-            OnDeviceEvent();
+            var hint = CreateHint(HidDeviceChangeKind.Added, deviceRef);
+            if (hint.PlatformDeviceId is not null && long.TryParse(hint.PlatformDeviceId, CultureInfo.InvariantCulture, out var entryId))
+            {
+                if (!TryRegisterArrivedEntryId(entryId))
+                {
+                    Logger.LogTrace("Suppressing initial macOS HID matching callback for entry ID {EntryId}", entryId);
+                    return;
+                }
+            }
+
+            OnDeviceEvent(hint);
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Failed to process macOS device arrival");
+            OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Added));
         }
     }
 
@@ -249,11 +289,114 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
     {
         try
         {
-            OnDeviceEvent();
+            var hint = CreateHint(HidDeviceChangeKind.Removed, deviceRef);
+            if (hint.PlatformDeviceId is not null && long.TryParse(hint.PlatformDeviceId, CultureInfo.InvariantCulture, out var entryId))
+            {
+                lock (_cacheLock)
+                {
+                    _knownEntryIds.Remove(entryId);
+                }
+            }
+
+            OnDeviceEvent(hint);
         }
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Failed to process macOS device removal");
+            OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
+        }
+    }
+
+    private void PopulateInitialKnownEntryIds()
+    {
+        if (_hidManager == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var deviceSet = IOKitNativeMethods.IOHIDManagerCopyDevices(_hidManager);
+        if (deviceSet == IntPtr.Zero)
+        {
+            return;
+        }
+
+        try
+        {
+            var deviceSetCount = CFNativeMethods.CFSetGetCount(deviceSet);
+            if (deviceSetCount <= 0)
+            {
+                return;
+            }
+
+            var devices = new IntPtr[deviceSetCount];
+            CFNativeMethods.CFSetGetValues(deviceSet, devices);
+
+            lock (_cacheLock)
+            {
+                foreach (var device in devices)
+                {
+                    if (TryGetEntryId(device, out var entryId))
+                    {
+                        _knownEntryIds.Add(entryId);
+                    }
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to populate initial macOS HID listener baseline");
+        }
+        finally
+        {
+            CFNativeMethods.CFRelease(deviceSet);
+        }
+    }
+
+    private bool TryRegisterArrivedEntryId(long entryId)
+    {
+        lock (_cacheLock)
+        {
+            return _knownEntryIds.Add(entryId);
+        }
+    }
+
+    private static HidDeviceRescanHint CreateHint(HidDeviceChangeKind changeKind, IntPtr deviceRef)
+    {
+        try
+        {
+            if (deviceRef == IntPtr.Zero)
+            {
+                return new HidDeviceRescanHint(changeKind);
+            }
+
+            var entryId = MacOSHidDevice.GetEntryId(deviceRef).ToString(CultureInfo.InvariantCulture);
+            return new HidDeviceRescanHint(changeKind, entryId, entryId);
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to read macOS HID registry entry ID");
+            return new HidDeviceRescanHint(changeKind);
+        }
+    }
+
+    private static bool TryGetEntryId(IntPtr deviceRef, out long entryId)
+    {
+        try
+        {
+            if (deviceRef == IntPtr.Zero)
+            {
+                entryId = 0;
+                return false;
+            }
+
+            entryId = MacOSHidDevice.GetEntryId(deviceRef);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            Logger.LogDebug(ex, "Failed to read macOS HID registry entry ID");
+            entryId = 0;
+            return false;
         }
     }
 

--- a/src/Core/src/Transports/Hid/MacOS/MacOSHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/MacOS/MacOSHidDeviceListener.cs
@@ -43,12 +43,12 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
     private IntPtr _runLoopMode;
     private Thread? _listenerThread;
     private volatile bool _shouldStop;
-    private volatile bool _managerOpened;
     private bool _disposed;
 
     // Keep callback delegates alive to prevent GC
     private IOKitNativeMethods.IOHIDDeviceCallback? _arrivedCallbackDelegate;
     private IOKitNativeMethods.IOHIDDeviceCallback? _removedCallbackDelegate;
+    private readonly List<IOKitNativeMethods.IOHIDDeviceCallback> _abandonedCallbackDelegates = [];
 
     /// <summary>
     /// Creates a new instance. The listener does not start automatically - call <see cref="Start"/>
@@ -68,6 +68,15 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
             {
                 return;
             }
+
+            if (_listenerThread is not null && _listenerThread.IsAlive)
+            {
+                Logger.LogWarning("macOS HID listener thread is still running; cannot restart until it exits");
+                Status = DeviceListenerStatus.Error;
+                return;
+            }
+
+            ReleaseDeadListenerState();
 
             try
             {
@@ -114,6 +123,7 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
             {
                 Logger.LogError(ex, "Failed to start macOS HID listener");
                 Status = DeviceListenerStatus.Error;
+                ReleaseDeadListenerState();
             }
         }
     }
@@ -123,7 +133,7 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
     {
         lock (_syncLock)
         {
-            if (Status == DeviceListenerStatus.Stopped)
+            if (Status == DeviceListenerStatus.Stopped && _listenerThread is null && !HasNativeState)
             {
                 return;
             }
@@ -141,26 +151,21 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
             {
                 if (!_listenerThread.Join(MaxDisposalWaitTime))
                 {
-                    Logger.LogWarning("macOS HID listener thread did not exit within timeout");
+                    Logger.LogError(
+                        "macOS HID listener thread did not exit within timeout; abandoning native handles to avoid use-after-free");
+                    AbandonNativeReferences();
+                    lock (_cacheLock)
+                    {
+                        _knownEntryIds.Clear();
+                    }
+
+                    Status = DeviceListenerStatus.Stopped;
+                    return;
                 }
             }
 
             _listenerThread = null;
-
-            // Release the run loop mode string
-            if (_runLoopMode != IntPtr.Zero)
-            {
-                CFNativeMethods.CFRelease(_runLoopMode);
-                _runLoopMode = IntPtr.Zero;
-            }
-
-            // Release the HID manager
-            if (_hidManager != IntPtr.Zero)
-            {
-                CFNativeMethods.CFRelease(_hidManager);
-                _hidManager = IntPtr.Zero;
-            }
-
+            ReleaseNativeReferences();
             _arrivedCallbackDelegate = null;
             _removedCallbackDelegate = null;
             lock (_cacheLock)
@@ -177,7 +182,16 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
         try
         {
             // Get the current run loop for this thread
-            _runLoop = CFNativeMethods.CFRunLoopGetCurrent();
+            var currentRunLoop = CFNativeMethods.CFRunLoopGetCurrent();
+            _runLoop = currentRunLoop == IntPtr.Zero
+                ? IntPtr.Zero
+                : CFNativeMethods.CFRetain(currentRunLoop);
+            if (_runLoop == IntPtr.Zero)
+            {
+                Logger.LogWarning("Failed to retain macOS HID listener run loop");
+                Status = DeviceListenerStatus.Error;
+                return;
+            }
 
             // Create the run loop mode string
             var modeBytes = Encoding.UTF8.GetBytes("kCFRunLoopDefaultMode");
@@ -187,20 +201,12 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
                 0x08000100); // kCFStringEncodingUTF8
 
             // Schedule the HID manager with this run loop
+            // Deliberately do not open the manager. Matching/removal callbacks do not require it, and
+            // opening all matched HID devices can require Input Monitoring TCC on macOS 10.15+.
             IOKitNativeMethods.IOHIDManagerScheduleWithRunLoop(
                 _hidManager,
                 _runLoop,
                 _runLoopMode);
-
-            var openResult = IOKitNativeMethods.IOHIDManagerOpen(_hidManager, 0);
-            if (openResult != 0)
-            {
-                Logger.LogWarning("IOHIDManagerOpen failed: 0x{Result:X8}", openResult);
-                Status = DeviceListenerStatus.Error;
-                return;
-            }
-
-            _managerOpened = true;
 
             // Run the loop until stopped
             while (!_shouldStop)
@@ -235,17 +241,6 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
         }
         finally
         {
-            if (_managerOpened && _hidManager != IntPtr.Zero)
-            {
-                var closeResult = IOKitNativeMethods.IOHIDManagerClose(_hidManager, 0);
-                if (!_shouldStop && closeResult != 0)
-                {
-                    Logger.LogWarning("IOHIDManagerClose failed: 0x{Result:X8}", closeResult);
-                }
-
-                _managerOpened = false;
-            }
-
             // Cleanup run loop resources
             if (_hidManager != IntPtr.Zero && _runLoop != IntPtr.Zero && _runLoopMode != IntPtr.Zero)
             {
@@ -370,7 +365,7 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
             }
 
             var entryId = MacOSHidDevice.GetEntryId(deviceRef).ToString(CultureInfo.InvariantCulture);
-            return new HidDeviceRescanHint(changeKind, entryId, entryId);
+            return new HidDeviceRescanHint(changeKind, entryId);
         }
         catch (Exception ex)
         {
@@ -400,6 +395,70 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
         }
     }
 
+    private bool HasNativeState =>
+        _hidManager != IntPtr.Zero ||
+        _runLoop != IntPtr.Zero ||
+        _runLoopMode != IntPtr.Zero ||
+        _arrivedCallbackDelegate is not null ||
+        _removedCallbackDelegate is not null;
+
+    private void ReleaseDeadListenerState()
+    {
+        if (_listenerThread is not null && _listenerThread.IsAlive)
+        {
+            return;
+        }
+
+        _listenerThread = null;
+        ReleaseNativeReferences();
+        _arrivedCallbackDelegate = null;
+        _removedCallbackDelegate = null;
+        lock (_cacheLock)
+        {
+            _knownEntryIds.Clear();
+        }
+    }
+
+    private void ReleaseNativeReferences()
+    {
+        if (_runLoopMode != IntPtr.Zero)
+        {
+            CFNativeMethods.CFRelease(_runLoopMode);
+            _runLoopMode = IntPtr.Zero;
+        }
+
+        if (_hidManager != IntPtr.Zero)
+        {
+            CFNativeMethods.CFRelease(_hidManager);
+            _hidManager = IntPtr.Zero;
+        }
+
+        if (_runLoop != IntPtr.Zero)
+        {
+            CFNativeMethods.CFRelease(_runLoop);
+            _runLoop = IntPtr.Zero;
+        }
+    }
+
+    private void AbandonNativeReferences()
+    {
+        if (_arrivedCallbackDelegate is not null)
+        {
+            _abandonedCallbackDelegates.Add(_arrivedCallbackDelegate);
+        }
+
+        if (_removedCallbackDelegate is not null)
+        {
+            _abandonedCallbackDelegates.Add(_removedCallbackDelegate);
+        }
+
+        _hidManager = IntPtr.Zero;
+        _runLoop = IntPtr.Zero;
+        _runLoopMode = IntPtr.Zero;
+        _arrivedCallbackDelegate = null;
+        _removedCallbackDelegate = null;
+    }
+
     protected override void Dispose(bool disposing)
     {
         if (_disposed)
@@ -422,13 +481,17 @@ internal sealed class MacOSHidDeviceListener : HidDeviceListener
             {
                 CFNativeMethods.CFRunLoopStop(_runLoop);
             }
-            if (_runLoopMode != IntPtr.Zero)
+
+            if (_listenerThread is not null && _listenerThread.IsAlive)
             {
-                CFNativeMethods.CFRelease(_runLoopMode);
+                AbandonNativeReferences();
             }
-            if (_hidManager != IntPtr.Zero)
+            else
             {
-                CFNativeMethods.CFRelease(_hidManager);
+                _listenerThread = null;
+                ReleaseNativeReferences();
+                _arrivedCallbackDelegate = null;
+                _removedCallbackDelegate = null;
             }
         }
 

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
@@ -40,6 +40,8 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
     private const int SymbolicLinkOffset = 24;
 
     private readonly Lock _syncLock = new();
+    private readonly Lock _cacheLock = new();
+    private readonly HashSet<string> _knownSymbolicLinks = new(StringComparer.OrdinalIgnoreCase);
     private GCHandle _marshalableThisPtr;
     private NativeMethods.CM_NOTIFY_CALLBACK? _callbackDelegate;
     private IntPtr _notificationHandle;
@@ -139,6 +141,10 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
             }
 
             _callbackDelegate = null;
+            lock (_cacheLock)
+            {
+                _knownSymbolicLinks.Clear();
+            }
 
             Status = DeviceListenerStatus.Stopped;
         }
@@ -178,31 +184,29 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
                 HandleDeviceArrival(eventData);
                 break;
             case NativeMethods.CM_NOTIFY_ACTION.DEVICEINTERFACEREMOVAL:
-                HandleDeviceRemoval();
+                HandleDeviceRemoval(eventData);
                 break;
         }
     }
 
     private void HandleDeviceArrival(IntPtr eventData)
     {
-        if (eventData == IntPtr.Zero)
-        {
-            return;
-        }
-
         try
         {
-            // The symbolic link (device path) starts at offset 24 in the event data
-            var symbolicLinkPtr = IntPtr.Add(eventData, SymbolicLinkOffset);
-            var devicePath = Marshal.PtrToStringUni(symbolicLinkPtr);
-
-            if (string.IsNullOrEmpty(devicePath))
+            var devicePath = ReadSymbolicLink(eventData);
+            if (devicePath is null)
             {
+                OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Added));
                 return;
             }
 
+            lock (_cacheLock)
+            {
+                _knownSymbolicLinks.Add(devicePath);
+            }
+
             Logger.LogDebug("HID device arrived: {DevicePath}", devicePath);
-            OnDeviceEvent();
+            OnDeviceEvent(CreateHint(HidDeviceChangeKind.Added, devicePath));
         }
         catch (Exception ex)
         {
@@ -210,10 +214,50 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         }
     }
 
-    private void HandleDeviceRemoval()
+    private void HandleDeviceRemoval(IntPtr eventData)
     {
-        OnDeviceEvent();
+        try
+        {
+            var devicePath = ReadSymbolicLink(eventData);
+            if (devicePath is null)
+            {
+                OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
+                return;
+            }
+
+            lock (_cacheLock)
+            {
+                _knownSymbolicLinks.Remove(devicePath);
+            }
+
+            Logger.LogDebug("HID device removed: {DevicePath}", devicePath);
+            OnDeviceEvent(CreateHint(HidDeviceChangeKind.Removed, devicePath));
+        }
+        catch (Exception ex)
+        {
+            Logger.LogWarning(ex, "Failed to process device removal");
+            OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
+        }
     }
+
+    private static string? ReadSymbolicLink(IntPtr eventData)
+    {
+        if (eventData == IntPtr.Zero)
+        {
+            return null;
+        }
+
+        // The symbolic link (device path) starts at offset 24 in CM_NOTIFY_EVENT_DATA.
+        var symbolicLinkPtr = IntPtr.Add(eventData, SymbolicLinkOffset);
+        var devicePath = Marshal.PtrToStringUni(symbolicLinkPtr);
+        return string.IsNullOrEmpty(devicePath) ? null : devicePath;
+    }
+
+    private static HidDeviceRescanHint CreateHint(HidDeviceChangeKind changeKind, string devicePath) =>
+        new(changeKind, NormalizeSymbolicLink(devicePath), devicePath);
+
+    private static string NormalizeSymbolicLink(string devicePath) =>
+        devicePath.ToUpperInvariant();
 
     protected override void Dispose(bool disposing)
     {

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
@@ -70,7 +70,13 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
                 // Keep callback delegate alive for the duration of the listener
                 _callbackDelegate = NotificationCallback;
 
-                // Keep a weak reference so native callbacks can recover the listener without self-rooting it.
+                // Deliberately Weak, not Normal: a strong handle would self-root the listener,
+                // making the finalizer unreachable while registered — an owner that drops the
+                // listener without Dispose() would leak the native registration forever and keep
+                // pumping events into an abandoned object graph. The Weak handle keeps the
+                // finalizer reachable so it can unregister (draining in-flight callbacks) and
+                // free this handle. During normal operation the owner strongly roots the
+                // listener, so callbacks never observe a collected target.
                 _marshalableThisPtr = GCHandle.Alloc(this, GCHandleType.Weak);
 
                 // Build the notification filter for HID device interfaces
@@ -153,6 +159,9 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         var handle = GCHandle.FromIntPtr(context);
         if (!handle.IsAllocated || handle.Target is not WindowsHidDeviceListener listener)
         {
+            // Weak handle target collected (listener dropped without Dispose); the finalizer
+            // will unregister the native notification. Drop the hint until then.
+            Logger.LogDebug("HID notification received for a collected listener; ignoring");
             return 0;
         }
 
@@ -223,7 +232,9 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         }
     }
 
-    private static string? ReadSymbolicLink(IntPtr eventData, int eventDataSize)
+    // Internal for unit testing: pure memory parsing with no P/Invoke, so the
+    // bounds behavior is verifiable on any platform.
+    internal static string? ReadSymbolicLink(IntPtr eventData, int eventDataSize)
     {
         if (eventData == IntPtr.Zero)
         {
@@ -239,8 +250,13 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         }
 
         // The symbolic link (device path) starts at offset 24 in CM_NOTIFY_EVENT_DATA.
+        // Windows NUL-terminates the string within eventDataSize, but never trust native
+        // sizes blindly: bound the read to the event payload and trim at the first NUL.
         var symbolicLinkPtr = IntPtr.Add(eventData, SymbolicLinkOffset);
-        var devicePath = Marshal.PtrToStringUni(symbolicLinkPtr);
+        var maxChars = (eventDataSize - SymbolicLinkOffset) / sizeof(char);
+        var buffer = Marshal.PtrToStringUni(symbolicLinkPtr, maxChars);
+        var nulIndex = buffer.IndexOf('\0');
+        var devicePath = nulIndex >= 0 ? buffer[..nulIndex] : buffer;
         return string.IsNullOrEmpty(devicePath) ? null : devicePath;
     }
 

--- a/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
+++ b/src/Core/src/Transports/Hid/Windows/WindowsHidDeviceListener.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using Microsoft.Extensions.Logging;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using Yubico.YubiKit.Core.Native.Windows.Cfgmgr32;
 
@@ -40,8 +41,6 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
     private const int SymbolicLinkOffset = 24;
 
     private readonly Lock _syncLock = new();
-    private readonly Lock _cacheLock = new();
-    private readonly HashSet<string> _knownSymbolicLinks = new(StringComparer.OrdinalIgnoreCase);
     private GCHandle _marshalableThisPtr;
     private NativeMethods.CM_NOTIFY_CALLBACK? _callbackDelegate;
     private IntPtr _notificationHandle;
@@ -71,11 +70,12 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
                 // Keep callback delegate alive for the duration of the listener
                 _callbackDelegate = NotificationCallback;
 
-                // Pin 'this' so we can pass it to the callback
-                _marshalableThisPtr = GCHandle.Alloc(this);
+                // Keep a weak reference so native callbacks can recover the listener without self-rooting it.
+                _marshalableThisPtr = GCHandle.Alloc(this, GCHandleType.Weak);
 
                 // Build the notification filter for HID device interfaces
                 var filterSize = Marshal.SizeOf<NativeMethods.CM_NOTIFY_FILTER>();
+                Debug.Assert(filterSize == NativeMethods.CmNotifyFilterSize);
                 var filter = new NativeMethods.CM_NOTIFY_FILTER
                 {
                     cbSize = filterSize,
@@ -99,6 +99,7 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
                     {
                         Logger.LogWarning("Failed to register HID notification: {Result}", result);
                         Status = DeviceListenerStatus.Error;
+                        ClearRegistrationState();
                         return;
                     }
 
@@ -113,6 +114,7 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
             {
                 Logger.LogError(ex, "Failed to start Windows HID listener");
                 Status = DeviceListenerStatus.Error;
+                ClearRegistrationState();
             }
         }
     }
@@ -134,17 +136,7 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
                 _notificationHandle = IntPtr.Zero;
             }
 
-            // Free the GCHandle
-            if (_marshalableThisPtr.IsAllocated)
-            {
-                _marshalableThisPtr.Free();
-            }
-
-            _callbackDelegate = null;
-            lock (_cacheLock)
-            {
-                _knownSymbolicLinks.Clear();
-            }
+            ClearRegistrationState();
 
             Status = DeviceListenerStatus.Stopped;
         }
@@ -166,7 +158,7 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
 
         try
         {
-            listener.HandleNotification(action, eventData);
+            listener.HandleNotification(action, eventData, eventDataSize);
         }
         catch (Exception ex)
         {
@@ -176,33 +168,28 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         return 0; // ERROR_SUCCESS
     }
 
-    private void HandleNotification(NativeMethods.CM_NOTIFY_ACTION action, IntPtr eventData)
+    private void HandleNotification(NativeMethods.CM_NOTIFY_ACTION action, IntPtr eventData, int eventDataSize)
     {
         switch (action)
         {
             case NativeMethods.CM_NOTIFY_ACTION.DEVICEINTERFACEARRIVAL:
-                HandleDeviceArrival(eventData);
+                HandleDeviceArrival(eventData, eventDataSize);
                 break;
             case NativeMethods.CM_NOTIFY_ACTION.DEVICEINTERFACEREMOVAL:
-                HandleDeviceRemoval(eventData);
+                HandleDeviceRemoval(eventData, eventDataSize);
                 break;
         }
     }
 
-    private void HandleDeviceArrival(IntPtr eventData)
+    private void HandleDeviceArrival(IntPtr eventData, int eventDataSize)
     {
         try
         {
-            var devicePath = ReadSymbolicLink(eventData);
+            var devicePath = ReadSymbolicLink(eventData, eventDataSize);
             if (devicePath is null)
             {
                 OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Added));
                 return;
-            }
-
-            lock (_cacheLock)
-            {
-                _knownSymbolicLinks.Add(devicePath);
             }
 
             Logger.LogDebug("HID device arrived: {DevicePath}", devicePath);
@@ -211,23 +198,19 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         catch (Exception ex)
         {
             Logger.LogWarning(ex, "Failed to process device arrival");
+            OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Added));
         }
     }
 
-    private void HandleDeviceRemoval(IntPtr eventData)
+    private void HandleDeviceRemoval(IntPtr eventData, int eventDataSize)
     {
         try
         {
-            var devicePath = ReadSymbolicLink(eventData);
+            var devicePath = ReadSymbolicLink(eventData, eventDataSize);
             if (devicePath is null)
             {
                 OnDeviceEvent(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
                 return;
-            }
-
-            lock (_cacheLock)
-            {
-                _knownSymbolicLinks.Remove(devicePath);
             }
 
             Logger.LogDebug("HID device removed: {DevicePath}", devicePath);
@@ -240,10 +223,18 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
         }
     }
 
-    private static string? ReadSymbolicLink(IntPtr eventData)
+    private static string? ReadSymbolicLink(IntPtr eventData, int eventDataSize)
     {
         if (eventData == IntPtr.Zero)
         {
+            return null;
+        }
+
+        if (eventDataSize < SymbolicLinkOffset + sizeof(char))
+        {
+            Logger.LogDebug(
+                "HID notification event data too small for symbolic link: {EventDataSize}",
+                eventDataSize);
             return null;
         }
 
@@ -258,6 +249,17 @@ internal sealed class WindowsHidDeviceListener : HidDeviceListener
 
     private static string NormalizeSymbolicLink(string devicePath) =>
         devicePath.ToUpperInvariant();
+
+    private void ClearRegistrationState()
+    {
+        if (_marshalableThisPtr.IsAllocated)
+        {
+            _marshalableThisPtr.Free();
+        }
+
+        _callbackDelegate = null;
+        _notificationHandle = IntPtr.Zero;
+    }
 
     protected override void Dispose(bool disposing)
     {

--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidDeviceListenerIntegrationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Transports/Hid/HidDeviceListenerIntegrationTests.cs
@@ -123,7 +123,7 @@ public class HidDeviceListenerIntegrationTests
 
         try
         {
-            listener.DeviceEvent = () => Interlocked.Increment(ref eventCount);
+            listener.DeviceEvent = _ => Interlocked.Increment(ref eventCount);
             listener.Start();
 
             // Act - wait briefly with listener running

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
@@ -14,6 +14,8 @@
 
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Transports.Hid;
+using Yubico.YubiKit.Core.Transports.SmartCard;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -336,7 +338,14 @@ public class YubiKeyDeviceManagerTests
     {
         var repository = new YubiKeyDeviceRepository();
         var findYubiKeys = new FakeFindYubiKeys([]);
-        var monitorService = new YubiKeyDeviceMonitorService(repository, findYubiKeys);
+
+        // Use fake listeners: real platform listeners would surface genuine hotplug events
+        // during test runs and perturb exact ScanCount assertions.
+        var monitorService = new YubiKeyDeviceMonitorService(
+            repository,
+            findYubiKeys,
+            static () => new FakeHidDeviceListener(),
+            static () => new FakeSmartCardDeviceListener());
         var manager = new YubiKeyDeviceManager(repository, monitorService);
 
         return (manager, findYubiKeys, repository);
@@ -357,26 +366,62 @@ public class YubiKeyDeviceManagerTests
     }
 
     /// <summary>
-    /// Fake IFindYubiKeys for testing with scan counting.
+    /// Fake IFindYubiKeys for testing with scan counting. Counters use interlocked/volatile
+    /// access because scans run on the monitor loop while tests read from the test thread.
     /// </summary>
     private sealed class FakeFindYubiKeys(IReadOnlyList<IYubiKey> initialDevices) : IFindYubiKeys
     {
+        private readonly Lock _syncLock = new();
         private IReadOnlyList<IYubiKey> _devices = initialDevices;
+        private int _scanCount;
 
-        public int ScanCount { get; private set; }
+        public int ScanCount => Volatile.Read(ref _scanCount);
 
-        public void SetDevices(IReadOnlyList<IYubiKey> devices) => _devices = devices;
+        public void SetDevices(IReadOnlyList<IYubiKey> devices)
+        {
+            lock (_syncLock)
+            {
+                _devices = devices;
+            }
+        }
 
         public Task<IReadOnlyList<IYubiKey>> FindAllAsync(
             ConnectionType type,
             CancellationToken cancellationToken = default)
         {
-            ScanCount++;
+            Interlocked.Increment(ref _scanCount);
+
+            IReadOnlyList<IYubiKey> devices;
+            lock (_syncLock)
+            {
+                devices = _devices;
+            }
+
             var filtered = type == ConnectionType.All
-                ? _devices
-                : _devices.Where(d => type.Matches(d.AvailableConnections)).ToList();
+                ? devices
+                : devices.Where(d => type.Matches(d.AvailableConnections)).ToList();
             return Task.FromResult<IReadOnlyList<IYubiKey>>(filtered);
         }
+    }
+
+    private sealed class FakeHidDeviceListener : HidDeviceListener
+    {
+        public override void Start() => Status = DeviceListenerStatus.Started;
+
+        public override void Stop() => Status = DeviceListenerStatus.Stopped;
+    }
+
+    private sealed class FakeSmartCardDeviceListener : ISmartCardDeviceListener
+    {
+        public Action? DeviceEvent { get; set; }
+
+        public DeviceListenerStatus Status { get; private set; } = DeviceListenerStatus.Stopped;
+
+        public void Start() => Status = DeviceListenerStatus.Started;
+
+        public void Stop() => Status = DeviceListenerStatus.Stopped;
+
+        public void Dispose() => DeviceEvent = null;
     }
 
     /// <summary>

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
@@ -104,9 +104,10 @@ public class YubiKeyDeviceManagerTests
         // Populate cache with an initial scan before monitoring starts
         await manager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
 
-        // Start monitoring (event-driven, does not trigger its own scan)
+        // Start monitoring performs one startup rescan, then FindAllAsync returns cache.
         manager.StartMonitoring(TimeSpan.FromSeconds(10));
 
+        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Monitoring startup rescan did not run");
         var scanCountAfterStart = findYubiKeys.ScanCount;
 
         // Act - Call FindAllAsync while monitoring
@@ -339,6 +340,20 @@ public class YubiKeyDeviceManagerTests
         var manager = new YubiKeyDeviceManager(repository, monitorService);
 
         return (manager, findYubiKeys, repository);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, string failureMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!condition())
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+            {
+                throw new TimeoutException(failureMessage);
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
+        }
     }
 
     /// <summary>

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
@@ -14,6 +14,8 @@
 
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Transports.Hid;
+using Yubico.YubiKit.Core.Transports.SmartCard;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -102,6 +104,121 @@ public class YubiKeyDeviceMonitorServiceTests
     }
 
 
+
+    [Fact]
+    public async Task StartMonitoring_PerformsInitialRescan()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, _, _) = CreateService();
+        findYubiKeys.SetDevices([new FakeYubiKey("device-1", ConnectionType.HidFido)]);
+
+        // Act
+        service.StartMonitoring(TimeSpan.FromSeconds(10));
+
+        // Assert
+        await WaitUntilAsync(() => repository.HasData, "Initial monitoring rescan did not update repository");
+        Assert.Single(repository.GetAll());
+        Assert.Equal(1, findYubiKeys.ScanCount);
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
+    }
+
+    [Fact]
+    public async Task HidListenerHint_DoesNotEmitPublicDeviceChangeWithoutRepositoryDiff()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, hidListener, _) = CreateService();
+        service.StartMonitoring(TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
+
+        var events = new List<DeviceEvent>();
+        using var subscription = repository.DeviceChanges.Subscribe(events.Add);
+        var scanCount = findYubiKeys.ScanCount;
+
+        // Act
+        hidListener.Raise(new HidDeviceRescanHint(
+            HidDeviceChangeKind.Added,
+            PlatformDeviceId: "diagnostic-only",
+            DevicePath: "/dev/hidraw999"));
+
+        // Assert
+        await WaitUntilAsync(() => findYubiKeys.ScanCount > scanCount, "HID hint did not trigger rescan");
+        Assert.Empty(events);
+        Assert.Empty(repository.GetAll());
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
+    }
+
+    [Fact]
+    public async Task HidUnknownRemoval_TriggersRepositoryRescan()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, hidListener, _) = CreateService();
+        service.StartMonitoring(TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
+
+        findYubiKeys.SetDevices([new FakeYubiKey("device-2", ConnectionType.HidOtp)]);
+
+        // Act - unknown removals must still fall back to a repository rescan.
+        hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
+
+        // Assert
+        await WaitUntilAsync(
+            () => repository.GetAll().Any(device => device.DeviceId == "device-2"),
+            "Unknown HID removal hint did not trigger repository rescan");
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
+    }
+
+    [Fact]
+    public async Task ConcurrentListenerEvents_DoNotRunConcurrentRescans()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, hidListener, smartCardListener) = CreateService();
+        findYubiKeys.ScanDelay = TimeSpan.FromMilliseconds(80);
+
+        service.StartMonitoring(TimeSpan.FromSeconds(10));
+        await WaitUntilAsync(
+            () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
+            "Initial monitoring rescan did not complete");
+
+        findYubiKeys.ResetCounters();
+
+        // Act
+        var start = new ManualResetEventSlim();
+        var tasks = Enumerable.Range(0, 32)
+            .Select(i => Task.Run(() =>
+            {
+                start.Wait(TestContext.Current.CancellationToken);
+                if (i % 2 == 0)
+                {
+                    hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Added, $"hid-{i}"));
+                }
+                else
+                {
+                    smartCardListener.Raise();
+                }
+            }, TestContext.Current.CancellationToken))
+            .ToArray();
+
+        start.Set();
+        await Task.WhenAll(tasks);
+
+        // Assert
+        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Listener events did not trigger a rescan");
+        Assert.Equal(1, findYubiKeys.MaxConcurrentScans);
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
+        start.Dispose();
+    }
 
     [Fact]
     public void IsMonitoring_InitiallyFalse()
@@ -317,20 +434,141 @@ public class YubiKeyDeviceMonitorServiceTests
     /// <summary>
     /// Fake IFindYubiKeys for testing.
     /// </summary>
+    private static (
+        YubiKeyDeviceMonitorService Service,
+        YubiKeyDeviceRepository Repository,
+        FakeFindYubiKeys FindYubiKeys,
+        FakeHidDeviceListener HidListener,
+        FakeSmartCardDeviceListener SmartCardListener) CreateService()
+    {
+        var repository = new YubiKeyDeviceRepository();
+        var findYubiKeys = new FakeFindYubiKeys([]);
+        var hidListener = new FakeHidDeviceListener();
+        var smartCardListener = new FakeSmartCardDeviceListener();
+        var service = new YubiKeyDeviceMonitorService(
+            repository,
+            findYubiKeys,
+            () => hidListener,
+            () => smartCardListener);
+
+        return (service, repository, findYubiKeys, hidListener, smartCardListener);
+    }
+
+    private static async Task WaitUntilAsync(Func<bool> condition, string failureMessage)
+    {
+        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (!condition())
+        {
+            if (DateTimeOffset.UtcNow >= deadline)
+            {
+                throw new TimeoutException(failureMessage);
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
+        }
+    }
+
+    private sealed class FakeHidDeviceListener : HidDeviceListener
+    {
+        public override void Start() => Status = DeviceListenerStatus.Started;
+
+        public override void Stop() => Status = DeviceListenerStatus.Stopped;
+
+        public void Raise(HidDeviceRescanHint hint) => OnDeviceEvent(hint);
+    }
+
+    private sealed class FakeSmartCardDeviceListener : ISmartCardDeviceListener
+    {
+        public Action? DeviceEvent { get; set; }
+
+        public DeviceListenerStatus Status { get; private set; } = DeviceListenerStatus.Stopped;
+
+        public void Start() => Status = DeviceListenerStatus.Started;
+
+        public void Stop() => Status = DeviceListenerStatus.Stopped;
+
+        public void Raise() => DeviceEvent?.Invoke();
+
+        public void Dispose() => DeviceEvent = null;
+    }
+
     private sealed class FakeFindYubiKeys(IReadOnlyList<IYubiKey> initialDevices) : IFindYubiKeys
     {
+        private readonly Lock _syncLock = new();
         private IReadOnlyList<IYubiKey> _devices = initialDevices;
+        private int _activeScans;
+        private int _maxConcurrentScans;
+        private int _scanCount;
 
-        public void SetDevices(IReadOnlyList<IYubiKey> devices) => _devices = devices;
+        public TimeSpan ScanDelay { get; set; }
 
-        public Task<IReadOnlyList<IYubiKey>> FindAllAsync(
+        public int ScanCount => Volatile.Read(ref _scanCount);
+
+        public int ActiveScans => Volatile.Read(ref _activeScans);
+
+        public int MaxConcurrentScans => Volatile.Read(ref _maxConcurrentScans);
+
+        public void SetDevices(IReadOnlyList<IYubiKey> devices)
+        {
+            lock (_syncLock)
+            {
+                _devices = devices;
+            }
+        }
+
+        public void ResetCounters()
+        {
+            Volatile.Write(ref _scanCount, 0);
+            Volatile.Write(ref _activeScans, 0);
+            Volatile.Write(ref _maxConcurrentScans, 0);
+        }
+
+        public async Task<IReadOnlyList<IYubiKey>> FindAllAsync(
             ConnectionType type,
             CancellationToken cancellationToken = default)
         {
-            var filtered = type == ConnectionType.All
-                ? _devices
-                : _devices.Where(d => type.Matches(d.AvailableConnections)).ToList();
-            return Task.FromResult<IReadOnlyList<IYubiKey>>(filtered);
+            Interlocked.Increment(ref _scanCount);
+            var activeScans = Interlocked.Increment(ref _activeScans);
+            UpdateMaxConcurrentScans(activeScans);
+
+            try
+            {
+                if (ScanDelay > TimeSpan.Zero)
+                {
+                    await Task.Delay(ScanDelay, cancellationToken).ConfigureAwait(false);
+                }
+
+                IReadOnlyList<IYubiKey> devices;
+                lock (_syncLock)
+                {
+                    devices = _devices;
+                }
+
+                return type == ConnectionType.All
+                    ? devices
+                    : devices.Where(d => type.Matches(d.AvailableConnections)).ToList();
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _activeScans);
+            }
+        }
+
+        private void UpdateMaxConcurrentScans(int activeScans)
+        {
+            while (true)
+            {
+                var current = Volatile.Read(ref _maxConcurrentScans);
+                if (activeScans <= current)
+                {
+                    return;
+                }
+
+                if (Interlocked.CompareExchange(ref _maxConcurrentScans, activeScans, current) == current)
+                {
+                    return;
+                }
+            }
         }
     }
 

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
@@ -106,6 +106,7 @@ public class YubiKeyDeviceMonitorServiceTests
 
 
     [Fact]
+    [Trait("Category", "RuntimeResilience")]
     public async Task StartMonitoring_PerformsInitialRescan()
     {
         // Arrange
@@ -126,6 +127,7 @@ public class YubiKeyDeviceMonitorServiceTests
     }
 
     [Fact]
+    [Trait("Category", "RuntimeResilience")]
     public async Task HidListenerHint_DoesNotEmitPublicDeviceChangeWithoutRepositoryDiff()
     {
         // Arrange
@@ -154,6 +156,7 @@ public class YubiKeyDeviceMonitorServiceTests
     }
 
     [Fact]
+    [Trait("Category", "RuntimeResilience")]
     public async Task HidUnknownRemoval_TriggersRepositoryRescan()
     {
         // Arrange
@@ -177,6 +180,7 @@ public class YubiKeyDeviceMonitorServiceTests
     }
 
     [Fact]
+    [Trait("Category", "RuntimeResilience")]
     public async Task ConcurrentListenerEvents_DoNotRunConcurrentRescans()
     {
         // Arrange
@@ -218,6 +222,97 @@ public class YubiKeyDeviceMonitorServiceTests
         await service.DisposeAsync();
         repository.Dispose();
         start.Dispose();
+    }
+
+    [Fact]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task HintBurst_CoalescesIntoBoundedRescans()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, hidListener, _) = CreateService();
+        service.StartMonitoring(TimeSpan.FromSeconds(30));
+        await WaitUntilAsync(
+            () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
+            "Initial monitoring rescan did not complete");
+
+        findYubiKeys.ResetCounters();
+
+        // Act - a rapid burst must coalesce into few rescans, not one rescan per hint.
+        for (var i = 0; i < 32; i++)
+        {
+            hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Added, $"hid-{i}"));
+        }
+
+        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Hint burst did not trigger a rescan");
+
+        // Allow any (incorrect) trailing per-hint rescans to surface before asserting the bound.
+        await Task.Delay(YubiKeyDeviceMonitorService.MaxCoalesceInterval + YubiKeyDeviceMonitorService.ThrottleInterval,
+            TestContext.Current.CancellationToken);
+
+        // Assert - the whole burst lands within the debounce window: at most the coalesced
+        // rescan plus one straggler, never anything approaching one rescan per hint.
+        Assert.InRange(findYubiKeys.ScanCount, 1, 2);
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
+    }
+
+    [Fact]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task SustainedHintStorm_RescanRunsWithinMaxCoalesceInterval()
+    {
+        // Arrange
+        var (service, repository, findYubiKeys, hidListener, _) = CreateService();
+        service.StartMonitoring(TimeSpan.FromSeconds(30));
+        await WaitUntilAsync(
+            () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
+            "Initial monitoring rescan did not complete");
+
+        findYubiKeys.ResetCounters();
+
+        // Act - hints arriving faster than the quiet period re-arm the debounce forever;
+        // the max coalesce cap must force a rescan while the storm is still running.
+        using var stormDone = new CancellationTokenSource();
+        var storm = Task.Run(async () =>
+        {
+            var i = 0;
+            while (!stormDone.IsCancellationRequested)
+            {
+                hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Added, $"storm-{i++}"));
+                try
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(20), stormDone.Token).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    break;
+                }
+            }
+        }, TestContext.Current.CancellationToken);
+
+        try
+        {
+            // Assert - without the cap this deadline is unreachable: the quiet period re-arms
+            // on every 20 ms hint until the storm ends.
+            var deadline = DateTimeOffset.UtcNow + YubiKeyDeviceMonitorService.MaxCoalesceInterval + TimeSpan.FromSeconds(2);
+            while (findYubiKeys.ScanCount < 1)
+            {
+                Assert.True(
+                    DateTimeOffset.UtcNow < deadline,
+                    "Sustained hint storm starved the rescan beyond the max coalesce interval");
+                await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
+            }
+        }
+        finally
+        {
+            stormDone.Cancel();
+            await storm;
+        }
+
+        service.StopMonitoring();
+        await service.DisposeAsync();
+        repository.Dispose();
     }
 
     [Fact]

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
@@ -471,6 +471,28 @@ public class YubiKeyDeviceMonitorServiceTests
     }
 
     [Fact]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task DisposeAsync_RescanHungIgnoringCancellation_CompletesWithinBoundedTime()
+    {
+        // Arrange - discovery scan hangs and ignores cancellation, holding the rescan gate
+        var (service, repository, findYubiKeys, _, _) = CreateService(shutdownTimeout: TimeSpan.FromMilliseconds(250));
+        findYubiKeys.HangIgnoringCancellation = true;
+
+        service.StartMonitoring(TimeSpan.FromHours(1));
+        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial rescan never started");
+
+        // Act - disposal must abandon the stuck loop and rescan gate instead of hanging
+        await service.DisposeAsync().AsTask()
+            .WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        // Cleanup - unblock the stuck scan; the abandoned (undisposed) gate accepts its Release
+        findYubiKeys.ReleaseHungScans();
+        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Hung rescan never completed after release");
+
+        repository.Dispose();
+    }
+
+    [Fact]
     public async Task RescanAsync_AfterDispose_ThrowsObjectDisposedException()
     {
         // Arrange
@@ -534,7 +556,7 @@ public class YubiKeyDeviceMonitorServiceTests
         YubiKeyDeviceRepository Repository,
         FakeFindYubiKeys FindYubiKeys,
         FakeHidDeviceListener HidListener,
-        FakeSmartCardDeviceListener SmartCardListener) CreateService()
+        FakeSmartCardDeviceListener SmartCardListener) CreateService(TimeSpan? shutdownTimeout = null)
     {
         var repository = new YubiKeyDeviceRepository();
         var findYubiKeys = new FakeFindYubiKeys([]);
@@ -544,7 +566,8 @@ public class YubiKeyDeviceMonitorServiceTests
             repository,
             findYubiKeys,
             () => hidListener,
-            () => smartCardListener);
+            () => smartCardListener,
+            shutdownTimeout);
 
         return (service, repository, findYubiKeys, hidListener, smartCardListener);
     }
@@ -590,12 +613,20 @@ public class YubiKeyDeviceMonitorServiceTests
     private sealed class FakeFindYubiKeys(IReadOnlyList<IYubiKey> initialDevices) : IFindYubiKeys
     {
         private readonly Lock _syncLock = new();
+        private readonly TaskCompletionSource _hangReleased = new(TaskCreationOptions.RunContinuationsAsynchronously);
         private IReadOnlyList<IYubiKey> _devices = initialDevices;
         private int _activeScans;
         private int _maxConcurrentScans;
         private int _scanCount;
 
         public TimeSpan ScanDelay { get; set; }
+
+        /// <summary>
+        /// When set, scans block until <see cref="ReleaseHungScans"/> is called,
+        /// ignoring the caller's cancellation token. Models a discovery backend
+        /// stuck in native I/O.
+        /// </summary>
+        public bool HangIgnoringCancellation { get; set; }
 
         public int ScanCount => Volatile.Read(ref _scanCount);
 
@@ -610,6 +641,8 @@ public class YubiKeyDeviceMonitorServiceTests
                 _devices = devices;
             }
         }
+
+        public void ReleaseHungScans() => _hangReleased.TrySetResult();
 
         public void ResetCounters()
         {
@@ -628,6 +661,11 @@ public class YubiKeyDeviceMonitorServiceTests
 
             try
             {
+                if (HangIgnoringCancellation)
+                {
+                    await _hangReleased.Task.ConfigureAwait(false);
+                }
+
                 if (ScanDelay > TimeSpan.Zero)
                 {
                     await Task.Delay(ScanDelay, cancellationToken).ConfigureAwait(false);

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Windows/CfgMgr32InteropTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Windows/CfgMgr32InteropTests.cs
@@ -1,0 +1,53 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.InteropServices;
+using Yubico.YubiKit.Core.Native.Windows.Cfgmgr32;
+using Yubico.YubiKit.Core.Transports.Hid.Windows;
+
+namespace Yubico.YubiKit.Core.UnitTests.Native.Windows;
+
+public class CfgMgr32InteropTests
+{
+    [Fact]
+    public void CmNotifyFilter_Size_MatchesNativeLayout()
+    {
+        Assert.Equal(416, Marshal.SizeOf<NativeMethods.CM_NOTIFY_FILTER>());
+        Assert.Equal(NativeMethods.CmNotifyFilterSize, Marshal.SizeOf<NativeMethods.CM_NOTIFY_FILTER>());
+    }
+
+    [Fact]
+    public void WindowsHidDeviceListener_Start_RegistersNotification()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Skip("Windows-only");
+        }
+
+        using var listener = new WindowsHidDeviceListener();
+
+        listener.Start();
+
+        try
+        {
+            Assert.Equal(DeviceListenerStatus.Started, listener.Status);
+        }
+        finally
+        {
+            listener.Stop();
+        }
+
+        Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidDeviceListenerDisposalTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/HidDeviceListenerDisposalTests.cs
@@ -215,7 +215,7 @@ public class HidDeviceListenerDisposalTests
         try
         {
             var eventCount = 0;
-            listener.DeviceEvent = () => Interlocked.Increment(ref eventCount);
+            listener.DeviceEvent = _ => Interlocked.Increment(ref eventCount);
 
             // Act - wait briefly, no events should fire
             Thread.Sleep(100);

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDeviceListenerFaultInjectionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDeviceListenerFaultInjectionTests.cs
@@ -1,0 +1,369 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Concurrent;
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Transports.Hid;
+using Yubico.YubiKit.Core.Transports.Hid.Linux;
+
+namespace Yubico.YubiKit.Core.UnitTests.Transports.Hid;
+
+/// <summary>
+/// No-hardware fault injection for <see cref="LinuxHidDeviceListener"/> via a fake
+/// <see cref="ILinuxHidEventSource"/>. Verifies the red-team failure modes: persistent
+/// poll/fd errors must transition to Error and exit without spinning, shutdown must unblock
+/// a waiting thread promptly, receive failures and unclassifiable events must emit
+/// unknown-change rescan hints instead of being suppressed, and every session must dispose
+/// its event source exactly once. Runs on all platforms because the fake replaces udev.
+/// </summary>
+[Trait("Category", "RuntimeResilience")]
+public class LinuxHidDeviceListenerFaultInjectionTests
+{
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    [Fact]
+    public void PersistentPollFailure_TransitionsToErrorWithoutSpinningAndDisposesSource() =>
+        AssertFailureOutcomeStopsListener(LinuxHidPollOutcome.PollFailed);
+
+    [Fact]
+    public void MonitorFdError_TransitionsToErrorWithoutSpinningAndDisposesSource() =>
+        AssertFailureOutcomeStopsListener(LinuxHidPollOutcome.MonitorFdError);
+
+    [Fact]
+    public void ShutdownFdError_TransitionsToErrorWithoutSpinningAndDisposesSource() =>
+        AssertFailureOutcomeStopsListener(LinuxHidPollOutcome.ShutdownFdError);
+
+    private static void AssertFailureOutcomeStopsListener(LinuxHidPollOutcome failureOutcome)
+    {
+        // Arrange
+        var source = new FakeLinuxHidEventSource();
+        source.ScriptOutcomes(failureOutcome);
+        using var listener = new LinuxHidDeviceListener(() => source);
+
+        // Act
+        listener.Start();
+
+        // Assert - the loop must exit on the first failure, not hot-spin retrying a broken fd.
+        Assert.True(
+            SpinWait.SpinUntil(() => listener.Status == DeviceListenerStatus.Error, DefaultTimeout),
+            $"Listener did not reach Error after {failureOutcome}");
+        Assert.True(
+            SpinWait.SpinUntil(() => source.Disposed, DefaultTimeout),
+            "Listener thread did not dispose its event source on the error path");
+        Assert.Equal(1, source.WaitCalls);
+
+        // Stop after Error must still land in Stopped without double-disposing the source.
+        listener.Stop();
+        Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
+        Assert.Equal(1, source.DisposeCalls);
+    }
+
+    [Fact]
+    public void Stop_WhileThreadBlockedInWait_UnblocksPromptlyAndDisposesSource()
+    {
+        // Arrange - no scripted outcomes: the fake blocks in WaitForEvent until shutdown,
+        // modeling a poll() blocked with no udev traffic.
+        var source = new FakeLinuxHidEventSource();
+        using var listener = new LinuxHidDeviceListener(() => source);
+        listener.Start();
+        Assert.True(source.WaitUntilBlocked(DefaultTimeout), "Listener thread never entered WaitForEvent");
+
+        // Act
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        listener.Stop();
+        stopwatch.Stop();
+
+        // Assert - shutdown signal must wake the blocked thread well before the join timeout.
+        Assert.True(
+            stopwatch.Elapsed < TimeSpan.FromSeconds(4),
+            $"Stop took {stopwatch.Elapsed}; shutdown signal failed to wake the blocked thread");
+        Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
+        Assert.True(source.Disposed, "Joined listener thread must have disposed its event source");
+        Assert.Equal(1, source.WaitCalls);
+    }
+
+    [Fact]
+    public void ReceiveFailure_EmitsUnknownRescanHintAndKeepsListening()
+    {
+        // Arrange - poll reports an event but the receive fails (e.g. ENOBUFS overrun),
+        // which is exactly when a removal may have been lost.
+        var source = new FakeLinuxHidEventSource();
+        source.ScriptOutcomes(LinuxHidPollOutcome.Event);
+        source.ScriptReceives((LinuxHidUdevEvent?)null);
+        using var listener = new LinuxHidDeviceListener(() => source);
+        var hints = new ConcurrentQueue<HidDeviceRescanHint>();
+        listener.DeviceEvent = hints.Enqueue;
+
+        // Act
+        listener.Start();
+
+        // Assert - never suppress: an unknown-change hint must trigger a discovery rescan.
+        Assert.True(
+            SpinWait.SpinUntil(() => !hints.IsEmpty, DefaultTimeout),
+            "Receive failure did not produce a rescan hint");
+        Assert.True(hints.TryDequeue(out var hint));
+        Assert.Equal(HidDeviceRescanHint.Unknown, hint);
+        Assert.Equal(DeviceListenerStatus.Started, listener.Status);
+
+        listener.Stop();
+        Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
+    }
+
+    [Fact]
+    public void EventWithoutAction_EmitsUnknownRescanHint()
+    {
+        // Arrange
+        var source = new FakeLinuxHidEventSource();
+        source.ScriptOutcomes(LinuxHidPollOutcome.Event);
+        source.ScriptReceives(new LinuxHidUdevEvent(Action: null, "/sys/devices/hid-1", "/dev/hidraw0"));
+        using var listener = new LinuxHidDeviceListener(() => source);
+        var hints = new ConcurrentQueue<HidDeviceRescanHint>();
+        listener.DeviceEvent = hints.Enqueue;
+
+        // Act
+        listener.Start();
+
+        // Assert
+        Assert.True(
+            SpinWait.SpinUntil(() => !hints.IsEmpty, DefaultTimeout),
+            "Action-less udev event did not produce a rescan hint");
+        Assert.True(hints.TryDequeue(out var hint));
+        Assert.Equal(HidDeviceRescanHint.Unknown, hint);
+
+        listener.Stop();
+    }
+
+    [Fact]
+    public void NonTopologyAction_DoesNotEmitHintAndLoopContinues()
+    {
+        // Arrange - a "change" event must be ignored, and the loop must stay healthy enough
+        // to deliver the "add" that follows it.
+        var source = new FakeLinuxHidEventSource();
+        source.ScriptOutcomes(LinuxHidPollOutcome.Event, LinuxHidPollOutcome.Event);
+        source.ScriptReceives(
+            new LinuxHidUdevEvent("change", "/sys/devices/hid-1", "/dev/hidraw0"),
+            new LinuxHidUdevEvent("add", "/sys/devices/hid-2", "/dev/hidraw1"));
+        using var listener = new LinuxHidDeviceListener(() => source);
+        var hints = new ConcurrentQueue<HidDeviceRescanHint>();
+        listener.DeviceEvent = hints.Enqueue;
+
+        // Act
+        listener.Start();
+
+        // Assert - exactly one hint: the add. The preceding change produced nothing.
+        Assert.True(
+            SpinWait.SpinUntil(() => !hints.IsEmpty, DefaultTimeout),
+            "Add event following an ignored change event did not produce a hint");
+        Assert.True(hints.TryDequeue(out var hint));
+        Assert.Equal(HidDeviceChangeKind.Added, hint!.ChangeKind);
+        Assert.Equal("/sys/devices/hid-2", hint.PlatformDeviceId);
+        Assert.Equal("/dev/hidraw1", hint.DevicePath);
+        Assert.True(hints.IsEmpty);
+
+        listener.Stop();
+    }
+
+    [Fact]
+    public void RemoveEvent_EmitsRemovedHintWithStableIdentity()
+    {
+        // Arrange
+        var source = new FakeLinuxHidEventSource();
+        source.ScriptOutcomes(LinuxHidPollOutcome.Event);
+        source.ScriptReceives(new LinuxHidUdevEvent("remove", "/sys/devices/hid-1", "/dev/hidraw0"));
+        using var listener = new LinuxHidDeviceListener(() => source);
+        var hints = new ConcurrentQueue<HidDeviceRescanHint>();
+        listener.DeviceEvent = hints.Enqueue;
+
+        // Act
+        listener.Start();
+
+        // Assert
+        Assert.True(
+            SpinWait.SpinUntil(() => !hints.IsEmpty, DefaultTimeout),
+            "Remove event did not produce a rescan hint");
+        Assert.True(hints.TryDequeue(out var hint));
+        Assert.Equal(HidDeviceChangeKind.Removed, hint!.ChangeKind);
+        Assert.Equal("/sys/devices/hid-1", hint.PlatformDeviceId);
+
+        listener.Stop();
+    }
+
+    [Fact]
+    public void AddEventWithUnreadyHidrawNode_EmitsDelayedFallbackHint()
+    {
+        // Arrange - the hidraw node is not ready at notification time; the listener must
+        // re-hint after the readiness delay so discovery retries once permissions settle.
+        var source = new FakeLinuxHidEventSource { HidrawReady = false };
+        source.ScriptOutcomes(LinuxHidPollOutcome.Event);
+        source.ScriptReceives(new LinuxHidUdevEvent("add", "/sys/devices/hid-1", "/dev/hidraw0"));
+        using var listener = new LinuxHidDeviceListener(() => source);
+        var hints = new ConcurrentQueue<HidDeviceRescanHint>();
+        listener.DeviceEvent = hints.Enqueue;
+
+        // Act
+        listener.Start();
+
+        // Assert
+        Assert.True(
+            SpinWait.SpinUntil(() => hints.Count >= 2, DefaultTimeout),
+            "Unready hidraw node did not produce a delayed fallback hint");
+        Assert.True(hints.TryDequeue(out var first));
+        Assert.True(hints.TryDequeue(out var fallback));
+        Assert.Equal(HidDeviceChangeKind.Added, first!.ChangeKind);
+        Assert.Equal(first, fallback);
+
+        listener.Stop();
+    }
+
+    [Fact]
+    public void InitializeFailure_SetsErrorAndDisposesSourceWithoutStartingThread()
+    {
+        // Arrange
+        var source = new FakeLinuxHidEventSource { InitializeResult = false };
+        using var listener = new LinuxHidDeviceListener(() => source);
+
+        // Act
+        listener.Start();
+
+        // Assert
+        Assert.Equal(DeviceListenerStatus.Error, listener.Status);
+        Assert.True(source.Disposed, "Failed initialization must dispose the event source");
+        Assert.Equal(0, source.WaitCalls);
+    }
+
+    [Fact]
+    public void StartAfterError_CreatesFreshSourceAndListens()
+    {
+        // Arrange - first session fails to initialize; a later Start must recover with a
+        // brand-new source instead of staying wedged in Error.
+        var broken = new FakeLinuxHidEventSource { InitializeResult = false };
+        var healthy = new FakeLinuxHidEventSource();
+        var sources = new Queue<FakeLinuxHidEventSource>([broken, healthy]);
+        var factoryCalls = 0;
+        using var listener = new LinuxHidDeviceListener(() =>
+        {
+            factoryCalls++;
+            return sources.Dequeue();
+        });
+
+        // Act
+        listener.Start();
+        Assert.Equal(DeviceListenerStatus.Error, listener.Status);
+        listener.Start();
+
+        // Assert
+        Assert.Equal(2, factoryCalls);
+        Assert.Equal(DeviceListenerStatus.Started, listener.Status);
+        Assert.True(healthy.WaitUntilBlocked(DefaultTimeout), "Recovered session never started listening");
+
+        listener.Stop();
+        Assert.Equal(DeviceListenerStatus.Stopped, listener.Status);
+        Assert.True(healthy.Disposed);
+    }
+
+    [Theory]
+    [InlineData("/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001/hidraw/hidraw3",
+        "/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001")]
+    [InlineData("/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001/hidraw",
+        "/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001")]
+    [InlineData("/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001",
+        "/sys/devices/pci0/usb1/1-1/1-1:1.0/0003:1050:0407.0001")]
+    public void TrimHidrawSyspath_MapsHidrawNodesToStableParentIdentity(string syspath, string expected)
+    {
+        // add and remove notifications arrive on the hidraw child; identity must resolve to
+        // the parent HID device path so both sides of a plug/unplug pair correlate.
+        Assert.Equal(expected, LinuxUdevHidEventSource.TrimHidrawSyspath(syspath));
+    }
+
+    /// <summary>
+    /// Scriptable fake event source. Scripted outcomes are returned in order; once exhausted,
+    /// <see cref="WaitForEvent"/> blocks (like a quiet poll()) until <see cref="SignalShutdown"/>.
+    /// </summary>
+    private sealed class FakeLinuxHidEventSource : ILinuxHidEventSource
+    {
+        private readonly ConcurrentQueue<LinuxHidPollOutcome> _outcomes = new();
+        private readonly ConcurrentQueue<LinuxHidUdevEvent?> _receives = new();
+        private readonly ManualResetEventSlim _shutdownWake = new(false);
+        private readonly ManualResetEventSlim _blockedInWait = new(false);
+        private volatile bool _shutdownSignaled;
+        private int _waitCalls;
+        private int _disposeCalls;
+
+        public bool InitializeResult { get; set; } = true;
+
+        public bool HidrawReady { get; set; } = true;
+
+        public int WaitCalls => Volatile.Read(ref _waitCalls);
+
+        public int DisposeCalls => Volatile.Read(ref _disposeCalls);
+
+        public bool Disposed => DisposeCalls > 0;
+
+        public void ScriptOutcomes(params LinuxHidPollOutcome[] outcomes)
+        {
+            foreach (var outcome in outcomes)
+            {
+                _outcomes.Enqueue(outcome);
+            }
+        }
+
+        public void ScriptReceives(params LinuxHidUdevEvent?[] events)
+        {
+            foreach (var udevEvent in events)
+            {
+                _receives.Enqueue(udevEvent);
+            }
+        }
+
+        public bool WaitUntilBlocked(TimeSpan timeout) => _blockedInWait.Wait(timeout);
+
+        public bool Initialize() => InitializeResult;
+
+        public LinuxHidPollOutcome WaitForEvent()
+        {
+            Interlocked.Increment(ref _waitCalls);
+
+            if (_shutdownSignaled)
+            {
+                return LinuxHidPollOutcome.ShutdownSignaled;
+            }
+
+            if (_outcomes.TryDequeue(out var outcome))
+            {
+                return outcome;
+            }
+
+            _blockedInWait.Set();
+            _shutdownWake.Wait();
+            return LinuxHidPollOutcome.ShutdownSignaled;
+        }
+
+        public LinuxHidUdevEvent? ReceiveEvent() =>
+            _receives.TryDequeue(out var udevEvent) ? udevEvent : null;
+
+        public void SignalShutdown()
+        {
+            _shutdownSignaled = true;
+            _shutdownWake.Set();
+        }
+
+        public bool IsHidrawReady(string? devNode) => HidrawReady;
+
+        public void Dispose()
+        {
+            Interlocked.Increment(ref _disposeCalls);
+            _shutdownWake.Set();
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/WindowsHidDeviceListenerTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/WindowsHidDeviceListenerTests.cs
@@ -1,0 +1,142 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Runtime.InteropServices;
+using Yubico.YubiKit.Core.Transports.Hid.Windows;
+
+namespace Yubico.YubiKit.Core.UnitTests.Transports.Hid;
+
+/// <summary>
+/// Verifies <see cref="WindowsHidDeviceListener.ReadSymbolicLink"/> never reads past the
+/// event payload reported by the native notification, even when the buffer is not
+/// NUL-terminated. Pure memory parsing with no P/Invoke, so it runs on all platforms.
+/// </summary>
+public class WindowsHidDeviceListenerTests
+{
+    /// <summary>
+    /// Offset of the SymbolicLink field in CM_NOTIFY_EVENT_DATA. Mirrors the constant in
+    /// <see cref="WindowsHidDeviceListener"/>.
+    /// </summary>
+    private const int SymbolicLinkOffset = 24;
+
+    [Fact]
+    public void ReadSymbolicLink_NulTerminatedWithinPayload_ReturnsPath()
+    {
+        const string expected = @"\\?\HID#VID_1050&PID_0407";
+
+        RunWithEventData(expected + '\0', trailingGarbage: false, (eventData, eventDataSize) =>
+        {
+            var result = WindowsHidDeviceListener.ReadSymbolicLink(eventData, eventDataSize);
+
+            Assert.Equal(expected, result);
+        });
+    }
+
+    [Fact]
+    public void ReadSymbolicLink_MissingNulTerminator_ReadsOnlyDeclaredPayload()
+    {
+        // No NUL anywhere in the declared payload; garbage characters follow it in memory.
+        // The parser must stop at eventDataSize instead of scanning for a terminator.
+        const string payload = @"\\?\HID#VID_1050";
+
+        RunWithEventData(payload, trailingGarbage: true, (eventData, eventDataSize) =>
+        {
+            var result = WindowsHidDeviceListener.ReadSymbolicLink(eventData, eventDataSize);
+
+            Assert.Equal(payload, result);
+        });
+    }
+
+    [Fact]
+    public void ReadSymbolicLink_NulBeforeEndOfPayload_TrimsAtFirstNul()
+    {
+        const string expected = @"\\?\HID#VID_1050";
+
+        RunWithEventData(expected + "\0IGNORED", trailingGarbage: false, (eventData, eventDataSize) =>
+        {
+            var result = WindowsHidDeviceListener.ReadSymbolicLink(eventData, eventDataSize);
+
+            Assert.Equal(expected, result);
+        });
+    }
+
+    [Fact]
+    public void ReadSymbolicLink_EmptyString_ReturnsNull()
+    {
+        RunWithEventData("\0", trailingGarbage: false, (eventData, eventDataSize) =>
+        {
+            var result = WindowsHidDeviceListener.ReadSymbolicLink(eventData, eventDataSize);
+
+            Assert.Null(result);
+        });
+    }
+
+    [Fact]
+    public void ReadSymbolicLink_PayloadTooSmallForAnyCharacter_ReturnsNull()
+    {
+        RunWithEventData("X", trailingGarbage: false, (eventData, _) =>
+        {
+            // Declared size covers the header only - no room for even one character.
+            var result = WindowsHidDeviceListener.ReadSymbolicLink(eventData, SymbolicLinkOffset);
+
+            Assert.Null(result);
+        });
+    }
+
+    [Fact]
+    public void ReadSymbolicLink_ZeroPointer_ReturnsNull()
+    {
+        var result = WindowsHidDeviceListener.ReadSymbolicLink(IntPtr.Zero, 256);
+
+        Assert.Null(result);
+    }
+
+    /// <summary>
+    /// Allocates a native buffer laid out like CM_NOTIFY_EVENT_DATA: 24 header bytes followed
+    /// by <paramref name="symbolicLink"/> as UTF-16. The declared event size covers exactly the
+    /// header plus the string. When <paramref name="trailingGarbage"/> is set, non-NUL sentinel
+    /// characters are written after the declared payload so an unbounded read would include them.
+    /// </summary>
+    private static void RunWithEventData(string symbolicLink, bool trailingGarbage, Action<IntPtr, int> assert)
+    {
+        var payloadChars = symbolicLink.ToCharArray();
+        var eventDataSize = SymbolicLinkOffset + (payloadChars.Length * sizeof(char));
+        var garbageChars = trailingGarbage ? 8 : 0;
+        var allocationSize = eventDataSize + (garbageChars * sizeof(char));
+
+        var eventData = Marshal.AllocHGlobal(allocationSize);
+        try
+        {
+            for (var i = 0; i < SymbolicLinkOffset; i++)
+            {
+                Marshal.WriteByte(eventData, i, 0);
+            }
+
+            Marshal.Copy(payloadChars, 0, IntPtr.Add(eventData, SymbolicLinkOffset), payloadChars.Length);
+
+            if (garbageChars > 0)
+            {
+                var garbage = new char[garbageChars];
+                Array.Fill(garbage, 'Z');
+                Marshal.Copy(garbage, 0, IntPtr.Add(eventData, eventDataSize), garbageChars);
+            }
+
+            assert(eventData, eventDataSize);
+        }
+        finally
+        {
+            Marshal.FreeHGlobal(eventData);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add typed HID rescan hints and route listener notifications through repository rescans only.
- Replace monitor Rx ingress with a single-reader channel debounce loop and startup rescan.
- Harden Windows, macOS, and Linux HID listeners for removal identity, native loop shutdown/error behavior, and Linux eventfd wakeup.
- Update migration and discovery docs for the HID listener callback break.

## Verification
- dotnet toolchain.cs build
- dotnet toolchain.cs -- test --project Core --filter "ClassName~YubiKeyDeviceMonitorServiceTests"
- dotnet toolchain.cs -- test --project Core --filter "ClassName~HidDeviceListener"
- dotnet toolchain.cs -- test --project Core
- dotnet toolchain.cs -- resilience --fast
- dotnet toolchain.cs -- test --integration --project Core --filter "FullyQualifiedName~HidEnumerationTests"
- dotnet toolchain.cs -- test --integration --project Core --filter "FullyQualifiedName~HidDeviceListenerIntegrationTests"
- dotnet toolchain.cs -- test --integration --project Core --filter "FullyQualifiedName~MonitorService_Enabled_Tests"
- dotnet format --no-restore --verify-no-changes --include <changed C# files>

## Notes
- Three read-only review passes were run; final pass found no HIGH/MEDIUM issues.
- Whole-tree dotnet format remains blocked by existing repo/tool issues: restore failure without --no-restore and unrelated pre-existing formatting findings with --no-restore.
- Windows and macOS listener behavior was statically reviewed; Linux behavior was also integration-tested on this machine.