### PR TITLE
fix(core): claim grouped device interfaces per connection

### DIFF
--- a/src/Core/src/Devices/CompositeYubiKey.cs
+++ b/src/Core/src/Devices/CompositeYubiKey.cs
@@ -46,8 +46,6 @@ internal sealed class CompositeYubiKey : IYubiKey, IDiscoveryConnectionProvider
         _members = members;
         DeviceInfo = deviceInfo;
         MemberDeviceIds = [.. members.Select(m => m.DeviceId).OrderBy(id => id, StringComparer.Ordinal)];
-        foreach (var member in members)
-            SetConnectionLeaseScope(member, MemberDeviceIds);
         PhysicalIdentityKey = EncodeInterfaceIds(MemberDeviceIds);
 
         var combined = ConnectionType.Unknown;
@@ -122,7 +120,13 @@ internal sealed class CompositeYubiKey : IYubiKey, IDiscoveryConnectionProvider
                 $"Connection type {typeof(TConnection).Name} is not supported by this YubiKey device.");
 
         if (TryResolveMember(requested, out var member))
-            return member.ConnectAsync<TConnection>(cancellationToken);
+        {
+            if (member is IScopedConnectionProvider provider)
+                return provider.ConnectWithLeaseScopeAsync<TConnection>(MemberDeviceIds, cancellationToken);
+
+            throw new InvalidOperationException(
+                $"The {member.GetType().Name} member does not support scoped connection acquisition.");
+        }
 
         throw new NotSupportedException(
             $"Connection type {typeof(TConnection).Name} ({requested}) is not available on this physical YubiKey " +
@@ -183,12 +187,6 @@ internal sealed class CompositeYubiKey : IYubiKey, IDiscoveryConnectionProvider
         if (typeof(TConnection) == typeof(IOtpHidConnection))
             return ConnectionType.HidOtp;
         return ConnectionType.Unknown;
-    }
-
-    private static void SetConnectionLeaseScope(IYubiKey member, IReadOnlyList<string> interfaceIds)
-    {
-        if (member is IConnectionLeaseScopeProvider provider)
-            provider.SetConnectionLeaseScope(interfaceIds);
     }
 
 }

--- a/src/Core/src/Devices/CompositeYubiKey.cs
+++ b/src/Core/src/Devices/CompositeYubiKey.cs
@@ -46,6 +46,8 @@ internal sealed class CompositeYubiKey : IYubiKey, IDiscoveryConnectionProvider
         _members = members;
         DeviceInfo = deviceInfo;
         MemberDeviceIds = [.. members.Select(m => m.DeviceId).OrderBy(id => id, StringComparer.Ordinal)];
+        foreach (var member in members)
+            SetConnectionLeaseScope(member, MemberDeviceIds);
         PhysicalIdentityKey = EncodeInterfaceIds(MemberDeviceIds);
 
         var combined = ConnectionType.Unknown;
@@ -182,4 +184,11 @@ internal sealed class CompositeYubiKey : IYubiKey, IDiscoveryConnectionProvider
             return ConnectionType.HidOtp;
         return ConnectionType.Unknown;
     }
+
+    private static void SetConnectionLeaseScope(IYubiKey member, IReadOnlyList<string> interfaceIds)
+    {
+        if (member is IConnectionLeaseScopeProvider provider)
+            provider.SetConnectionLeaseScope(interfaceIds);
+    }
+
 }

--- a/src/Core/src/Devices/DeviceConnectionRegistry.cs
+++ b/src/Core/src/Devices/DeviceConnectionRegistry.cs
@@ -17,6 +17,11 @@ using Yubico.YubiKit.Core.Abstractions;
 
 namespace Yubico.YubiKit.Core.Devices;
 
+internal interface IConnectionLeaseScopeProvider
+{
+    void SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds);
+}
+
 /// <summary>
 ///     Process-wide ownership coordinator per interface device, keyed by <see cref="IYubiKey.DeviceId" />.
 ///     Connections hold the lease; discovery takes a nonblocking exclusive lease. This makes the
