### PR TITLE
feat(core): add guarded raw transport sessions

### DIFF
--- a/src/Core/src/Devices/YubiKeyConnectionExtensions.cs
+++ b/src/Core/src/Devices/YubiKeyConnectionExtensions.cs
@@ -15,6 +15,7 @@
 using Microsoft.Extensions.Logging;
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
 using Yubico.YubiKit.Core.Sessions;
 using Yubico.YubiKit.Core.Transports.Hid;
@@ -31,7 +32,6 @@ public static class YubiKeyConnectionExtensions
 
     public static Task<RawSmartCardSession> CreateRawSmartCardSessionAsync(
         this IYubiKey yubiKey,
-        ScpKeyParameters? scpKeyParameters = null,
         CancellationToken cancellationToken = default) =>
         yubiKey.CreateSessionOverTransportAsync(
             ConnectionType.SmartCard,
@@ -39,13 +39,38 @@ public static class YubiKeyConnectionExtensions
             {
                 RawSmartCardSession session = await RawSmartCardSession.CreateAsync(
                         (ISmartCardConnection)connection,
-                        scpKeyParameters,
                         token)
                     .ConfigureAwait(false);
                 session.OwnConnection();
                 return session;
             },
             cancellationToken);
+
+    public static Task<RawSmartCardSession> CreateRawSmartCardSessionAsync(
+        this IYubiKey yubiKey,
+        ScpKeyParameters scpKeyParameters,
+        FirmwareVersion firmwareVersion,
+        ProtocolConfiguration? configuration = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(scpKeyParameters);
+        ArgumentNullException.ThrowIfNull(firmwareVersion);
+        return yubiKey.CreateSessionOverTransportAsync(
+            ConnectionType.SmartCard,
+            async (connection, token) =>
+            {
+                RawSmartCardSession session = await RawSmartCardSession.CreateAsync(
+                        (ISmartCardConnection)connection,
+                        scpKeyParameters,
+                        firmwareVersion,
+                        configuration,
+                        token)
+                    .ConfigureAwait(false);
+                session.OwnConnection();
+                return session;
+            },
+            cancellationToken);
+    }
 
     public static Task<RawFidoHidSession> CreateRawFidoHidSessionAsync(
         this IYubiKey yubiKey,

--- a/src/Core/src/Devices/YubiKeyConnectionExtensions.cs
+++ b/src/Core/src/Devices/YubiKeyConnectionExtensions.cs
@@ -15,6 +15,8 @@
 using Microsoft.Extensions.Logging;
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
+using Yubico.YubiKit.Core.Sessions;
 using Yubico.YubiKit.Core.Transports.Hid;
 using Yubico.YubiKit.Core.Transports.SmartCard;
 
@@ -26,6 +28,56 @@ namespace Yubico.YubiKit.Core.Devices;
 public static class YubiKeyConnectionExtensions
 {
     private static readonly ILogger Logger = YubiKitLogging.CreateLogger(nameof(YubiKeyConnectionExtensions));
+
+    public static Task<RawSmartCardSession> CreateRawSmartCardSessionAsync(
+        this IYubiKey yubiKey,
+        ScpKeyParameters? scpKeyParameters = null,
+        CancellationToken cancellationToken = default) =>
+        yubiKey.CreateSessionOverTransportAsync(
+            ConnectionType.SmartCard,
+            async (connection, token) =>
+            {
+                RawSmartCardSession session = await RawSmartCardSession.CreateAsync(
+                        (ISmartCardConnection)connection,
+                        scpKeyParameters,
+                        token)
+                    .ConfigureAwait(false);
+                session.OwnConnection();
+                return session;
+            },
+            cancellationToken);
+
+    public static Task<RawFidoHidSession> CreateRawFidoHidSessionAsync(
+        this IYubiKey yubiKey,
+        CancellationToken cancellationToken = default) =>
+        yubiKey.CreateSessionOverTransportAsync(
+            ConnectionType.HidFido,
+            async (connection, token) =>
+            {
+                RawFidoHidSession session = await RawFidoHidSession.CreateAsync(
+                        (IFidoHidConnection)connection,
+                        token)
+                    .ConfigureAwait(false);
+                session.OwnConnection();
+                return session;
+            },
+            cancellationToken);
+
+    public static Task<RawOtpHidSession> CreateRawOtpHidSessionAsync(
+        this IYubiKey yubiKey,
+        CancellationToken cancellationToken = default) =>
+        yubiKey.CreateSessionOverTransportAsync(
+            ConnectionType.HidOtp,
+            async (connection, token) =>
+            {
+                RawOtpHidSession session = await RawOtpHidSession.CreateAsync(
+                        (IOtpHidConnection)connection,
+                        token)
+                    .ConfigureAwait(false);
+                session.OwnConnection();
+                return session;
+            },
+            cancellationToken);
 
     /// <summary>
     ///     Returns the first connection in <paramref name="preferenceOrder" /> that this device supports, or

--- a/src/Core/src/Protocols/Fido/Hid/FidoHidConnection.cs
+++ b/src/Core/src/Protocols/Fido/Hid/FidoHidConnection.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Transports.Hid;
 
@@ -36,8 +37,16 @@ internal class FidoHidConnection(IHidConnection connection) : IFidoHidConnection
             throw new ArgumentException($"FIDO packet must be exactly {PacketSize} bytes, got {packet.Length}",
                 nameof(packet));
 
-        connection.SetReport(packet.ToArray());
-        return Task.CompletedTask;
+        byte[] report = packet.ToArray();
+        try
+        {
+            connection.SetReport(report);
+            return Task.CompletedTask;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(report);
+        }
     }
 
     public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)

--- a/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
+++ b/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
@@ -24,10 +24,11 @@ namespace Yubico.YubiKit.Core.Protocols.Fido.Hid;
 ///     completion.
 /// </remarks>
 internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidProtocol>? logger = null)
-    : IFidoHidProtocol
+    : IFidoHidProtocol, IAsyncDisposable
 {
     private readonly IFidoHidConnection _connection = connection ?? throw new ArgumentNullException(nameof(connection));
     private readonly ExchangeGuard _exchangeGuard = new();
+    private readonly DisposalGate _disposalGate = new();
     private readonly ILogger<FidoHidProtocol> _logger = logger ?? NullLogger<FidoHidProtocol>.Instance;
     private uint? _channelId;
     private FirmwareVersion? _firmwareVersion;
@@ -109,45 +110,49 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
         // Generate 8-byte random nonce
         var nonce = new byte[CtapConstants.NonceSize];
         RandomNumberGenerator.Fill(nonce);
-
-        // Send CTAPHID_INIT to broadcast channel
-        var response = await TransmitCommand(
-                CtapConstants.BroadcastChannelId,
-                CtapConstants.CtapHidInit,
-                nonce.AsMemory(),
-                cancellationToken)
-            .ConfigureAwait(false);
-
-        // Verify nonce echo
-        if (response.Length < 17)  // nonce(8) + channelId(4) + version(1) + firmware(3) + capabilities(1)
+        try
         {
-            _logger.LogError("CTAPHID_INIT response too short: {Length} bytes. Expected at least 17.", response.Length);
-            throw new InvalidOperationException($"CTAPHID_INIT response too short: {response.Length} bytes");
-        }
+            // Send CTAPHID_INIT to broadcast channel
+            var response = await TransmitCommand(
+                    CtapConstants.BroadcastChannelId,
+                    CtapConstants.CtapHidInit,
+                    nonce.AsMemory(),
+                    cancellationToken)
+                .ConfigureAwait(false);
 
-        var receivedNonce = response.Span[..CtapConstants.NonceSize];
-        if (!CryptographicOperations.FixedTimeEquals(nonce, receivedNonce))
+            // Verify nonce echo
+            if (response.Length < 17)  // nonce(8) + channelId(4) + version(1) + firmware(3) + capabilities(1)
+            {
+                _logger.LogError("CTAPHID_INIT response too short: {Length} bytes. Expected at least 17.", response.Length);
+                throw new InvalidOperationException($"CTAPHID_INIT response too short: {response.Length} bytes");
+            }
+
+            var receivedNonce = response.Span[..CtapConstants.NonceSize];
+            if (!CryptographicOperations.FixedTimeEquals(nonce, receivedNonce))
+            {
+                _logger.LogError("CTAPHID_INIT nonce mismatch");
+                throw new InvalidOperationException("CTAPHID_INIT nonce mismatch");
+            }
+
+            // Extract channel ID (bytes 8-11, big-endian)
+            _channelId = BinaryPrimitives.ReadUInt32BigEndian(response.Span[8..12]);
+
+            // Extract firmware version (bytes 13-15) - skip protocol version byte at 12
+            if (response.Length >= 16)
+            {
+                var major = response.Span[13];
+                var minor = response.Span[14];
+                var patch = response.Span[15];
+                _firmwareVersion = new FirmwareVersion(major, minor, patch);
+                _logger.LogDebug("Extracted firmware version from CTAPHID_INIT: {Version}", _firmwareVersion);
+            }
+
+            _logger.LogDebug("Acquired CTAP HID channel: 0x{ChannelId:X8}", _channelId.Value);
+        }
+        finally
         {
-            _logger.LogError("CTAPHID_INIT nonce mismatch. Sent: {SentNonce}, Received: {ReceivedNonce}",
-                Convert.ToHexString(nonce),
-                Convert.ToHexString(receivedNonce));
-            throw new InvalidOperationException("CTAPHID_INIT nonce mismatch");
+            CryptographicOperations.ZeroMemory(nonce);
         }
-
-        // Extract channel ID (bytes 8-11, big-endian)
-        _channelId = BinaryPrimitives.ReadUInt32BigEndian(response.Span[8..12]);
-
-        // Extract firmware version (bytes 13-15) - skip protocol version byte at 12
-        if (response.Length >= 16)
-        {
-            var major = response.Span[13];
-            var minor = response.Span[14];
-            var patch = response.Span[15];
-            _firmwareVersion = new FirmwareVersion(major, minor, patch);
-            _logger.LogDebug("Extracted firmware version from CTAPHID_INIT: {Version}", _firmwareVersion);
-        }
-
-        _logger.LogDebug("Acquired CTAP HID channel: 0x{ChannelId:X8}", _channelId.Value);
     }
 
     /// <summary>
@@ -160,7 +165,7 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
         CancellationToken cancellationToken)
     {
         await SendRequest(channelId, command, data, cancellationToken).ConfigureAwait(false);
-        return await ReceiveResponse(channelId, cancellationToken).ConfigureAwait(false);
+        return await ReceiveResponse(channelId, command, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -181,7 +186,14 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
 
         // Send initialization packet
         var initPacket = ConstructInitPacket(channelId, command, data.Span, data.Length);
-        await _connection.SendAsync(initPacket, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _connection.SendAsync(initPacket, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(initPacket);
+        }
 
         // Send continuation packets if needed
         if (data.Length > CtapConstants.InitDataSize)
@@ -194,7 +206,14 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
                 var span = remaining.Span;
                 var chunkSize = Math.Min(span.Length, CtapConstants.ContinuationDataSize);
                 var continuationPacket = ConstructContinuationPacket(channelId, sequence, span[..chunkSize]);
-                await _connection.SendAsync(continuationPacket, cancellationToken).ConfigureAwait(false);
+                try
+                {
+                    await _connection.SendAsync(continuationPacket, cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(continuationPacket);
+                }
 
                 remaining = remaining[chunkSize..];
                 sequence++;
@@ -209,6 +228,7 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
     /// </summary>
     private async Task<ReadOnlyMemory<byte>> ReceiveResponse(
         uint channelId,
+        byte expectedCommand,
         CancellationToken cancellationToken)
     {
         _logger.LogTrace("Receiving CTAP HID response");
@@ -227,6 +247,19 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
         var responseLength = GetPacketLength(initPacket.Span);
         if (responseLength > CtapConstants.MaxPayloadSize)
             throw new InvalidOperationException($"Response length {responseLength} exceeds max payload size");
+
+        byte responseCommand = GetPacketCommand(initPacket.Span);
+        if (responseCommand == CtapConstants.CtapHidError)
+        {
+            byte errorCode = responseLength > 0 ? initPacket.Span[CtapConstants.InitHeaderSize] : (byte)0x7F;
+            throw new InvalidOperationException($"CTAP HID error response: 0x{errorCode:X2}");
+        }
+
+        if (responseCommand != expectedCommand)
+        {
+            throw new InvalidOperationException(
+                $"CTAP HID response command 0x{responseCommand:X2} does not match request command 0x{expectedCommand:X2}");
+        }
 
         // Allocate buffer for complete response
         var responseData = new byte[responseLength];
@@ -357,9 +390,18 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
     /// </summary>
     public void Dispose()
     {
-        if (_disposed) return;
+        _disposalGate.Dispose(() =>
+        {
+            _exchangeGuard.CloseAndDrain();
+            _channelId = null;
+            _disposed = true;
+        });
+    }
 
+    public ValueTask DisposeAsync() => _disposalGate.DisposeAsync(async () =>
+    {
+        await _exchangeGuard.CloseAndDrainAsync().ConfigureAwait(false);
         _channelId = null;
         _disposed = true;
-    }
+    });
 }

--- a/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
+++ b/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
@@ -23,13 +23,17 @@ namespace Yubico.YubiKit.Core.Protocols.Fido.Hid;
 ///     through an internal guard: overlapping calls are refused immediately. An exchange in flight runs to
 ///     completion.
 /// </remarks>
-internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidProtocol>? logger = null)
+internal class FidoHidProtocol(
+    IFidoHidConnection connection,
+    ILogger<FidoHidProtocol>? logger = null,
+    Func<int, byte[]>? responseBufferFactory = null)
     : IFidoHidProtocol, IAsyncDisposable
 {
     private readonly IFidoHidConnection _connection = connection ?? throw new ArgumentNullException(nameof(connection));
     private readonly ExchangeGuard _exchangeGuard = new();
     private readonly DisposalGate _disposalGate = new();
     private readonly ILogger<FidoHidProtocol> _logger = logger ?? NullLogger<FidoHidProtocol>.Instance;
+    private readonly Func<int, byte[]> _responseBufferFactory = responseBufferFactory ?? (static length => new byte[length]);
     private uint? _channelId;
     private FirmwareVersion? _firmwareVersion;
     private bool _disposed;
@@ -255,39 +259,49 @@ internal class FidoHidProtocol(IFidoHidConnection connection, ILogger<FidoHidPro
             throw new InvalidOperationException($"CTAP HID error response: 0x{errorCode:X2}");
         }
 
-        if (responseCommand != expectedCommand)
+        byte normalizedExpectedCommand = (byte)(expectedCommand & ~CtapConstants.InitPacketMask);
+        if (responseCommand != normalizedExpectedCommand)
         {
             throw new InvalidOperationException(
                 $"CTAP HID response command 0x{responseCommand:X2} does not match request command 0x{expectedCommand:X2}");
         }
 
-        // Allocate buffer for complete response
-        var responseData = new byte[responseLength];
-        var initDataLength = Math.Min(responseLength, CtapConstants.InitDataSize);
-
-        initPacket.Span.Slice(CtapConstants.InitHeaderSize, initDataLength)
-            .CopyTo(responseData);
-
-        // Receive continuation packets if needed
-        var bytesReceived = initDataLength;
-        byte expectedSequence = 0;
-        while (bytesReceived < responseLength)
+        byte[] responseData = _responseBufferFactory(responseLength);
+        var ownershipTransferred = false;
+        try
         {
-            var contPacket = await _connection.ReceiveAsync(cancellationToken).ConfigureAwait(false);
-            ValidateContinuationPacket(contPacket.Span, channelId, expectedSequence);
-            var contDataLength = Math.Min(
-                responseLength - bytesReceived,
-                CtapConstants.ContinuationDataSize);
+            var initDataLength = Math.Min(responseLength, CtapConstants.InitDataSize);
 
-            contPacket.Span.Slice(CtapConstants.ContinuationHeaderSize, contDataLength)
-                .CopyTo(responseData.AsSpan(bytesReceived));
+            initPacket.Span.Slice(CtapConstants.InitHeaderSize, initDataLength)
+                .CopyTo(responseData);
 
-            bytesReceived += contDataLength;
-            expectedSequence++;
+            // Receive continuation packets if needed
+            var bytesReceived = initDataLength;
+            byte expectedSequence = 0;
+            while (bytesReceived < responseLength)
+            {
+                var contPacket = await _connection.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                ValidateContinuationPacket(contPacket.Span, channelId, expectedSequence);
+                var contDataLength = Math.Min(
+                    responseLength - bytesReceived,
+                    CtapConstants.ContinuationDataSize);
+
+                contPacket.Span.Slice(CtapConstants.ContinuationHeaderSize, contDataLength)
+                    .CopyTo(responseData.AsSpan(bytesReceived));
+
+                bytesReceived += contDataLength;
+                expectedSequence++;
+            }
+
+            _logger.LogTrace("Received {Length} bytes in response", responseLength);
+            ownershipTransferred = true;
+            return responseData;
         }
-
-        _logger.LogTrace("Received {Length} bytes in response", responseLength);
-        return responseData;
+        finally
+        {
+            if (!ownershipTransferred)
+                CryptographicOperations.ZeroMemory(responseData);
+        }
     }
 
     /// <summary>

--- a/src/Core/src/Protocols/Otp/Hid/OtpHidConnection.cs
+++ b/src/Core/src/Protocols/Otp/Hid/OtpHidConnection.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Transports.Hid;
 
@@ -37,8 +38,16 @@ internal class OtpHidConnection(IHidConnection connection) : IOtpHidConnection
                 $"OTP feature report must be exactly {FeatureReportSize} bytes, got {report.Length}",
                 nameof(report));
 
-        connection.SetReport(report.ToArray());
-        return Task.CompletedTask;
+        byte[] reportCopy = report.ToArray();
+        try
+        {
+            connection.SetReport(reportCopy);
+            return Task.CompletedTask;
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(reportCopy);
+        }
     }
 
     public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)

