### PR TITLE
fix: specify full .NET SDK version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-      "version": "9.0.0",
+      "version": "9.0.100",
       "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
## Summary
- Specify the .NET 9.0.100 SDK feature-band baseline in global.json.
- Retain latestFeature roll-forward behavior.

## Verification
- dotnet restore Yubico.NET.SDK.sln --verbosity minimal
- dotnet build Yubico.NET.SDK.sln --configuration Debug --no-restore --nologo --verbosity minimal

Fixes the GitHub managed NuGet dependency-submission workflow, which rejects the incomplete 9.0.0 SDK version when rollForward is configured.