### PR TITLE
docs(readme): add v2 alpha plug

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ limitations under the License. -->
 
 Enterprise-grade cross-platform SDK for YubiKey integration, built on .NET.
 
+> **👀 A ground-up v2 is in the works.** We're building the next major version of
+> this SDK from scratch — a modern, type-safe API surface with first-class async,
+> spanning PIV, FIDO2/WebAuthn, OATH, OpenPGP, YubiOTP, Security Domain, and
+> YubiHSM Auth. It's an early **alpha** on the [`yubikit`](https://github.com/Yubico/Yubico.NET.SDK/tree/yubikit)
+> branch — not production-ready and pending a formal security review — but you can
+> try it today and help shape it. See the [alpha feed & preview](https://yubico.github.io/Yubico.NET.SDK/).
+
 ## Table of Contents
 - [.NET YubiKey SDK](#net-yubikey-sdk)
   - [Table of Contents](#table-of-contents)


### PR DESCRIPTION
Adds a short, honest callout near the top of the `develop` README announcing the ground-up v2 rewrite.

**What it says:** v2 is a from-scratch, modern, type-safe rewrite (PIV, FIDO2/WebAuthn, OATH, OpenPGP, YubiOTP, Security Domain, YubiHSM Auth), currently an early **alpha** on the `yubikit` branch — explicitly noted as *not production-ready and pending a formal security review* — with links to the branch and the public alpha feed/preview site.

**Scope:** single-file, +7 lines, placed above the Table of Contents using the repo's existing blockquote convention. No ToC or other sections touched.

Links verified live (HTTP 200): [yubikit branch](https://github.com/Yubico/Yubico.NET.SDK/tree/yubikit) and [alpha feed & preview](https://yubico.github.io/Yubico.NET.SDK/).