--- a/src/Core/src/Protocols/Otp/Hid/OtpHidProtocol.cs
+++ b/src/Core/src/Protocols/Otp/Hid/OtpHidProtocol.cs
@@ -14,6 +14,7 @@
 
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using System.Buffers;
 using System.Buffers.Binary;
 using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Devices;
@@ -42,14 +43,19 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol, IAsyncDisposable
     private readonly ExchangeGuard _exchangeGuard = new();
     private readonly DisposalGate _disposalGate = new();
     private readonly ILogger<OtpHidProtocol> _logger;
+    private readonly ArrayPool<byte> _bufferPool;
     private FirmwareVersion? _firmwareVersion;
     private bool _initialized;
     private bool _disposed;
 
-    public OtpHidProtocol(IOtpHidConnection connection, ILogger<OtpHidProtocol>? logger = null)
+    public OtpHidProtocol(
+        IOtpHidConnection connection,
+        ILogger<OtpHidProtocol>? logger = null,
+        ArrayPool<byte>? bufferPool = null)
     {
         _connection = connection ?? throw new ArgumentNullException(nameof(connection));
         _logger = logger ?? NullLogger<OtpHidProtocol>.Instance;
+        _bufferPool = bufferPool ?? ArrayPool<byte>.Shared;
     }
 
     public FirmwareVersion? FirmwareVersion => _firmwareVersion;
@@ -260,48 +266,62 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol, IAsyncDisposable
         ReadOnlyMemory<byte> firstReport,
         CancellationToken cancellationToken)
     {
-        using var stream = new MemoryStream();
+        const int maximumResponseLength = (OtpConstants.SequenceMask + 1) * OtpConstants.FeatureReportDataSize;
+        byte[] responseBuffer = _bufferPool.Rent(maximumResponseLength);
         var previousSeq = -1;
+        var responseLength = 0;
 
-        // Process the first report (already has ReadPending set)
-        var report = firstReport;
-
-        while (true)
+        try
         {
-            var statusByte = report.Span[OtpConstants.FeatureReportDataSize];
+            // Process the first report (already has ReadPending set)
+            var report = firstReport;
 
-            // Check if ReadPending is still set
-            if ((statusByte & OtpConstants.ResponsePendingFlag) == 0)
+            while (true)
             {
-                // End of data chain
-                _logger.LogDebug("End of data chain (ReadPending cleared)");
-                break;
+                var statusByte = report.Span[OtpConstants.FeatureReportDataSize];
+
+                // Check if ReadPending is still set
+                if ((statusByte & OtpConstants.ResponsePendingFlag) == 0)
+                {
+                    // End of data chain
+                    _logger.LogDebug("End of data chain (ReadPending cleared)");
+                    break;
+                }
+
+                var packetSeq = statusByte & OtpConstants.SequenceMask;
+
+                // Check for sequence reset (second time seeing seq=0 means end of transmission)
+                if (packetSeq == 0 && previousSeq != -1)
+                {
+                    await ResetStateAsync(cancellationToken).ConfigureAwait(false);
+                    _logger.LogDebug("Transmission complete (seq reset to 0)");
+                    break;
+                }
+
+                if (responseLength > maximumResponseLength - OtpConstants.FeatureReportDataSize)
+                    throw new InvalidOperationException("OTP HID response exceeds the maximum packet sequence range.");
+
+                // Add payload to buffer (7 bytes)
+                report.Span[..OtpConstants.FeatureReportDataSize]
+                    .CopyTo(responseBuffer.AsSpan(responseLength));
+                responseLength += OtpConstants.FeatureReportDataSize;
+                previousSeq = packetSeq;
+
+                _logger.LogTrace("Added packet seq={Seq}, total={Total} bytes", packetSeq, responseLength);
+
+                // Read next report
+                report = await ReadFeatureReportAsync(cancellationToken).ConfigureAwait(false);
             }
 
-            var packetSeq = statusByte & OtpConstants.SequenceMask;
-
-            // Check for sequence reset (second time seeing seq=0 means end of transmission)
-            if (packetSeq == 0 && previousSeq != -1)
-            {
-                await ResetStateAsync(cancellationToken).ConfigureAwait(false);
-                _logger.LogDebug("Transmission complete (seq reset to 0)");
-                break;
-            }
-
-            // Add payload to buffer (7 bytes)
-            stream.Write(report.Span[..OtpConstants.FeatureReportDataSize]);
-            previousSeq = packetSeq;
-
-            _logger.LogTrace("Added packet seq={Seq}, total={Total} bytes", packetSeq, stream.Length);
-
-            // Read next report
-            report = await ReadFeatureReportAsync(cancellationToken).ConfigureAwait(false);
+            var rawResponse = responseBuffer.AsSpan(0, responseLength).ToArray();
+            _logger.LogDebug("{Length} bytes read over HID", rawResponse.Length);
+            return rawResponse;
         }
-
-        var rawResponse = stream.ToArray();
-        _logger.LogDebug("{Length} bytes read over HID", rawResponse.Length);
-
-        return rawResponse;
+        finally
+        {
+            CryptographicOperations.ZeroMemory(responseBuffer);
+            _bufferPool.Return(responseBuffer);
+        }
     }
 
     /// <summary>

--- a/src/Core/src/Protocols/Otp/Hid/OtpHidProtocol.cs
+++ b/src/Core/src/Protocols/Otp/Hid/OtpHidProtocol.cs
@@ -15,6 +15,7 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Buffers.Binary;
+using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Transports.Hid;
@@ -35,10 +36,11 @@ namespace Yubico.YubiKit.Core.Protocols.Otp.Hid;
 ///     The initialization path itself issues a slot command on NEO (firmware 3.x), so it runs inside the caller's guarded
 ///     exchange via the unguarded core methods — it must never call the public guarded methods.
 /// </remarks>
-internal sealed class OtpHidProtocol : IOtpHidProtocol
+internal sealed class OtpHidProtocol : IOtpHidProtocol, IAsyncDisposable
 {
     private readonly IOtpHidConnection _connection;
     private readonly ExchangeGuard _exchangeGuard = new();
+    private readonly DisposalGate _disposalGate = new();
     private readonly ILogger<OtpHidProtocol> _logger;
     private FirmwareVersion? _firmwareVersion;
     private bool _initialized;
@@ -95,6 +97,10 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol
             {
                 // Expected to fail - the scan map command should be rejected
             }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(scanMap);
+            }
         }
 
         _initialized = true;
@@ -135,13 +141,19 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol
         // Pad data to slot data size (64 bytes)
         var payload = new byte[OtpConstants.SlotDataSize];
         data.Span.CopyTo(payload);
+        try
+        {
+            _logger.LogTrace("Sending OTP slot command 0x{Slot:X2} with {Length} bytes payload", slot, data.Length);
 
-        _logger.LogTrace("Sending OTP slot command 0x{Slot:X2} with {Length} bytes payload", slot, data.Length);
+            var programmingSequence = await SendFrameAsync(slot, payload, cancellationToken).ConfigureAwait(false);
 
-        var programmingSequence = await SendFrameAsync(slot, payload, cancellationToken).ConfigureAwait(false);
-
-        // Read response using Java-style single polling loop
-        return await ReadFrameJavaStyleAsync(programmingSequence, cancellationToken).ConfigureAwait(false);
+            // Read response using Java-style single polling loop
+            return await ReadFrameJavaStyleAsync(programmingSequence, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(payload);
+        }
     }
 
     /// <summary>
@@ -386,50 +398,60 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol
 
         // Format 70-byte frame: [64-byte payload][1-byte slot][2-byte CRC][3-byte filler]
         var frame = new byte[OtpConstants.FrameSize];
-        payload.CopyTo(frame.AsSpan());
-        frame[OtpConstants.SlotDataSize] = slot;
-
-        // Calculate and write CRC (little-endian)
-        var crc = ChecksumUtils.CalculateCrc(payload, payload.Length);
-        BinaryPrimitives.WriteUInt16LittleEndian(frame.AsSpan(OtpConstants.SlotDataSize + 1), crc);
-        // Last 3 bytes are filler (already zero)
-
-        _logger.LogTrace("Prepared 70-byte frame for transmission");
-
-        // Get current programming sequence
-        var statusReport = await ReadFeatureReportAsync(cancellationToken).ConfigureAwait(false);
-        var programmingSequence = statusReport.Span[OtpConstants.StatusOffsetProgSeq];
-
-        _logger.LogDebug("Initial programming sequence: {ProgSeq}, statusReport: {ByteCount} bytes",
-            programmingSequence, statusReport.Length);
-
-        // Send frame as 8-byte feature reports
-        var report = new byte[OtpConstants.FeatureReportSize];
-        byte seq = 0;
-        var frameOffset = 0;
-        var sentCount = 0;
-
-        while (frameOffset < OtpConstants.FrameSize)
+        byte[]? report = null;
+        try
         {
-            // Copy 7 bytes of frame data to report
-            var bytesToCopy = Math.Min(OtpConstants.FeatureReportDataSize, OtpConstants.FrameSize - frameOffset);
-            Array.Clear(report, 0, OtpConstants.FeatureReportDataSize);
-            Array.Copy(frame, frameOffset, report, 0, bytesToCopy);
+            payload.CopyTo(frame.AsSpan());
+            frame[OtpConstants.SlotDataSize] = slot;
 
-            // Set sequence with write flag
-            report[OtpConstants.FeatureReportDataSize] = (byte)(OtpConstants.SlotWriteFlag | seq);
-            await AwaitReadyToWriteAsync(cancellationToken).ConfigureAwait(false);
-            _logger.LogTrace("Sending report #{Count} (seq={Seq}): {ByteCount} bytes",
-                sentCount, seq, report.Length);
-            await WriteFeatureReportAsync(report, cancellationToken).ConfigureAwait(false);
-            sentCount++;
+            // Calculate and write CRC (little-endian)
+            var crc = ChecksumUtils.CalculateCrc(payload, payload.Length);
+            BinaryPrimitives.WriteUInt16LittleEndian(frame.AsSpan(OtpConstants.SlotDataSize + 1), crc);
+            // Last 3 bytes are filler (already zero)
 
-            frameOffset += OtpConstants.FeatureReportDataSize;
-            seq++;
+            _logger.LogTrace("Prepared 70-byte frame for transmission");
+
+            // Get current programming sequence
+            var statusReport = await ReadFeatureReportAsync(cancellationToken).ConfigureAwait(false);
+            var programmingSequence = statusReport.Span[OtpConstants.StatusOffsetProgSeq];
+
+            _logger.LogDebug("Initial programming sequence: {ProgSeq}, statusReport: {ByteCount} bytes",
+                programmingSequence, statusReport.Length);
+
+            // Send frame as 8-byte feature reports
+            report = new byte[OtpConstants.FeatureReportSize];
+            byte seq = 0;
+            var frameOffset = 0;
+            var sentCount = 0;
+
+            while (frameOffset < OtpConstants.FrameSize)
+            {
+                // Copy 7 bytes of frame data to report
+                var bytesToCopy = Math.Min(OtpConstants.FeatureReportDataSize, OtpConstants.FrameSize - frameOffset);
+                Array.Clear(report, 0, OtpConstants.FeatureReportDataSize);
+                Array.Copy(frame, frameOffset, report, 0, bytesToCopy);
+
+                // Set sequence with write flag
+                report[OtpConstants.FeatureReportDataSize] = (byte)(OtpConstants.SlotWriteFlag | seq);
+                await AwaitReadyToWriteAsync(cancellationToken).ConfigureAwait(false);
+                _logger.LogTrace("Sending report #{Count} (seq={Seq}): {ByteCount} bytes",
+                    sentCount, seq, report.Length);
+                await WriteFeatureReportAsync(report, cancellationToken).ConfigureAwait(false);
+                sentCount++;
+
+                frameOffset += OtpConstants.FeatureReportDataSize;
+                seq++;
+            }
+
+            _logger.LogDebug("Sent {Count} reports, returning programmingSequence={ProgSeq}", sentCount, programmingSequence);
+            return programmingSequence;
         }
-
-        _logger.LogDebug("Sent {Count} reports, returning programmingSequence={ProgSeq}", sentCount, programmingSequence);
-        return programmingSequence;
+        finally
+        {
+            CryptographicOperations.ZeroMemory(frame);
+            if (report is not null)
+                CryptographicOperations.ZeroMemory(report);
+        }
     }
 
     /// <summary>