@@ -103,6 +108,43 @@ internal static class DeviceConnectionRegistry
         GetOwnership(deviceId).AcquireConnectionAsync(deviceId, cancellationToken);
 
     /// <summary>
+    ///     Acquires every known interface lease for one physical YubiKey as a single logical registration.
+    ///     Interface ids are de-duplicated and acquired in ordinal order so racing callers cannot deadlock.
+    /// </summary>
+    public static async ValueTask<IDisposable> AcquireConnectionAsync(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(interfaceIds);
+        if (interfaceIds.Count == 0)
+            throw new ArgumentException("At least one interface id is required.", nameof(interfaceIds));
+
+        var uniqueIds = new HashSet<string>(interfaceIds, StringComparer.Ordinal);
+        var orderedIds = new string[uniqueIds.Count];
+        uniqueIds.CopyTo(orderedIds);
+        Array.Sort(orderedIds, StringComparer.Ordinal);
+
+        var acquired = new List<IDisposable>(orderedIds.Length);
+        try
+        {
+            foreach (var id in orderedIds)
+            {
+                acquired.Add(await GetOwnership(id)
+                    .AcquireConnectionAsync(id, cancellationToken)
+                    .ConfigureAwait(false));
+            }
+
+            return new CompositeRegistration(acquired);
+        }
+        catch
+        {
+            for (var i = acquired.Count - 1; i >= 0; i--)
+                acquired[i].Dispose();
+            throw;
+        }
+    }
+
+    /// <summary>
     ///     Attempts to acquire exclusive discovery ownership without waiting. Returns <c>null</c> while any
     ///     connection owns or is already waiting for the interface.
     /// </summary>
@@ -176,9 +218,9 @@ internal static class DeviceConnectionRegistry
         {
             if (_connectionCount > 0)
                 throw new ConnectionInUseException(
-                    $"The exclusive interface '{deviceId}' already has a live connection in this process. " +
-                    "Concurrent connections could change shared application state or interleave a multi-report " +
-                    "exchange. Dispose the existing connection first, then open the next connection.");
+                    $"This YubiKey already has a live connection in this process (held interface: '{deviceId}'). " +
+                    "A physical YubiKey supports one live connection at a time across all interfaces. " +
+                    "Dispose the existing connection first; connections are reused sequentially, not in parallel.");
 
             _connectionCount++;
             return new Registration(this, LeaseKind.Connection);
@@ -233,6 +275,20 @@ internal static class DeviceConnectionRegistry
                 return;
 
             ownership.Release(kind);
+        }
+    }
+
+    private sealed class CompositeRegistration(IReadOnlyList<IDisposable> registrations) : IDisposable
+    {
+        private int _disposed;
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
+                return;
+
+            for (var i = registrations.Count - 1; i >= 0; i--)
+                registrations[i].Dispose();
         }
     }
 }

--- a/src/Core/src/Devices/DeviceConnectionRegistry.cs
+++ b/src/Core/src/Devices/DeviceConnectionRegistry.cs
@@ -17,11 +17,6 @@ using Yubico.YubiKit.Core.Abstractions;
 
 namespace Yubico.YubiKit.Core.Devices;
 
-internal interface IConnectionLeaseScopeProvider
-{
-    void SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds);
-}
-
 /// <summary>
 ///     Process-wide ownership coordinator per interface device, keyed by <see cref="IYubiKey.DeviceId" />.
 ///     Connections hold the lease; discovery takes a nonblocking exclusive lease. This makes the

--- a/src/Core/src/Devices/IScopedConnectionProvider.cs
+++ b/src/Core/src/Devices/IScopedConnectionProvider.cs
@@ -1,0 +1,29 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Abstractions;
+
+namespace Yubico.YubiKit.Core.Devices;
+
+/// <summary>
+///     Opens a member connection while claiming the immutable physical-device interface scope supplied
+///     by the caller for this request.
+/// </summary>
+internal interface IScopedConnectionProvider
+{
+    Task<TConnection> ConnectWithLeaseScopeAsync<TConnection>(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken)
+        where TConnection : class, IConnection;
+}

