### PR TITLE
test(core): align ownership assertions with grouped leases

### DIFF
--- a/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Devices/FidoHidOwnershipIntegrationTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.IntegrationTests/Devices/FidoHidOwnershipIntegrationTests.cs
@@ -22,7 +22,7 @@ using Yubico.YubiKit.Tests.Shared.Infrastructure;
 namespace Yubico.YubiKit.Core.IntegrationTests.Devices;
 
 /// <summary>
-///     Hardware-gated confirmation of the exclusive FIDO HID interface ownership contract.
+///     Hardware-gated confirmation of the physical-key ownership contract through the FIDO HID entry point.
 /// </summary>
 public class FidoHidOwnershipIntegrationTests
 {

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
@@ -29,10 +29,10 @@ namespace Yubico.YubiKit.Core.UnitTests.Devices;
 /// </summary>
 /// <remarks>
 ///     <para>
-///         Two rules, one fact at two scopes. A CCID interface admits ONE live connection, and a connection
-///         admits ONE live session. Both are refused before any command reaches the card, because a YubiKey's
-///         CCID interface holds exactly one selected applet and a second applet SELECT deselects the first —
-///         measured, SW=0x6D00, see docs/architecture/connection-ownership-and-contention.md.
+///         Two rules at two scopes. A grouped physical YubiKey admits ONE live connection across all known
+///         interfaces, and a connection admits ONE live session. Both are refused before any command reaches
+///         the card. The motivating CCID failure was a second applet SELECT deselecting the first — measured,
+///         SW=0x6D00, see docs/architecture/connection-ownership-and-contention.md.
 ///     </para>
 ///     <para>
 ///         The third rule is ownership: a protocol/session is a pure USER of the connection it is handed.
@@ -46,7 +46,7 @@ public class ConnectionOwnershipContractTests
     private static CancellationToken Ct => TestContext.Current.CancellationToken;
 
     // ------------------------------------------------------------------------------------------------
-    // Rule 1 — one live connection per stateful or multi-report interface.
+    // Rule 1 — one live connection per grouped physical key (or standalone interface record).
     // ------------------------------------------------------------------------------------------------
 
     /// <summary>
@@ -120,9 +120,8 @@ public class ConnectionOwnershipContractTests
     }
 
     /// <summary>
-    ///     FIDO HID is now exclusive: one physical YubiKey FIDO HID interface admits exactly one SDK
-    ///     connection/native HID handle at a time. A second connection is refused immediately before
-    ///     opening the second native handle.
+    ///     A standalone FIDO HID record admits one SDK connection/native HID handle at a time. When discovery
+    ///     groups it with other interfaces, that connection claims the complete physical-key lease scope.
     /// </summary>
     [Fact]
     public async Task ConnectAsync_SecondConnectionToHeldFidoHidInterface_IsRefusedBeforePhysicalOpen()
@@ -142,7 +141,7 @@ public class ConnectionOwnershipContractTests
     }
 
     /// <summary>
-    ///     Exclusive is not permanent: the FIDO HID interface is reusable the moment the holder is disposed.
+    ///     Exclusive is not permanent: the lease scope is reusable the moment the holder is disposed.
     /// </summary>
     [Fact]
     public async Task ConnectAsync_FidoHidConnectionDisposed_InterfaceReopens()
@@ -179,7 +178,13 @@ public class ConnectionOwnershipContractTests
         var refusal = await Assert.ThrowsAsync<ConnectionInUseException>(
             () => composite.ConnectAsync<IFidoHidConnection>(Ct));
 
-        Assert.Contains(hid.DeviceId, refusal.Message, StringComparison.Ordinal);
+        Assert.Matches("held interface: '[^']+'", refusal.Message);
+        Assert.True(
+            refusal.Message.Contains(smartCard.DeviceId, StringComparison.Ordinal)
+            || refusal.Message.Contains(hid.DeviceId, StringComparison.Ordinal),
+            "The refusal should identify a held member of the grouped physical key.");
+        Assert.Contains("one live connection at a time across all interfaces", refusal.Message,
+            StringComparison.Ordinal);
         Assert.Equal(0, hidDevice.IoReportConnectCalls);
         _ = await ccid.TransmitAndReceiveAsync(new byte[] { 0x00 }, Ct);
         Assert.Equal(1, factory.CreateCalls);

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceConnectionRegistryTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceConnectionRegistryTests.cs
@@ -28,9 +28,9 @@ public class DeviceConnectionRegistryTests
     private static string NewId() => $"test:{Guid.NewGuid():N}";
 
     /// <summary>
