### PR TITLE
docs(workflow): add and fix stacked PR guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -577,7 +577,7 @@ If you answered "no" to any of these, don't write the test.
 
 Minimal stack flow:
 ```bash
-gh stack init --base develop <branch>
+gh stack init          # bases on current branch by default
 gh stack add <branch>
 gh stack submit
 gh stack rebase && gh stack push && gh stack submit

--- a/docs/DEV-GUIDE.md
+++ b/docs/DEV-GUIDE.md
@@ -6,9 +6,9 @@
 - Unrelated work must start a **new stack**. Do not mix unrelated concerns into an existing stack or PR.
 - Keep every PR focused and independently reviewable: one purpose per PR, minimal diff, clear review boundary.
 
-Minimal flow (trunk is `develop`):
+Minimal flow:
 ```bash
-gh stack init --base develop <branch>
+gh stack init          # bases on current branch by default
 gh stack add <branch>
 gh stack submit
 gh stack rebase && gh stack push && gh stack submit


### PR DESCRIPTION
## Summary

Stacked on top of #553.

- Adds **Stacked PR Workflow** policy to `CLAUDE.md` and `docs/DEV-GUIDE.md`
- Fixes `gh stack init` example to not hardcode `--base develop`; base defaults to current branch

## Changes
- `6a81dcd` docs(workflow): add stacked PR guidance  
- `3cd1e1f` docs(workflow): fix gh stack init example to not hardcode develop base