@@ -438,13 +460,30 @@ internal sealed class OtpHidProtocol : IOtpHidProtocol
     private async Task ResetStateAsync(CancellationToken cancellationToken)
     {
         var buffer = new byte[OtpConstants.FeatureReportSize];
-        buffer[OtpConstants.FeatureReportSize - 1] = OtpConstants.DummyReportWrite;
-        await WriteFeatureReportAsync(buffer, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            buffer[OtpConstants.FeatureReportSize - 1] = OtpConstants.DummyReportWrite;
+            await WriteFeatureReportAsync(buffer, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+        }
     }
 
     /// <summary>
     ///     Releases this protocol. The connection is NOT disposed: a protocol is a user of the connection it
     ///     was handed, never its owner. Whoever created the connection disposes it.
     /// </summary>
-    public void Dispose() => _disposed = true;
+    public void Dispose() => _disposalGate.Dispose(() =>
+    {
+        _exchangeGuard.CloseAndDrain();
+        _disposed = true;
+    });
+
+    public ValueTask DisposeAsync() => _disposalGate.DisposeAsync(async () =>
+    {
+        await _exchangeGuard.CloseAndDrainAsync().ConfigureAwait(false);
+        _disposed = true;
+    });
 }

--- a/src/Core/src/Protocols/SmartCard/Apdu/PcscProtocol.cs
+++ b/src/Core/src/Protocols/SmartCard/Apdu/PcscProtocol.cs
@@ -25,7 +25,7 @@ namespace Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 ///     a smart card is a stateful sequential peer, so interleaved APDUs from two operations would corrupt
 ///     each other's chained state.
 /// </summary>
-internal partial class PcscProtocol : ISmartCardProtocol
+internal partial class PcscProtocol : ISmartCardProtocol, IAsyncDisposable
 {
     private const byte INS_SELECT = 0xA4;
     private const byte P1_SELECT = 0x04;
@@ -35,6 +35,7 @@ internal partial class PcscProtocol : ISmartCardProtocol
     private readonly ISmartCardConnection _connection;
     private readonly ILogger<PcscProtocol> _logger;
     private readonly ExchangeGuard _exchangeGuard = new();
+    private readonly DisposalGate _disposalGate = new();
     internal byte InsSendRemaining { get; private set; }
     private IApduProcessor _processor;
     private bool _disposed;
@@ -88,7 +89,17 @@ internal partial class PcscProtocol : ISmartCardProtocol
     ///     Releases this protocol. The connection is NOT disposed: a protocol is a user of the connection it
     ///     was handed, never its owner. Whoever created the connection disposes it.
     /// </summary>
-    public void Dispose() => _disposed = true;
+    public void Dispose() => _disposalGate.Dispose(() =>
+    {
+        _exchangeGuard.CloseAndDrain();
+        _disposed = true;
+    });
+
+    public ValueTask DisposeAsync() => _disposalGate.DisposeAsync(async () =>
+    {
+        await _exchangeGuard.CloseAndDrainAsync().ConfigureAwait(false);
+        _disposed = true;
+    });
 
     public async Task<ApduResponse> TransmitAndReceiveAsync(
         ApduCommand command,

--- a/src/Core/src/Protocols/SmartCard/Apdu/PcscProtocol.cs
+++ b/src/Core/src/Protocols/SmartCard/Apdu/PcscProtocol.cs
@@ -145,32 +145,35 @@ internal partial class PcscProtocol : ISmartCardProtocol, IAsyncDisposable
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        FirmwareVersion = firmwareVersion;
-        var insSendRemainingChanged = ConfigureInsSendRemaining(configuration);
-
-        if (FirmwareVersion.IsAlphaOrBeta)
+        _exchangeGuard.Run(() =>
         {
-            UseExtendedApdus = _connection.SupportsExtendedApdu();
-            MaxApduSize = SmartCardMaxApduSizes.Yk43;
-            ReconfigureProcessor();
-            return;
-        }
+            FirmwareVersion = firmwareVersion;
+            var insSendRemainingChanged = ConfigureInsSendRemaining(configuration);
 
-        if (!FirmwareVersion.IsAtLeast(FirmwareVersion.V4_0_0))
-        {
-            if (insSendRemainingChanged)
+            if (FirmwareVersion.IsAlphaOrBeta)
+            {
+                UseExtendedApdus = _connection.SupportsExtendedApdu();
+                MaxApduSize = SmartCardMaxApduSizes.Yk43;
                 ReconfigureProcessor();
+                return;
+            }
 
-            return;
-        }
+            if (!FirmwareVersion.IsAtLeast(FirmwareVersion.V4_0_0))
+            {
+                if (insSendRemainingChanged)
+                    ReconfigureProcessor();
 
-        var forceShortApdu = configuration is { ForceShortApdus: true };
-        UseExtendedApdus = _connection.SupportsExtendedApdu() && !forceShortApdu;
-        MaxApduSize = firmwareVersion.IsAtLeast(FirmwareVersion.V4_3_0)
-            ? SmartCardMaxApduSizes.Yk43
-            : SmartCardMaxApduSizes.Yk4;
+                return;
+            }
 
-        ReconfigureProcessor();
+            var forceShortApdu = configuration is { ForceShortApdus: true };
+            UseExtendedApdus = _connection.SupportsExtendedApdu() && !forceShortApdu;
+            MaxApduSize = firmwareVersion.IsAtLeast(FirmwareVersion.V4_3_0)
+                ? SmartCardMaxApduSizes.Yk43
+                : SmartCardMaxApduSizes.Yk4;
+
+            ReconfigureProcessor();
+        });
     }
 
     private bool ConfigureInsSendRemaining(ProtocolConfiguration? configuration)

--- a/src/Core/src/Protocols/SmartCard/Scp/PcscProtocolScp.cs
+++ b/src/Core/src/Protocols/SmartCard/Scp/PcscProtocolScp.cs
@@ -24,11 +24,12 @@ namespace Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
 ///     by the same guard as the wrapped protocol (SCP MAC chaining makes
 ///     interleaving doubly fatal — each MAC depends on the previous command's MAC).
 /// </summary>
-public sealed class PcscProtocolScp : ISmartCardProtocol
+public sealed class PcscProtocolScp : ISmartCardProtocol, IAsyncDisposable
 {
     private readonly PcscProtocol _baseProtocol;
     private readonly DataEncryptor _dataEncryptor;
     private readonly ExchangeGuard _exchangeGuard;
+    private readonly DisposalGate _disposalGate = new();
     private readonly IApduProcessor _scpProcessor;
     private bool _disposed;
 
@@ -103,17 +104,24 @@ public sealed class PcscProtocolScp : ISmartCardProtocol
     public void Configure(FirmwareVersion version, ProtocolConfiguration? configuration = null)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
-
-        // Delegate configuration to base protocol
-        // SCP state is already established and doesn't need reconfiguration
-        _baseProtocol.Configure(version, configuration);
+        throw new InvalidOperationException(
+            "SmartCard protocol configuration must be applied before SCP is established.");
     }
 
-    public void Dispose()
+    public void Dispose() => _disposalGate.Dispose(() =>
     {
-        if (_disposed)
-            return;
+        _exchangeGuard.CloseAndDrain();
+        DisposeAfterDrain();
+    });
 