-    ///     An interface admits one live connection and refuses the second immediately —
-    ///     refuse, never queue: waiting for an unbounded session to finish is worse than a clear error, and
-    ///     the caller usually has another transport. Releasing the holder makes the interface available again.
+    ///     A lease scope admits one live connection and refuses the second immediately — refuse, never queue:
+    ///     waiting for an unbounded session to finish is worse than a clear error. A grouped physical key's
+    ///     other transports belong to the same scope. Releasing the holder makes the scope available again.
     /// </summary>
     [Fact]
     public async Task AcquireConnection_ExclusiveInterface_SecondAcquisitionIsRefused()

--- a/src/Oath/tests/Yubico.YubiKit.Oath.IntegrationTests/OathHashAlgorithmTests.cs
+++ b/src/Oath/tests/Yubico.YubiKit.Oath.IntegrationTests/OathHashAlgorithmTests.cs
@@ -195,8 +195,8 @@ public class OathHashAlgorithmTests
         }, cancellationToken: NewToken());
 
         // A FRESH session is what observes the lock — the session that set the key is already
-        // authenticated and would report nothing useful. It is disposed above rather than held
-        // open alongside this one: two live sessions on one CCID interface are refused.
+        // authenticated and would report nothing useful. It is disposed above rather than held open
+        // alongside this one: each convenience session owns a connection, and the physical key admits one.
         await using var lockedSession = await state.Device
             .CreateOathSessionAsync(cancellationToken: NewToken());
 

--- a/src/Oath/tests/Yubico.YubiKit.Oath.IntegrationTests/OathPasswordChangeTests.cs
+++ b/src/Oath/tests/Yubico.YubiKit.Oath.IntegrationTests/OathPasswordChangeTests.cs
@@ -28,8 +28,9 @@ namespace Yubico.YubiKit.Oath.IntegrationTests;
 /// <remarks>
 ///     These tests observe lock state from a <em>fresh</em> session, which is the whole point — a
 ///     session that already holds the applet cannot tell you what a new caller would see. Each such
-///     session is therefore scoped and disposed before the next one opens: one live session per CCID
-///     interface is the contract, and overlapping them is refused with <c>ConnectionInUseException</c>.
+///     session is therefore scoped and disposed before the next one opens. Each convenience session owns a
+///     connection to the physical key, and overlapping connections are refused with
+///     <c>ConnectionInUseException</c>.
 /// </remarks>
 public class OathPasswordChangeTests
 {

--- a/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivHotplugContentionTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivHotplugContentionTests.cs
@@ -25,9 +25,9 @@ namespace Yubico.YubiKit.Piv.IntegrationTests;
 /// <remarks>
 ///     <para>
 ///         The risk this effort owns is not that the operation fails — of course it fails, the card is gone.
-///         It is that the CCID interface lease could be STRANDED. The lease is released in the connection's
+///         It is that the grouped physical-key lease could be STRANDED. The lease is released in the connection's
 ///         disposal path, and there is deliberately no finalizer backstop, so if removal made disposal hang
-///         or throw before the release, the interface would stay marked in-use for the process lifetime and
+///         or throw before the release, the physical key would stay marked in-use for the process lifetime and
 ///         every later open would be refused with <c>ConnectionInUseException</c> — on a key the user has
 ///         already plugged back in.
 ///     </para>
@@ -68,7 +68,7 @@ public class PivHotplugContentionTests
         }
         finally
         {
-            // Must complete even though the card vanished; this is what releases the interface lease.
+            // Must complete even though the card vanished; this is what releases the physical-key lease.
             await connection.DisposeAsync();
         }
 
@@ -78,7 +78,7 @@ public class PivHotplugContentionTests
             "Re-run and physically unplug the key while it is executing.");
 
         // The lease must be gone. A second open may fail because the device is absent, but it must never
-        // fail because this process still believes it holds the interface.
+        // fail because this process still believes it holds the physical key.
         var reopen = await Record.ExceptionAsync(async () =>
         {
             await using var second = await state.Device.ConnectAsync<ISmartCardConnection>();
@@ -86,7 +86,7 @@ public class PivHotplugContentionTests
 
         Assert.False(
             reopen is ConnectionInUseException,
-            "The CCID lease was stranded by hotplug removal: reopening reported the interface as still in " +
+            "The physical-key lease was stranded by hotplug removal: reopening reported the key as still in " +
             $"use by this process. Removal failure was: {removalFailure}");
     }
 

--- a/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivManagementKeyTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivManagementKeyTests.cs
@@ -62,10 +62,9 @@ public class PivManagementKeyTests
                 await session.SetManagementKeyAsync(newKeyType, newKey);
             }
 
-            // Successive, not nested: the mutating session above has released the CCID interface.
-            // The requirement is that the new key authenticates on a FRESH session, which is what
-            // a consumer would do. Two live PIV sessions on one interface are refused by design —
-            // they would share the card's security state.
+            // Successive, not nested: the mutating convenience session above has released its connection
+            // and the physical-key lease. The requirement is that the new key authenticates on a FRESH
+            // session, which is what a consumer would do. Overlapping convenience sessions are refused.
             await using var verification = await state.Device.CreatePivSessionAsync();
 
             // Old key should fail

