### PR TITLE
fix(ci): ignore generated documentation pushes

### DIFF
--- a/.github/workflows/docs-update.yml
+++ b/.github/workflows/docs-update.yml
@@ -8,6 +8,10 @@ on:
         default: false
   push:
     branches: [ yubikit ]
+    # Generated documentation PRs modify only these paths and must not recurse on merge.
+    paths-ignore:
+      - docs/migration/**
+      - docs/architecture/**
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Ignore migration and architecture documentation-only pushes on yubikit.
- Prevent generated documentation PR merges from recursively starting Documentation Update.

## Validation

- docs-qa target passed.
- docs-architecture target passed.
- Workflow YAML parsed and the diff is whitespace-clean.