+    public ValueTask DisposeAsync() => _disposalGate.DisposeAsync(async () =>
+    {
+        await _exchangeGuard.CloseAndDrainAsync().ConfigureAwait(false);
+        DisposeAfterDrain();
+    });
+
+    private void DisposeAfterDrain()
+    {
         _disposed = true;
         try
         {

--- a/src/Core/src/Sessions/ApplicationSession.cs
+++ b/src/Core/src/Sessions/ApplicationSession.cs
@@ -282,7 +282,7 @@ public abstract class ApplicationSession : IApplicationSession, IAsyncDisposable
     {
         try
         {
-            DisposeProtocol();
+            await DisposeProtocolAsync().ConfigureAwait(false);
         }
         finally
         {
@@ -295,6 +295,16 @@ public abstract class ApplicationSession : IApplicationSession, IAsyncDisposable
         IProtocol? protocol = Protocol;
         Protocol = null;
         protocol?.Dispose();
+    }
+
+    private async ValueTask DisposeProtocolAsync()
+    {
+        IProtocol? protocol = Protocol;
+        Protocol = null;
+        if (protocol is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync().ConfigureAwait(false);
+        else
+            protocol?.Dispose();
     }
 
     /// <summary>Detaches from the connection, and disposes it only if this session was given ownership.</summary>

--- a/src/Core/src/Sessions/RawFidoHidSession.cs
+++ b/src/Core/src/Sessions/RawFidoHidSession.cs
@@ -1,0 +1,49 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Protocols;
+using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+
+namespace Yubico.YubiKit.Core.Sessions;
+
+public sealed class RawFidoHidSession : ApplicationSession
+{
+    private IFidoHidProtocol FidoProtocol =>
+        (IFidoHidProtocol)(Protocol ?? throw new ObjectDisposedException(nameof(RawFidoHidSession)));
+
+    private RawFidoHidSession(IFidoHidConnection connection)
+        : base(connection)
+    {
+    }
+
+    public static Task<RawFidoHidSession> CreateAsync(
+        IFidoHidConnection connection,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        RawFidoHidSession session = Construct(connection, () => new RawFidoHidSession(connection));
+        session.Protocol = ProtocolFactory.Create(connection);
+        session.IsInitialized = true;
+        return Task.FromResult(session);
+    }
+
+    public Task<ReadOnlyMemory<byte>> SendAndReceiveAsync(
+        byte command,
+        ReadOnlyMemory<byte> payload,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return FidoProtocol.SendVendorCommandAsync(command, payload, cancellationToken);
+    }
+}

--- a/src/Core/src/Sessions/RawFidoHidSession.cs
+++ b/src/Core/src/Sessions/RawFidoHidSession.cs
@@ -33,9 +33,17 @@ public sealed class RawFidoHidSession : ApplicationSession
     {
         cancellationToken.ThrowIfCancellationRequested();
         RawFidoHidSession session = Construct(connection, () => new RawFidoHidSession(connection));
-        session.Protocol = ProtocolFactory.Create(connection);
-        session.IsInitialized = true;
-        return Task.FromResult(session);
+        try
+        {
+            session.Protocol = ProtocolFactory.Create(connection);
+            session.IsInitialized = true;
+            return Task.FromResult(session);
+        }
+        catch
+        {
+            session.DisposeAfterInitializationFailure();
+            throw;
+        }
     }
 
     public Task<ReadOnlyMemory<byte>> SendAndReceiveAsync(

--- a/src/Core/src/Sessions/RawOtpHidSession.cs
+++ b/src/Core/src/Sessions/RawOtpHidSession.cs
@@ -1,0 +1,50 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Protocols;
+using Yubico.YubiKit.Core.Protocols.Otp.Hid;
+using Yubico.YubiKit.Core.Transports.Hid;
+
+namespace Yubico.YubiKit.Core.Sessions;
+
+public sealed class RawOtpHidSession : ApplicationSession
+{
+    private IOtpHidProtocol OtpProtocol =>
+        (IOtpHidProtocol)(Protocol ?? throw new ObjectDisposedException(nameof(RawOtpHidSession)));
+
+    private RawOtpHidSession(IOtpHidConnection connection)
+        : base(connection)
+    {
+    }
+
+    public static Task<RawOtpHidSession> CreateAsync(
+        IOtpHidConnection connection,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        RawOtpHidSession session = Construct(connection, () => new RawOtpHidSession(connection));
+        session.Protocol = ProtocolFactory.Create(connection);
+        session.IsInitialized = true;
+        return Task.FromResult(session);
+    }
+
+    public Task<ReadOnlyMemory<byte>> SendAndReceiveAsync(
+        byte command,
+        ReadOnlyMemory<byte> payload,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return OtpProtocol.SendAndReceiveAsync(command, payload, cancellationToken);
+    }
+}

--- a/src/Core/src/Sessions/RawOtpHidSession.cs
+++ b/src/Core/src/Sessions/RawOtpHidSession.cs
@@ -34,9 +34,17 @@ public sealed class RawOtpHidSession : ApplicationSession
     {
         cancellationToken.ThrowIfCancellationRequested();
         RawOtpHidSession session = Construct(connection, () => new RawOtpHidSession(connection));
-        session.Protocol = ProtocolFactory.Create(connection);
-        session.IsInitialized = true;
-        return Task.FromResult(session);
+        try
+        {
+            session.Protocol = ProtocolFactory.Create(connection);
+            session.IsInitialized = true;
+            return Task.FromResult(session);
+        }
+        catch
+        {
+            session.DisposeAfterInitializationFailure();
+            throw;
+        }
     }
 
     public Task<ReadOnlyMemory<byte>> SendAndReceiveAsync(

--- a/src/Core/src/Sessions/RawSmartCardSession.cs
+++ b/src/Core/src/Sessions/RawSmartCardSession.cs
@@ -1,0 +1,103 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
+using Yubico.YubiKit.Core.Transports.SmartCard;
+
+namespace Yubico.YubiKit.Core.Sessions;
+
+public sealed class RawSmartCardSession : ApplicationSession
+{
+    private ISmartCardProtocol SmartCardProtocol =>
+        (ISmartCardProtocol)(Protocol ?? throw new ObjectDisposedException(nameof(RawSmartCardSession)));
+
+    private RawSmartCardSession(ISmartCardConnection connection)
+        : base(connection)
+    {
+    }
+
+    public static Task<RawSmartCardSession> CreateAsync(
+        ISmartCardConnection connection,
+        CancellationToken cancellationToken = default) =>
+        CreateAsync(connection, scpKeyParameters: null, cancellationToken);
+
+    public static async Task<RawSmartCardSession> CreateAsync(
+        ISmartCardConnection connection,
+        ScpKeyParameters? scpKeyParameters,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        RawSmartCardSession session = Construct(connection, () => new RawSmartCardSession(connection));
+        ISmartCardProtocol protocol = ProtocolFactory.Create(connection);
+        session.Protocol = protocol;
+
+        try
+        {
+            if (scpKeyParameters is null)
+            {
+                session.IsInitialized = true;
+            }
+            else
+            {
+                await session.InitializeProtocolAsync(
+                        protocol,
+                        new FirmwareVersion(),
+                        scpKeyParams: scpKeyParameters,
+                        cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            return session;
+        }
+        catch
+        {
+            // ApplicationSession only disposes a connection after OwnConnection transfers ownership.
+            // Direct creation borrows this connection; the IYubiKey extension owns and cleans up its hidden one.
+            session.DisposeAfterInitializationFailure();
+            throw;
+        }
+    }
+
+    public Task<ReadOnlyMemory<byte>> SelectAsync(
+        ReadOnlyMemory<byte> applicationId,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return SmartCardProtocol.SelectAsync(applicationId, cancellationToken);
+    }
+
+    public Task<ApduResponse> TransmitAndReceiveAsync(
+        ApduCommand command,
+        bool throwOnError = true,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowIfDisposed();
+        return SmartCardProtocol.TransmitAndReceiveAsync(command, throwOnError, cancellationToken);
+    }
+
+    public void Configure(
+        FirmwareVersion firmwareVersion,
+        ProtocolConfiguration? configuration = null)
+    {
+        ThrowIfDisposed();
+        // A plain protocol configures directly. An SCP wrapper forwards this to its base protocol without
+        // rebuilding secure-channel state. SCP establishment deliberately accepts unknown firmware so a raw
+        // caller can configure framing later when the device version is known.
+        SmartCardProtocol.Configure(firmwareVersion, configuration);
+        FirmwareVersion = firmwareVersion;
+    }
+}

--- a/src/Core/src/Sessions/RawSmartCardSession.cs
+++ b/src/Core/src/Sessions/RawSmartCardSession.cs
@@ -22,26 +22,54 @@ namespace Yubico.YubiKit.Core.Sessions;
 
 public sealed class RawSmartCardSession : ApplicationSession
 {
+    private readonly bool _usesScp;
     private ISmartCardProtocol SmartCardProtocol =>
         (ISmartCardProtocol)(Protocol ?? throw new ObjectDisposedException(nameof(RawSmartCardSession)));
 
-    private RawSmartCardSession(ISmartCardConnection connection)
+    private RawSmartCardSession(ISmartCardConnection connection, bool usesScp)
         : base(connection)
     {
+        _usesScp = usesScp;
     }
 
     public static Task<RawSmartCardSession> CreateAsync(
         ISmartCardConnection connection,
         CancellationToken cancellationToken = default) =>
-        CreateAsync(connection, scpKeyParameters: null, cancellationToken);
+        CreateCoreAsync(
+            connection,
+            scpKeyParameters: null,
+            new FirmwareVersion(),
+            configuration: null,
+            cancellationToken);
 
-    public static async Task<RawSmartCardSession> CreateAsync(
+    public static Task<RawSmartCardSession> CreateAsync(
         ISmartCardConnection connection,
-        ScpKeyParameters? scpKeyParameters,
+        ScpKeyParameters scpKeyParameters,
+        FirmwareVersion firmwareVersion,
+        ProtocolConfiguration? configuration = null,
         CancellationToken cancellationToken = default)
     {
+        ArgumentNullException.ThrowIfNull(scpKeyParameters);
+        ArgumentNullException.ThrowIfNull(firmwareVersion);
+        return CreateCoreAsync(
+            connection,
+            scpKeyParameters,
+            firmwareVersion,
+            configuration,
+            cancellationToken);
+    }
+
+    private static async Task<RawSmartCardSession> CreateCoreAsync(
+        ISmartCardConnection connection,
+        ScpKeyParameters? scpKeyParameters,
+        FirmwareVersion firmwareVersion,
+        ProtocolConfiguration? configuration,
+        CancellationToken cancellationToken)
+    {
         cancellationToken.ThrowIfCancellationRequested();
-        RawSmartCardSession session = Construct(connection, () => new RawSmartCardSession(connection));
+        RawSmartCardSession session = Construct(
+            connection,
+            () => new RawSmartCardSession(connection, usesScp: scpKeyParameters is not null));
         ISmartCardProtocol protocol = ProtocolFactory.Create(connection);
         session.Protocol = protocol;
 
@@ -55,7 +83,8 @@ public sealed class RawSmartCardSession : ApplicationSession
             {
                 await session.InitializeProtocolAsync(
                         protocol,
-                        new FirmwareVersion(),
+                        firmwareVersion,
+                        configuration,
                         scpKeyParams: scpKeyParameters,
                         cancellationToken: cancellationToken)
                     .ConfigureAwait(false);
@@ -94,9 +123,12 @@ public sealed class RawSmartCardSession : ApplicationSession
         ProtocolConfiguration? configuration = null)
     {
         ThrowIfDisposed();
-        // A plain protocol configures directly. An SCP wrapper forwards this to its base protocol without
-        // rebuilding secure-channel state. SCP establishment deliberately accepts unknown firmware so a raw
-        // caller can configure framing later when the device version is known.
+        if (_usesScp)
+        {
+            throw new InvalidOperationException(
+                "An SCP raw session must be configured during creation, before SCP is established.");
+        }
+
         SmartCardProtocol.Configure(firmwareVersion, configuration);
         FirmwareVersion = firmwareVersion;
     }

--- a/src/Core/src/Sessions/RawSmartCardSession.cs
+++ b/src/Core/src/Sessions/RawSmartCardSession.cs
@@ -70,11 +70,12 @@ public sealed class RawSmartCardSession : ApplicationSession
         RawSmartCardSession session = Construct(
             connection,
             () => new RawSmartCardSession(connection, usesScp: scpKeyParameters is not null));
-        ISmartCardProtocol protocol = ProtocolFactory.Create(connection);
-        session.Protocol = protocol;
 
         try
         {
+            ISmartCardProtocol protocol = ProtocolFactory.Create(connection);
+            session.Protocol = protocol;
+
             if (scpKeyParameters is null)
             {
                 session.IsInitialized = true;

--- a/src/Core/src/Utilities/ExchangeGuard.cs
+++ b/src/Core/src/Utilities/ExchangeGuard.cs
@@ -50,20 +50,7 @@ internal sealed class ExchangeGuard
         Func<CancellationToken, Task<T>> exchange,
         CancellationToken cancellationToken = default)
     {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        lock (_stateLock)
-        {
-            ObjectDisposedException.ThrowIf(_closing, this);
-            if (_active)
-            {
-                throw new InvalidOperationException(
-                    "This session already has an exchange in flight. Sessions support one operation at a time; " +
-                    "await each call before issuing the next.");
-            }
-
-            _active = true;
-        }
+        Enter(cancellationToken);
 
         try
         {
@@ -71,14 +58,7 @@ internal sealed class ExchangeGuard
         }
         finally
         {
-            TaskCompletionSource? drained;
-            lock (_stateLock)
-            {
-                _active = false;
-                drained = _closing ? _drained : null;
-            }
-
-            drained?.TrySetResult();
+            Exit();
         }
     }
 
@@ -97,6 +77,20 @@ internal sealed class ExchangeGuard
             },
             cancellationToken);
 
+    /// <summary>Runs a synchronous state mutation under the same close-aware admission as an exchange.</summary>
+    public void Run(Action action)
+    {
+        Enter(CancellationToken.None);
+        try
+        {
+            action();
+        }
+        finally
+        {
+            Exit();
+        }
+    }
+
     /// <summary>Refuses future admissions and synchronously waits for an admitted exchange to finish.</summary>
     public void CloseAndDrain() => CloseAndDrainAsync().AsTask().GetAwaiter().GetResult();
 
@@ -112,5 +106,35 @@ internal sealed class ExchangeGuard
             _drained ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
             return new ValueTask(_drained.Task);
         }
+    }
+
+    private void Enter(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        lock (_stateLock)
+        {
+            ObjectDisposedException.ThrowIf(_closing, this);
+            if (_active)
+            {
+                throw new InvalidOperationException(
+                    "This session already has an exchange in flight. Sessions support one operation at a time; " +
+                    "await each call before issuing the next.");
+            }
+
+            _active = true;
+        }
+    }
+
+    private void Exit()
+    {
+        TaskCompletionSource? drained;
+        lock (_stateLock)
+        {
+            _active = false;
+            drained = _closing ? _drained : null;
+        }
+
+        drained?.TrySetResult();
     }
 }

--- a/src/Core/src/Utilities/ExchangeGuard.cs
+++ b/src/Core/src/Utilities/ExchangeGuard.cs
@@ -35,7 +35,10 @@ namespace Yubico.YubiKit.Core.Utilities;
 /// </remarks>
 internal sealed class ExchangeGuard
 {
-    private int _active;
+    private readonly object _stateLock = new();
+    private TaskCompletionSource? _drained;
+    private bool _active;
+    private bool _closing;
 
     /// <summary>
     ///     Runs <paramref name="exchange" /> exclusively; overlapping calls are refused immediately.
@@ -49,11 +52,17 @@ internal sealed class ExchangeGuard
     {
         cancellationToken.ThrowIfCancellationRequested();
 
-        if (Interlocked.CompareExchange(ref _active, 1, 0) != 0)
+        lock (_stateLock)
         {
-            throw new InvalidOperationException(
-                "This session already has an exchange in flight. Sessions support one operation at a time; " +
-                "await each call before issuing the next.");
+            ObjectDisposedException.ThrowIf(_closing, this);
+            if (_active)
+            {
+                throw new InvalidOperationException(
+                    "This session already has an exchange in flight. Sessions support one operation at a time; " +
+                    "await each call before issuing the next.");
+            }
+
+            _active = true;
         }
 
         try
@@ -62,7 +71,14 @@ internal sealed class ExchangeGuard
         }
         finally
         {
-            Volatile.Write(ref _active, 0);
+            TaskCompletionSource? drained;
+            lock (_stateLock)
+            {
+                _active = false;
+                drained = _closing ? _drained : null;
+            }
+
+            drained?.TrySetResult();
         }
     }
 
@@ -80,4 +96,21 @@ internal sealed class ExchangeGuard
                 return null;
             },
             cancellationToken);
+
+    /// <summary>Refuses future admissions and synchronously waits for an admitted exchange to finish.</summary>
+    public void CloseAndDrain() => CloseAndDrainAsync().AsTask().GetAwaiter().GetResult();
+
+    /// <summary>Refuses future admissions and asynchronously waits for an admitted exchange to finish.</summary>
+    public ValueTask CloseAndDrainAsync()
+    {
+        lock (_stateLock)
+        {
+            _closing = true;
+            if (!_active)
+                return ValueTask.CompletedTask;
+
+            _drained ??= new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+            return new ValueTask(_drained.Task);
+        }
+    }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Buffers.Binary;
+using System.Runtime.InteropServices;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.Fido.Hid;
 
@@ -137,6 +138,25 @@ public class FidoHidProtocolTests
                 TestContext.Current.CancellationToken));
 
         Assert.Contains("command", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData(CtapConstants.CtapYubikeyDeviceConfig)]
+    [InlineData(CtapConstants.CtapReadConfig)]
+    [InlineData(CtapConstants.CtapWriteConfig)]
+    [InlineData(CtapConstants.CtapHidPing)]
+    public async Task SendVendorCommandAsync_MatchingResponse_NormalizesInitBitOnBothCommands(byte command)
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        connection.QueueResponsePackets(CreateInitPacket(0x01020304, command, [0xAA]));
+
+        ReadOnlyMemory<byte> response = await protocol.SendVendorCommandAsync(
+            command,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(new byte[] { 0xAA }, response.ToArray());
     }
 
     [Fact]
@@ -351,6 +371,59 @@ public class FidoHidProtocolTests
         ReadOnlyMemory<byte> retained = Assert.Single(connection.RetainedSentPackets);
         Assert.All(retained.ToArray(), value => Assert.Equal(0, value));
         Assert.Contains((byte)0x11, Assert.Single(connection.SentPacketSnapshots));
+    }
+
+    [Fact]
+    public async Task SendVendorCommandAsync_WhenContinuationValidationFails_ZerosPartialResponseBuffer()
+    {
+        var allocatedBuffers = new List<byte[]>();
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection, responseBufferFactory: length =>
+        {
+            var buffer = new byte[length];
+            allocatedBuffers.Add(buffer);
+            return buffer;
+        });
+        byte[] responsePayload = Enumerable.Range(1, CtapConstants.InitDataSize + 1)
+            .Select(value => (byte)value)
+            .ToArray();
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, responsePayload),
+            CreateContinuationPacket(0x01020304, sequence: 1, responsePayload.AsSpan(CtapConstants.InitDataSize)));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken));
+
+        byte[] partialResponseBuffer = allocatedBuffers[^1];
+        Assert.Equal(responsePayload.Length, partialResponseBuffer.Length);
+        Assert.All(partialResponseBuffer, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public async Task SendVendorCommandAsync_WhenResponseSucceeds_TransfersUnclearedResponseBuffer()
+    {
+        var allocatedBuffers = new List<byte[]>();
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection, responseBufferFactory: length =>
+        {
+            var buffer = new byte[length];
+            allocatedBuffers.Add(buffer);
+            return buffer;
+        });
+        byte[] responsePayload = [0xAA, 0xBB, 0xCC];
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, responsePayload));
+
+        ReadOnlyMemory<byte> response = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.True(MemoryMarshal.TryGetArray(response, out ArraySegment<byte> responseSegment));
+        Assert.Same(allocatedBuffers[^1], responseSegment.Array);
+        Assert.Equal(responsePayload, response.ToArray());
     }
 
     private static byte[] CreateInitPacket(uint channelId, byte command, ReadOnlySpan<byte> payload)

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
@@ -123,6 +123,58 @@ public class FidoHidProtocolTests
     }
 
     [Fact]
