### PR TITLE
build: replace NuGet release signing with the .NET Sign CLI

### DIFF
--- a/.claude/skills/Release/SKILL.md
+++ b/.claude/skills/Release/SKILL.md
@@ -11,7 +11,7 @@ The skill works in two modes:
 - **`/Release`** — full flow from phase 1 (pre-flight) onward
 - **`/Release resume <version>`** — picks up at the current phase using cached state from `~/Releases/<version>/.state.json`. Most commonly used to resume at phase 5 (sign+publish) when phases 1–4 ran on macOS/Linux and the operator switches to Windows for signing, but works at any phase boundary.
 
-The Windows-only constraint (`build/sign.ps1` + smart-card YubiKey + `signtool.exe`) is enforced at phase 5 — the skill detects platform and either runs the full wizard (Windows) or stops with a handoff (macOS/Linux).
+The Windows-only constraint (`build/sign-v2.ps1` + smart-card YubiKey + the .NET Sign CLI, whose Authenticode signing is Windows-only) is enforced at phase 5 — the skill detects platform and either runs the full wizard (Windows) or stops with a handoff (macOS/Linux).
 
 ## Workflow Routing
 
@@ -29,7 +29,7 @@ User: "/Release"
 → Phase 2: detects no Yubico.NativeShims/ changes, skips NativeShims rebuild
 → Phase 3: creates release/1.16.1 from develop, drafts whats-new.md, opens PR to main
 → Phase 4: after PR merged, dispatches build.yml with version=1.16.1, polls until green, tags 1.16.1
-→ Phase 5 (Windows): downloads artifacts to ~/Releases/1.16.1/, runs sign.ps1, publishes to NuGet.org
+→ Phase 5 (Windows): downloads artifacts to ~/Releases/1.16.1/, runs sign-v2.ps1 (Sign CLI), publishes to NuGet.org
 → Phase 6: creates draft GitHub release with signed assets, triggers deploy-docs.yml
 → Phase 7: merges main back to develop, prints Slack #ask-tla announcement ready to copy
 ```
@@ -43,7 +43,7 @@ Operator (on macOS): "/Release"
 
 Operator (on Windows): "/Release resume 1.16.1"
 → Loads cached state, skips phases 1-4
-→ Phase 5: downloads artifacts (NativeShims first if rebuilt), runs sign.ps1, publishes
+→ Phase 5: downloads artifacts (NativeShims first if rebuilt), runs sign-v2.ps1, publishes
 → Phases 6-7 complete normally
 ```
 
@@ -72,7 +72,7 @@ User: "/Release"
 
 ## Hard Constraints
 
-- **Code-signing YubiKey must be unplugged during phases 1–4**: The operator's code-signing YubiKey must NOT be connected to the machine while any build or CI step runs. Integration tests that enumerate YubiKeys can accidentally run PIV/PGP resets against any connected key. The skill gates this: Phase 1 asks the operator to confirm the YubiKey is unplugged. Phase 5 is the ONLY phase where it should be plugged in — `signtool.exe` and `nuget sign` read the PIV certificate safely but cannot coexist with stray test runs. The skill must NEVER run integration tests itself.
+- **Code-signing YubiKey must be unplugged during phases 1–4**: The operator's code-signing YubiKey must NOT be connected to the machine while any build or CI step runs. Integration tests that enumerate YubiKeys can accidentally run PIV/PGP resets against any connected key. The skill gates this: Phase 1 asks the operator to confirm the YubiKey is unplugged. Phase 5 is the ONLY phase where it should be plugged in — the Sign CLI reads the PIV certificate safely but cannot coexist with stray test runs. The skill must NEVER run integration tests itself.
 - **Windows-only sign step**: phase 5 refuses to run on non-Windows
 - **NativeShims ordering**: when rebuilt (from either develop or main), NativeShims signs + publishes to NuGet.org *before* main `build.yml` dispatches. The operator chooses whether to build from develop (immediate) or main (deferred to after PR merge).
 - **Tag only after green CI**: `git tag` runs only after `build.yml` reports success — failed builds mean broken artifacts and a poisoned tag

--- a/.claude/skills/Release/Workflows/DropRelease.md
+++ b/.claude/skills/Release/Workflows/DropRelease.md
@@ -46,7 +46,7 @@ The state file is the single source of truth for resume. Update it before any op
 4. `AskUserQuestion`: "Confirm release version" — default option is `+1 patch` of `previousTag` (e.g., `1.16.0` → `1.16.1`); also offer `+1 minor`, `+1 major`, custom
 5. `AskUserQuestion`: "Release date" — default today (in `Month Dth, YYYY` format matching whats-new.md style)
 6. **Hardware test reminder** — print: "Before continuing, confirm you've tested PIV + SCP on real YubiKey hardware. The skill cannot do this for you." Gate with `AskUserQuestion`: "Hardware tests pass?" / "Skip (not recommended)"
