### PR TITLE
release(alpha): v2.0.0-alpha.2 + anonymous GitHub Pages NuGet feed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: 1
@@ -62,7 +64,13 @@ jobs:
         run: dotnet toolchain.cs -- resilience --fast
 
       - name: Pack NuGet packages
-        run: dotnet toolchain.cs pack --package-version 2.0.0-preview.${{ github.run_number }}
+        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.1
+
+      - name: Attest build provenance for packages
+        if: github.event_name == 'push'
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: 'artifacts/packages/*.nupkg'
 
       - name: Publish to GitHub Packages
         if: github.event_name == 'push'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
         run: dotnet toolchain.cs -- resilience --fast
 
       - name: Pack NuGet packages
-        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.1
+        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.2
 
       - name: Attest build provenance for packages
         if: github.event_name == 'push'

--- a/.github/workflows/publish-alpha-feed.yml
+++ b/.github/workflows/publish-alpha-feed.yml
@@ -1,0 +1,75 @@
+name: Publish Alpha NuGet Feed (2.0)
+
+# Builds, packs, attests, and publishes the anonymous static NuGet feed to the
+# gh-pages branch (served at https://yubico.github.io/Yubico.NET.SDK/alpha/).
+# Runs only on pushes to yubikit. The feed is regenerated in full each run so
+# GitHub Pages always reflects the latest alpha packages (auto-update for consumers).
+
+on:
+  push:
+    branches: [ yubikit ]
+
+concurrency:
+  group: alpha-feed
+  cancel-in-progress: false
+
+permissions:
+  contents: write        # commit/push to gh-pages
+  id-token: write        # provenance attestation
+  attestations: write
+
+jobs:
+  publish-feed:
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_NOLOGO: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    steps:
+      - name: Check out source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install PC/SC dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends pcscd libpcsclite-dev libudev-dev
+
+      - name: Build
+        run: dotnet toolchain.cs build
+
+      - name: Pack NuGet packages
+        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.1
+
+      - name: Attest build provenance for packages
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
+        with:
+          subject-path: 'artifacts/packages/*.nupkg'
+
+      - name: Install Sleet
+        run: dotnet tool install -g sleet
+
+      - name: Generate static feed
+        run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
+          mkdir -p "$GITHUB_WORKSPACE/feed-output/alpha"
+          sleet init --config scripts/alpha/sleet.json --source alpha
+          sleet push artifacts/packages --config scripts/alpha/sleet.json --source alpha
+
+      - name: Assemble gh-pages content
+        run: |
+          mkdir -p publish/alpha
+          touch publish/.nojekyll
+          cp -R "$GITHUB_WORKSPACE/feed-output/alpha/." publish/alpha/
+
+      - name: Deploy to gh-pages
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./publish
+          publish_branch: gh-pages
+          keep_files: true

--- a/.github/workflows/publish-alpha-feed.yml
+++ b/.github/workflows/publish-alpha-feed.yml
@@ -4,10 +4,11 @@ name: Publish Alpha NuGet Feed (2.0)
 # gh-pages branch (served at https://yubico.github.io/Yubico.NET.SDK/alpha/).
 # Runs only on pushes to yubikit.
 #
-# The feed is rebuilt from the packages produced by this run. With a single pinned
-# version (2.0.0-alpha.1) each run simply refreshes that version. If multiple alpha
-# versions must coexist, seed feed-output from the live published feed before pushing
-# (see "Seed from published feed" step) so prior versions are retained in the catalog.
+# The feed is regenerated fresh each run and deployed as a full mirror
+# (keep_files: false), so gh-pages always exactly reflects the current alpha
+# packages. With a single pinned version (2.0.0-alpha.1) this is deterministic
+# and self-healing. To retain multiple coexisting versions later, the feed must
+# be generated against the previously published feed state (not a fresh init).
 
 on:
   push:
@@ -57,25 +58,13 @@ jobs:
       - name: Install Sleet
         run: dotnet tool install -g sleet
 
-      - name: Restore existing feed from gh-pages
-        # Seed feed-output from the current gh-pages content so previously-published
-        # alpha versions are retained when the catalog is regenerated. Best-effort:
-        # on the first publish the gh-pages branch may not exist yet.
-        continue-on-error: true
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
-        with:
-          ref: gh-pages
-          path: gh-pages-existing
-
       - name: Generate static feed
+        # Single pinned version (2.0.0-alpha.1): always generate a fresh, complete
+        # feed. Combined with keep_files:false below, gh-pages is an authoritative
+        # mirror of publish/ — deterministic and self-healing, no stale catalog.
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
-          mkdir -p "$GITHUB_WORKSPACE/feed-output/alpha"
-          if [ -f "$GITHUB_WORKSPACE/gh-pages-existing/alpha/index.json" ]; then
-            cp -R "$GITHUB_WORKSPACE/gh-pages-existing/alpha/." "$GITHUB_WORKSPACE/feed-output/alpha/"
-          else
-            sleet init --config scripts/alpha/sleet.json --source alpha
-          fi
+          sleet init --config scripts/alpha/sleet.json --source alpha
           sleet push artifacts/packages --config scripts/alpha/sleet.json --source alpha --force
 
       - name: Assemble gh-pages content
@@ -83,6 +72,8 @@ jobs:
           mkdir -p publish/alpha
           touch publish/.nojekyll
           cp -R "$GITHUB_WORKSPACE/feed-output/alpha/." publish/alpha/
+          # Preserve the landing page (full-mirror deploy replaces gh-pages contents).
+          cp scripts/alpha/index.html publish/index.html
 
       - name: Deploy to gh-pages
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
@@ -90,4 +81,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./publish
           publish_branch: gh-pages
-          keep_files: true
+          keep_files: false