+    public async Task SendVendorCommandAsync_ResponseWithWrongCommand_ThrowsInvalidOperationException()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapHidPing, [0xAA]));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            protocol.SendVendorCommandAsync(
+                CtapConstants.CtapVendorFirst,
+                ReadOnlyMemory<byte>.Empty,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("command", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendVendorCommandAsync_CtapHidError_ThrowsProtocolFailureWithErrorCode()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapHidError, [0x06]));
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            protocol.SendVendorCommandAsync(
+                CtapConstants.CtapVendorFirst,
+                ReadOnlyMemory<byte>.Empty,
+                TestContext.Current.CancellationToken));
+
+        Assert.Contains("CTAP HID error", exception.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("0x06", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task SendVendorCommandAsync_KeepAliveThenMatchingResponse_Succeeds()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapHidKeepAlive, [0x01]),
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0xAA]));
+
+        ReadOnlyMemory<byte> response = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(new byte[] { 0xAA }, response.ToArray());
+    }
+
+    [Fact]
     public async Task SendVendorCommandAsync_ResponseWithShortInitPacket_ThrowsInvalidOperationException()
     {
         var connection = new FakeFidoHidConnection();
@@ -245,6 +297,62 @@ public class FidoHidProtocolTests
         Assert.Contains("init", ex.Message, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task SendVendorCommandAsync_AfterSuccessfulSends_ZerosSdkOwnedPacketsButNotCallerPayload()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        await protocol.InitializeAsync(TestContext.Current.CancellationToken);
+        connection.ClearCapturedPackets();
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0xAA]));
+        byte[] callerPayload = Enumerable.Range(1, CtapConstants.InitDataSize + 2)
+            .Select(value => (byte)value)
+            .ToArray();
+        byte[] expectedCallerPayload = callerPayload.ToArray();
+
+        _ = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            callerPayload,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(expectedCallerPayload, callerPayload);
+        Assert.Equal(2, connection.SentPacketSnapshots.Count);
+        Assert.Equal(
+            expectedCallerPayload[..CtapConstants.InitDataSize],
+            connection.SentPacketSnapshots[0].AsSpan(
+                CtapConstants.InitHeaderSize,
+                CtapConstants.InitDataSize).ToArray());
+        Assert.Equal(
+            expectedCallerPayload[CtapConstants.InitDataSize..],
+            connection.SentPacketSnapshots[1].AsSpan(
+                CtapConstants.ContinuationHeaderSize,
+                expectedCallerPayload.Length - CtapConstants.InitDataSize).ToArray());
+        Assert.All(connection.RetainedSentPackets, packet =>
+            Assert.All(packet.ToArray(), value => Assert.Equal(0, value)));
+    }
+
+    [Fact]
+    public async Task SendVendorCommandAsync_WhenSendThrows_ZerosSdkOwnedPacketButNotCallerPayload()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        await protocol.InitializeAsync(TestContext.Current.CancellationToken);
+        connection.ClearCapturedPackets();
+        connection.ThrowOnNextSend = true;
+        byte[] callerPayload = [0x11, 0x22, 0x33];
+
+        await Assert.ThrowsAsync<IOException>(() => protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            callerPayload,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, callerPayload);
+        ReadOnlyMemory<byte> retained = Assert.Single(connection.RetainedSentPackets);
+        Assert.All(retained.ToArray(), value => Assert.Equal(0, value));
+        Assert.Contains((byte)0x11, Assert.Single(connection.SentPacketSnapshots));
+    }
+
     private static byte[] CreateInitPacket(uint channelId, byte command, ReadOnlySpan<byte> payload)
     {
         var packet = new byte[CtapConstants.PacketSize];
@@ -278,6 +386,9 @@ public class FidoHidProtocolTests
         public ConnectionType Type => ConnectionType.HidFido;
 
         public int InitRequestCount { get; private set; }
+        public bool ThrowOnNextSend { get; set; }
+        public List<ReadOnlyMemory<byte>> RetainedSentPackets { get; } = [];
+        public List<byte[]> SentPacketSnapshots { get; } = [];
 
         public void QueueResponsePackets(params byte[][] packets)
         {
@@ -290,13 +401,28 @@ public class FidoHidProtocolTests
         public Task SendAsync(ReadOnlyMemory<byte> packet, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            if ((packet.Span[4] & ~CtapConstants.InitPacketMask) == CtapConstants.CtapHidInit)
+            RetainedSentPackets.Add(packet);
+            byte[] snapshot = packet.ToArray();
+            SentPacketSnapshots.Add(snapshot);
+            if ((snapshot[4] & ~CtapConstants.InitPacketMask) == CtapConstants.CtapHidInit)
             {
                 InitRequestCount++;
-                _lastInitRequest = packet.ToArray();
+                _lastInitRequest = snapshot;
+            }
+
+            if (ThrowOnNextSend)
+            {
+                ThrowOnNextSend = false;
+                throw new IOException("Scripted send failure.");
             }
 
             return Task.CompletedTask;
+        }
+
+        public void ClearCapturedPackets()
+        {
+            RetainedSentPackets.Clear();
+            SentPacketSnapshots.Clear();
         }
 
         public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Otp/Hid/OtpHidProtocolTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Otp/Hid/OtpHidProtocolTests.cs
@@ -157,4 +157,97 @@ public class OtpHidProtocolTests
         await Assert.ThrowsAsync<ObjectDisposedException>(
             () => protocol.SendAndReceiveAsync(0x13, ReadOnlyMemory<byte>.Empty, TestContext.Current.CancellationToken));
     }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_AfterSuccessfulSends_ZerosSdkOwnedReportsButNotCallerPayload()
+    {
+        var connection = new RetainingOtpHidConnection();
+        QueueStatusOnlyExchange(connection);
+        var protocol = new OtpHidProtocol(connection);
+        byte[] callerPayload = [0x11, 0x22, 0x33];
+
+        _ = await protocol.SendAndReceiveAsync(
+            0x13,
+            callerPayload,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, callerPayload);
+        Assert.Equal(10, connection.SentReportSnapshots.Count);
+        Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, connection.SentReportSnapshots[0][..3]);
+        Assert.All(connection.RetainedSentReports, report =>
+            Assert.All(report.ToArray(), value => Assert.Equal(0, value)));
+    }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_WhenSendThrows_ZerosSdkOwnedReportButNotCallerPayload()
+    {
+        var connection = new RetainingOtpHidConnection();
+        connection.Enqueue(Status(versionMajor: 5));
+        connection.Enqueue(Status(programmingSequence: 1));
+        connection.Enqueue(Status(programmingSequence: 1));
+        connection.ThrowOnNextSend = true;
+        var protocol = new OtpHidProtocol(connection);
+        byte[] callerPayload = [0x11, 0x22, 0x33];
+
+        await Assert.ThrowsAsync<IOException>(() => protocol.SendAndReceiveAsync(
+            0x13,
+            callerPayload,
+            TestContext.Current.CancellationToken));
+
+        Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, callerPayload);
+        ReadOnlyMemory<byte> retained = Assert.Single(connection.RetainedSentReports);
+        Assert.All(retained.ToArray(), value => Assert.Equal(0, value));
+        Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, Assert.Single(connection.SentReportSnapshots)[..3]);
+    }
+
+    private static void QueueStatusOnlyExchange(RetainingOtpHidConnection connection)
+    {
+        connection.Enqueue(Status(versionMajor: 5));
+        connection.Enqueue(Status(programmingSequence: 1));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(Status(programmingSequence: 1));
+        connection.Enqueue(Status(programmingSequence: 2));
+    }
+
+    private static byte[] Status(byte versionMajor = 0, byte programmingSequence = 0) =>
+        [0x00, versionMajor, 0x04, 0x03, programmingSequence, 0x00, 0x00, 0x00];
+
+    private sealed class RetainingOtpHidConnection : IOtpHidConnection
+    {
+        private readonly Queue<ReadOnlyMemory<byte>> _reports = new();
+
+        public int FeatureReportSize => 8;
+        public ConnectionType Type => ConnectionType.HidOtp;
+        public bool ThrowOnNextSend { get; set; }
+        public List<ReadOnlyMemory<byte>> RetainedSentReports { get; } = [];
+        public List<byte[]> SentReportSnapshots { get; } = [];
+
+        public void Enqueue(ReadOnlyMemory<byte> report) => _reports.Enqueue(report);
+
+        public Task SendAsync(ReadOnlyMemory<byte> report, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RetainedSentReports.Add(report);
+            SentReportSnapshots.Add(report.ToArray());
+            if (ThrowOnNextSend)
+            {
+                ThrowOnNextSend = false;
+                throw new IOException("Scripted send failure.");
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(_reports.Dequeue());
+        }
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Otp/Hid/OtpHidProtocolTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Otp/Hid/OtpHidProtocolTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2025 Yubico AB
 // Licensed under the Apache License, Version 2.0 (the "License").
 
+using System.Buffers;
 using System.Diagnostics;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.Otp.Hid;
@@ -200,6 +201,41 @@ public class OtpHidProtocolTests
         Assert.Equal(new byte[] { 0x11, 0x22, 0x33 }, Assert.Single(connection.SentReportSnapshots)[..3]);
     }
 
+    [Fact]
+    public async Task SendAndReceiveAsync_DataResponse_ZerosRentedAccumulationBufferAndPreservesReturnedCopy()
+    {
+        var connection = new RetainingOtpHidConnection();
+        QueueDataExchange(connection, completeResponse: true);
+        var pool = new RetainingArrayPool();
+        var protocol = new OtpHidProtocol(connection, bufferPool: pool);
+
+        ReadOnlyMemory<byte> response = await protocol.SendAndReceiveAsync(
+            0x13,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(Enumerable.Range(1, 14).Select(value => (byte)value), response.ToArray());
+        Assert.NotNull(pool.ReturnedArray);
+        Assert.All(pool.ReturnedArray, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_WhenDataResponseReceiveFails_ZerosRentedAccumulationBuffer()
+    {
+        var connection = new RetainingOtpHidConnection();
+        QueueDataExchange(connection, completeResponse: false);
+        var pool = new RetainingArrayPool();
+        var protocol = new OtpHidProtocol(connection, bufferPool: pool);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => protocol.SendAndReceiveAsync(
+            0x13,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken));
+
+        Assert.NotNull(pool.ReturnedArray);
+        Assert.All(pool.ReturnedArray, value => Assert.Equal(0, value));
+    }
+
     private static void QueueStatusOnlyExchange(RetainingOtpHidConnection connection)
     {
         connection.Enqueue(Status(versionMajor: 5));
@@ -207,6 +243,30 @@ public class OtpHidProtocolTests
         for (int i = 0; i < 10; i++)
             connection.Enqueue(Status(programmingSequence: 1));
         connection.Enqueue(Status(programmingSequence: 2));
+    }
+
+    private static void QueueDataExchange(RetainingOtpHidConnection connection, bool completeResponse)
+    {
+        connection.Enqueue(Status(versionMajor: 5));
+        connection.Enqueue(Status(programmingSequence: 1));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(Status(programmingSequence: 1));
+
+        connection.Enqueue(DataReport(sequence: 0, startValue: 1));
+        if (completeResponse)
+        {
+            connection.Enqueue(DataReport(sequence: 1, startValue: 8));
+            connection.Enqueue(DataReport(sequence: 0, startValue: 0));
+        }
+    }
+
+    private static byte[] DataReport(byte sequence, byte startValue)
+    {
+        var report = new byte[OtpConstants.FeatureReportSize];
+        for (int i = 0; i < OtpConstants.FeatureReportDataSize; i++)
+            report[i] = (byte)(startValue + i);
+        report[OtpConstants.FeatureReportDataSize] = (byte)(OtpConstants.ResponsePendingFlag | sequence);
+        return report;
     }
 
     private static byte[] Status(byte versionMajor = 0, byte programmingSequence = 0) =>
@@ -249,5 +309,14 @@ public class OtpHidProtocolTests
         }
 
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    private sealed class RetainingArrayPool : ArrayPool<byte>
+    {
+        public byte[]? ReturnedArray { get; private set; }
+
+        public override byte[] Rent(int minimumLength) => new byte[minimumLength];
+
+        public override void Return(byte[] array, bool clearArray = false) => ReturnedArray = array;
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/SmartCard/Scp/PcscProtocolScpTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/SmartCard/Scp/PcscProtocolScpTests.cs
@@ -118,18 +118,16 @@ public class PcscProtocolScpTests
     }
 
     [Fact]
-    public void Configure_DelegatesToBaseProtocol()
+    public void Configure_AfterScpEstablishment_ThrowsInvalidOperationException()
     {
         // Arrange
         var baseProtocol = new PcscProtocol(_fakeConnection, default, _logger);
         var adapter = new PcscProtocolScp(baseProtocol, _fakeScpProcessor, null!);
         var firmware = new FirmwareVersion(5, 7, 2);
 
-        // Act - Should not throw
-        adapter.Configure(firmware);
-
-        // Assert - Configuration is applied to base protocol
-        Assert.NotNull(adapter);
+        // Act + Assert
+        var exception = Assert.Throws<InvalidOperationException>(() => adapter.Configure(firmware));
+        Assert.Contains("before", exception.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -170,6 +168,32 @@ public class PcscProtocolScpTests
     }
 
     [Fact]
+    public async Task DisposeAsync_DuringExchange_DrainsBeforeDisposingScpProcessor()
+    {
+        var baseProtocol = new PcscProtocol(_fakeConnection, default, _logger);
+        var scpProcessor = new BlockingDisposableApduProcessor();
+        var adapter = new PcscProtocolScp(baseProtocol, scpProcessor, null!);
+        Task<ApduResponse> exchange = adapter.TransmitAndReceiveAsync(
+            new ApduCommand(0x00, 0x01, 0x00, 0x00),
+            cancellationToken: TestContext.Current.CancellationToken);
+        await scpProcessor.Started.Task.WaitAsync(TestContext.Current.CancellationToken);
+
+        var asyncDisposable = Assert.IsAssignableFrom<IAsyncDisposable>(adapter);
+        Task disposal = asyncDisposable.DisposeAsync().AsTask();
+
+        Assert.False(disposal.IsCompleted);
+        Assert.Equal(0, scpProcessor.DisposeCount);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => adapter.TransmitAndReceiveAsync(
+            new ApduCommand(0x00, 0x02, 0x00, 0x00),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        scpProcessor.Release.SetResult();
+        Assert.True((await exchange).IsOK());
+        await disposal;
+        Assert.Equal(1, scpProcessor.DisposeCount);
+    }
+
+    [Fact]
     public void Dispose_Twice_DisposesScpProcessorOnce_AndNeverTheConnection()
     {
         // Arrange
@@ -184,6 +208,28 @@ public class PcscProtocolScpTests
         // Assert
         Assert.Equal(0, _fakeConnection.DisposeCount);
         Assert.Equal(1, scpProcessor.DisposeCount);
+    }
+
+    private sealed class BlockingDisposableApduProcessor : IApduProcessor, IDisposable
+    {
+        public TaskCompletionSource Started { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource Release { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int DisposeCount { get; private set; }
+        public IApduFormatter Formatter { get; } = new FakeApduFormatter();
+
+        public async Task<ApduResponse> TransmitAsync(
+            ApduCommand command,
+            bool useScp = true,
+            CancellationToken cancellationToken = default)
+        {
+            Started.SetResult();
+            await Release.Task.WaitAsync(cancellationToken);
+            return new ApduResponse(new byte[] { 0x90, 0x00 });
+        }
+
+        public void Dispose() => DisposeCount++;
     }
 
     [Fact]

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawFidoHidSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawFidoHidSessionTests.cs
@@ -1,0 +1,160 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Buffers.Binary;
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Sessions;
+
+namespace Yubico.YubiKit.Core.UnitTests.Sessions;
+
+public class RawFidoHidSessionTests
+{
+    [Fact]
+    public async Task SendAndReceiveAsync_ProcessesKeepAliveAndContinuationPackets()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new ScriptedFidoConnection();
+        byte[] expected = Enumerable.Range(0, 60).Select(value => (byte)value).ToArray();
+        connection.QueueResponse(
+            CreateInitPacket(0x01020304, 0x3B, new byte[] { 0x01 }),
+            CreateInitPacket(0x01020304, 0x42, expected),
+            CreateContinuationPacket(0x01020304, 0, expected.AsSpan(57)));
+
+        await using var raw = await RawFidoHidSession.CreateAsync(connection, cancellationToken);
+        Assert.Empty(connection.SentPackets);
+
+        ReadOnlyMemory<byte> response = await raw.SendAndReceiveAsync(
+            0x42,
+            new byte[] { 0xAA, 0xBB },
+            cancellationToken);
+
+        Assert.Equal(expected, response.ToArray());
+        Assert.Equal(2, connection.SentPackets.Count);
+        Assert.Equal(0x42, connection.SentPackets[1][4] & 0x7F);
+
+        await raw.DisposeAsync();
+        Assert.Equal(0, connection.DisposeCount);
+    }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_OverlappingOperationThrowsThenSequentialCallSucceeds()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new ScriptedFidoConnection();
+        connection.QueueResponse(
+            CreateInitPacket(0x01020304, 0x42, new byte[] { 0x01 }),
+            CreateInitPacket(0x01020304, 0x43, new byte[] { 0x02 }));
+        await using var raw = await RawFidoHidSession.CreateAsync(connection, cancellationToken);
+        connection.HoldNextSend();
+
+        Task<ReadOnlyMemory<byte>> first = raw.SendAndReceiveAsync(0x42, ReadOnlyMemory<byte>.Empty, cancellationToken);
+        await connection.SendStarted.Task.WaitAsync(cancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => raw.SendAndReceiveAsync(0x43, ReadOnlyMemory<byte>.Empty, cancellationToken));
+
+        connection.ReleaseSend();
+        Assert.Equal(new byte[] { 0x01 }, (await first).ToArray());
+        Assert.Equal(
+            new byte[] { 0x02 },
+            (await raw.SendAndReceiveAsync(0x43, ReadOnlyMemory<byte>.Empty, cancellationToken)).ToArray());
+    }
+
+    private static byte[] CreateInitPacket(uint channelId, byte command, ReadOnlySpan<byte> payload)
+    {
+        var packet = new byte[64];
+        BinaryPrimitives.WriteUInt32BigEndian(packet, channelId);
+        packet[4] = (byte)(command | 0x80);
+        packet[5] = (byte)(payload.Length >> 8);
+        packet[6] = (byte)payload.Length;
+        payload[..Math.Min(payload.Length, 57)].CopyTo(packet.AsSpan(7));
+        return packet;
+    }
+
+    private static byte[] CreateContinuationPacket(uint channelId, byte sequence, ReadOnlySpan<byte> payload)
+    {
+        var packet = new byte[64];
+        BinaryPrimitives.WriteUInt32BigEndian(packet, channelId);
+        packet[4] = sequence;
+        payload[..Math.Min(payload.Length, 59)].CopyTo(packet.AsSpan(5));
+        return packet;
+    }
+
+    private sealed class ScriptedFidoConnection : IFidoHidConnection
+    {
+        private readonly Queue<ReadOnlyMemory<byte>> _responses = new();
+        private byte[]? _initRequest;
+        private TaskCompletionSource? _sendHold;
+
+        public List<byte[]> SentPackets { get; } = [];
+        public int DisposeCount { get; private set; }
+        public int PacketSize => 64;
+        public ConnectionType Type => ConnectionType.HidFido;
+        public TaskCompletionSource SendStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void QueueResponse(params byte[][] packets)
+        {
+            foreach (byte[] packet in packets)
+                _responses.Enqueue(packet);
+        }
+
+        public async Task SendAsync(ReadOnlyMemory<byte> packet, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            byte[] copy = packet.ToArray();
+            SentPackets.Add(copy);
+            if ((copy[4] & 0x7F) == 0x06)
+                _initRequest = copy;
+            TaskCompletionSource? hold = _sendHold;
+            if (hold is not null)
+            {
+                SendStarted.TrySetResult();
+                await hold.Task.WaitAsync(cancellationToken);
+                _sendHold = null;
+            }
+        }
+
+        public void HoldNextSend() =>
+            _sendHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseSend() => _sendHold?.TrySetResult();
+
+        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_initRequest is not null)
+            {
+                byte[] payload = new byte[17];
+                _initRequest.AsSpan(7, 8).CopyTo(payload);
+                BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(8), 0x01020304);
+                payload[12] = 2;
+                payload[13] = 5;
+                payload[14] = 8;
+                _initRequest = null;
+                return Task.FromResult<ReadOnlyMemory<byte>>(CreateInitPacket(uint.MaxValue, 0x06, payload));
+            }
+
+            return Task.FromResult(_responses.Dequeue());
+        }
+
+        public void Dispose() => DisposeCount++;
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawOtpHidSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawOtpHidSessionTests.cs
@@ -1,0 +1,146 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Buffers.Binary;
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols.Otp.Hid;
+using Yubico.YubiKit.Core.Sessions;
+using Yubico.YubiKit.Core.Transports.Hid;
+
+namespace Yubico.YubiKit.Core.UnitTests.Sessions;
+
+public class RawOtpHidSessionTests
+{
+    [Fact]
+    public async Task SendAndReceiveAsync_UsesOtpFramingAndCrcWithoutOwningConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new ScriptedOtpConnection();
+        connection.Enqueue(Status(versionMajor: 5));
+        connection.Enqueue(Status(programmingSequence: 1));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(Status(programmingSequence: 1));
+        connection.Enqueue(Status(programmingSequence: 2));
+
+        await using var raw = await RawOtpHidSession.CreateAsync(connection, cancellationToken);
+        ReadOnlyMemory<byte> response = await raw.SendAndReceiveAsync(
+            0x13,
+            new byte[] { 0xAA, 0xBB },
+            cancellationToken);
+
+        Assert.Equal(6, response.Length);
+        Assert.Equal(10, connection.SentReports.Count);
+        // The protocol writes its 70-byte frame as ten reports carrying seven frame bytes each.
+        byte[] frame = connection.SentReports.SelectMany(report => report.AsSpan(0, 7).ToArray()).ToArray();
+        Assert.Equal(70, frame.Length);
+        Assert.Equal(0xAA, frame[0]);
+        Assert.Equal(0xBB, frame[1]);
+        Assert.Equal(0x13, frame[64]);
+        Assert.Equal(
+            ChecksumUtils.CalculateCrc(frame, 64),
+            BinaryPrimitives.ReadUInt16LittleEndian(frame.AsSpan(65, 2)));
+
+        await raw.DisposeAsync();
+        Assert.Equal(0, connection.DisposeCount);
+    }
+
+    [Fact]
+    public async Task SendAndReceiveAsync_OverlappingOperationThrowsThenSequentialCallSucceeds()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new ScriptedOtpConnection();
+        connection.Enqueue(Status(versionMajor: 5));
+        QueueStatusOnlyExchange(connection, 1);
+        QueueStatusOnlyExchange(connection, 2);
+        await using var raw = await RawOtpHidSession.CreateAsync(connection, cancellationToken);
+        connection.HoldNextReceive();
+
+        Task<ReadOnlyMemory<byte>> first = raw.SendAndReceiveAsync(
+            0x13,
+            ReadOnlyMemory<byte>.Empty,
+            cancellationToken);
+        await connection.ReceiveStarted.Task.WaitAsync(cancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => raw.SendAndReceiveAsync(
+            0x14,
+            ReadOnlyMemory<byte>.Empty,
+            cancellationToken));
+
+        connection.ReleaseReceive();
+        Assert.Equal(6, (await first).Length);
+        Assert.Equal(6, (await raw.SendAndReceiveAsync(
+            0x14,
+            ReadOnlyMemory<byte>.Empty,
+            cancellationToken)).Length);
+    }
+
+    private static void QueueStatusOnlyExchange(ScriptedOtpConnection connection, byte programmingSequence)
+    {
+        connection.Enqueue(Status(programmingSequence: programmingSequence));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(Status(programmingSequence: programmingSequence));
+        connection.Enqueue(Status(programmingSequence: (byte)(programmingSequence + 1)));
+    }
+
+    private static byte[] Status(byte versionMajor = 0, byte programmingSequence = 0) =>
+        [0x00, versionMajor, 0x04, 0x03, programmingSequence, 0x00, 0x00, 0x00];
+
+    private sealed class ScriptedOtpConnection : IOtpHidConnection
+    {
+        private readonly Queue<ReadOnlyMemory<byte>> _reports = new();
+        private TaskCompletionSource? _receiveHold;
+
+        public List<byte[]> SentReports { get; } = [];
+        public int DisposeCount { get; private set; }
+        public int FeatureReportSize => 8;
+        public ConnectionType Type => ConnectionType.HidOtp;
+        public TaskCompletionSource ReceiveStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Enqueue(ReadOnlyMemory<byte> report) => _reports.Enqueue(report);
+
+        public Task SendAsync(ReadOnlyMemory<byte> report, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            SentReports.Add(report.ToArray());
+            return Task.CompletedTask;
+        }
+
+        public async Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            TaskCompletionSource? hold = _receiveHold;
+            if (hold is not null)
+            {
+                ReceiveStarted.TrySetResult();
+                await hold.Task.WaitAsync(cancellationToken);
+                _receiveHold = null;
+            }
+
+            return _reports.Dequeue();
+        }
+
+        public void HoldNextReceive() =>
+            _receiveHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseReceive() => _receiveHold?.TrySetResult();
+
+        public void Dispose() => DisposeCount++;
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawOtpHidSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawOtpHidSessionTests.cs
@@ -85,6 +85,28 @@ public class RawOtpHidSessionTests
             cancellationToken)).Length);
     }
 