--- a/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivSessionContentionTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivSessionContentionTests.cs
@@ -150,7 +150,7 @@ public class PivSessionContentionTests
 
         // A grouped connection claims every member in ordinal order, so the reported collision may be
         // any held member of the physical key rather than the SmartCard route requested by this call.
-        Assert.Matches("(?i)held interface: '(?:pcsc|hid):[^']+'", exception.Message);
+        Assert.Matches("held interface: '[^']+'", exception.Message);
         Assert.Contains("one live connection at a time across all interfaces", exception.Message,
             StringComparison.Ordinal);
 
@@ -161,10 +161,10 @@ public class PivSessionContentionTests
     }
 
     /// <summary>
-    ///     The documented migration path for the ownership change. "One session at a time per interface" is
-    ///     only acceptable because a caller who owns the connection can run successive applet sessions over
-    ///     it — dispose session A, construct session B on the same handle, no reconnect and no
-    ///     re-enumeration. Disposing a session must therefore NOT dispose a caller-created connection.
+    ///     The documented migration path for the ownership change. One live connection per physical key and
+    ///     one live session per connection remain practical because a caller-owned connection supports
+    ///     successive applet sessions — dispose session A, construct session B on the same handle, no reconnect
+    ///     and no re-enumeration. Disposing a session must therefore NOT dispose a caller-created connection.
     /// </summary>
     [SkippableTheory]
     [WithYubiKey(ConnectionType = ConnectionType.SmartCard)]

--- a/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivSessionContentionTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivSessionContentionTests.cs
@@ -148,9 +148,11 @@ public class PivSessionContentionTests
             await using var second = await state.Device.ConnectAsync<ISmartCardConnection>();
         });
 
-        // Interface-scope acquisition knows the concrete member interface, not which applet/session holds it.
-        // Pin the non-empty PC/SC identity rather than accepting the constant word "SmartCard" as evidence.
-        Assert.Matches("(?i)'pcsc:[^']+'", exception.Message);
+        // A grouped connection claims every member in ordinal order, so the reported collision may be
+        // any held member of the physical key rather than the SmartCard route requested by this call.
+        Assert.Matches("(?i)held interface: '(?:pcsc|hid):[^']+'", exception.Message);
+        Assert.Contains("one live connection at a time across all interfaces", exception.Message,
+            StringComparison.Ordinal);
 
         // The refusal must be non-destructive: the victim keeps its verified-PIN state.
         var digest = SHA256.HashData("refused acquisition"u8);

--- a/src/YubiOtp/tests/Yubico.YubiKit.YubiOtp.IntegrationTests/YubiOtpSlotConfigTests.cs
+++ b/src/YubiOtp/tests/Yubico.YubiKit.YubiOtp.IntegrationTests/YubiOtpSlotConfigTests.cs
@@ -35,7 +35,7 @@ public class YubiOtpSlotConfigTests
     {
         // The test creates the connection, so the test disposes it: YubiOtpSession.CreateAsync borrows a
         // caller-created connection and never closes it. Leaking it would hold the physical-device lease
-        // for the process lifetime and fail every later OTP HID open in this run.
+        // for the process lifetime and fail later opens through any known interface of this key.
         await using var connection = await state.Device.ConnectAsync<IOtpHidConnection>();
         await using var session = await YubiOtpSession.CreateAsync(connection);
 


### PR DESCRIPTION
## Summary

- update grouped-lease contention assertions to accept any held member of a physical YubiKey instead of pinning the requested transport
- require the one-YubiKey/one-connection diagnostic contract and a concrete held member ID
- align Core, FIDO HID, PIV, OATH, and YubiOTP test descriptions with device-wide ownership terminology

## Root cause

Some tests and comments predated device-wide connection leases and assumed that contention must identify the interface requested by the second caller. Grouped connections now claim all known member interfaces in ordinal order, so acquisition can first encounter any held member. For example, a SmartCard request can report a held `hid:` member. The runtime refusal is correct; the transport-specific assertions and per-interface descriptions were stale.

The audit found no stale functional assertion in Fido2 or WebAuthn. Their availability-based transport selection and no-fallback-on-failure tests match the current contract.

## Verification

- `dotnet toolchain.cs -- test --project Core` (866 passed, 3 expected skips)
- `dotnet toolchain.cs -- test --integration --project Piv --filter "FullyQualifiedName~ConnectAsync_SecondSmartCardConnection_WhilePivSessionOpen_IsRefused"` (hardware pass on connected YubiKeys 103 and 125)
- `dotnet toolchain.cs -- test --integration --project Piv --smoke` (167 unit tests and 76 hardware integration tests passed before the broader ownership-comment sweep)