--- a/.github/workflows/publish-alpha-feed.yml
+++ b/.github/workflows/publish-alpha-feed.yml
@@ -2,8 +2,12 @@ name: Publish Alpha NuGet Feed (2.0)
 
 # Builds, packs, attests, and publishes the anonymous static NuGet feed to the
 # gh-pages branch (served at https://yubico.github.io/Yubico.NET.SDK/alpha/).
-# Runs only on pushes to yubikit. The feed is regenerated in full each run so
-# GitHub Pages always reflects the latest alpha packages (auto-update for consumers).
+# Runs only on pushes to yubikit.
+#
+# The feed is rebuilt from the packages produced by this run. With a single pinned
+# version (2.0.0-alpha.1) each run simply refreshes that version. If multiple alpha
+# versions must coexist, seed feed-output from the live published feed before pushing
+# (see "Seed from published feed" step) so prior versions are retained in the catalog.
 
 on:
   push:
@@ -53,12 +57,26 @@ jobs:
       - name: Install Sleet
         run: dotnet tool install -g sleet
 
+      - name: Restore existing feed from gh-pages
+        # Seed feed-output from the current gh-pages content so previously-published
+        # alpha versions are retained when the catalog is regenerated. Best-effort:
+        # on the first publish the gh-pages branch may not exist yet.
+        continue-on-error: true
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          ref: gh-pages
+          path: gh-pages-existing
+
       - name: Generate static feed
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
           mkdir -p "$GITHUB_WORKSPACE/feed-output/alpha"
-          sleet init --config scripts/alpha/sleet.json --source alpha
-          sleet push artifacts/packages --config scripts/alpha/sleet.json --source alpha
+          if [ -f "$GITHUB_WORKSPACE/gh-pages-existing/alpha/index.json" ]; then
+            cp -R "$GITHUB_WORKSPACE/gh-pages-existing/alpha/." "$GITHUB_WORKSPACE/feed-output/alpha/"
+          else
+            sleet init --config scripts/alpha/sleet.json --source alpha
+          fi
+          sleet push artifacts/packages --config scripts/alpha/sleet.json --source alpha --force
 
       - name: Assemble gh-pages content
         run: |

--- a/.github/workflows/publish-alpha-feed.yml
+++ b/.github/workflows/publish-alpha-feed.yml
@@ -1,31 +1,36 @@
 name: Publish Alpha NuGet Feed (2.0)
 
-# Builds, packs, attests, and publishes the anonymous static NuGet feed to the
-# gh-pages branch (served at https://yubico.github.io/Yubico.NET.SDK/alpha/).
+# Builds, packs, attests, and publishes the anonymous static NuGet feed to
+# GitHub Pages (served at https://yubico.github.io/Yubico.NET.SDK/alpha/).
 # Runs only on pushes to yubikit.
 #
-# The feed is regenerated fresh each run and deployed as a full mirror
-# (keep_files: false), so gh-pages always exactly reflects the current alpha
-# packages. With a single pinned version (2.0.0-alpha.2) this is deterministic
-# and self-healing. To retain multiple coexisting versions later, the feed must
-# be generated against the previously published feed state (not a fresh init).
+# Uses the modern GitHub Pages deployment (upload-pages-artifact + deploy-pages),
+# which uploads the feed verbatim with no Jekyll processing. The feed is
+# regenerated fresh each run and deployed as a full replacement, so Pages always
+# exactly reflects the current alpha packages. With a single pinned version
+# (2.0.0-alpha.2) this is deterministic and self-healing.
 
 on:
   push:
     branches: [ yubikit ]
+  workflow_dispatch:
 
 concurrency:
-  group: alpha-feed
+  group: pages
   cancel-in-progress: false
 
 permissions:
-  contents: write        # commit/push to gh-pages
-  id-token: write        # provenance attestation
+  contents: read
+  id-token: write        # provenance attestation + Pages deploy
   attestations: write
+  pages: write           # deploy to Pages
 
 jobs:
   publish-feed:
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
       DOTNET_NOLOGO: 1
@@ -59,26 +64,22 @@ jobs:
         run: dotnet tool install -g sleet
 
       - name: Generate static feed
-        # Single pinned version (2.0.0-alpha.2): always generate a fresh, complete
-        # feed. Combined with keep_files:false below, gh-pages is an authoritative
-        # mirror of publish/ — deterministic and self-healing, no stale catalog.
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
           sleet init --config scripts/alpha/sleet.json --source alpha
           sleet push artifacts/packages --config scripts/alpha/sleet.json --source alpha --force
 
-      - name: Assemble gh-pages content
+      - name: Assemble Pages content
         run: |
           mkdir -p publish/alpha
-          touch publish/.nojekyll
           cp -R "$GITHUB_WORKSPACE/feed-output/alpha/." publish/alpha/
-          # Preserve the landing page (full-mirror deploy replaces gh-pages contents).
           cp scripts/alpha/index.html publish/index.html
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./publish
-          publish_branch: gh-pages
-          keep_files: false
+          path: ./publish
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/publish-alpha-feed.yml
+++ b/.github/workflows/publish-alpha-feed.yml
@@ -6,7 +6,7 @@ name: Publish Alpha NuGet Feed (2.0)
 #
 # The feed is regenerated fresh each run and deployed as a full mirror
 # (keep_files: false), so gh-pages always exactly reflects the current alpha
-# packages. With a single pinned version (2.0.0-alpha.1) this is deterministic
+# packages. With a single pinned version (2.0.0-alpha.2) this is deterministic
 # and self-healing. To retain multiple coexisting versions later, the feed must
 # be generated against the previously published feed state (not a fresh init).
 
@@ -48,7 +48,7 @@ jobs:
         run: dotnet toolchain.cs build
 
       - name: Pack NuGet packages
-        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.1
+        run: dotnet toolchain.cs pack --package-version 2.0.0-alpha.2
 
       - name: Attest build provenance for packages
         uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3.0.0