+    [Fact]
+    public async Task SendAndReceiveAsync_ReturnsRawResponseWithoutCommandSpecificCrcValidation()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new ScriptedOtpConnection();
+        connection.Enqueue(Status(versionMajor: 5));
+        connection.Enqueue(Status(programmingSequence: 1));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(Status(programmingSequence: 1));
+        connection.Enqueue(new byte[] { 0xAA, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 });
+        connection.Enqueue(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40 });
+        await using var raw = await RawOtpHidSession.CreateAsync(connection, cancellationToken);
+
+        ReadOnlyMemory<byte> response = await raw.SendAndReceiveAsync(
+            0x13,
+            ReadOnlyMemory<byte>.Empty,
+            cancellationToken);
+
+        Assert.Equal(new byte[] { 0xAA, 0xBB, 0x00, 0x00, 0x00, 0x00, 0x00 }, response.ToArray());
+        Assert.False(ChecksumUtils.CheckCrc(response.Span, length: 4));
+    }
+
     private static void QueueStatusOnlyExchange(ScriptedOtpConnection connection, byte programmingSequence)
     {
         connection.Enqueue(Status(programmingSequence: programmingSequence));

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionConstructionFailureTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionConstructionFailureTests.cs
@@ -1,0 +1,184 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Protocols.Otp.Hid;
+using Yubico.YubiKit.Core.Sessions;
+using Yubico.YubiKit.Core.Transports.Hid;
+using Yubico.YubiKit.Core.Transports.SmartCard;
+
+namespace Yubico.YubiKit.Core.UnitTests.Sessions;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class RawSessionConstructionFailureCollection
+{
+    public const string Name = nameof(RawSessionConstructionFailureCollection);
+}
+
+[Collection(RawSessionConstructionFailureCollection.Name)]
+public class RawSessionConstructionFailureTests
+{
+    [Fact]
+    public async Task CreateRawSmartCardSession_WhenProtocolConstructionThrows_ReleasesClaimWithoutDisposingConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var failure = new InvalidOperationException("Scripted SupportsExtendedApdu failure.");
+        var connection = new ThrowOnceSmartCardConnection(failure);
+
+        InvalidOperationException actual = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => RawSmartCardSession.CreateAsync(connection, cancellationToken));
+
+        Assert.Same(failure, actual);
+        await using (RawSmartCardSession second = await RawSmartCardSession.CreateAsync(connection, cancellationToken))
+            Assert.NotNull(second);
+        Assert.Equal(0, connection.DisposeCount);
+    }
+
+    [Fact]
+    public async Task CreateRawFidoHidSession_WhenProtocolLoggerConstructionThrows_ReleasesClaimWithoutDisposingConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var failure = new InvalidOperationException("Scripted FIDO protocol logger failure.");
+        var connection = new ReusableFidoConnection();
+
+        using (YubiKitLogging.UseTemporary(new ThrowOnSecondLoggerFactory(failure)))
+        {
+            InvalidOperationException actual = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => RawFidoHidSession.CreateAsync(connection, cancellationToken));
+            Assert.Same(failure, actual);
+        }
+
+        await using (RawFidoHidSession second = await RawFidoHidSession.CreateAsync(connection, cancellationToken))
+            Assert.NotNull(second);
+        Assert.Equal(0, connection.DisposeCount);
+    }
+
+    [Fact]
+    public async Task CreateRawOtpHidSession_WhenProtocolLoggerConstructionThrows_ReleasesClaimWithoutDisposingConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var failure = new InvalidOperationException("Scripted OTP protocol logger failure.");
+        var connection = new ReusableOtpConnection();
+
+        using (YubiKitLogging.UseTemporary(new ThrowOnSecondLoggerFactory(failure)))
+        {
+            InvalidOperationException actual = await Assert.ThrowsAsync<InvalidOperationException>(
+                () => RawOtpHidSession.CreateAsync(connection, cancellationToken));
+            Assert.Same(failure, actual);
+        }
+
+        await using (RawOtpHidSession second = await RawOtpHidSession.CreateAsync(connection, cancellationToken))
+            Assert.NotNull(second);
+        Assert.Equal(0, connection.DisposeCount);
+    }
+
+    private sealed class ThrowOnSecondLoggerFactory(Exception failure) : ILoggerFactory
+    {
+        private int _createCount;
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            if (Interlocked.Increment(ref _createCount) == 2)
+                throw failure;
+
+            return NullLogger.Instance;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public void Dispose()
+        {
+        }
+    }
+
+    private sealed class ThrowOnceSmartCardConnection(Exception failure) : ISmartCardConnection
+    {
+        private int _supportsCallCount;
+
+        public int DisposeCount { get; private set; }
+        public ConnectionType Type => ConnectionType.SmartCard;
+        public Transport Transport => Transport.Usb;
+
+        public Task<ReadOnlyMemory<byte>> TransmitAndReceiveAsync(
+            ReadOnlyMemory<byte> command,
+            CancellationToken cancellationToken = default) =>
+            Task.FromResult<ReadOnlyMemory<byte>>(new byte[] { 0x90, 0x00 });
+
+        public IDisposable BeginTransaction(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public bool SupportsExtendedApdu()
+        {
+            if (Interlocked.Increment(ref _supportsCallCount) == 1)
+                throw failure;
+
+            return true;
+        }
+
+        public void Dispose() => DisposeCount++;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ReusableFidoConnection : IFidoHidConnection
+    {
+        public int DisposeCount { get; private set; }
+        public int PacketSize => 64;
+        public ConnectionType Type => ConnectionType.HidFido;
+
+        public Task SendAsync(ReadOnlyMemory<byte> packet, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Dispose() => DisposeCount++;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class ReusableOtpConnection : IOtpHidConnection
+    {
+        public int DisposeCount { get; private set; }
+        public int FeatureReportSize => 8;
+        public ConnectionType Type => ConnectionType.HidOtp;
+
+        public Task SendAsync(ReadOnlyMemory<byte> report, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public void Dispose() => DisposeCount++;
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
@@ -1,0 +1,129 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Abstractions;
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
+using Yubico.YubiKit.Core.Sessions;
+using Yubico.YubiKit.Core.Transports.Hid;
+using Yubico.YubiKit.Core.Transports.SmartCard;
+
+namespace Yubico.YubiKit.Core.UnitTests.Sessions;
+
+public class RawSessionYubiKeyExtensionsTests
+{
+    [Fact]
+    public async Task CreateRawSmartCardSessionAsync_DisposeSession_DisposesHiddenConnection()
+    {
+        var connection = new MultiTransportConnection(ConnectionType.SmartCard);
+        var yubiKey = new StubYubiKey(connection);
+
+        RawSmartCardSession session = await yubiKey.CreateRawSmartCardSessionAsync(
+            cancellationToken: TestContext.Current.CancellationToken);
+        await session.DisposeAsync();
+
+        Assert.Equal(1, connection.DisposeAsyncCount);
+        Assert.Equal([typeof(ISmartCardConnection)], yubiKey.RequestedConnections);
+    }
+
+    [Fact]
+    public async Task CreateRawFidoHidSessionAsync_DisposeSession_DisposesHiddenConnection()
+    {
+        var connection = new MultiTransportConnection(ConnectionType.HidFido);
+        var yubiKey = new StubYubiKey(connection);
+
+        RawFidoHidSession session = await yubiKey.CreateRawFidoHidSessionAsync(TestContext.Current.CancellationToken);
+        await session.DisposeAsync();
+
+        Assert.Equal(1, connection.DisposeAsyncCount);
+        Assert.Equal([typeof(IFidoHidConnection)], yubiKey.RequestedConnections);
+    }
+
+    [Fact]
+    public async Task CreateRawOtpHidSessionAsync_DisposeSession_DisposesHiddenConnection()
+    {
+        var connection = new MultiTransportConnection(ConnectionType.HidOtp);
+        var yubiKey = new StubYubiKey(connection);
+
+        RawOtpHidSession session = await yubiKey.CreateRawOtpHidSessionAsync(TestContext.Current.CancellationToken);
+        await session.DisposeAsync();
+
+        Assert.Equal(1, connection.DisposeAsyncCount);
+        Assert.Equal([typeof(IOtpHidConnection)], yubiKey.RequestedConnections);
+    }
+
+    [Fact]
+    public async Task CreateRawSmartCardSessionAsync_WhenScpInitializationFails_DisposesHiddenConnection()
+    {
+        var connection = new MultiTransportConnection(ConnectionType.SmartCard);
+        var yubiKey = new StubYubiKey(connection);
+        using var scp = Scp03KeyParameters.Default;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            yubiKey.CreateRawSmartCardSessionAsync(scp, TestContext.Current.CancellationToken));
+
+        Assert.Equal(1, connection.DisposeAsyncCount);
+    }
+
+    private sealed class StubYubiKey(IConnection connection) : IYubiKey
+    {
+        public string DeviceId => "raw-session-test";
+        public ConnectionType AvailableConnections => connection.Type;
+        public List<Type> RequestedConnections { get; } = [];
+
+        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
+            where TConnection : class, IConnection
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            RequestedConnections.Add(typeof(TConnection));
+            return Task.FromResult((TConnection)connection);
+        }
+    }
+
+    private sealed class MultiTransportConnection(ConnectionType type)
+        : ISmartCardConnection, IFidoHidConnection, IOtpHidConnection
+    {
+        public ConnectionType Type { get; } = type;
+        public int DisposeAsyncCount { get; private set; }
+        public Transport Transport => Transport.Usb;
+        public int PacketSize => 64;
+        public int FeatureReportSize => 8;
+
+        public Task<ReadOnlyMemory<byte>> TransmitAndReceiveAsync(
+            ReadOnlyMemory<byte> command,
+            CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("No scripted response.");
+
+        public Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default) =>
+            Task.CompletedTask;
+
+        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default) =>
+            throw new InvalidOperationException("No scripted response.");
+
+        public IDisposable BeginTransaction(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public bool SupportsExtendedApdu() => true;
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeAsyncCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
@@ -12,9 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Buffers.Binary;
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.Fido.Hid;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
 using Yubico.YubiKit.Core.Sessions;
 using Yubico.YubiKit.Core.Transports.Hid;
@@ -72,10 +74,134 @@ public class RawSessionYubiKeyExtensionsTests
         using var scp = Scp03KeyParameters.Default;
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
-            yubiKey.CreateRawSmartCardSessionAsync(scp, TestContext.Current.CancellationToken));
+            yubiKey.CreateRawSmartCardSessionAsync(
+                scp,
+                new FirmwareVersion(5, 7, 2),
+                cancellationToken: TestContext.Current.CancellationToken));
 
         Assert.Equal(1, connection.DisposeAsyncCount);
     }
+
+    [Fact]
+    public async Task SmartCardDisposeAsync_DuringAdmittedExchange_DrainsBeforeDisposingHiddenConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new MultiTransportConnection(ConnectionType.SmartCard);
+        connection.Enqueue(new byte[] { 0x90, 0x00 });
+        connection.HoldNextOperation();
+        var yubiKey = new StubYubiKey(connection);
+        RawSmartCardSession session = await yubiKey.CreateRawSmartCardSessionAsync(
+            cancellationToken: cancellationToken);
+        Task<ApduResponse> exchange = session.TransmitAndReceiveAsync(
+            new ApduCommand(0x00, 0x01, 0x00, 0x00),
+            cancellationToken: cancellationToken);
+        await connection.OperationStarted.Task.WaitAsync(cancellationToken);
+
+        Task asyncDisposal = session.DisposeAsync().AsTask();
+
+        try
+        {
+            Assert.False(asyncDisposal.IsCompleted);
+            Assert.Equal(0, connection.DisposeAsyncCount + connection.DisposeCount);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() => session.TransmitAndReceiveAsync(
+                new ApduCommand(0x00, 0x02, 0x00, 0x00),
+                cancellationToken: cancellationToken));
+        }
+        finally
+        {
+            connection.ReleaseOperation();
+        }
+
+        Assert.True((await exchange).IsOK());
+        await asyncDisposal.WaitAsync(cancellationToken);
+        Assert.Equal(1, connection.DisposeAsyncCount + connection.DisposeCount);
+    }
+
+    [Fact]
+    public async Task FidoDisposeAsync_DuringAdmittedExchange_DrainsBeforeDisposingHiddenConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new MultiTransportConnection(ConnectionType.HidFido);
+        connection.Enqueue(CreateFidoInitPacket(0x01020304, 0x42, [0xAB]));
+        connection.HoldNextOperation();
+        var yubiKey = new StubYubiKey(connection);
+        RawFidoHidSession session = await yubiKey.CreateRawFidoHidSessionAsync(cancellationToken);
+        Task<ReadOnlyMemory<byte>> exchange = session.SendAndReceiveAsync(
+            0x42,
+            new byte[] { 0x10 },
+            cancellationToken);
+        await connection.OperationStarted.Task.WaitAsync(cancellationToken);
+
+        Task disposal = session.DisposeAsync().AsTask();
+
+        try
+        {
+            Assert.False(disposal.IsCompleted);
+            Assert.Equal(0, connection.DisposeAsyncCount);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                session.SendAndReceiveAsync(0x42, ReadOnlyMemory<byte>.Empty, cancellationToken));
+        }
+        finally
+        {
+            connection.ReleaseOperation();
+        }
+
+        Assert.Equal(new byte[] { 0xAB }, (await exchange).ToArray());
+        await disposal;
+        Assert.Equal(1, connection.DisposeAsyncCount);
+    }
+
+    [Fact]
+    public async Task OtpDisposeAsync_DuringAdmittedExchange_DrainsBeforeDisposingHiddenConnection()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new MultiTransportConnection(ConnectionType.HidOtp);
+        connection.Enqueue(OtpStatus(versionMajor: 5));
+        connection.Enqueue(OtpStatus(programmingSequence: 1));
+        for (int i = 0; i < 10; i++)
+            connection.Enqueue(OtpStatus(programmingSequence: 1));
+        connection.Enqueue(OtpStatus(programmingSequence: 2));
+        connection.HoldNextOperation();
+        var yubiKey = new StubYubiKey(connection);
+        RawOtpHidSession session = await yubiKey.CreateRawOtpHidSessionAsync(cancellationToken);
+        Task<ReadOnlyMemory<byte>> exchange = session.SendAndReceiveAsync(
+            0x13,
+            new byte[] { 0x10 },
+            cancellationToken);
+        await connection.OperationStarted.Task.WaitAsync(cancellationToken);
+
+        Task disposal = session.DisposeAsync().AsTask();
+
+        try
+        {
+            Assert.False(disposal.IsCompleted);
+            Assert.Equal(0, connection.DisposeAsyncCount);
+            await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+                session.SendAndReceiveAsync(0x13, ReadOnlyMemory<byte>.Empty, cancellationToken));
+        }
+        finally
+        {
+            connection.ReleaseOperation();
+        }
+
+        Assert.Equal(6, (await exchange).Length);
+        await disposal;
+        Assert.Equal(1, connection.DisposeAsyncCount);
+    }
+
+    private static byte[] CreateFidoInitPacket(uint channelId, byte command, ReadOnlySpan<byte> payload)
+    {
+        var packet = new byte[64];
+        BinaryPrimitives.WriteUInt32BigEndian(packet, channelId);
+        packet[4] = (byte)(command | 0x80);
+        packet[5] = (byte)(payload.Length >> 8);
+        packet[6] = (byte)payload.Length;
+        payload[..Math.Min(payload.Length, 57)].CopyTo(packet.AsSpan(7));
+        return packet;
+    }
+
+    private static byte[] OtpStatus(byte versionMajor = 0, byte programmingSequence = 0) =>
+        [0x00, versionMajor, 0x04, 0x03, programmingSequence, 0x00, 0x00, 0x00];
 
     private sealed class StubYubiKey(IConnection connection) : IYubiKey
     {
@@ -96,21 +222,70 @@ public class RawSessionYubiKeyExtensionsTests
         : ISmartCardConnection, IFidoHidConnection, IOtpHidConnection
     {
         public ConnectionType Type { get; } = type;
+        private readonly Queue<ReadOnlyMemory<byte>> _responses = new();
+        private TaskCompletionSource? _operationHold;
+        private byte[]? _fidoInitRequest;
+
         public int DisposeAsyncCount { get; private set; }
+        public int DisposeCount { get; private set; }
         public Transport Transport => Transport.Usb;
         public int PacketSize => 64;
         public int FeatureReportSize => 8;
 
-        public Task<ReadOnlyMemory<byte>> TransmitAndReceiveAsync(
+        public TaskCompletionSource OperationStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<ReadOnlyMemory<byte>> TransmitAndReceiveAsync(
             ReadOnlyMemory<byte> command,
-            CancellationToken cancellationToken = default) =>
-            throw new InvalidOperationException("No scripted response.");
+            CancellationToken cancellationToken = default)
+        {
+            await WaitIfHeldAsync(cancellationToken);
+            return _responses.Dequeue();
+        }
 
-        public Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default) =>
-            Task.CompletedTask;
+        public async Task SendAsync(ReadOnlyMemory<byte> data, CancellationToken cancellationToken = default)
+        {
+            byte[] snapshot = data.ToArray();
+            if (Type == ConnectionType.HidFido && (snapshot[4] & 0x7F) == 0x06)
+                _fidoInitRequest = snapshot;
+            await WaitIfHeldAsync(cancellationToken);
+        }
 
-        public Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default) =>
-            throw new InvalidOperationException("No scripted response.");
+        public async Task<ReadOnlyMemory<byte>> ReceiveAsync(CancellationToken cancellationToken = default)
+        {
+            await WaitIfHeldAsync(cancellationToken);
+            if (_fidoInitRequest is not null)
+            {
+                byte[] payload = new byte[17];
+                _fidoInitRequest.AsSpan(7, 8).CopyTo(payload);
+                BinaryPrimitives.WriteUInt32BigEndian(payload.AsSpan(8), 0x01020304);
+                payload[12] = 2;
+                payload[13] = 5;
+                payload[14] = 8;
+                _fidoInitRequest = null;
+                return CreateFidoInitPacket(uint.MaxValue, 0x06, payload);
+            }
+
+            return _responses.Dequeue();
+        }
+
+        public void Enqueue(ReadOnlyMemory<byte> response) => _responses.Enqueue(response);
+
+        public void HoldNextOperation() =>
+            _operationHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseOperation() => _operationHold?.TrySetResult();
+
+        private async Task WaitIfHeldAsync(CancellationToken cancellationToken)
+        {
+            TaskCompletionSource? hold = _operationHold;
+            if (hold is null)
+                return;
+
+            OperationStarted.TrySetResult();
+            await hold.Task.WaitAsync(cancellationToken);
+            _operationHold = null;
+        }
 
         public IDisposable BeginTransaction(CancellationToken cancellationToken = default) =>
             throw new NotSupportedException();