--- a/src/Core/src/Devices/Implementations/HidYubiKey.cs
+++ b/src/Core/src/Devices/Implementations/HidYubiKey.cs
@@ -30,10 +30,8 @@ namespace Yubico.YubiKit.Core.Devices;
 internal class HidYubiKey(
     IHidDevice hidDevice,
     ILogger<HidYubiKey> logger)
-    : IYubiKey, IDiscoveryConnectionProvider, IConnectionLeaseScopeProvider
+    : IYubiKey, IDiscoveryConnectionProvider, IScopedConnectionProvider
 {
-    private IReadOnlyList<string>? _connectionLeaseScope;
-
     public string DeviceId { get; } =
         $"hid:{hidDevice.ReaderName}:{hidDevice.DescriptorInfo.Usage:X4}";
 
@@ -42,13 +40,18 @@ internal class HidYubiKey(
     /// </summary>
     public ConnectionType AvailableConnections => ConnectionTypeMapper.ToConnectionType(hidDevice.InterfaceType);
 
-    internal IReadOnlyList<string> ConnectionLeaseScope =>
-        Volatile.Read(ref _connectionLeaseScope) ?? [DeviceId];
+    public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+        where TConnection : class, IConnection
+        => ConnectWithLeaseScopeAsync<TConnection>([DeviceId], cancellationToken);
 
-    void IConnectionLeaseScopeProvider.SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds) =>
-        Interlocked.Exchange(ref _connectionLeaseScope, interfaceIds);
+    Task<TConnection> IScopedConnectionProvider.ConnectWithLeaseScopeAsync<TConnection>(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken) =>
+        ConnectWithLeaseScopeAsync<TConnection>(interfaceIds, cancellationToken);
 
-    public async Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+    private async Task<TConnection> ConnectWithLeaseScopeAsync<TConnection>(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken)
         where TConnection : class, IConnection
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -66,7 +69,7 @@ internal class HidYubiKey(
         // YubiKeyConnectionExtensions, not through concurrent connection sharing.
         var ownership = await DeviceConnectionRegistry
             .AcquireConnectionAsync(
-                ConnectionLeaseScope,
+                interfaceIds,
                 cancellationToken)
             .ConfigureAwait(false);
         try

--- a/src/Core/src/Devices/Implementations/HidYubiKey.cs
+++ b/src/Core/src/Devices/Implementations/HidYubiKey.cs
@@ -30,8 +30,10 @@ namespace Yubico.YubiKit.Core.Devices;
 internal class HidYubiKey(
     IHidDevice hidDevice,
     ILogger<HidYubiKey> logger)
-    : IYubiKey, IDiscoveryConnectionProvider
+    : IYubiKey, IDiscoveryConnectionProvider, IConnectionLeaseScopeProvider
 {
+    private IReadOnlyList<string>? _connectionLeaseScope;
+
     public string DeviceId { get; } =
         $"hid:{hidDevice.ReaderName}:{hidDevice.DescriptorInfo.Usage:X4}";
 
@@ -39,6 +41,12 @@ internal class HidYubiKey(
     /// The connections this YubiKey HID interface exposes (a single concrete HID connection in this phase).
     /// </summary>
     public ConnectionType AvailableConnections => ConnectionTypeMapper.ToConnectionType(hidDevice.InterfaceType);
+
+    internal IReadOnlyList<string> ConnectionLeaseScope =>
+        Volatile.Read(ref _connectionLeaseScope) ?? [DeviceId];
+
+    void IConnectionLeaseScopeProvider.SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds) =>
+        Interlocked.Exchange(ref _connectionLeaseScope, interfaceIds);
 
     public async Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
         where TConnection : class, IConnection
@@ -58,7 +66,7 @@ internal class HidYubiKey(
         // YubiKeyConnectionExtensions, not through concurrent connection sharing.
         var ownership = await DeviceConnectionRegistry
             .AcquireConnectionAsync(
-                DeviceId,
+                ConnectionLeaseScope,
                 cancellationToken)
             .ConfigureAwait(false);
         try

--- a/src/Core/src/Devices/Implementations/PcscYubiKey.cs
+++ b/src/Core/src/Devices/Implementations/PcscYubiKey.cs
@@ -23,9 +23,10 @@ internal class PcscYubiKey(
     IPcscDevice pcscDevice,
     ISmartCardConnectionFactory connectionFactory,
     ILogger<PcscYubiKey> logger)
-    : IYubiKey, IDiscoveryConnectionProvider
+    : IYubiKey, IDiscoveryConnectionProvider, IConnectionLeaseScopeProvider
 {
     private readonly string _readerName = pcscDevice.ReaderName;
+    private IReadOnlyList<string>? _connectionLeaseScope;
 
     private async Task<ISmartCardConnection> CreateConnection(CancellationToken cancellationToken = default)
     {
@@ -42,6 +43,12 @@ internal class PcscYubiKey(
     public string DeviceId { get; } = $"pcsc:{pcscDevice.ReaderName}";
     public ConnectionType AvailableConnections => ConnectionType.SmartCard;
 
+    internal IReadOnlyList<string> ConnectionLeaseScope =>
+        Volatile.Read(ref _connectionLeaseScope) ?? [DeviceId];
+
+    void IConnectionLeaseScopeProvider.SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds) =>
+        Interlocked.Exchange(ref _connectionLeaseScope, interfaceIds);
+
     public async Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
         where TConnection : class, IConnection
     {
@@ -52,7 +59,7 @@ internal class PcscYubiKey(
         // Exclusive: one live connection per CCID interface. The lease is held by the connection returned
         // below and released when that connection is disposed.
         var ownership = await DeviceConnectionRegistry
-            .AcquireConnectionAsync(DeviceId, cancellationToken)
+            .AcquireConnectionAsync(ConnectionLeaseScope, cancellationToken)
             .ConfigureAwait(false);
         try
         {

--- a/src/Core/src/Devices/Implementations/PcscYubiKey.cs
+++ b/src/Core/src/Devices/Implementations/PcscYubiKey.cs
@@ -23,10 +23,9 @@ internal class PcscYubiKey(
     IPcscDevice pcscDevice,
     ISmartCardConnectionFactory connectionFactory,
     ILogger<PcscYubiKey> logger)
-    : IYubiKey, IDiscoveryConnectionProvider, IConnectionLeaseScopeProvider
+    : IYubiKey, IDiscoveryConnectionProvider, IScopedConnectionProvider
 {
     private readonly string _readerName = pcscDevice.ReaderName;
-    private IReadOnlyList<string>? _connectionLeaseScope;
 
     private async Task<ISmartCardConnection> CreateConnection(CancellationToken cancellationToken = default)
     {
@@ -43,13 +42,18 @@ internal class PcscYubiKey(
     public string DeviceId { get; } = $"pcsc:{pcscDevice.ReaderName}";
     public ConnectionType AvailableConnections => ConnectionType.SmartCard;
 
-    internal IReadOnlyList<string> ConnectionLeaseScope =>
-        Volatile.Read(ref _connectionLeaseScope) ?? [DeviceId];
+    public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+        where TConnection : class, IConnection
+        => ConnectWithLeaseScopeAsync<TConnection>([DeviceId], cancellationToken);
 
-    void IConnectionLeaseScopeProvider.SetConnectionLeaseScope(IReadOnlyList<string> interfaceIds) =>
-        Interlocked.Exchange(ref _connectionLeaseScope, interfaceIds);
+    Task<TConnection> IScopedConnectionProvider.ConnectWithLeaseScopeAsync<TConnection>(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken) =>
+        ConnectWithLeaseScopeAsync<TConnection>(interfaceIds, cancellationToken);
 
-    public async Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+    private async Task<TConnection> ConnectWithLeaseScopeAsync<TConnection>(
+        IReadOnlyCollection<string> interfaceIds,
+        CancellationToken cancellationToken)
         where TConnection : class, IConnection
     {
         if (typeof(TConnection) != typeof(ISmartCardConnection))
@@ -59,7 +63,7 @@ internal class PcscYubiKey(
         // Exclusive: one live connection per CCID interface. The lease is held by the connection returned
         // below and released when that connection is disposed.
         var ownership = await DeviceConnectionRegistry
-            .AcquireConnectionAsync(ConnectionLeaseScope, cancellationToken)
+            .AcquireConnectionAsync(interfaceIds, cancellationToken)
             .ConfigureAwait(false);
         try
         {

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeYubiKeyTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeYubiKeyTests.cs
@@ -104,7 +104,7 @@ public class CompositeYubiKeyTests
 
     // FakeMember.ConnectAsync always throws a distinctive InvalidOperationException naming the connection it
     // backs, so a routing test can assert which member the composite dispatched to without full connection fakes.
-    private sealed class FakeMember : IYubiKey
+    private sealed class FakeMember : IYubiKey, IScopedConnectionProvider
     {
         private readonly ConnectionType _connection;
 
@@ -116,5 +116,11 @@ public class CompositeYubiKeyTests
         public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
             where TConnection : class, IConnection
             => throw new InvalidOperationException($"routed-to:{_connection}:{typeof(TConnection).Name}");
+
+        public Task<TConnection> ConnectWithLeaseScopeAsync<TConnection>(
+            IReadOnlyCollection<string> interfaceIds,
+            CancellationToken cancellationToken)
+            where TConnection : class, IConnection
+            => ConnectAsync<TConnection>(cancellationToken);
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
@@ -189,6 +189,43 @@ public class ConnectionOwnershipContractTests
         Assert.Equal(1, hidDevice.IoReportConnectCalls);
     }
 
+    [Fact]
+    public async Task ConnectAsync_AliasedMembersRegroupedLater_OlderCompositeScopeRemainsStable()
+    {
+        var firstSmartCardFactory = new CountingFactory();
+        var firstSmartCard = CreateSmartCardDevice(firstSmartCardFactory);
+        var firstHidDevice = new FakeHidDevice(
+            $"ownership-fido-{Guid.NewGuid():N}",
+            HidInterfaceType.Fido);
+        var firstHid = CreateHidDevice(firstHidDevice);
+        var olderComposite = new CompositeYubiKey(
+            $"composite:{Guid.NewGuid():N}",
+            [firstSmartCard, firstHid],
+            null);
+
+        var laterHid = CreateHidDevice(new FakeHidDevice(
+            $"ownership-fido-{Guid.NewGuid():N}",
+            HidInterfaceType.Fido));
+        _ = new CompositeYubiKey(
+            $"composite:{Guid.NewGuid():N}",
+            [firstSmartCard, laterHid],
+            null);
+
+        var laterSmartCard = CreateSmartCardDevice(new CountingFactory());
+        _ = new CompositeYubiKey(
+            $"composite:{Guid.NewGuid():N}",
+            [laterSmartCard, firstHid],
+            null);
+
+        await using var ccid = await olderComposite.ConnectAsync<ISmartCardConnection>(Ct);
+
+        _ = await Assert.ThrowsAsync<ConnectionInUseException>(
+            () => olderComposite.ConnectAsync<IFidoHidConnection>(Ct));
+
+        Assert.Equal(0, firstHidDevice.IoReportConnectCalls);
+        Assert.Equal(1, firstSmartCardFactory.CreateCalls);
+    }
+
     // ------------------------------------------------------------------------------------------------
     // Rule 2 — one live session per connection (Python's model, enforced at binding).
     // ------------------------------------------------------------------------------------------------

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
@@ -161,24 +161,32 @@ public class ConnectionOwnershipContractTests
     }
 
     /// <summary>
-    ///     INVARIANT PIN (must pass before and after). The independent interfaces of one physical key remain
-    ///     independent: a held CCID interface must not block that key's HID interface. Management-over-HID
-    ///     fallback is achieved through held-transport exception detection in YubiKeyConnectionExtensions,
-    ///     not through concurrent connection sharing. A held FIDO interface triggers fallback to OTP if
-    ///     present.
+    ///     A connection through one member of a grouped physical key claims every known member interface.
+    ///     The refusal happens before a second native handle is opened, and the first connection stays usable.
     /// </summary>
     [Fact]
-    public async Task ConnectAsync_CcidHeld_SameKeysHidInterfaceStillConnects()
+    public async Task ConnectAsync_CcidHeld_GroupedKeysHidInterfaceIsRefused()
     {
-        var smartCard = CreateSmartCardDevice(new CountingFactory());
-        var hid = CreateHidDevice(new FakeHidDevice(
+        var factory = new CountingFactory();
+        var smartCard = CreateSmartCardDevice(factory);
+        var hidDevice = new FakeHidDevice(
             $"ownership-fido-{Guid.NewGuid():N}",
-            HidInterfaceType.Fido));
+            HidInterfaceType.Fido);
+        var hid = CreateHidDevice(hidDevice);
+        var composite = new CompositeYubiKey($"composite:{Guid.NewGuid():N}", [smartCard, hid], null);
 
-        await using var ccid = await smartCard.ConnectAsync<ISmartCardConnection>(Ct);
-        await using var fido = await hid.ConnectAsync<IFidoHidConnection>(Ct);
+        await using var ccid = await composite.ConnectAsync<ISmartCardConnection>(Ct);
+        var refusal = await Assert.ThrowsAsync<ConnectionInUseException>(
+            () => composite.ConnectAsync<IFidoHidConnection>(Ct));
 
-        Assert.NotNull(fido);
+        Assert.Contains(hid.DeviceId, refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(0, hidDevice.IoReportConnectCalls);
+        _ = await ccid.TransmitAndReceiveAsync(new byte[] { 0x00 }, Ct);
+        Assert.Equal(1, factory.CreateCalls);
+
+        await ccid.DisposeAsync();
+        await using var fido = await composite.ConnectAsync<IFidoHidConnection>(Ct);
+        Assert.Equal(1, hidDevice.IoReportConnectCalls);
     }
 
     // ------------------------------------------------------------------------------------------------
@@ -278,7 +286,8 @@ public class ConnectionOwnershipContractTests
 
     private static void AssertExclusiveInterfaceRefusal(ConnectionInUseException refusal, string deviceId)
     {
-        Assert.Contains($"exclusive interface '{deviceId}'", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains($"held interface: '{deviceId}'", refusal.Message, StringComparison.Ordinal);
+        Assert.Contains("one live connection at a time across all interfaces", refusal.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("SmartCard", refusal.Message, StringComparison.Ordinal);
         Assert.DoesNotContain("CCID", refusal.Message, StringComparison.Ordinal);
     }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceConnectionRegistryTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceConnectionRegistryTests.cs
@@ -52,6 +52,100 @@ public class DeviceConnectionRegistryTests
         Assert.True(DeviceConnectionRegistry.IsInUse(id));
     }
 
+    [Fact]
+    public async Task AcquireConnection_MultipleInterfaces_DeduplicatesAndReleasesAllMembers()
+    {
+        var firstId = NewId();
+        var secondId = NewId();
+
+        var lease = await DeviceConnectionRegistry.AcquireConnectionAsync(
+            new[] { secondId, firstId, secondId }, TestContext.Current.CancellationToken);
+
+        Assert.True(DeviceConnectionRegistry.IsInUse(firstId));
+        Assert.True(DeviceConnectionRegistry.IsInUse(secondId));
+
+        lease.Dispose();
+        lease.Dispose();
+
+        Assert.False(DeviceConnectionRegistry.IsInUse(firstId));
+        Assert.False(DeviceConnectionRegistry.IsInUse(secondId));
+    }
+
+    [Fact]
+    public async Task AcquireConnection_LaterMemberHeld_RollsBackEarlierClaims()
+    {
+        var prefix = NewId();
+        var firstId = $"{prefix}:a";
+        var secondId = $"{prefix}:b";
+        using var held = await DeviceConnectionRegistry.AcquireConnectionAsync(
+            secondId, TestContext.Current.CancellationToken);
+
+        await Assert.ThrowsAsync<ConnectionInUseException>(async () =>
+            await DeviceConnectionRegistry.AcquireConnectionAsync(
+                new[] { secondId, firstId }, TestContext.Current.CancellationToken));
+
+        using var firstClaim = await DeviceConnectionRegistry.AcquireConnectionAsync(
+            firstId, TestContext.Current.CancellationToken);
+        Assert.True(DeviceConnectionRegistry.IsInUse(firstId));
+    }
+
+    [Fact]
+    public async Task AcquireConnection_RacingGroupedClaims_AdmitsExactlyOneWinner()
+    {
+        var ids = new[] { NewId(), NewId(), NewId() };
+
+        static async Task<object> TryAcquireAsync(string[] scope, CancellationToken cancellationToken)
+        {
+            try
+            {
+                return await DeviceConnectionRegistry.AcquireConnectionAsync(scope, cancellationToken);
+            }
+            catch (ConnectionInUseException exception)
+            {
+                return exception;
+            }
+        }
+
+        var first = Task.Run(
+            () => TryAcquireAsync(ids, TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+        var second = Task.Run(
+            () => TryAcquireAsync(ids, TestContext.Current.CancellationToken),
+            TestContext.Current.CancellationToken);
+        var results = await Task.WhenAll(first, second).WaitAsync(TimeSpan.FromSeconds(5), TestContext.Current.CancellationToken);
+
+        var winner = Assert.Single(results.OfType<IDisposable>());
+        Assert.Single(results.OfType<ConnectionInUseException>());
+        winner.Dispose();
+        Assert.All(ids, id => Assert.False(DeviceConnectionRegistry.IsInUse(id)));
+    }
+
+    [Fact]
+    public async Task AcquireConnection_DiscoveryOnMember_CancellationRollsBackAndLiveClaimBlocksAllDiscovery()
+    {
+        var prefix = NewId();
+        var firstId = $"{prefix}:a";
+        var secondId = $"{prefix}:b";
+        using var discovery = DeviceConnectionRegistry.TryAcquireDiscovery(secondId);
+        Assert.NotNull(discovery);
+        using var cancellation = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+
+        var waitingClaim = DeviceConnectionRegistry.AcquireConnectionAsync(
+            new[] { secondId, firstId }, cancellation.Token).AsTask();
+        Assert.Null(DeviceConnectionRegistry.TryAcquireDiscovery(firstId));
+        await cancellation.CancelAsync();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => waitingClaim);
+
+        using (var firstDiscovery = DeviceConnectionRegistry.TryAcquireDiscovery(firstId))
+            Assert.NotNull(firstDiscovery);
+
+        discovery.Dispose();
+        using var connection = await DeviceConnectionRegistry.AcquireConnectionAsync(
+            new[] { secondId, firstId }, TestContext.Current.CancellationToken);
+        Assert.Null(DeviceConnectionRegistry.TryAcquireDiscovery(firstId));
+        Assert.Null(DeviceConnectionRegistry.TryAcquireDiscovery(secondId));
+    }
+
     /// <summary>
     ///     An identity read against an interface this process holds a live connection to must be skipped
     ///     entirely (no connection opened — a discovery SELECT would clobber the session's applet state).
@@ -71,24 +165,23 @@ public class DeviceConnectionRegistryTests
     }
 
     /// <summary>
-    ///     The metadata read must skip only the in-use member interface of a composite and still attempt
-    ///     the remaining free transports (independent USB interfaces are safe to read).
+    ///     A live grouped connection claims every member, so metadata discovery must skip all transports.
     /// </summary>
     [Fact]
-    public async Task MetadataRead_CompositeWithInUseSmartCardMember_SkipsItButTriesOtpTransport()
+    public async Task MetadataRead_CompositeWithLiveConnection_SkipsEveryMember()
     {
         var smartCardMember = new RecordingYubiKey(NewId(), ConnectionType.SmartCard);
         var otpMember = new RecordingYubiKey(NewId(), ConnectionType.HidOtp);
         var composite = new CompositeYubiKey(NewId(), [smartCardMember, otpMember], deviceInfo: null);
         using var registration = await DeviceConnectionRegistry.AcquireConnectionAsync(
-            smartCardMember.DeviceId, TestContext.Current.CancellationToken);
+            composite.MemberDeviceIds, TestContext.Current.CancellationToken);
 
         var info = await CompositeMetadataReader.TryReadAsync(
             composite, TimeSpan.FromSeconds(5), NullLogger.Instance, TestContext.Current.CancellationToken);
 
-        Assert.Null(info); // OTP member's connect fails by design; result degrades to null
+        Assert.Null(info);
         Assert.Equal(0, smartCardMember.ConnectCalls);
-        Assert.Equal(1, otpMember.ConnectCalls);
+        Assert.Equal(0, otpMember.ConnectCalls);
     }
 
     [Fact]

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/HeldExceptionPropagationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/HeldExceptionPropagationTests.cs
@@ -58,12 +58,19 @@ public class HeldExceptionPropagationTests
         Assert.Equal(unchecked((int)ErrorCode.SCARD_E_SERVER_TOO_BUSY), ex.HResult);
     }
 
-    private sealed class ThrowingMember(ConnectionType available, Exception exception) : IYubiKey
+    private sealed class ThrowingMember(ConnectionType available, Exception exception)
+        : IYubiKey, IScopedConnectionProvider
     {
         public string DeviceId => $"member:{available}";
         public ConnectionType AvailableConnections => available;
 
         public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+            where TConnection : class, IConnection =>
+            Task.FromException<TConnection>(exception);
+
+        public Task<TConnection> ConnectWithLeaseScopeAsync<TConnection>(
+            IReadOnlyCollection<string> interfaceIds,
+            CancellationToken cancellationToken)
             where TConnection : class, IConnection =>
             Task.FromException<TConnection>(exception);
     }


### PR DESCRIPTION
## Summary

Makes one in-process connection lease cover every known interface of a grouped physical YubiKey.

## Changes

- Adds atomic multi-member acquisition to `DeviceConnectionRegistry`.
- Sorts and deduplicates member IDs and rolls back partial claims on cancellation or failure.
- Uses request-scoped immutable member ID sets when a composite opens CCID or HID.
- Keeps standalone member connects scoped to that member's `[DeviceId]`.
- Removes mutable lease-scope state/setters from member implementations and never keys ownership by composite DeviceId.
- Adds alias/regrouping coverage proving older composite references retain stable exclusion behavior.

## TDD Evidence

- **RED:** `ConnectAsync_AliasedMembersRegroupedLater_OlderCompositeScopeRemainsStable` failed because no `ConnectionInUseException` was thrown.
- **GREEN:** the same focused test passed after request-scoped acquisition replaced member mutation.
- `dotnet toolchain.cs -- test --project Core` — 827 passed, 3 expected skips on the layer branch.
- Final stack: Core 819 passed, 3 expected skips; all 12 unit-test projects passed.

## Craftsman Phase 4 Follow-up

- **Tracer:** Traced composite member resolution through scoped acquisition, registry claims, native open, disposal, and lease release, including aliased members reused by later composites.
- **Fit boundary:** Core device routing, registry acquisition, concrete CCID/HID members, and ownership contract tests.
- **Gate decision:** The internal `IScopedConnectionProvider` keeps `IYubiKey` unchanged while making the composite's immutable sorted member IDs request data rather than shared member state.
- **Alternatives:** Rejected adding the capability to public `IYubiKey`; rejected nesting it under `CompositeYubiKey`; placed it beside `IDiscoveryConnectionProvider` as a peer internal device capability.
- **DevTeam correctness:** Cross-vendor verdict `pass`; no correctness or boundary regressions found. The explicit failure for a non-capable internal member is retained as a defensive invariant.
- **Simplify Apply:** Verified no-op; the capability is the minimum seam and the existing registry remains the single ownership subsystem.

## Stack

1. #558 protocol exchange guard
2. **This PR:** physical-device connection lease
3. #560 single transport selection
4. #561 documentation and architecture diagrams