@@ -59,7 +59,7 @@ jobs:
         run: dotnet tool install -g sleet
 
       - name: Generate static feed
-        # Single pinned version (2.0.0-alpha.1): always generate a fresh, complete
+        # Single pinned version (2.0.0-alpha.2): always generate a fresh, complete
         # feed. Combined with keep_files:false below, gh-pages is an authoritative
         # mirror of publish/ — deterministic and self-healing, no stale catalog.
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - `--integration` requires `--project`: `dotnet toolchain.cs -- test --integration --project Piv --smoke`.
 - `--smoke` skips `Slow` and `RequiresUserPresence`; agents should not run touch/insert/remove tests unless a human explicitly coordinates hardware.
 - Use `dotnet toolchain.cs -- --help` when arguments act strangely; every script long option, including `--project`, requires the preceding `--` separator.
-- CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.1`.
+- CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.2`.
 - Run `dotnet format` or `dotnet format --verify-no-changes` before claiming formatting is clean.
 
 ## Project Shape

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 - `--integration` requires `--project`: `dotnet toolchain.cs -- test --integration --project Piv --smoke`.
 - `--smoke` skips `Slow` and `RequiresUserPresence`; agents should not run touch/insert/remove tests unless a human explicitly coordinates hardware.
 - Use `dotnet toolchain.cs -- --help` when arguments act strangely; every script long option, including `--project`, requires the preceding `--` separator.
-- CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-preview.<run>`.
+- CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.1`.
 - Run `dotnet format` or `dotnet format --verify-no-changes` before claiming formatting is clean.
 
 ## Project Shape

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -48,11 +48,12 @@
         <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
-        <!-- Alpha disclaimer (single source of truth). Surfaced via PackageReadmeFile
-             (package page) and PackageReleaseNotes (plain-text fallback). Remove when
-             the SDK exits alpha and completes the formal security audit. -->
+        <!-- Alpha disclaimer surfaced in package metadata via PackageReadmeFile
+             (package page) and PackageReleaseNotes (plain-text fallback). The
+             canonical long-form text lives in PACKAGE_README.md; keep these aligned.
+             Remove when the SDK exits alpha and completes the formal security audit. -->
         <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
-        <PackageReleaseNotes>ALPHA - NOT FOR PRODUCTION. Pre-release, subject to change, and not yet security-audited by Yubico. No security guarantees. Package names/namespaces may change. Evaluation / hackathon use only.</PackageReleaseNotes>
+        <PackageReleaseNotes>ALPHA - NOT FOR PRODUCTION. Pre-release, unsigned, subject to change, and not yet security-audited by Yubico. No security guarantees. Package names/namespaces may change. Evaluation / hackathon use only.</PackageReleaseNotes>
     </PropertyGroup>
 
     <!-- Ship the shared alpha PACKAGE_README.md in every packable package's root. -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,4 +1,10 @@
 <Project>
+    <!-- Determine if this is a test project (needed early for packaging conditions below) -->
+    <PropertyGroup>
+        <IsTestProject Condition="$(MSBuildProjectName.Contains('Test'))">true</IsTestProject>
+        <IsPackable Condition="'$(IsTestProject)' == 'true'">false</IsPackable>
+    </PropertyGroup>
+
     <PropertyGroup>
         <!-- Common Language Settings -->
         <LangVersion>14</LangVersion>
@@ -41,7 +47,18 @@
         <!-- Package Output -->
         <PackageOutputPath>$(MSBuildThisFileDirectory)artifacts</PackageOutputPath>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
+        <!-- Alpha disclaimer (single source of truth). Surfaced via PackageReadmeFile
+             (package page) and PackageReleaseNotes (plain-text fallback). Remove when
+             the SDK exits alpha and completes the formal security audit. -->
+        <PackageReadmeFile>PACKAGE_README.md</PackageReadmeFile>
+        <PackageReleaseNotes>ALPHA - NOT FOR PRODUCTION. Pre-release, subject to change, and not yet security-audited by Yubico. No security guarantees. Package names/namespaces may change. Evaluation / hackathon use only.</PackageReleaseNotes>
     </PropertyGroup>
+
+    <!-- Ship the shared alpha PACKAGE_README.md in every packable package's root. -->
+    <ItemGroup Condition="'$(IsTestProject)' != 'true'">
+        <None Include="$(MSBuildThisFileDirectory)PACKAGE_README.md" Pack="true" PackagePath="\" Visible="false"/>
+    </ItemGroup>
 
     <!-- Source Link Package (for all projects) -->
     <ItemGroup>
@@ -50,8 +67,6 @@
 
     <!-- Determine if this is a test project -->
     <PropertyGroup>
-        <IsTestProject Condition="$(MSBuildProjectName.Contains('Test'))">true</IsTestProject>
-        <IsPackable Condition="'$(IsTestProject)' == 'true'">false</IsPackable>
         <!-- Disable XML documentation for test projects -->
         <GenerateDocumentationFile Condition="'$(IsTestProject)' == 'true'">false</GenerateDocumentationFile>
     </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <!-- Enable Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- SDK Version - ALL packages ship with same version -->
-    <YubiKitVersion>2.0.0-preview.1</YubiKitVersion>
+    <YubiKitVersion>2.0.0-alpha.1</YubiKitVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Microsoft Dependencies -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
     <!-- Enable Central Package Management -->
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- SDK Version - ALL packages ship with same version -->
-    <YubiKitVersion>2.0.0-alpha.1</YubiKitVersion>
+    <YubiKitVersion>2.0.0-alpha.2</YubiKitVersion>
   </PropertyGroup>
   <ItemGroup>
     <!-- Microsoft Dependencies -->

--- a/PACKAGE_README.md
+++ b/PACKAGE_README.md
@@ -6,6 +6,7 @@
 > change** and has **not yet completed Yubico's formal security audit**.
 >
 > - **No security guarantees** are made until that audit is complete.
