### PR TITLE
fix: align Yubico.NativeShims to 16 KB pages for Android 15+

### DIFF
--- a/Yubico.NativeShims/CMakeLists.txt
+++ b/Yubico.NativeShims/CMakeLists.txt
@@ -35,6 +35,10 @@ if (APPLE OR UNIX)
         set(BACKEND "pcsc")
         # RELRO + NOW = full read-only relocations (exploit mitigation)
         add_link_options("-Wl,-z,relro,-z,now,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.gnu")
+        # 16 KB max page size: required for Android 15+ devices with 16 KB memory pages
+        # (and by Google Play). x86_64 links at 4 KB by default; arm64 already defaults to 64 KB.
+        # https://developer.android.com/guide/practices/page-sizes
+        add_link_options("-Wl,-z,max-page-size=16384")
     endif()
 
     # --- macOS / Linux: security hardening (GCC/Clang) ---


### PR DESCRIPTION
## Summary

The Linux `x86_64` build of `libYubico.NativeShims.so` is linked with **4 KB (`2**12`) segment alignment**, which fails the [Android 16 KB page-size requirement](https://developer.android.com/guide/practices/page-sizes) for apps running on Android 15+ devices that use 16 KB memory pages (and is now required by Google Play). The `arm64` build is unaffected because the aarch64 linker already defaults to 64 KB alignment.

This surfaced downstream: a .NET Android app that transitively bundles this shim fails its `validate-16kb-compatibility` gate on `lib/x86_64/libYubico.NativeShims.so: UNALIGNED (2**12)`.

## Change

Add a single linker option in the Linux branch of `Yubico.NativeShims/CMakeLists.txt`:

```cmake
add_link_options("-Wl,-z,max-page-size=16384")
```

- Forces 16 KB-aligned `LOAD` segments on both Linux architectures.
- No-op for `arm64` (already ≥16 KB); fixes `x86_64`.
- `zig cc` (used by the build scripts) forwards `-Wl,…` to LLD, which honors `-z max-page-size=`.

## Verification

I have **not** built the artifacts locally (no Linux toolchain on hand), so the numbers below are the *expected* result to confirm against the CI build output rather than a measured run.

Check the `LOAD` segment alignment of the produced `.so`:

```
readelf -lW linux-x64/libYubico.NativeShims.so | awk '$1=="LOAD"{print $NF}'
```

Expected: every `LOAD` segment reports alignment `0x4000` (16384) or larger. Prior to this change the `x86_64` build reports `0x1000` (4 KB).

If useful, I'm happy to add an assertion to the `build-linux-*.sh` scripts (fail if any `LOAD` alignment `< 0x4000`), mirroring the existing glibc-version check, so this can't silently regress — let me know if you'd like it folded into this PR.
