### PR TITLE
fix: align Yubico.NativeShims Linux shims to 64 KB pages (supersedes #531)

### DIFF
--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -271,6 +271,10 @@ jobs:
         working-directory: Yubico.NativeShims
         run: |
           bash tests/check_exports.sh linux-x64/libYubico.NativeShims.so
+      - name: Verify 16 KB/64 KB page alignment of LOAD segments
+        working-directory: Yubico.NativeShims
+        run: |
+          bash tests/check_alignment.sh linux-x64/libYubico.NativeShims.so
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: linux-x64
@@ -437,6 +441,11 @@ jobs:
         run: |
           # nm reads ELF metadata regardless of target arch — works on x86_64 host inspecting aarch64 .so
           bash tests/check_exports.sh linux-arm64/libYubico.NativeShims.so
+      - name: Verify 16 KB/64 KB page alignment of LOAD segments
+        working-directory: Yubico.NativeShims
+        run: |
+          # readelf reads ELF metadata regardless of target arch — works on x86_64 host inspecting aarch64 .so
+          bash tests/check_alignment.sh linux-arm64/libYubico.NativeShims.so
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: linux-arm64

--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -272,6 +272,9 @@ jobs:
         run: |
           bash tests/check_exports.sh linux-x64/libYubico.NativeShims.so
       - name: Verify >= 64 KB page alignment of LOAD segments
+        working-directory: Yubico.NativeShims
+        run: |
+          bash tests/check_alignment.sh linux-x64/libYubico.NativeShims.so
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: linux-x64

--- a/.github/workflows/build-nativeshims.yml
+++ b/.github/workflows/build-nativeshims.yml
@@ -271,10 +271,7 @@ jobs:
         working-directory: Yubico.NativeShims
         run: |
           bash tests/check_exports.sh linux-x64/libYubico.NativeShims.so
-      - name: Verify 16 KB/64 KB page alignment of LOAD segments
-        working-directory: Yubico.NativeShims
-        run: |
-          bash tests/check_alignment.sh linux-x64/libYubico.NativeShims.so
+      - name: Verify >= 64 KB page alignment of LOAD segments
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: linux-x64

--- a/Yubico.NativeShims/CMakeLists.txt
+++ b/Yubico.NativeShims/CMakeLists.txt
@@ -35,6 +35,13 @@ if (APPLE OR UNIX)
         set(BACKEND "pcsc")
         # RELRO + NOW = full read-only relocations (exploit mitigation)
         add_link_options("-Wl,-z,relro,-z,now,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exports.gnu")
+        # 64 KB max page size: aligns LOAD segments so the shim is loadable on systems
+        # with larger memory pages. Required for Android 15+ 16 KB-page devices (Google
+        # Play, Nov 2025) AND for aarch64 Linux distros that use 64 KB kernel pages
+        # (e.g. RHEL/Fedora). 64 KB is a superset alignment: it satisfies 4 KB, 16 KB and
+        # 64 KB page sizes. x86_64 defaults to 4 KB; aarch64 already defaults to 64 KB, so
+        # this is a no-op there and never lowers it. https://developer.android.com/guide/practices/page-sizes
+        add_link_options("-Wl,-z,max-page-size=65536")
     endif()
 
     # --- macOS / Linux: security hardening (GCC/Clang) ---

--- a/Yubico.NativeShims/tests/check_alignment.sh
+++ b/Yubico.NativeShims/tests/check_alignment.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Validate that a built Yubico.NativeShims Linux shared library has all PT_LOAD
+# segments aligned to at least 64 KB (0x10000).
+#
+# Usage:  check_alignment.sh <path-to-libYubico.NativeShims.so>
+#
+# Why: an ELF segment aligned to N bytes can only be memory-mapped on a system
+# whose runtime page size divides N. x86_64 links at 4 KB by default, which fails
+# on Android 15+ 16 KB-page devices (Google Play requirement) and on 64 KB-page
+# aarch64 Linux distros (RHEL/Fedora). 64 KB alignment is a superset that loads
+# correctly on 4 KB, 16 KB and 64 KB page systems. See CMakeLists.txt and
+# https://developer.android.com/guide/practices/page-sizes
+#
+# Works on cross-compiled binaries because it reads ELF file metadata, not the
+# runtime loader. Exits non-zero if any LOAD segment is aligned below 64 KB.
+
+set -euo pipefail
+
+# Minimum acceptable PT_LOAD alignment (64 KB). Covers Android 16 KB pages and
+# aarch64 Linux 64 KB-page kernels in a single value.
+MIN_ALIGN=$((0x10000))
+
+if [ "$#" -ne 1 ]; then
+    echo "usage: $0 <path-to-shared-library>" >&2
+    exit 2
+fi
+
+LIB="$1"
+
+if [ ! -f "$LIB" ]; then
+    echo "ERROR: shared library not found: $LIB" >&2
+    exit 2
+fi
+
+# Pick an available ELF reader. readelf (GNU binutils) is present on Linux CI;
+# llvm-readelf is the LLVM equivalent used on macOS dev machines.
+READELF=""
+for candidate in readelf llvm-readelf; do
+    if command -v "$candidate" >/dev/null 2>&1; then
+        READELF="$candidate"
+        break
+    fi
+done
+if [ -z "$READELF" ]; then
+    echo "ERROR: neither 'readelf' nor 'llvm-readelf' found on PATH" >&2
+    exit 2
+fi
+
+# Collect the alignment column (last field) of every LOAD program header.
+# -W (wide) keeps each header on a single line so $NF is reliably the Align.
+ALIGNS=$("$READELF" -lW "$LIB" | awk '$1=="LOAD"{print $NF}')
+
+if [ -z "$ALIGNS" ]; then
+    echo "ERROR: no PT_LOAD segments found in $LIB (not an ELF shared library?)" >&2
+    exit 2
+fi
+
+echo "Library:  $LIB"
+echo "Required: LOAD alignment >= 0x$(printf '%x' "$MIN_ALIGN") (64 KB)"
+
+STATUS=0
+COUNT=0
+while IFS= read -r align; do
+    [ -z "$align" ] && continue
+    COUNT=$((COUNT + 1))
+    # Alignments are reported as hex (e.g. 0x10000). Normalize to a number.
+    dec=$((align))
+    if [ "$dec" -lt "$MIN_ALIGN" ]; then
+        echo "  FAIL: LOAD segment aligned to $align (< 64 KB)"
+        STATUS=1
+    else
+        echo "  ok:   LOAD segment aligned to $align"
+    fi
+done <<< "$ALIGNS"
+
+echo "Checked:  $COUNT LOAD segment(s)"
+
+if [ $STATUS -eq 0 ]; then
+    echo "PASS: all LOAD segments aligned to >= 64 KB"
+else
+    echo "FAIL: one or more LOAD segments aligned below 64 KB" >&2
+    echo "      Ensure -Wl,-z,max-page-size=65536 is applied at link time." >&2
+fi
+exit $STATUS


### PR DESCRIPTION
# Description

Aligns the Linux `Yubico.NativeShims` shared libraries to **64 KB pages** by linking with `-Wl,-z,max-page-size=65536`, so all `PT_LOAD` segments are loadable on systems with larger memory pages.

This supersedes and builds on the excellent investigation in #531 by @maxbrousseau, which correctly identified that the x86_64 shim links at 4 KB and fails the Android 15+ 16 KB page-size requirement (Google Play, Nov 2025). Thank you again for putting us on the right track!

## Why 64 KB instead of 16 KB

We verified linker behavior empirically (zig/LLD, both arches) and against primary sources (ELF gABI, glibc `BZ #28688`, LLD `Target.h`/`AArch64.cpp`):

- **x86_64** defaults to **4 KB** (`0x1000`) → fails Android 16 KB. ✅ fixed by this change.
- **aarch64** already defaults to **64 KB** (`0x10000`) in LLD.
- `max-page-size=16384` (as in #531) would have **lowered aarch64 from 64 KB to 16 KB**, risking load failures on 64 KB-page aarch64 Linux distros (e.g. RHEL/Fedora) — a regression on an officially supported platform.
- **64 KB is a superset alignment**: a 64 KB-aligned segment loads correctly on 4 KB, 16 KB *and* 64 KB page systems (`p_vaddr ≡ p_offset` congruence holds for every smaller page size). Increasing alignment is backward- and forward-compatible for loading; only *lowering* it below a target's runtime page size breaks. The only cost is a small amount of file padding, negligible for a native shim.

This single value future-proofs every audience: desktop/server Windows/macOS/Linux (x64 + arm64), aarch64 Linux on 64 KB kernels, and Android 15+ bundlers — without regressing anyone.

`common-page-size` was evaluated and is **not** needed: all LOAD segments pass Google's `check_elf_alignment.sh` (≥16 KB) with `max-page-size` alone, and setting `common-page-size` would only add committed-memory cost on 4 KB systems.

Refs: #531

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How has this been tested?

1. **Local cross-compile (macOS + zig/LLD):** built the shim for `x86_64-linux-gnu` and `aarch64-linux-gnu` in baseline / 16 KB / 64 KB variants and inspected `LOAD` alignment with `llvm-readelf`. Confirmed x64 baseline = `0x1000`, arm64 baseline = `0x10000`, arm64 @16 KB = `0x4000` (the regression), and both @64 KB = `0x10000`.
2. **CI (real toolchain):** the `Build Yubico.NativeShims` workflow built the production shim (OpenSSL + pcsc + LTO via the zig wrappers) on both Linux arches. The new alignment step reports all 4 `LOAD` segments at `0x10000` and passes on `linux-x64` and `linux-arm64`.
3. **Regression guard:** new `tests/check_alignment.sh` (mirrors `tests/check_exports.sh`) fails the build if any `LOAD` segment is `< 64 KB`. Verified it passes at 64 KB and fails at both 4 KB and 16 KB.

**Test configuration**:
* OS version: Ubuntu 24.04 (CI) + macOS (local repro)
* Toolchain: zig cc → LLD, targeting glibc 2.23

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective (CI alignment check on both Linux arches)
- [x] New and existing unit tests pass locally with my changes