+> - Packages are **unsigned**.
 > - **Package names and namespaces may change** before the stable release.
 > - Provided for **evaluation and hackathon use only**.
 

--- a/PACKAGE_README.md
+++ b/PACKAGE_README.md
@@ -17,7 +17,7 @@ YubiHSM Auth, and device management.
 ## Install (prerelease)
 
 ```bash
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
 ```
 
 Alpha packages are distributed from a public, anonymous feed — no authentication

--- a/PACKAGE_README.md
+++ b/PACKAGE_README.md
@@ -1,0 +1,28 @@
+# Yubico .NET SDK v2 — ALPHA
+
+> ## ⚠️ ALPHA — NOT FOR PRODUCTION
+>
+> This is a **pre-release alpha** of the Yubico .NET SDK v2. It is **subject to
+> change** and has **not yet completed Yubico's formal security audit**.
+>
+> - **No security guarantees** are made until that audit is complete.
+> - **Package names and namespaces may change** before the stable release.
+> - Provided for **evaluation and hackathon use only**.
+
+The v2 SDK provides modern, type-safe .NET APIs for YubiKey hardware security
+devices, including PIV, FIDO2/WebAuthn, OATH, OpenPGP, YubiOTP, Security Domain,
+YubiHSM Auth, and device management.
+
+## Install (prerelease)
+
+```bash
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+```
+
+Alpha packages are distributed from a public, anonymous feed — no authentication
+required. See the project's GitHub Release notes for the feed URL and setup.
+
+## Links
+
+- Project: https://github.com/Yubico/Yubico.NET.SDK
+- License: Apache-2.0

--- a/PACKAGE_README.md
+++ b/PACKAGE_README.md
@@ -17,7 +17,7 @@ YubiHSM Auth, and device management.
 ## Install (prerelease)
 
 ```bash
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.2
 ```
 
 Alpha packages are distributed from a public, anonymous feed — no authentication

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # Yubico.NET.SDK
 
+> ## ⚠️ v2 ALPHA — NOT FOR PRODUCTION
+>
+> The v2 SDK (`2.0.0-alpha.1`, `yubikit` branch) is a **pre-release alpha**. It is
+> **subject to change** and has **not yet completed Yubico's formal security audit**.
+> **No security guarantees** are made until that audit is complete. Package names and
+> namespaces may change. Provided for **evaluation and hackathon use only**.
+
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Yubico/Yubico.NET.SDK/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Yubico/Yubico.NET.SDK)
 
 A comprehensive .NET SDK for interacting with YubiKey hardware security devices. This SDK provides high-level APIs for YubiKey's various applications including PIV, FIDO2, OATH, OpenPGP, and more.

--- a/README.md
+++ b/README.md
@@ -32,17 +32,23 @@ YubiKey is a hardware authentication device that supports multiple protocols and
 
 ## Installation
 
-Install packages from NuGet for the specific YubiKey applications you need:
+> **Alpha:** `2.0.0-alpha.1` is distributed from a public, anonymous prerelease
+> feed (not nuget.org). Add the feed first, then install with `--prerelease`.
+> Keep nuget.org enabled so transitive dependencies (e.g. `Yubico.NativeShims`)
+> resolve. Full details in the [release notes](scripts/alpha/RELEASE_NOTES.md).
 
 ```bash
-# Core library (required)
-dotnet add package Yubico.YubiKit.Core
+# 1. Add the anonymous alpha feed (one time)
+dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
 
-# Application modules (install as needed)
-dotnet add package Yubico.YubiKit.Piv
-dotnet add package Yubico.YubiKit.Fido2
-dotnet add package Yubico.YubiKit.Oath
-dotnet add package Yubico.YubiKit.Management
+# 2. Core library (required)
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+
+# 3. Application modules (install as needed)
+dotnet add package Yubico.YubiKit.Piv --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Fido2 --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Oath --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Management --version 2.0.0-alpha.1 --prerelease
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > ## ⚠️ v2 ALPHA — NOT FOR PRODUCTION
 >
-> The v2 SDK (`2.0.0-alpha.1`, `yubikit` branch) is a **pre-release alpha**. It is
+> The v2 SDK (`2.0.0-alpha.2`, `yubikit` branch) is a **pre-release alpha**. It is
 > **subject to change** and has **not yet completed Yubico's formal security audit**.
 > **No security guarantees** are made until that audit is complete. Package names and
 > namespaces may change. Provided for **evaluation and hackathon use only**.
@@ -32,7 +32,7 @@ YubiKey is a hardware authentication device that supports multiple protocols and
 
 ## Installation
 
-> **Alpha:** `2.0.0-alpha.1` is distributed from a public, anonymous prerelease
+> **Alpha:** `2.0.0-alpha.2` is distributed from a public, anonymous prerelease
 > feed (not nuget.org). Add the feed first, then install the explicit alpha version.
 > Keep nuget.org enabled so transitive dependencies (e.g. `Yubico.NativeShims`)
 > resolve. Full details in the [release notes](scripts/alpha/RELEASE_NOTES.md).
@@ -42,13 +42,13 @@ YubiKey is a hardware authentication device that supports multiple protocols and
 dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
 
 # 2. Core library (required)
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.2
 
 # 3. Application modules (install as needed)
-dotnet add package Yubico.YubiKit.Piv --version 2.0.0-alpha.1
-dotnet add package Yubico.YubiKit.Fido2 --version 2.0.0-alpha.1
-dotnet add package Yubico.YubiKit.Oath --version 2.0.0-alpha.1
-dotnet add package Yubico.YubiKit.Management --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Piv --version 2.0.0-alpha.2
+dotnet add package Yubico.YubiKit.Fido2 --version 2.0.0-alpha.2
+dotnet add package Yubico.YubiKit.Oath --version 2.0.0-alpha.2
+dotnet add package Yubico.YubiKit.Management --version 2.0.0-alpha.2
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ YubiKey is a hardware authentication device that supports multiple protocols and
 ## Installation
 
 > **Alpha:** `2.0.0-alpha.1` is distributed from a public, anonymous prerelease
-> feed (not nuget.org). Add the feed first, then install with `--prerelease`.
+> feed (not nuget.org). Add the feed first, then install the explicit alpha version.
 > Keep nuget.org enabled so transitive dependencies (e.g. `Yubico.NativeShims`)
 > resolve. Full details in the [release notes](scripts/alpha/RELEASE_NOTES.md).
 
@@ -42,13 +42,13 @@ YubiKey is a hardware authentication device that supports multiple protocols and
 dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
 
 # 2. Core library (required)
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
 
 # 3. Application modules (install as needed)
-dotnet add package Yubico.YubiKit.Piv --version 2.0.0-alpha.1 --prerelease
-dotnet add package Yubico.YubiKit.Fido2 --version 2.0.0-alpha.1 --prerelease
-dotnet add package Yubico.YubiKit.Oath --version 2.0.0-alpha.1 --prerelease
-dotnet add package Yubico.YubiKit.Management --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Piv --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Fido2 --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Oath --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Management --version 2.0.0-alpha.1
 ```
 
 ## Quick Start

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <!--
+    Pin restore to nuget.org only. Required for Central Package Management (NU1507),
+    which rejects multiple unmapped sources. Keeps local/CI restores deterministic
+    regardless of machine-global NuGet sources. Publishing to internal feeds uses an
+    explicit push URL and is unaffected by this restore source.
+  -->
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/scripts/alpha/RELEASE_NOTES.md
+++ b/scripts/alpha/RELEASE_NOTES.md
@@ -20,19 +20,26 @@ dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json
 dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
 ```
 
-Or use the bootstrap script:
+### Optional: bootstrap script
+
+Prefer the manual command above. If you want the script, **download, review, then
+run it** — do not pipe it straight into your shell:
 
 ```bash
 # macOS / Linux