-7. **Code-signing YubiKey safety gate** — `AskUserQuestion`: "⚠️ IMPORTANT: Your code-signing YubiKey must be UNPLUGGED from this machine during phases 1–4. Integration tests that enumerate YubiKeys can run PIV/PGP resets against any connected key. Only plug it back in when Phase 5 (sign+publish) explicitly asks for it — signtool and nuget-sign read the PIV certificate safely, but no other YubiKey operation should touch the key. Is the code-signing YubiKey unplugged?" Options: "Yes, it's unplugged" / "Let me unplug it now". If the operator needs to unplug, wait for confirmation before proceeding.
+7. **Code-signing YubiKey safety gate** — `AskUserQuestion`: "⚠️ IMPORTANT: Your code-signing YubiKey must be UNPLUGGED from this machine during phases 1–4. Integration tests that enumerate YubiKeys can run PIV/PGP resets against any connected key. Only plug it back in when Phase 5 (sign+publish) explicitly asks for it — the .NET Sign CLI reads the PIV certificate safely, but no other YubiKey operation should touch the key. Is the code-signing YubiKey unplugged?" Options: "Yes, it's unplugged" / "Let me unplug it now". If the operator needs to unplug, wait for confirmation before proceeding.
 8. Create `~/Releases/<version>/` and write initial `.state.json`
 
 ## Phase 2 — NativeShims gate (cross-platform, conditional)
@@ -236,9 +236,9 @@ Exit cleanly. Do NOT mark phase 5 complete.
 
 **5a. Pre-flight asserts** (each is a hard gate; on failure print fix instructions and stop):
 - `gh auth status` — authenticated with `repo` + `workflow` scope
-- `Get-Command signtool.exe` (PowerShell) — resolvable
-- `Get-Command nuget.exe` — resolvable
-- `$env:YUBICO_SIGNING_THUMBPRINT` — set; if not, AskUserQuestion to provide and persist for session
+- Sign CLI resolvable — `Get-Command sign` (the dotnet tool, `dotnet tool install --global sign --prerelease`). NOTE: the repo's `build/sign.ps1` shim can shadow it on PATH; if so, pass the tool executable via `-SignCliPath` to `Invoke-NuGetPackageSigningV2`.
+- `Get-Command nuget.exe` — resolvable (still used by the publish step)
+- `$env:YUBICO_SIGNING_SHA256_FINGERPRINT` — set (the **SHA-256** cert fingerprint, 64 hex, NOT the SHA-1 thumbprint); if not, AskUserQuestion to provide and persist for session. Derive from the cert: `[BitConverter]::ToString([System.Security.Cryptography.SHA256]::Create().ComputeHash((Get-ChildItem Cert:\CurrentUser\My | Where-Object Subject -match 'Yubico').RawData)).Replace('-','')`
 - YubiKey presence — best-effort: `Get-PnpDevice -Class SmartCard | Where-Object Status -eq 'OK'`. If empty, prompt: "No smart card detected — is YubiKey plugged in?"
 
 **5b. Staging**:
@@ -278,17 +278,17 @@ Never echo the API key. Never persist it to the state file.
    $outFile = "$staging\nativeshims\NativeShims-Package.zip"
    gh api "repos/Yubico/Yubico.NET.SDK/actions/artifacts/$($nsArtifact.id)/zip" > $outFile
    ```
-   **WARNING**: NEVER name a zip `*.nupkg.zip` — `GetFileNameWithoutExtension` produces a name ending in `.nupkg` which collides with `Get-ChildItem -Filter "*.nupkg"` inside sign.ps1.
+   **WARNING**: NEVER name a zip `*.nupkg.zip` — `GetFileNameWithoutExtension` produces a name ending in `.nupkg` which collides with `Get-ChildItem -Filter "*.nupkg"` inside sign-v2.ps1.
 2. Verify zip exists and is non-empty: `(Get-Item $outFile).Length -gt 0`
 3. Sign:
    ```powershell
-   . ./build/sign.ps1
-   Invoke-NuGetPackageSigning `
-     -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
+   . ./build/sign-v2.ps1
+   Invoke-NuGetPackageSigningV2 `
+     -Fingerprint $env:YUBICO_SIGNING_SHA256_FINGERPRINT `
      -WorkingDirectory "$staging\nativeshims" `
      -NativeShimsZip "NativeShims-Package.zip"
    ```
-   YubiKey PIN prompt will surface; tell the operator to enter it.
+   YubiKey PIN prompt will surface once; tell the operator to enter it.
 4. Verify: `Get-ChildItem "$staging\nativeshims\signed\packages\*.nupkg"` non-empty.
 5. Publish:
    ```powershell