@@ -118,6 +293,7 @@ public class RawSessionYubiKeyExtensionsTests
         public bool SupportsExtendedApdu() => true;
         public void Dispose()
         {
+            DisposeCount++;
         }
 
         public ValueTask DisposeAsync()

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
@@ -97,6 +97,49 @@ public class RawSmartCardSessionTests
     }
 
     [Fact]
+    public async Task Configure_DuringBlockedExchange_ThrowsWithoutChangingConfiguration()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+        connection.HoldNextTransmission();
+        Task<ApduResponse> exchange = raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 0, 0),
+            cancellationToken: cancellationToken);
+        await connection.TransmissionStarted.Task.WaitAsync(cancellationToken);
+        FirmwareVersion firmwareVersionBeforeConfigure = raw.FirmwareVersion;
+
+        Assert.Throws<InvalidOperationException>(() => raw.Configure(
+            new FirmwareVersion(5, 7, 0),
+            new ProtocolConfiguration { ForceShortApdus = true }));
+
+        connection.ReleaseTransmission();
+        Assert.True((await exchange).IsOK());
+        Assert.Equal(firmwareVersionBeforeConfigure, raw.FirmwareVersion);
+    }
+
+    [Fact]
+    public async Task Configure_AfterDisposalBegins_ThrowsObjectDisposedException()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+        connection.HoldNextTransmission();
+        Task<ApduResponse> exchange = raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 0, 0),
+            cancellationToken: cancellationToken);
+        await connection.TransmissionStarted.Task.WaitAsync(cancellationToken);
+        Task disposal = raw.DisposeAsync().AsTask();
+
+        Assert.Throws<ObjectDisposedException>(() => raw.Configure(new FirmwareVersion(5, 7, 0)));
+
+        connection.ReleaseTransmission();
+        await Task.WhenAll(exchange, disposal);
+    }
+
+    [Fact]
     public async Task Dispose_BorrowedConnection_RemainsOpenForSequentialSession()
     {
         CancellationToken cancellationToken = TestContext.Current.CancellationToken;

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
@@ -138,12 +138,36 @@ public class RawSmartCardSessionTests
         using var scp = Scp03KeyParameters.Default;
 
         await Assert.ThrowsAsync<InvalidOperationException>(
-            () => RawSmartCardSession.CreateAsync(connection, scp, cancellationToken));
+            () => RawSmartCardSession.CreateAsync(
+                connection,
+                scp,
+                new FirmwareVersion(5, 7, 2),
+                cancellationToken: cancellationToken));
 
         Assert.Equal(0, connection.DisposeCount);
         Assert.Equal(0x50, Assert.Single(connection.Commands).Span[1]);
         using StubAppletSession next = StubAppletSession.Create(connection);
         Assert.NotNull(next);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithScp_ConfiguresBaseProcessorBeforeEstablishment()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        using var scp = Scp03KeyParameters.Default;