-curl -fsSL https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.sh | bash
+curl -fsSLO https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.sh
+# review install-yubikit-alpha.sh, then:
+bash install-yubikit-alpha.sh
 ```
 ```powershell
 # Windows
-iwr https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.ps1 | iex
+iwr https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.ps1 -OutFile install-yubikit-alpha.ps1
+# review install-yubikit-alpha.ps1, then:
+./install-yubikit-alpha.ps1
 ```
 
-Piping a remote script to your shell is itself a trust decision — the non-piped
-`dotnet nuget add source` command above is the manual, inspectable equivalent.
+The scripts refuse to run when piped (they require a terminal for the confirmation
+prompt), so download-and-run is the supported path.
 
 ## Packages (10)
 

--- a/scripts/alpha/RELEASE_NOTES.md
+++ b/scripts/alpha/RELEASE_NOTES.md
@@ -1,0 +1,62 @@
+# Yubico .NET SDK v2 — `2.0.0-alpha.1`
+
+> ## ⚠️ ALPHA — NOT FOR PRODUCTION
+>
+> This is a **pre-release alpha** of the Yubico .NET SDK v2. It is **subject to
+> change** and has **not yet completed Yubico's formal security audit**.
+>
+> - **No security guarantees** are made until that audit is complete.
+> - Packages are **unsigned**.
+> - **Package names and namespaces may change** before the stable release.
+> - Provided for **evaluation and hackathon use only**.
+
+## Install (anonymous public feed — no authentication)
+
+Add the alpha feed (keep nuget.org enabled so transitive dependencies such as
+`Yubico.NativeShims` resolve):
+
+```bash
+dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+```
+
+Or use the bootstrap script:
+
+```bash
+# macOS / Linux
+curl -fsSL https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.sh | bash
+```
+```powershell
+# Windows
+iwr https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.ps1 | iex
+```
+
+Piping a remote script to your shell is itself a trust decision — the non-piped
+`dotnet nuget add source` command above is the manual, inspectable equivalent.
+
+## Packages (10)
+
+`Yubico.YubiKit.Core`, `.Management`, `.Piv`, `.Fido2`, `.WebAuthn`, `.Oath`,
+`.YubiOtp`, `.OpenPgp`, `.SecurityDomain`, `.YubiHsm` — all `2.0.0-alpha.1`.
+
+## Updates
+
+The feed is static and public; new alpha versions published to it are picked up
+automatically by `dotnet restore`. No need to re-run the installer.
+
+## Troubleshooting
+
+- **Unsigned packages:** consumable under default NuGet configuration. Environments
+  that enforce package signature validation (`signatureValidationMode=require`) will
+  reject these alpha packages.
+- **Package source mapping:** if you use source mapping, map `Yubico.NativeShims`
+  (and any other transitive `Yubico.*` deps you don't get from this feed) to
+  `nuget.org`, and the `Yubico.YubiKit.*` packages to this alpha feed.
+- **Build provenance:** each package is attested via GitHub build provenance. Verify
+  with `gh attestation verify <pkg>.nupkg --repo Yubico/Yubico.NET.SDK`.
+
+## Teardown
+
+```bash
+dotnet nuget remove source yubikit-alpha
+```

--- a/scripts/alpha/RELEASE_NOTES.md
+++ b/scripts/alpha/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Yubico .NET SDK v2 — `2.0.0-alpha.1`
+# Yubico .NET SDK v2 — `2.0.0-alpha.2`
 
 > ## ⚠️ ALPHA — NOT FOR PRODUCTION
 >
@@ -17,7 +17,7 @@ Add the alpha feed (keep nuget.org enabled so transitive dependencies such as
 
 ```bash
 dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.2
 ```
 
 ### Optional: bootstrap script
@@ -27,13 +27,13 @@ run it** — do not pipe it straight into your shell:
 
 ```bash
 # macOS / Linux
