### PR TITLE
fix(ci): allow downloaded documentation patches

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -283,7 +283,7 @@ jobs:
           done
           outside="$(git status --porcelain --untracked-files=all | while IFS= read -r line; do
             path="${line#???}"
-            case "$path" in docs/migration/*|docs/architecture/*) ;; *) printf '%s\n' "$path" ;; esac
+            case "$path" in docs/migration/*|docs/architecture/*|patches/*) ;; *) printf '%s\n' "$path" ;; esac
           done)"
           if [[ -n "$outside" ]]; then
             echo "Documentation patches contain paths outside docs/migration and docs/architecture:" >&2


### PR DESCRIPTION
Allows the final documentation PR job to retain its downloaded patch artifacts while enforcing that applied changes are limited to documentation directories.\n\nThis fixes the first live run of the consolidated workflow, which correctly applied both patches but then rejected the untracked artifact files.