@@ -315,8 +315,9 @@ Never echo the API key. Never persist it to the state file.
    Verify both zips exist and are non-empty.
 2. Sign:
    ```powershell
-   Invoke-NuGetPackageSigning `
-     -Thumbprint $env:YUBICO_SIGNING_THUMBPRINT `
+   . ./build/sign-v2.ps1
+   Invoke-NuGetPackageSigningV2 `
+     -Fingerprint $env:YUBICO_SIGNING_SHA256_FINGERPRINT `
      -WorkingDirectory "$staging\core" `
      -NuGetPackagesZip "Nuget-Packages.zip" `
      -SymbolsPackagesZip "Symbols-Packages.zip"

--- a/build/sign-v2.ps1
+++ b/build/sign-v2.ps1
@@ -1,0 +1,668 @@
+# Helper Functions
+#
+# ============================================================================
+# sign-v2.ps1 - NuGet release signing via the .NET Sign CLI (dotnet/sign).
+#
+# This is the replacement for sign.ps1. It signs the assemblies *inside* each
+# .nupkg/.snupkg and re-signs the container in place, without the lossy
+# extract -> strip -> `nuget pack` regenerate round-trip that sign.ps1 used.
+#
+# What is kept from sign.ps1:
+#   - required-asset validation (Test-RequiredAssets)
+#   - GitHub attestation verification before signing (Test-GithubAttestation)
+#   - certificate expiry warning
+#   - signed-package summary
+#   - the push function (Invoke-NuGetPackagePush), verbatim - never auto-run
+#
+# What is removed (the Sign CLI does it internally, in place):
+#   - Expand-Archive of each package
+#   - stripping _rels / package / [Content_Types].xml
+#   - per-DLL signtool loop
+#   - `nuget pack` regeneration from the extracted .nuspec
+#   - the separate final `nuget sign` loop
+#
+# Prerequisites:
+#   - .NET 8+ SDK
+#   - Sign CLI: dotnet tool install --global sign --prerelease
+#     (invoke via -SignCliPath if it is not on PATH, e.g. the repo `sign`
+#     shim shadows it)
+#   - GitHub CLI (gh), authenticated
+#   - The signing certificate in Cert:\CurrentUser\My with its private key on
+#     the YubiKey (CNG Smart Card KSP)
+#
+# NOTE: dot-source EITHER sign.ps1 OR sign-v2.ps1 in a session, not both - they
+# share helper function names by design so this file can replace sign.ps1 later.
+# ============================================================================
+
+function Clean-Directory {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaseDirectory
+    )
+
+    Write-Host "`nCleaning up working directories..." -ForegroundColor Yellow
+
+    $dirsToClean = @(
+        Join-Path $BaseDirectory "unsigned"
+        Join-Path $BaseDirectory "signed"
+    )
+
+    foreach ($dir in $dirsToClean) {
+        if (Test-Path $dir) {
+            Write-Host "Removing: $dir"
+            Remove-Item $dir -Recurse -Force
+        }
+    }
+    Write-Host "OK Cleanup completed"
+}
+
+function Test-RequiredAssets {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NuGetPackagesZip,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SymbolsPackagesZip,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NativeShimsZip
+    )
+
+    Write-Host "`nValidating required build assets..."
+
+    $hasCorePackages = -not [string]::IsNullOrWhiteSpace($NuGetPackagesZip) -and -not [string]::IsNullOrWhiteSpace($SymbolsPackagesZip)
+    $hasNativeShims = -not [string]::IsNullOrWhiteSpace($NativeShimsZip)
+
+    if (-not $hasCorePackages -and -not $hasNativeShims) {
+        throw "No package files specified. Please provide either core packages or native shims package paths."
+    }
+
+    if ($hasCorePackages) {
+        Write-Host "  Validating core packages..." -ForegroundColor Cyan
+        $coreFiles = @{
+            $NuGetPackagesZip   = "NuGet packages"
+            $SymbolsPackagesZip = "Symbol packages"
+        }
+
+        foreach ($required in $coreFiles.GetEnumerator()) {
+            $found = Get-ChildItem -Path $WorkingDirectory -Filter $required.Key -ErrorAction SilentlyContinue
+            if (-not $found) {
+                throw "Required build asset not found: $($required.Key)`nThis file should contain $($required.Value)"
+            }
+            Write-Host "    OK Found $($required.Value) in: $($found.Name)" -ForegroundColor Green
+        }
+    }
+
+    if ($hasNativeShims) {
+        Write-Host "  Validating native shims package..." -ForegroundColor Cyan
+        $found = Get-ChildItem -Path $WorkingDirectory -Filter $NativeShimsZip -ErrorAction SilentlyContinue
+        if (-not $found) {
+            throw "Required native shims asset not found: $NativeShimsZip"
+        }
+        Write-Host "    OK Found Native Shims package in: $($found.Name)" -ForegroundColor Green
+    }
+}
+
+function Test-GithubAttestation {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$FilePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoName
+    )
+
+    $fileName = (Get-ChildItem $FilePath).Name
+    Write-Host "      Verifying attestation for: $fileName" -ForegroundColor Gray
+
+    try {
+        $output = gh attestation verify $FilePath --repo $RepoName 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host $output -ForegroundColor Red
+            throw $output
+        }
+
+        Write-Host "        OK Verified" -ForegroundColor Green
+        return $true
+    }
+    catch {
+        Write-Host "        FAILED Verification failed: $_" -ForegroundColor Red
+        return $false
+    }
+}
+
+function Resolve-SigningCertificate {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Fingerprint
+    )
+
+    # The Sign CLI (and NuGet) identify the certificate by a SHA-256/384/512
+    # fingerprint (the hash over the DER-encoded certificate), NOT the SHA-1
+    # thumbprint that sign.ps1 used. Reject a 40-hex SHA-1 value early with an
+    # actionable message.
+    $fp = $Fingerprint -replace '[^0-9A-Fa-f]', ''
+    if ($fp.Length -eq 40) {
+        throw @"
+The value '$Fingerprint' looks like a SHA-1 thumbprint (40 hex chars).
+The Sign CLI requires a SHA-256 (64), SHA-384 (96) or SHA-512 (128) fingerprint.
+Derive the SHA-256 fingerprint from the certificate, e.g.:
+
+  `$c = Get-ChildItem Cert:\CurrentUser\My | Where-Object Thumbprint -eq '$Fingerprint'
+  [BitConverter]::ToString(
+    [System.Security.Cryptography.SHA256]::Create().ComputeHash(`$c.RawData)
+  ).Replace('-','')
+"@
+    }
+    if ($fp.Length -notin 64, 96, 128) {
+        throw "Certificate fingerprint must be a SHA-256 (64), SHA-384 (96) or SHA-512 (128) hex string. Got $($fp.Length) hex chars."
+    }
+
+    $algo = switch ($fp.Length) { 64 { 'SHA256' } 96 { 'SHA384' } 128 { 'SHA512' } }
+    $hasher = [System.Security.Cryptography.HashAlgorithm]::Create($algo)
+
+    $match = $null
+    foreach ($c in (Get-ChildItem Cert:\CurrentUser\My)) {
+        $certFp = [BitConverter]::ToString($hasher.ComputeHash($c.RawData)).Replace('-', '')
+        if ($certFp -eq $fp) { $match = $c; break }
+    }
+
+    if (-not $match) {
+        throw "Certificate with $algo fingerprint $fp not found in Cert:\CurrentUser\My"
+    }
+
+    return @{ Certificate = $match; Fingerprint = $fp }
+}
+
+function Initialize-DirectoryStructure {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$BaseDirectory
+    )
+
+    $directories = @{
+        WorkingDir = $BaseDirectory
+        Unsigned   = Join-Path $BaseDirectory "unsigned"
+        Signed     = Join-Path $BaseDirectory "signed"
+        Packages   = Join-Path $BaseDirectory "signed\packages"
+    }
+
+    $directories.Keys | Where-Object { $_ -ne 'WorkingDir' } | ForEach-Object {
+        $dir = $directories[$_]
+        if (-not (Test-Path $dir)) {
+            New-Item -ItemType Directory -Path $dir -Force | Out-Null
+            Write-Debug "Created: $dir"
+        }
+    }
+
+    return $directories
+}
+
+function Expand-PackagesFromZip {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$ZipFile,
+
+        [Parameter(Mandatory = $true)]
+        [hashtable]$Directories,
+
+        [Parameter(Mandatory = $true)]
+        [string]$RepoName
+    )
+
+    Write-Host "`n  Extracting: $ZipFile" -ForegroundColor Cyan
+
+    $zipPath = Join-Path $Directories.WorkingDir $ZipFile
+    $extractPath = Join-Path $Directories.Unsigned ([System.IO.Path]::GetFileNameWithoutExtension($ZipFile))
+    Expand-Archive -Path $zipPath -DestinationPath $extractPath -Force
+
+    $packages = Get-ChildItem -Path $extractPath -Recurse -Include *.nupkg, *.snupkg
+    foreach ($package in $packages) {
+        Write-Host "      Package: $($package.Name)"
+
+        # Verify GitHub attestation on the unsigned artifact before we alter its bytes.
+        if (-not (Test-GithubAttestation -FilePath $package.FullName -RepoName $RepoName)) {
+            throw "Attestation verification failed for: $($package.Name)"
+        }
+
+        Copy-Item -Path $package.FullName -Destination $Directories.Unsigned -Force
+    }
+    Write-Host "    OK Staged $($packages.Count) package(s)"
+}
+
+function Invoke-SignCliOnPackage {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$OutputDirectory,
+
+        [Parameter(Mandatory = $true)]
+        [string]$SignCliPath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Fingerprint,
+
+        [Parameter(Mandatory = $true)]
+        [string]$TimestampServer,
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileList,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$Interactive
+    )
+
+    $outputFile = Join-Path $OutputDirectory (Split-Path $PackagePath -Leaf)
+
+    # certificate-store with fingerprint-only lookup. For a CNG smart-card key we
+    # deliberately OMIT --crypto-service-provider / --key-container: those are the
+    # legacy CSP path and cause LegacyKeySpec failures against a KSP-backed key
+    # (dotnet/sign #780). Fingerprint-only resolves the key via GetRSAPrivateKey().
+    #
+    # --max-concurrency 1 serialises packages. NOTE: the Sign CLI still signs the
+    # DLLs *within* a single package concurrently (unbounded Parallel.ForEachAsync);
+    # if that inner concurrency ever proves unsafe against the single PIV session,
+    # the mitigation is to invoke this per assembly with a one-entry --file-list.
+    $signArgs = @(
+        'code', 'certificate-store',
+        '--certificate-fingerprint', $Fingerprint,
+        '--file-digest', 'SHA256',
+        '--timestamp-url', $TimestampServer,
+        '--timestamp-digest', 'SHA256',
+        '--max-concurrency', '1',
+        '--output', $outputFile,
+        '--verbosity', 'information'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($FileList)) {
+        $signArgs += @('--file-list', $FileList)
+    }
+    if ($Interactive) {
+        $signArgs += '--interactive'
+    }
+    $signArgs += $PackagePath
+
+    Write-Host "    Signing: $(Split-Path $PackagePath -Leaf)" -ForegroundColor White
+    $output = & $SignCliPath @signArgs 2>&1
+    $output | ForEach-Object { Write-Host "      $_" -ForegroundColor Gray }
+    if ($LASTEXITCODE -ne 0) {
+        throw "Sign CLI failed (exit $LASTEXITCODE) for: $PackagePath"
+    }
+}
+
+<#
+.SYNOPSIS
+Signs NuGet and Symbol packages using a YubiKey-held certificate via the .NET Sign CLI.
+
+.DESCRIPTION
+Replacement for Invoke-NuGetPackageSigning. Signs assemblies inside each
+.nupkg/.snupkg and re-signs the container in place using the .NET Sign CLI
+(dotnet/sign), avoiding the lossy extract/strip/`nuget pack` round-trip.
+
+Flow:
+1. Validate assets and tools.
+2. Resolve the signing certificate by SHA-256 fingerprint.
+3. Extract the GitHub build-artifact zips.
+4. Verify GitHub attestation on each unsigned package.
+5. Run `sign code certificate-store` on each package into signed\packages.
+
+How to use:
+1. Create a release folder, e.g. ../releases/1.12
+2. Download the build assets from the SDK build action into it.
+3. In PowerShell:  . .\Yubico.NET.SDK\build\sign-v2.ps1
+4. Call Invoke-NuGetPackageSigningV2 (see examples).
+
+.PARAMETER Fingerprint
+SHA-256 (or SHA-384/512) fingerprint of the signing certificate. NOT the SHA-1
+thumbprint. Can also be provided via the YUBICO_SIGNING_SHA256_FINGERPRINT
+environment variable.
+
+.PARAMETER WorkingDirectory
+Directory containing the build-artifact zips and where signing takes place.
+
+.PARAMETER SignCliPath
+Optional. Path to the Sign CLI executable. Defaults to "sign". Set this if the
+repo's `sign` shim shadows the tool (e.g. the tool-path executable).
+
+.PARAMETER TimestampServer
+Optional. RFC3161 timestamp URL. Defaults to "http://timestamp.acs.microsoft.com".
+
+.PARAMETER FileList
+Optional. Path to a Sign CLI --file-list scoping which assemblies inside the
+container get Authenticode-signed. Omitted by default, so every signable
+assembly in the container is signed (matches the previous script). Supply this
+only if a package ever bundles a third-party or pre-signed assembly that must be
+skipped.
+
+.PARAMETER NuGetPackagesZip
+Optional. Name of the NuGet packages zip. Required for core packages.
+
+.PARAMETER SymbolsPackagesZip
+Optional. Name of the symbols packages zip. Required for core packages.
+
+.PARAMETER NativeShimsZip
+Optional. Name of the native shims package zip.
+
+.PARAMETER NonInteractive
+Optional switch. Omit --interactive (no PIN dialog). By default the PIN dialog
+is shown so the operator can enter the YubiKey PIN once.
+
+.PARAMETER CleanWorkingDirectory
+Optional switch. Cleans unsigned/ and signed/ before processing.
+
+.EXAMPLE
+Invoke-NuGetPackageSigningV2 -Fingerprint "A01E...DE6" -WorkingDirectory "C:\Signing" -NuGetPackagesZip "Nuget Packages.zip" -SymbolsPackagesZip "Symbols Packages.zip"
+
+.EXAMPLE
+Invoke-NuGetPackageSigningV2 -WorkingDirectory "C:\Signing" -NativeShimsZip "Yubico.NativeShims.nupkg.zip"
+# Fingerprint taken from YUBICO_SIGNING_SHA256_FINGERPRINT
+
+.NOTES
+Requires: .NET 8+ SDK, Sign CLI (dotnet/sign), GitHub CLI, the certificate in
+Cert:\CurrentUser\My with the private key on the YubiKey. Windows-only:
+Authenticode signing of .dll/.exe in the Sign CLI is Windows-only.
+#>
+function Invoke-NuGetPackageSigningV2 {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $false)]
+        [string]$Fingerprint,
+
+        [Parameter(Mandatory = $true)]
+        [string]$WorkingDirectory,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SignCliPath = "sign",
+
+        [Parameter(Mandatory = $false)]
+        [string]$TimestampServer = "http://timestamp.acs.microsoft.com",
+
+        [Parameter(Mandatory = $false)]
+        [string]$FileList,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NuGetPackagesZip,
+
+        [Parameter(Mandatory = $false)]
+        [string]$SymbolsPackagesZip,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NativeShimsZip,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$NonInteractive,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$CleanWorkingDirectory
+    )
+
+    $RepoName = "Yubico/Yubico.NET.SDK"
+
+    try {
+        Write-Host "`nInitializing NuGet package signing (Sign CLI)..." -ForegroundColor Cyan
+
+        # Resolve fingerprint from environment variable if not provided.
+        if ([string]::IsNullOrWhiteSpace($Fingerprint)) {
+            $Fingerprint = $env:YUBICO_SIGNING_SHA256_FINGERPRINT
+        }
+        if ([string]::IsNullOrWhiteSpace($Fingerprint)) {
+            throw "Fingerprint is required. Provide via -Fingerprint or YUBICO_SIGNING_SHA256_FINGERPRINT (SHA-256 fingerprint, not the SHA-1 thumbprint)."
+        }
+
+
+        # Validate tools.
+        Write-Host "`nVerifying required tools..."
+        $signCmd = Get-Command $SignCliPath -ErrorAction SilentlyContinue
+        if (-not $signCmd) {
+            throw "Sign CLI not found at: $SignCliPath. Install: dotnet tool install --global sign --prerelease"
+        }
+        $signCliResolved = if ($signCmd.Source) { $signCmd.Source } else { $SignCliPath }
+        Write-Host "OK Sign CLI found at: $signCliResolved"
+
+        if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+            throw "GitHub CLI not installed or not found in PATH"
+        }
+        Write-Host "OK GitHub CLI found"
+
+        # Resolve and validate the certificate.
+        $resolved = Resolve-SigningCertificate -Fingerprint $Fingerprint
+        $cert = $resolved.Certificate
+        $Fingerprint = $resolved.Fingerprint
+
+        Write-Host "`nCertificate Details:" -ForegroundColor Cyan
+        Write-Host "  Subject:      $($cert.Subject)"
+        Write-Host "  Issuer:       $($cert.Issuer)"
+        Write-Host "  Thumbprint:   $($cert.Thumbprint) (SHA-1)"
+        Write-Host "  Fingerprint:  $Fingerprint (SHA-256)"
+        Write-Host "  Valid From:   $($cert.NotBefore)"
+        Write-Host "  Valid To:     $($cert.NotAfter)"
+
+        if ($cert.NotAfter -le (Get-Date).AddMonths(1)) {
+            Write-Warning "Certificate will expire within one month on $($cert.NotAfter)"
+        }
+
+        if ($CleanWorkingDirectory) {
+            Clean-Directory -BaseDirectory $WorkingDirectory
+        }
+
+        $directories = Initialize-DirectoryStructure -BaseDirectory $WorkingDirectory
+
+        Test-RequiredAssets -WorkingDirectory $WorkingDirectory -NuGetPackagesZip $NuGetPackagesZip -SymbolsPackagesZip $SymbolsPackagesZip -NativeShimsZip $NativeShimsZip
+
+        $hasCorePackages = -not [string]::IsNullOrWhiteSpace($NuGetPackagesZip) -and -not [string]::IsNullOrWhiteSpace($SymbolsPackagesZip)
+        $hasNativeShims = -not [string]::IsNullOrWhiteSpace($NativeShimsZip)
+
+        # Extract + attest all packages (nupkg and snupkg) into the unsigned dir.
+        if ($hasCorePackages) {
+            Write-Host "`nProcessing Core Packages..." -ForegroundColor Yellow
+            Expand-PackagesFromZip -ZipFile $NuGetPackagesZip -Directories $directories -RepoName $RepoName
+            Expand-PackagesFromZip -ZipFile $SymbolsPackagesZip -Directories $directories -RepoName $RepoName
+        }
+        if ($hasNativeShims) {
+            Write-Host "`nProcessing Native Shims Package..." -ForegroundColor Yellow
+            Expand-PackagesFromZip -ZipFile $NativeShimsZip -Directories $directories -RepoName $RepoName
+        }
+
+        # Sign every staged package in place (assemblies + container) into signed\packages.
+        Write-Host "`nSigning packages with the Sign CLI..." -ForegroundColor Cyan
+        $staged = Get-ChildItem -Path $directories.Unsigned -Include *.nupkg, *.snupkg -File
+        if (-not $staged -or $staged.Count -eq 0) {
+            throw "No .nupkg/.snupkg found to sign in $($directories.Unsigned)"
+        }
+        foreach ($package in $staged) {
+            Invoke-SignCliOnPackage -PackagePath $package.FullName `
+                -OutputDirectory $directories.Packages `
+                -SignCliPath $SignCliPath `
+                -Fingerprint $Fingerprint `
+                -TimestampServer $TimestampServer `
+                -FileList $FileList `
+                -Interactive:(-not $NonInteractive)
+        }
+
+        # Summary of signed packages.
+        Write-Host "`nSigned Packages Summary:" -ForegroundColor Yellow
+        Write-Host "  NuGet Packages:" -ForegroundColor White
+        Get-ChildItem -Path $directories.Packages -Filter "*.nupkg" | ForEach-Object {
+            $size = "{0:N2}" -f ($_.Length / 1KB)
+            Write-Host "    $($_.Name) [$size KB]" -ForegroundColor Gray
+        }
+        Write-Host "  Symbol Packages:" -ForegroundColor White
+        Get-ChildItem -Path $directories.Packages -Filter "*.snupkg" | ForEach-Object {
+            $size = "{0:N2}" -f ($_.Length / 1KB)
+            Write-Host "    $($_.Name) [$size KB]" -ForegroundColor Gray
+        }
+
+        Write-Host "`nPackage signing completed." -ForegroundColor Green
+        Write-Host "Signed packages: $($directories.Packages)" -ForegroundColor Yellow
+
+        $examplePackage = Get-ChildItem -Path $directories.Packages -Filter "*.nupkg" | Select-Object -First 1
+        Write-Host "`nTo push (manual step - never run automatically):" -ForegroundColor Cyan
+        if ($examplePackage) {
+            Write-Host "  Invoke-NuGetPackagePush -PackagePath `"$($examplePackage.FullName)`"" -ForegroundColor Gray
+        }
+        Write-Host "  Invoke-NuGetPackagePush -PackagePath `"$($directories.Packages)`" -SkipDuplicate" -ForegroundColor Gray
+        Write-Host ""
+
+        return
+    }
+    catch {
+        Write-Host "`nError occurred:" -ForegroundColor Red
+        Write-Error $_.Exception.Message
+        throw
+    }
+}
+
+<#
+.SYNOPSIS
+Pushes NuGet packages to a NuGet feed using the NuGet CLI.
+
+.DESCRIPTION
+Pushes .nupkg/.snupkg to nuget.org or another feed. Kept verbatim from sign.ps1.
+This is always a manual, human-initiated step - it is never called automatically
+by the signing flow.
+
+.PARAMETER PackagePath
+Path to a single package or a directory containing packages.
+
+.PARAMETER ApiKey
+API key. Can also be provided via NUGET_API_KEY.
+
+.PARAMETER Source
+Optional. Feed URL. Defaults to nuget.org.
+
+.PARAMETER Timeout
+Optional. Push timeout in seconds. Defaults to 300.
+
+.PARAMETER SkipDuplicate
+Optional switch. Skip packages that already exist instead of failing.
+
+.PARAMETER NuGetPath
+Optional. Path to nuget.exe. Defaults to "nuget.exe".
+#>
+function Invoke-NuGetPackagePush {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$PackagePath,
+
+        [Parameter(Mandatory = $false)]
+        [string]$ApiKey,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Source = "https://api.nuget.org/v3/index.json",
+
+        [Parameter(Mandatory = $false)]
+        [int]$Timeout = 300,
+
+        [Parameter(Mandatory = $false)]
+        [switch]$SkipDuplicate,
+
+        [Parameter(Mandatory = $false)]
+        [string]$NuGetPath = "nuget.exe"
+    )
+
+    try {
+        Write-Host "`nInitializing NuGet package push process..." -ForegroundColor Cyan
+
+        if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+            $ApiKey = $env:NUGET_API_KEY
+        }
+
+        if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+            throw "ApiKey is required. Provide via -ApiKey parameter or NUGET_API_KEY environment variable."
+        }
+
+        if (-not (Get-Command $NuGetPath -ErrorAction SilentlyContinue)) {
+            throw "NuGet CLI not found at path: $NuGetPath"
+        }
+        Write-Host "OK NuGet CLI found at: $NuGetPath"
+
+        if (-not (Test-Path $PackagePath)) {
+            throw "Package path not found: $PackagePath"
+        }
+
+        $isDirectory = (Get-Item $PackagePath).PSIsContainer
+
+        if ($isDirectory) {
+            Write-Host "`nSearching for package files in: $PackagePath" -ForegroundColor Yellow
+            $packages = Get-ChildItem -Path "$PackagePath\*" -Include "*.nupkg", "*.snupkg" -File
+
+            if ($packages.Count -eq 0) {
+                throw "No .nupkg or .snupkg files found in directory: $PackagePath"
+            }
+
+            $nupkgCount = ($packages | Where-Object { $_.Extension -eq ".nupkg" }).Count
+            $snupkgCount = ($packages | Where-Object { $_.Extension -eq ".snupkg" }).Count
+            Write-Host "OK Found $($packages.Count) package(s) to push ($nupkgCount .nupkg, $snupkgCount .snupkg)"
+        }
+        else {
+            if (-not ($PackagePath.EndsWith(".nupkg") -or $PackagePath.EndsWith(".snupkg"))) {
+                throw "Package file must have .nupkg or .snupkg extension: $PackagePath"
+            }
+            $packages = @(Get-Item $PackagePath)
+        }
+
+        Write-Host "`nPush Configuration:" -ForegroundColor Cyan
+        Write-Host "  Target Source: $Source"
+        Write-Host "  Timeout:       $Timeout seconds"
+        Write-Host "  Skip Existing: $($SkipDuplicate.IsPresent)"
+
+        $successCount = 0
+        $failCount = 0
+
+        foreach ($package in $packages) {
+            Write-Host "`nPushing: $($package.Name)" -ForegroundColor White
+
+            $pushArgs = @(
+                "push",
+                $package.FullName,
+                $ApiKey,
+                "-Source", $Source,
+                "-Timeout", $Timeout,
+                "-NonInteractive"
+            )
+
+            if ($SkipDuplicate) {
+                $pushArgs += "-SkipDuplicate"
+            }
+
+            $output = & $NuGetPath $pushArgs 2>&1
+
+            if ($LASTEXITCODE -eq 0) {
+                Write-Host "  OK Successfully pushed" -ForegroundColor Green
+                $successCount++
+            }
+            else {
+                Write-Host "  FAILED to push" -ForegroundColor Red
+                $output | ForEach-Object { Write-Host "    $_" -ForegroundColor Red }
+                $failCount++
+            }
+        }
+
+        Write-Host "`nPush Summary:" -ForegroundColor Yellow
+        Write-Host "  Total Packages:      $($packages.Count)"
+        Write-Host "  Successfully Pushed: $successCount" -ForegroundColor Green
+        if ($failCount -gt 0) {
+            Write-Host "  Failed:              $failCount" -ForegroundColor Red
+            throw "$failCount package(s) failed to push"
+        }
+
+        Write-Host "`nPackage push process completed successfully." -ForegroundColor Green
+    }
+    catch {
+        Write-Host "`nError occurred:" -ForegroundColor Red
+        Write-Error $_.Exception.Message
+        throw
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the NuGet release-signing round-trip with the [.NET Sign CLI](https://github.com/dotnet/sign) (`sign code certificate-store`).

`build/sign.ps1` signed packages by extracting each `.nupkg`, stripping `_rels`/`package/`/`[Content_Types].xml`, `signtool`-ing the DLLs, then **regenerating** the package with `nuget pack` against the extracted `.nuspec`. That regeneration is lossy — it can perturb dependency groups, `contentFiles`, `build/`/`runtimes/` trees and repository metadata, and breaks the link to the attested artifact.

`build/sign-v2.ps1` signs the assemblies **inside** the container and re-signs the container **in place**, so nothing is regenerated — the only entry added is `.signature.p7s`.

## What changed

- **New `build/sign-v2.ps1`** — `Invoke-NuGetPackageSigningV2`, in-place signing via the Sign CLI.
  - Identifies the cert by **SHA-256 fingerprint** (rejects the SHA-1 thumbprint the old script used); resolves the YubiKey CNG smart-card key via fingerprint-only lookup (no `-csp`/`-k`).
  - **RFC3161 SHA-256 timestamp**, fixing the legacy `signtool /t` SHA-1 timestamp mismatch.
  - Keeps asset validation, GitHub attestation verification, cert-expiry warning, signed-package summary, and the manual push function.
  - Optional `-FileList` to scope Authenticode signing; default signs all assemblies (matches old behaviour).
- **Release skill updated** — `DropRelease.md` (phase 5a/5d/5e) and `SKILL.md` now drive the new script and `YUBICO_SIGNING_SHA256_FINGERPRINT`.
- `build/sign.ps1` is **retained** until a live release confirms the new path.

## Validation

Verified end-to-end on Windows with the real code-signing YubiKey against a throwaway package:

- `nuget verify -Signatures` → **Successfully verified** (`CN=Yubico AB` → DigiCert Trusted G4, SHA-256 author signature, RFC3161 Microsoft timestamp).
- All target-framework DLLs → Authenticode **Valid**, RFC3161 SHA-256 timestamp.
- In-place / non-lossy: only `.signature.p7s` added to the container.
- Fingerprint-only lookup binds the CNG smart-card key; in-package DLLs sign safely against the single PIV session after one PIN.

## Operator migration

- Install: `dotnet tool install --global sign --prerelease`
- Set `YUBICO_SIGNING_SHA256_FINGERPRINT` (the SHA-256 fingerprint, not the SHA-1 thumbprint)
- Signing/publishing remains a manual, human-initiated step — no automated `nuget push`.

> Note: authored with assistance from Copilot CLI; reviewed by the release maintainer.