-curl -fsSLO https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.sh
+curl -fsSLO https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.2/install-yubikit-alpha.sh
 # review install-yubikit-alpha.sh, then:
 bash install-yubikit-alpha.sh
 ```
 ```powershell
 # Windows
-iwr https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.1/install-yubikit-alpha.ps1 -OutFile install-yubikit-alpha.ps1
+iwr https://github.com/Yubico/Yubico.NET.SDK/releases/download/v2.0.0-alpha.2/install-yubikit-alpha.ps1 -OutFile install-yubikit-alpha.ps1
 # review install-yubikit-alpha.ps1, then:
 ./install-yubikit-alpha.ps1
 ```
@@ -44,7 +44,7 @@ prompt), so download-and-run is the supported path.
 ## Packages (10)
 
 `Yubico.YubiKit.Core`, `.Management`, `.Piv`, `.Fido2`, `.WebAuthn`, `.Oath`,
-`.YubiOtp`, `.OpenPgp`, `.SecurityDomain`, `.YubiHsm` — all `2.0.0-alpha.1`.
+`.YubiOtp`, `.OpenPgp`, `.SecurityDomain`, `.YubiHsm` — all `2.0.0-alpha.2`.
 
 ## Updates
 

--- a/scripts/alpha/RELEASE_NOTES.md
+++ b/scripts/alpha/RELEASE_NOTES.md
@@ -17,7 +17,7 @@ Add the alpha feed (keep nuget.org enabled so transitive dependencies such as
 
 ```bash
 dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha
-dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease
+dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1
 ```
 
 ### Optional: bootstrap script

--- a/scripts/alpha/index.html
+++ b/scripts/alpha/index.html
@@ -22,7 +22,7 @@
   <h2>Add the feed</h2>
   <pre>dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha</pre>
   <h2>Install a package</h2>
-  <pre>dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1</pre>
+  <pre>dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.2</pre>
   <p>Transitive dependencies (e.g. <code>Yubico.NativeShims</code>) resolve from
      nuget.org, so keep nuget.org enabled alongside this feed.</p>
   <p><a href="https://github.com/Yubico/Yubico.NET.SDK">Project on GitHub</a></p>

--- a/scripts/alpha/index.html
+++ b/scripts/alpha/index.html
@@ -22,7 +22,7 @@
   <h2>Add the feed</h2>
   <pre>dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha</pre>
   <h2>Install a package</h2>
-  <pre>dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease</pre>
+  <pre>dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1</pre>
   <p>Transitive dependencies (e.g. <code>Yubico.NativeShims</code>) resolve from
      nuget.org, so keep nuget.org enabled alongside this feed.</p>
   <p><a href="https://github.com/Yubico/Yubico.NET.SDK">Project on GitHub</a></p>

--- a/scripts/alpha/index.html
+++ b/scripts/alpha/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Yubico .NET SDK v2 — Alpha NuGet Feed</title>
+  <style>
+    body { font-family: system-ui, sans-serif; max-width: 46rem; margin: 3rem auto; padding: 0 1rem; line-height: 1.5; }
+    code { background: #f3f3f3; padding: .15rem .35rem; border-radius: 4px; }
+    pre { background: #f3f3f3; padding: 1rem; border-radius: 6px; overflow-x: auto; }
+    .warn { background: #fff4e5; border-left: 4px solid #e69500; padding: 1rem; border-radius: 4px; }
+  </style>
+</head>
+<body>
+  <h1>Yubico .NET SDK v2 — Alpha NuGet Feed</h1>
+  <div class="warn">
+    <strong>⚠️ ALPHA — NOT FOR PRODUCTION.</strong> Pre-release, subject to change, and
+    not yet security-audited by Yubico. No security guarantees. Package names and
+    namespaces may change. Evaluation / hackathon use only.
+  </div>
+  <p>Anonymous, public NuGet v3 feed. No authentication required.</p>
+  <h2>Add the feed</h2>
+  <pre>dotnet nuget add source https://yubico.github.io/Yubico.NET.SDK/alpha/index.json -n yubikit-alpha</pre>
+  <h2>Install a package</h2>
+  <pre>dotnet add package Yubico.YubiKit.Core --version 2.0.0-alpha.1 --prerelease</pre>
+  <p>Transitive dependencies (e.g. <code>Yubico.NativeShims</code>) resolve from
+     nuget.org, so keep nuget.org enabled alongside this feed.</p>
+  <p><a href="https://github.com/Yubico/Yubico.NET.SDK">Project on GitHub</a></p>
+</body>
+</html>

--- a/scripts/alpha/install-yubikit-alpha.ps1
+++ b/scripts/alpha/install-yubikit-alpha.ps1
@@ -4,7 +4,7 @@ $ErrorActionPreference = 'Stop'
 
 $FeedUrl = 'https://yubico.github.io/Yubico.NET.SDK/alpha/index.json'
 $SrcName = 'yubikit-alpha'
-$Version = '2.0.0-alpha.1'
+$Version = '2.0.0-alpha.2'
 
 Write-Host '============================================================'
 Write-Host ' Yubico .NET SDK v2 - ALPHA'

--- a/scripts/alpha/install-yubikit-alpha.ps1
+++ b/scripts/alpha/install-yubikit-alpha.ps1
@@ -52,7 +52,7 @@ if (Get-Command gh -ErrorAction SilentlyContinue) {
 
 Write-Host ''
 Write-Host "Done. Install a package with, for example:"
-Write-Host "  dotnet add package Yubico.YubiKit.Core --version $Version --prerelease"
+Write-Host "  dotnet add package Yubico.YubiKit.Core --version $Version"
 Write-Host ''
 Write-Host 'Teardown:'
 Write-Host "  dotnet nuget remove source $SrcName"

--- a/scripts/alpha/install-yubikit-alpha.ps1
+++ b/scripts/alpha/install-yubikit-alpha.ps1
@@ -1,0 +1,52 @@
+# Yubico .NET SDK v2 - ALPHA feed bootstrap (Windows / PowerShell)
+# Adds the anonymous public alpha NuGet feed and (best-effort) verifies build provenance.
+$ErrorActionPreference = 'Stop'
+
+$FeedUrl = 'https://yubico.github.io/Yubico.NET.SDK/alpha/index.json'
+$SrcName = 'yubikit-alpha'
+$Version = '2.0.0-alpha.1'
+
+Write-Host '============================================================'
+Write-Host ' Yubico .NET SDK v2 - ALPHA'
+Write-Host ' Pre-release, subject to change, and NOT yet security-audited'
+Write-Host ' by Yubico. No security guarantees. Package names/namespaces'
+Write-Host ' may change. Evaluation / hackathon use only.'
+Write-Host '============================================================'
+
+$reply = Read-Host 'Add the alpha feed and continue? [y/N]'
+if ($reply -ne 'y' -and $reply -ne 'Y') { Write-Host 'Aborted.'; exit 1 }
+
+# Add the feed as an ADDITIONAL source (keep nuget.org for transitive deps like Yubico.NativeShims).
+$existing = & dotnet nuget list source 2>$null
+if ($existing -match [regex]::Escape($FeedUrl)) {
+    Write-Host 'Feed already registered.'
+} else {
+    & dotnet nuget add source $FeedUrl -n $SrcName
+}
+
+# Best-effort provenance verification (requires GitHub CLI; skipped if absent).
+if (Get-Command gh -ErrorAction SilentlyContinue) {
+    Write-Host 'Verifying build provenance (best-effort)...'
+    $tmp = New-Item -ItemType Directory -Path ([System.IO.Path]::GetTempPath()) -Name ([System.Guid]::NewGuid())
+    $nupkg = Join-Path $tmp 'core.nupkg'
+    $url = "https://yubico.github.io/Yubico.NET.SDK/alpha/flatcontainer/yubico.yubikit.core/$Version/yubico.yubikit.core.$Version.nupkg"
+    try {
+        Invoke-WebRequest $url -OutFile $nupkg
+        & gh attestation verify $nupkg --repo Yubico/Yubico.NET.SDK
+        if ($LASTEXITCODE -eq 0) { Write-Host 'Provenance verified.' }
+        else { Write-Host 'WARNING: provenance verification failed or unavailable for this alpha. Continuing.' }
+    } catch {
+        Write-Host 'WARNING: provenance check could not run. Continuing.'
+    } finally {
+        Remove-Item -Recurse -Force $tmp -ErrorAction SilentlyContinue
+    }
+} else {
+    Write-Host 'NOTE: GitHub CLI (gh) not found - skipping provenance check. These are unsigned alpha packages.'
+}
+
+Write-Host ''
+Write-Host "Done. Install a package with, for example:"
+Write-Host "  dotnet add package Yubico.YubiKit.Core --version $Version --prerelease"
+Write-Host ''
+Write-Host 'Teardown:'
+Write-Host "  dotnet nuget remove source $SrcName"

--- a/scripts/alpha/install-yubikit-alpha.ps1
+++ b/scripts/alpha/install-yubikit-alpha.ps1
@@ -13,6 +13,12 @@ Write-Host ' by Yubico. No security guarantees. Package names/namespaces'
 Write-Host ' may change. Evaluation / hackathon use only.'
 Write-Host '============================================================'
 
+# Confirmation. If not interactive (e.g. piped `iwr | iex`), refuse rather than
+# consuming the piped script as input. Download and run instead.
+if ([System.Console]::IsInputRedirected) {
+    Write-Error 'Run this script from a terminal (download it first), not via a pipe (iwr | iex).'
+    exit 1
+}
 $reply = Read-Host 'Add the alpha feed and continue? [y/N]'
 if ($reply -ne 'y' -and $reply -ne 'Y') { Write-Host 'Aborted.'; exit 1 }
 

--- a/scripts/alpha/install-yubikit-alpha.sh
+++ b/scripts/alpha/install-yubikit-alpha.sh
@@ -57,7 +57,7 @@ fi
 cat <<EOF
 
 Done. Install a package with, for example:
-  dotnet add package Yubico.YubiKit.Core --version ${VERSION} --prerelease
+  dotnet add package Yubico.YubiKit.Core --version ${VERSION}
 
 Teardown:
   dotnet nuget remove source ${SRC_NAME}

--- a/scripts/alpha/install-yubikit-alpha.sh
+++ b/scripts/alpha/install-yubikit-alpha.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 
 FEED_URL="https://yubico.github.io/Yubico.NET.SDK/alpha/index.json"
 SRC_NAME="yubikit-alpha"
-VERSION="2.0.0-alpha.1"
+VERSION="2.0.0-alpha.2"
 
 cat <<'BANNER'
 ============================================================

--- a/scripts/alpha/install-yubikit-alpha.sh
+++ b/scripts/alpha/install-yubikit-alpha.sh
@@ -16,6 +16,13 @@ cat <<'BANNER'
 ============================================================
 BANNER
 
+# Confirmation. If not attached to a terminal (e.g. piped `curl | bash`), refuse
+# rather than silently consuming the piped script as input. Download and run instead.
+if [ ! -t 0 ]; then
+  echo "ERROR: run this script from a terminal (download it first), not via a pipe." >&2
+  echo "  curl -fsSLO <url> && bash install-yubikit-alpha.sh" >&2
+  exit 1
+fi
 read -r -p "Add the alpha feed and continue? [y/N] " reply
 case "$reply" in
   [yY]) ;;
@@ -39,6 +46,8 @@ if command -v gh >/dev/null 2>&1; then
     else
       echo "WARNING: provenance verification failed or unavailable for this alpha. Continuing."
     fi
+  else
+    echo "WARNING: could not download package for provenance check. Continuing."
   fi
   rm -rf "$tmp"
 else

--- a/scripts/alpha/install-yubikit-alpha.sh
+++ b/scripts/alpha/install-yubikit-alpha.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Yubico .NET SDK v2 — ALPHA feed bootstrap (macOS/Linux)
+# Adds the anonymous public alpha NuGet feed and (best-effort) verifies build provenance.
+set -euo pipefail
+
+FEED_URL="https://yubico.github.io/Yubico.NET.SDK/alpha/index.json"
+SRC_NAME="yubikit-alpha"
+VERSION="2.0.0-alpha.1"
+
+cat <<'BANNER'
+============================================================
+ Yubico .NET SDK v2 - ALPHA
+ Pre-release, subject to change, and NOT yet security-audited
+ by Yubico. No security guarantees. Package names/namespaces
+ may change. Evaluation / hackathon use only.
+============================================================
+BANNER
+
+read -r -p "Add the alpha feed and continue? [y/N] " reply
+case "$reply" in
+  [yY]) ;;
+  *) echo "Aborted."; exit 1 ;;
+esac
+
+# Add the feed as an ADDITIONAL source (keep nuget.org for transitive deps like Yubico.NativeShims).
+if dotnet nuget list source 2>/dev/null | grep -q "$FEED_URL"; then
+  echo "Feed already registered."
+else
+  dotnet nuget add source "$FEED_URL" -n "$SRC_NAME"
+fi
+
+# Best-effort provenance verification (requires GitHub CLI; skipped if absent).
+if command -v gh >/dev/null 2>&1; then
+  echo "Verifying build provenance (best-effort)..."
+  tmp="$(mktemp -d)"
+  if curl -fsSL "https://yubico.github.io/Yubico.NET.SDK/alpha/flatcontainer/yubico.yubikit.core/${VERSION}/yubico.yubikit.core.${VERSION}.nupkg" -o "$tmp/core.nupkg"; then
+    if gh attestation verify "$tmp/core.nupkg" --repo Yubico/Yubico.NET.SDK; then
+      echo "Provenance verified."
+    else
+      echo "WARNING: provenance verification failed or unavailable for this alpha. Continuing."
+    fi
+  fi
+  rm -rf "$tmp"
+else
+  echo "NOTE: GitHub CLI (gh) not found — skipping provenance check. These are unsigned alpha packages."
+fi
+
+cat <<EOF
+
+Done. Install a package with, for example:
+  dotnet add package Yubico.YubiKit.Core --version ${VERSION} --prerelease
+
+Teardown:
+  dotnet nuget remove source ${SRC_NAME}
+EOF

--- a/scripts/alpha/sleet.json
+++ b/scripts/alpha/sleet.json
@@ -1,0 +1,12 @@
+{
+  "username": "",
+  "useremail": "",
+  "sources": [
+    {
+      "name": "alpha",
+      "type": "local",
+      "path": "$GITHUB_WORKSPACE$/feed-output/alpha",
+      "baseURI": "https://yubico.github.io/Yubico.NET.SDK/alpha/"
+    }
+  ]
+}

--- a/src/Cli/YkTool/Program.cs
+++ b/src/Cli/YkTool/Program.cs
@@ -16,7 +16,7 @@ var app = new CommandApp();
 app.Configure(config =>
 {
     config.SetApplicationName("yk");
-    config.SetApplicationVersion("2.0.0-alpha.1");
+    config.SetApplicationVersion("2.0.0-alpha.2");
     config.SetInterceptor(new YkCommandInterceptor());
 
     // ── Management ───────────────────────────────────────────────────────────

--- a/src/Cli/YkTool/Program.cs
+++ b/src/Cli/YkTool/Program.cs
@@ -16,7 +16,7 @@ var app = new CommandApp();
 app.Configure(config =>
 {
     config.SetApplicationName("yk");
-    config.SetApplicationVersion("1.0.0-preview");
+    config.SetApplicationVersion("2.0.0-alpha.1");
     config.SetInterceptor(new YkCommandInterceptor());
 
     // ── Management ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Publishes the v2 SDK as `2.0.0-alpha.1` for the hackathon, from the `yubikit` branch, via an **anonymous static NuGet feed** on GitHub Pages (`https://yubico.github.io/Yubico.NET.SDK/alpha/index.json`). Security-team approved conditional on clear alpha disclaiming.

