### PR TITLE
ci: add generated documentation scheduler

### DIFF
--- a/.github/workflows/docs-scheduler-wrapper.yml
+++ b/.github/workflows/docs-scheduler-wrapper.yml
@@ -1,0 +1,21 @@
+name: Documentation Scheduler Wrapper
+
+on:
+  schedule:
+    - cron: '23 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: docs-yubikit
+  cancel-in-progress: false
+
+jobs:
+  update:
+    uses: Yubico/Yubico.NET.SDK/.github/workflows/docs-update.yml@yubikit
+    with:
+      migration_reconciliation: true
+    secrets: inherit


### PR DESCRIPTION
Adds the default-branch weekly scheduler wrapper required by GitHub Actions. It calls the reusable yubikit documentation workflow with full migration reconciliation enabled.

Depends on PR #573 being merged first.