+        Task<RawSmartCardSession> creation = RawSmartCardSession.CreateAsync(
+            connection,
+            scp,
+            new FirmwareVersion(5, 7, 2),
+            new ProtocolConfiguration { ForceShortApdus = true },
+            cancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => creation);
+
+        ReadOnlyMemory<byte> initializeUpdate = Assert.Single(connection.Commands);
+        Assert.Equal(0x50, initializeUpdate.Span[1]);
+        Assert.Equal(8, initializeUpdate.Span[4]);
     }
 
     [Fact]

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSmartCardSessionTests.cs
@@ -1,0 +1,236 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
+using Yubico.YubiKit.Core.Protocols.SmartCard.Scp;
+using Yubico.YubiKit.Core.Sessions;
+using Yubico.YubiKit.Core.Transports.SmartCard;
+
+namespace Yubico.YubiKit.Core.UnitTests.Sessions;
+
+public class RawSmartCardSessionTests
+{
+    [Fact]
+    public async Task CreateAsync_WhileRawSessionHoldsConnection_RefusesAppletBeforeWireIo()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+
+        _ = Assert.Throws<ConnectionInUseException>(() => StubAppletSession.Create(connection));
+
+        Assert.Empty(connection.Commands);
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        ApduResponse response = await raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 2, 3),
+            cancellationToken: cancellationToken);
+        Assert.True(response.IsOK());
+    }
+
+    [Fact]
+    public async Task SelectAsync_SendsOnlyCallerAidAndCreationPerformsNoWireIo()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+        Assert.Empty(connection.Commands);
+        connection.EnqueueResponse(new byte[] { 0x01, 0x02, 0x90, 0x00 });
+
+        ReadOnlyMemory<byte> result = await raw.SelectAsync(
+            new byte[] { 0xA0, 0x00, 0x01 },
+            cancellationToken);
+
+        Assert.Equal(new byte[] { 0x01, 0x02 }, result.ToArray());
+        byte[] command = Assert.Single(connection.Commands).ToArray();
+        Assert.Equal(new byte[] { 0x00, 0xA4, 0x04, 0x00 }, command[..4]);
+        Assert.Equal(new byte[] { 0xA0, 0x00, 0x01 }, command.AsSpan(7, 3).ToArray());
+    }
+
+    [Fact]
+    public async Task TransmitAndReceiveAsync_WithThrowOnErrorFalse_ReturnsDataAndStatus()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        connection.EnqueueResponse(new byte[] { 0xCA, 0xFE, 0x69, 0x82 });
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+
+        ApduResponse response = await raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 2, 3),
+            throwOnError: false,
+            cancellationToken);
+
+        Assert.Equal(new byte[] { 0xCA, 0xFE }, response.Data.ToArray());
+        Assert.Equal(0x6982, (ushort)response.SW);
+    }
+
+    [Fact]
+    public async Task Configure_ForceShortApdus_ChangesFormattingAndRecordsFirmwareVersion()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+
+        raw.Configure(
+            new FirmwareVersion(5, 7, 0),
+            new ProtocolConfiguration { ForceShortApdus = true });
+        _ = await raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 2, 3, new byte[] { 0xAA, 0xBB, 0xCC }),
+            cancellationToken: cancellationToken);
+
+        Assert.Equal(new FirmwareVersion(5, 7, 0), raw.FirmwareVersion);
+        Assert.Equal(
+            new byte[] { 0x00, 0x01, 0x02, 0x03, 0x03, 0xAA, 0xBB, 0xCC, 0x00 },
+            Assert.Single(connection.Commands).ToArray());
+    }
+
+    [Fact]
+    public async Task Dispose_BorrowedConnection_RemainsOpenForSequentialSession()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        var first = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+
+        await first.DisposeAsync();
+
+        Assert.Equal(0, connection.DisposeCount);
+        await using var applet = StubAppletSession.Create(connection);
+        Assert.NotNull(applet);
+    }
+
+    [Fact]
+    public async Task AppletThenRawThenApplet_ReusesOneConnectionSequentially()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        using (StubAppletSession firstApplet = StubAppletSession.Create(connection))
+        {
+            await Assert.ThrowsAsync<ConnectionInUseException>(
+                () => RawSmartCardSession.CreateAsync(connection, cancellationToken));
+        }
+
+        await using (RawSmartCardSession raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken))
+        {
+            Assert.NotNull(raw);
+        }
+
+        using StubAppletSession secondApplet = StubAppletSession.Create(connection);
+        Assert.NotNull(secondApplet);
+    }
+
+    [Fact]
+    public async Task CreateAsync_ScpInitializationFails_ReleasesClaimAndLeavesBorrowedConnectionOpen()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        using var scp = Scp03KeyParameters.Default;
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => RawSmartCardSession.CreateAsync(connection, scp, cancellationToken));
+
+        Assert.Equal(0, connection.DisposeCount);
+        Assert.Equal(0x50, Assert.Single(connection.Commands).Span[1]);
+        using StubAppletSession next = StubAppletSession.Create(connection);
+        Assert.NotNull(next);
+    }
+
+    [Fact]
+    public async Task TransmitAndReceiveAsync_OverlappingOperationThrowsThenSequentialCallSucceeds()
+    {
+        CancellationToken cancellationToken = TestContext.Current.CancellationToken;
+        var connection = new RecordingSmartCardConnection();
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        connection.EnqueueResponse(new byte[] { 0x90, 0x00 });
+        await using var raw = await RawSmartCardSession.CreateAsync(connection, cancellationToken);
+        connection.HoldNextTransmission();
+
+        Task<ApduResponse> first = raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 1, 0, 0),
+            cancellationToken: cancellationToken);
+        await connection.TransmissionStarted.Task.WaitAsync(cancellationToken);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 2, 0, 0),
+            cancellationToken: cancellationToken));
+
+        connection.ReleaseTransmission();
+        Assert.True((await first).IsOK());
+        Assert.True((await raw.TransmitAndReceiveAsync(
+            new ApduCommand(0, 3, 0, 0),
+            cancellationToken: cancellationToken)).IsOK());
+    }
+
+    private sealed class StubAppletSession : ApplicationSession
+    {
+        private StubAppletSession(ISmartCardConnection connection)
+            : base(connection)
+        {
+        }
+
+        public static StubAppletSession Create(ISmartCardConnection connection) =>
+            Construct(connection, () => new StubAppletSession(connection));
+    }
+
+    private sealed class RecordingSmartCardConnection : ISmartCardConnection
+    {
+        private readonly Queue<ReadOnlyMemory<byte>> _responses = new();
+        private TaskCompletionSource? _transmissionHold;
+
+        public List<ReadOnlyMemory<byte>> Commands { get; } = [];
+        public int DisposeCount { get; private set; }
+        public ConnectionType Type => ConnectionType.SmartCard;
+        public Transport Transport => Transport.Usb;
+        public TaskCompletionSource TransmissionStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void EnqueueResponse(ReadOnlyMemory<byte> response) => _responses.Enqueue(response);
+
+        public async Task<ReadOnlyMemory<byte>> TransmitAndReceiveAsync(
+            ReadOnlyMemory<byte> command,
+            CancellationToken cancellationToken = default)
+        {
+            Commands.Add(command.ToArray());
+            TaskCompletionSource? hold = _transmissionHold;
+            if (hold is not null)
+            {
+                TransmissionStarted.TrySetResult();
+                await hold.Task.WaitAsync(cancellationToken);
+                _transmissionHold = null;
+            }
+
+            return _responses.Dequeue();
+        }
+
+        public void HoldNextTransmission() =>
+            _transmissionHold = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void ReleaseTransmission() => _transmissionHold?.TrySetResult();
+
+        public IDisposable BeginTransaction(CancellationToken cancellationToken = default) =>
+            throw new NotSupportedException();
+
+        public bool SupportsExtendedApdu() => true;
+        public void Dispose()
+        {
+            DisposeCount++;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/ExchangeGuardTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/ExchangeGuardTests.cs
@@ -90,6 +90,39 @@ public class ExchangeGuardTests
     }
 
     [Fact]
+    public async Task Run_WhileAsyncExchangeIsActive_ThrowsWithoutRunningAction()
+    {
+        var guard = new ExchangeGuard();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task exchange = guard.RunAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }, TestContext.Current.CancellationToken);
+        await entered.Task;
+        bool actionRan = false;
+
+        Assert.Throws<InvalidOperationException>(() => guard.Run(() => actionRan = true));
+
+        Assert.False(actionRan);
+        release.SetResult();
+        await exchange;
+    }
+
+    [Fact]
+    public void Run_AfterClose_ThrowsWithoutRunningAction()
+    {
+        var guard = new ExchangeGuard();
+        guard.CloseAndDrain();
+        bool actionRan = false;
+
+        Assert.Throws<ObjectDisposedException>(() => guard.Run(() => actionRan = true));
+
+        Assert.False(actionRan);
+    }
+
+    [Fact]
     public async Task CloseAndDrainAsync_RefusesNewAdmissionsAndWaitsForAdmittedExchange()
     {
         var guard = new ExchangeGuard();

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/ExchangeGuardTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/ExchangeGuardTests.cs
@@ -88,4 +88,49 @@ public class ExchangeGuardTests
 
         Assert.False(observed.CanBeCanceled);
     }
+
+    [Fact]
+    public async Task CloseAndDrainAsync_RefusesNewAdmissionsAndWaitsForAdmittedExchange()
+    {
+        var guard = new ExchangeGuard();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task exchange = guard.RunAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }, TestContext.Current.CancellationToken);
+        await entered.Task;
+
+        Task drain = guard.CloseAndDrainAsync().AsTask();
+
+        Assert.False(drain.IsCompleted);
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            guard.RunAsync(_ => Task.CompletedTask, TestContext.Current.CancellationToken));
+
+        release.SetResult();
+        await Task.WhenAll(exchange, drain);
+    }
+
+    [Fact]
+    public async Task CloseAndDrain_ConcurrentWithAsyncClose_SharesDrainWithoutDeadlock()
+    {
+        var guard = new ExchangeGuard();
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        Task exchange = guard.RunAsync(async _ =>
+        {
+            entered.SetResult();
+            await release.Task;
+        }, TestContext.Current.CancellationToken);
+        await entered.Task;
+
+        Task asyncClose = guard.CloseAndDrainAsync().AsTask();
+        Task syncClose = Task.Run(guard.CloseAndDrain, TestContext.Current.CancellationToken);
+        Assert.False(asyncClose.IsCompleted);
+        Assert.False(syncClose.IsCompleted);
+
+        release.SetResult();
+        await Task.WhenAll(exchange, asyncClose, syncClose).WaitAsync(TestContext.Current.CancellationToken);
+    }
 }


### PR DESCRIPTION
## Summary

- add public guarded raw SmartCard, FIDO HID, and OTP HID sessions
- drain admitted exchanges before protocol, SCP state, or owned connection teardown
- configure SmartCard framing before SCP establishment and reject post-establishment reconfiguration
- correlate FIDO final response commands, accept intermediate KEEPALIVE, and reject CTAPHID_ERROR
- clear SDK-owned outgoing HID payload copies, packets, frames, and reports after success or failure
- keep OTP inbound CRC command-agnostic and caller-validated

## Stack

1. **#565 — raw sessions and review fixes**
2. #566 — internalize protocol machinery
3. #567 — documentation and migration guidance

Base: `single-conn/4-docs`

## Independent Review Resolutions

- **HIGH disposal race:** `ExchangeGuard` now closes admission atomically with active-operation state. New calls fail immediately; disposal drains the admitted operation before teardown. Protocols share idempotent `DisposalGate` completion across sync/async callers.
- **MEDIUM SCP configuration:** the SCP factory requires firmware/configuration, applies it before `InitializeScpAsync`, and rejects later `Configure`. No processor graph replacement occurs.
- **MEDIUM FIDO correlation:** final command must match; KEEPALIVE is intermediate-only; CTAPHID_ERROR throws with its error byte.
- **MEDIUM security:** SDK-owned FIDO/OTP outgoing copies are zeroed in `finally`; caller request memory is unchanged.
- **LOW OTP CRC:** outbound CRC remains in Core; inbound validation remains caller-owned because expected response length is command-specific.

## Craftsman Phase 4

- **Reshaped:** Reused `ExchangeGuard` as the protocol operation-lifetime boundary and `DisposalGate` as shared teardown completion instead of introducing a second session-level operation tracker.
- **Reshaped:** Kept the SCP processor graph immutable after establishment; configuration moved to creation.
- **Reshaped:** Kept OTP raw sessions command-agnostic and exposed existing `ChecksumUtils` for caller validation.
- **Deferred:** Synchronous disposal necessarily blocks for drain and must not be called from inside the operation being drained; documented in #567. The unrelated `.gitignore` duplication remains user-owned and untouched.
- **Correctness:** autonomous fit review passed; cross-vendor DevTeam returned PASS WITH NOTES; Simplify Apply was a verified no-op after the contained using-order fix.

## Verification

- focused RED then GREEN: `ExchangeGuardTests` (6), `RawSessionYubiKeyExtensionsTests` (7), `PcscProtocolScpTests` (17), `FidoHidProtocolTests` (24), `OtpHidProtocolTests` (9), `RawSmartCardSessionTests` (9), `RawOtpHidSessionTests` (3)
- `dotnet toolchain.cs -- test --project Core`: 851 passed, 3 hardware/platform skips
- `dotnet toolchain.cs build`
- `dotnet toolchain.cs test`: all 12 unit-test projects passed
- `dotnet toolchain.cs -- resilience --fast`: 70 passed
- scoped `dotnet format --verify-no-changes` and diff checks passed

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

## Second Independent Review Follow-up

- **HIGH FIDO compatibility:** response and expected command bytes are now both init-bit-normalized. Regression coverage includes `CtapYubikeyDeviceConfig` (`0xC0`), `CtapReadConfig` (`0xC2`), `CtapWriteConfig` (`0xC3`), low-bit `CtapHidPing`, wrong-command rejection, CTAPHID_ERROR, and KEEPALIVE.
- **MEDIUM Configure race:** synchronous `ExchangeGuard.Run(Action)` reuses the exact async admission/release primitives. `PcscProtocol.Configure` now refuses overlap and close/disposal before any configuration mutation; SCP creation-time configuration remains green.
- **MEDIUM OTP duplicate:** response accumulation now uses a bounded pooled buffer, copies only the successful response surface, and zeroes the complete rented array in `finally` before return on success or failure.
- **MEDIUM FIDO exceptional response:** partial response arrays are zeroed unless ownership transfers successfully to the caller; successful returned memory remains intact.

### Autonomous Craftsman / DevTeam / Simplify

- Craftsman fit audit passed. One V2/C2 ballot considered unifying FIDO and OTP buffer seams. Alternatives were: use a pool plus success copy, introduce a shared allocator abstraction, or retain distinct ownership-shaped seams. Retaining the current shape won: OTP storage is temporary and returnable, while FIDO storage becomes the returned response; unification would add allocation or abstraction without reducing risk.
- Cross-vendor DevTeam verdict: **PASS**. Two LOW explanatory notes required no code change.
- Simplify Apply: verified no-op; the shared `ExchangeGuard.Enter`/`Exit` extraction and distinct buffer ownership paths are necessary complexity.

### Second-review verification

- RED witnessed: 3 high-bit FIDO cases failed while low-bit passed; `ExchangeGuard.Run` tests initially failed compilation; OTP/FIDO controlled-seam tests initially failed compilation before implementation.
- Focused GREEN: `FidoHidProtocolTests` 30/30, `OtpHidProtocolTests` 11/11, `RawSmartCardSessionTests` 11/11, `ExchangeGuardTests` 8/8, `PcscProtocolTests` 23/23, `PcscProtocolScpTests` 17/17.
- Full build passed with 0 errors (3 pre-existing test-project warnings).
- Full unit suite: 12/12 projects; 2,173 passed and 3 hardware/platform skips. Core: 863 passed and 3 skipped.
- Fast resilience: 70/70. Documentation architecture, documentation QA, scoped formatting, and diff checks passed.


## Final Independent Review Follow-up

- Moved every throwable operation after `ApplicationSession.Construct` into initialization-failure cleanup for `RawSmartCardSession`, `RawFidoHidSession`, and `RawOtpHidSession`, including protocol/logger construction and protocol assignment.
- Failure cleanup accepts a null or assigned protocol, detaches `ConnectionSessionGuard`, preserves the original exception, and never disposes a caller-owned connection.
- Added real construction-failure coverage: SmartCard throws from `SupportsExtendedApdu`; FIDO and OTP throw from their protocol logger creation after session attachment. All three assert exact exception identity, zero connection disposals, and successful second raw-session reuse.

### Final Craftsman / DevTeam / Simplify report

- Contained autonomous Craftsman fit audit: **PASS**, no findings. The direct try/catch shape matches every existing `ApplicationSession` factory and reuses `DisposeAfterInitializationFailure`.
- Cross-vendor DevTeam verdict: **PASS**. It verified the leak, detach path, exception preservation, ownership, and test realism.
- Simplify Apply: verified no-op; extracting another helper would obscure the established per-factory cleanup boundary.

### Final verification

- TDD RED: all three regression tests failed because a second session received `ConnectionInUseException`.
- Focused GREEN: construction failures 3/3; Raw SmartCard 11/11; Raw FIDO 2/2; Raw OTP 3/3; raw YubiKey extensions 7/7.
- Core: 866 passed, 3 hardware/platform skips.
- Full unit suite: 12/12 projects; 2,176 passed, 3 hardware/platform skips.
- Full build: 0 errors, 1 pre-existing generated test-project warning.
- Fast resilience: 70/70. Scoped formatting and diff checks passed.