## What's included
- **Version** → `2.0.0-alpha.1` (Directory.Packages.props, build.yml, AGENTS.md, YkTool)
- **Alpha disclaimer** via shared `PACKAGE_README.md` (PackageReadmeFile) + `PackageReleaseNotes` (no per-project Description edits), README banner, RELEASE_NOTES
- **Anonymous feed**: Sleet-generated, deployed to `gh-pages` by `.github/workflows/publish-alpha-feed.yml` (auto full-mirror on push to yubikit)
- **Provenance**: `actions/attest-build-provenance` in CI; best-effort `gh attestation verify` in install scripts
- **Bootstrap scripts** (.sh/.ps1): additive feed source, tty-guarded (refuse pipe-to-shell), disclaimer prompt
- **nuget.config**: pins restore to nuget.org (CPM NU1507); transitive NativeShims resolves from nuget.org

## Verification
- Clean `toolchain.cs build` + pack (10 packages)
- Disclaimer embedded in nupkg (readme + releaseNotes) verified
- **Two proof gates passed**: local Sleet feed restore AND live `https://yubico.github.io/...` restore — both resolved `Core 2.0.0-alpha.1` + transitive `Yubico.NativeShims` from nuget.org, no auth
- Cross-vendor DevTeam review + CodeAudit passes applied (incl. critical: tracked nuget.config; feed workflow simplified to deterministic full-mirror)

Packages unsigned (alpha). `gh-pages` feed already live.

⚠️ Alpha — not for production; not yet security-audited.