### PR TITLE
fix(fido2): tolerate unsupported COSE public keys (+ forward-compat audit)

### DIFF
--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/AuthenticatorData.cs
@@ -107,8 +107,17 @@ namespace Yubico.YubiKey.Fido2
         /// The Credential's public key. This is an optional value and can be null.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// When making a credential, this information will be provided, when
-        /// getting an assertion, it will not.
+        /// getting an assertion, it will not. This property is null if and only
+        /// if the authenticator data contained no attested credential data.
+        /// </para>
+        /// <para>
+        /// If the key uses a COSE algorithm this SDK does not model, this is a
+        /// <see cref="CoseUnsupportedPublicKey"/> carrying the original
+        /// encoding, rather than null. Callers that need to detect such a key
+        /// should test for that type rather than testing for null.
+        /// </para>
         /// </remarks>
         public CoseKey? CredentialPublicKey { get; private set; }
 
@@ -117,8 +126,8 @@ namespace Yubico.YubiKey.Fido2
         /// </summary>
         /// <remarks>
         /// This property is always populated when attested credential data is present,
-        /// regardless of whether the key was parsed into a <see cref="CoseKey"/> via
-        /// <see cref="CredentialPublicKey"/>.
+        /// regardless of whether the key was parsed into a modeled <see cref="CoseKey"/>
+        /// subclass via <see cref="CredentialPublicKey"/>.
         /// </remarks>
         public ReadOnlyMemory<byte>? EncodedCredentialPublicKey { get; private set; }
 
@@ -195,19 +204,10 @@ namespace Yubico.YubiKey.Fido2
                 // Always read the COSE key bytes to determine their length and store them
                 var coseKeyReader = new CborReader(EncodedAuthenticatorData[offset..], CborConformanceMode.Ctap2Canonical);
                 ReadOnlyMemory<byte> coseKeyBytes = coseKeyReader.ReadEncodedValue();
-                int bytesRead = coseKeyBytes.Length;
                 EncodedCredentialPublicKey = coseKeyBytes.ToArray();
+                CredentialPublicKey = CoseKey.CreateOrUnsupported(coseKeyBytes);
 
-                try
-                {
-                    CredentialPublicKey = CoseKey.Create(coseKeyBytes, out _);
-                }
-                catch (NotSupportedException)
-                {
-                    CredentialPublicKey = null;
-                }
-
-                offset += bytesRead;
+                offset += coseKeyBytes.Length;
             }
             // For some versions of the YubiKey, it is possible there is no
             // extensions data, yet the extensions bit is set. This generally

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementData.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Commands/CredentialManagementData.cs
@@ -160,8 +160,17 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// The public key for a credential returned.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// Not all calls to get credential management data will return this
         /// element, hence, it can be null.
+        /// </para>
+        /// <para>
+        /// If the response contained a public key using a COSE algorithm this
+        /// SDK does not model, this is a <see cref="CoseUnsupportedPublicKey"/>
+        /// carrying the original encoding, rather than null. Callers that need
+        /// to detect such a key should test for that type rather than testing
+        /// for null.
+        /// </para>
         /// </remarks>
         public CoseKey? CredentialPublicKey { get; private set; }
 
@@ -260,7 +269,7 @@ namespace Yubico.YubiKey.Fido2.Commands
                         break;
 
                     case KeyPublicKey:
-                        CredentialPublicKey = CoseKey.Create(cborReader.ReadEncodedValue(), out int _);
+                        CredentialPublicKey = CoseKey.CreateOrUnsupported(cborReader.ReadEncodedValue());
                         break;
 
                     case KeyTotalRpCredentials:

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseEcPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseEcPublicKey.cs
@@ -31,7 +31,7 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// </para>
     /// <para>
     /// The FIDO2 standard also specifies an encoding of the public key information. It uses the representation defined
-    /// in RFC8152: CBOR Object Signing and Encryption (COSE) standard. Supplementary information can be found in
+    /// in RFC 9052 and RFC 9053: CBOR Object Signing and Encryption (COSE). Supplementary information can be found in
     /// section 6.5.6 of the CTAP2.1 specification (under the heading `getPublicKey()`).
     /// </para>
     /// <para>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseEdDsaPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseEdDsaPublicKey.cs
@@ -28,7 +28,7 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// </para>
     /// <para>
     /// The FIDO2 standard also specifies an encoding of the public key information. It uses the representation defined
-    /// in RFC8152: CBOR Object Signing and Encryption (COSE) standard. Supplementary information can be found in
+    /// in RFC 9052 and RFC 9053: CBOR Object Signing and Encryption (COSE). Supplementary information can be found in
     /// section 6.5.6 of the CTAP2.1 specification (under the heading `getPublicKey()`).
     /// </para>
     /// </remarks>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
@@ -77,6 +77,22 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// <summary>
         /// Creates the correct COSE key representation based on the CBOR data provided.
         /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This is the strict entry point. Use it when you require a key this SDK
+        /// can fully model and want an exception otherwise — for example when
+        /// validating a key at a trust boundary before relying on it.
+        /// </para>
+        /// <para>
+        /// If the encoding came from an authenticator rather than from your own
+        /// code, and an algorithm this SDK does not model should not be fatal,
+        /// use <see cref="CreateOrUnsupported(ReadOnlyMemory{byte})"/> instead.
+        /// That returns a <see cref="CoseUnsupportedPublicKey"/> preserving the
+        /// original encoding rather than throwing. This applies both when
+        /// decoding a live response and when re-reading a key your application
+        /// persisted earlier.
+        /// </para>
+        /// </remarks>
         /// <param name="coseEncodedKey">
         /// A valid COSE key representation.
         /// </param>
@@ -98,6 +114,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// <exception cref="NotSupportedException">
         /// The <see cref="CoseAlgorithmIdentifier"/> is not supported by this object representation.
         /// </exception>
+        /// <seealso cref="CreateOrUnsupported(ReadOnlyMemory{byte})"/>
         public static CoseKey Create(ReadOnlyMemory<byte> coseEncodedKey, out int bytesRead)
         {
             var cborMap = new CborMap<int>(coseEncodedKey);
@@ -204,6 +221,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// length is not. Such a key is currently rejected rather than returned
         /// as a <see cref="CoseUnsupportedPublicKey"/>.
         /// </exception>
+        /// <seealso cref="Create"/>
         public static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey) =>
             CreateOrUnsupported(coseEncodedKey, out _);
 
@@ -248,6 +266,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// length is not. Such a key is currently rejected rather than returned
         /// as a <see cref="CoseUnsupportedPublicKey"/>.
         /// </exception>
+        /// <seealso cref="Create"/>
         public static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey, out int bytesRead)
         {
             // Build the map outside the try, so that the only

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
@@ -86,9 +86,6 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// <returns>
         /// A COSE key instance corresponding to the type described by the CBOR data.
         /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// The <paramref name="coseEncodedKey"/> parameter was null.
-        /// </exception>
         /// <exception cref="Ctap2DataException">
         /// <para>
         /// The CBOR reader is not in the correct position.
@@ -168,8 +165,16 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// instead. Both reject the input; only the reported reason differs.
         /// </para>
         /// <para>
-        /// Use this when decoding a response field where an unrecognized key
-        /// must not abort decoding of the surrounding data.
+        /// Use this in preference to <see cref="Create"/> whenever the encoding
+        /// came from an authenticator rather than from your own code. Two common
+        /// cases: decoding a response field where an unrecognized key must not
+        /// abort decoding of the surrounding data, and re-reading a key your
+        /// application persisted earlier, which may have been produced by an
+        /// extension whose algorithm this SDK does not model.
+        /// </para>
+        /// <para>
+        /// To decode the raw bytes of a <see cref="CoseUnsupportedPublicKey"/>,
+        /// read <see cref="CoseUnsupportedPublicKey.EncodedKey"/>.
         /// </para>
         /// </remarks>
         /// <param name="coseEncodedKey">
@@ -181,10 +186,69 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// not model the algorithm.
         /// </returns>
         /// <exception cref="Ctap2DataException">
-        /// The encoding is not a correct COSE key encoding, or it is missing the
-        /// key type or the algorithm.
+        /// The encoding is not a CBOR map, is missing the key type or the
+        /// algorithm, or pairs a modeled algorithm with the wrong key type.
         /// </exception>
-        internal static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey)
+        /// <exception cref="System.Formats.Cbor.CborContentException">
+        /// The encoding is not well-formed CBOR, or violates the CTAP2 canonical
+        /// encoding rules.
+        /// </exception>
+        /// <exception cref="InvalidCastException">
+        /// A field within the encoding is not of the expected CBOR type.
+        /// </exception>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">
+        /// A modeled key type is missing a field that type requires.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The algorithm is one this SDK models, but the curve or a coordinate
+        /// length is not. Such a key is currently rejected rather than returned
+        /// as a <see cref="CoseUnsupportedPublicKey"/>.
+        /// </exception>
+        public static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey) =>
+            CreateOrUnsupported(coseEncodedKey, out _);
+
+        /// <summary>
+        /// Creates the COSE key representation for <paramref name="coseEncodedKey"/>,
+        /// tolerating algorithms this SDK does not model, and reports how many
+        /// bytes were consumed.
+        /// </summary>
+        /// <remarks>
+        /// This behaves exactly as
+        /// <see cref="CreateOrUnsupported(ReadOnlyMemory{byte})"/>. Use this
+        /// overload when the COSE key is embedded in a larger buffer and you
+        /// need to know where it ends.
+        /// </remarks>
+        /// <param name="coseEncodedKey">
+        /// A valid COSE key representation, possibly followed by further data.
+        /// </param>
+        /// <param name="bytesRead">
+        /// The method will return the number of bytes read in this argument.
+        /// </param>
+        /// <returns>
+        /// A COSE key instance corresponding to the type described by the CBOR
+        /// data, or a <see cref="CoseUnsupportedPublicKey"/> if this SDK does
+        /// not model the algorithm.
+        /// </returns>
+        /// <exception cref="Ctap2DataException">
+        /// The encoding is not a CBOR map, is missing the key type or the
+        /// algorithm, or pairs a modeled algorithm with the wrong key type.
+        /// </exception>
+        /// <exception cref="System.Formats.Cbor.CborContentException">
+        /// The encoding is not well-formed CBOR, or violates the CTAP2 canonical
+        /// encoding rules.
+        /// </exception>
+        /// <exception cref="InvalidCastException">
+        /// A field within the encoding is not of the expected CBOR type.
+        /// </exception>
+        /// <exception cref="System.Collections.Generic.KeyNotFoundException">
+        /// A modeled key type is missing a field that type requires.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The algorithm is one this SDK models, but the curve or a coordinate
+        /// length is not. Such a key is currently rejected rather than returned
+        /// as a <see cref="CoseUnsupportedPublicKey"/>.
+        /// </exception>
+        public static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey, out int bytesRead)
         {
             // Build the map outside the try, so that the only
             // NotSupportedException the catch below can observe is the one the
@@ -195,6 +259,7 @@ namespace Yubico.YubiKey.Fido2.Cose
             // data rather than an unrecognized algorithm, and must not be
             // absorbed into an unsupported key if that ever changes.
             var cborMap = new CborMap<int>(coseEncodedKey);
+            bytesRead = cborMap.BytesRead;
 
             try
             {
@@ -221,7 +286,11 @@ namespace Yubico.YubiKey.Fido2.Cose
 
                 var keyType = (CoseKeyType)cborMap.ReadInt32(TagKeyType);
 
-                return new CoseUnsupportedPublicKey(coseEncodedKey, keyType, algorithm);
+                // Preserve the key alone. The caller's buffer may contain
+                // further data after it, which must not leak into EncodedKey or
+                // the result of Encode().
+                return new CoseUnsupportedPublicKey(
+                    coseEncodedKey.Slice(0, bytesRead), keyType, algorithm);
             }
         }
 

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
@@ -154,19 +154,20 @@ namespace Yubico.YubiKey.Fido2.Cose
 
         /// <summary>
         /// Creates the COSE key representation for <paramref name="coseEncodedKey"/>,
-        /// tolerating algorithms this SDK does not model.
+        /// tolerating algorithms this SDK does not implement in its typed decoder.
         /// </summary>
         /// <remarks>
         /// <para>
         /// This never returns null. When the algorithm is one this SDK models,
         /// the behavior is identical to <see cref="Create"/>. When the algorithm
-        /// is unrecognized, this returns a <see cref="CoseUnsupportedPublicKey"/>
+        /// is not implemented by the typed decoder, this returns a
+        /// <see cref="CoseUnsupportedPublicKey"/>
         /// carrying the original encoding plus the reported key type and
         /// algorithm, instead of throwing <see cref="NotSupportedException"/>.
         /// </para>
         /// <para>
         /// This still throws when the encoding is malformed, when the key type
-        /// or algorithm is missing, or when a recognized algorithm is paired
+        /// or algorithm is missing, or when a modeled algorithm is paired
         /// with the wrong key type. Those indicate corrupt data rather than a
         /// future algorithm, so they are not tolerated. Malformed CBOR fails
         /// here exactly as it does in <see cref="Create"/>, with the same
@@ -200,7 +201,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// <returns>
         /// A COSE key instance corresponding to the type described by the CBOR
         /// data, or a <see cref="CoseUnsupportedPublicKey"/> if this SDK does
-        /// not model the algorithm.
+        /// not implement the algorithm.
         /// </returns>
         /// <exception cref="Ctap2DataException">
         /// The encoding is not a CBOR map, is missing the key type or the
@@ -227,7 +228,7 @@ namespace Yubico.YubiKey.Fido2.Cose
 
         /// <summary>
         /// Creates the COSE key representation for <paramref name="coseEncodedKey"/>,
-        /// tolerating algorithms this SDK does not model, and reports how many
+        /// tolerating algorithms this SDK does not implement in its typed decoder, and reports how many
         /// bytes were consumed.
         /// </summary>
         /// <remarks>
@@ -245,7 +246,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// <returns>
         /// A COSE key instance corresponding to the type described by the CBOR
         /// data, or a <see cref="CoseUnsupportedPublicKey"/> if this SDK does
-        /// not model the algorithm.
+        /// not implement the algorithm in its typed decoder.
         /// </returns>
         /// <exception cref="Ctap2DataException">
         /// The encoding is not a CBOR map, is missing the key type or the

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseKey.cs
@@ -108,6 +108,11 @@ namespace Yubico.YubiKey.Fido2.Cose
             // Set out-parameter
             bytesRead = cborMap.BytesRead;
 
+            return CreateFromMap(cborMap, coseEncodedKey);
+        }
+
+        private static CoseKey CreateFromMap(CborMap<int> cborMap, ReadOnlyMemory<byte> coseEncodedKey)
+        {
             var algorithm = GetAlgorithm(cborMap);
             return algorithm switch
             {
@@ -131,6 +136,93 @@ namespace Yubico.YubiKey.Fido2.Cose
                 _ => throw new NotSupportedException(
                     string.Format(CultureInfo.CurrentCulture, ExceptionMessages.UnsupportedAlgorithm))
             };
+        }
+
+        /// <summary>
+        /// Creates the COSE key representation for <paramref name="coseEncodedKey"/>,
+        /// tolerating algorithms this SDK does not model.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// This never returns null. When the algorithm is one this SDK models,
+        /// the behavior is identical to <see cref="Create"/>. When the algorithm
+        /// is unrecognized, this returns a <see cref="CoseUnsupportedPublicKey"/>
+        /// carrying the original encoding plus the reported key type and
+        /// algorithm, instead of throwing <see cref="NotSupportedException"/>.
+        /// </para>
+        /// <para>
+        /// This still throws when the encoding is malformed, when the key type
+        /// or algorithm is missing, or when a recognized algorithm is paired
+        /// with the wrong key type. Those indicate corrupt data rather than a
+        /// future algorithm, so they are not tolerated. Malformed CBOR fails
+        /// here exactly as it does in <see cref="Create"/>, with the same
+        /// exception.
+        /// </para>
+        /// <para>
+        /// One case differs from <see cref="Create"/> by design. For an
+        /// algorithm this SDK does not model, <see cref="Create"/> never
+        /// inspects the key type, so it reports the unrecognized algorithm and
+        /// throws <see cref="NotSupportedException"/> whether or not a key type
+        /// is present. This method must read the key type in order to build the
+        /// result, so a missing one surfaces as <see cref="Ctap2DataException"/>
+        /// instead. Both reject the input; only the reported reason differs.
+        /// </para>
+        /// <para>
+        /// Use this when decoding a response field where an unrecognized key
+        /// must not abort decoding of the surrounding data.
+        /// </para>
+        /// </remarks>
+        /// <param name="coseEncodedKey">
+        /// A valid COSE key representation.
+        /// </param>
+        /// <returns>
+        /// A COSE key instance corresponding to the type described by the CBOR
+        /// data, or a <see cref="CoseUnsupportedPublicKey"/> if this SDK does
+        /// not model the algorithm.
+        /// </returns>
+        /// <exception cref="Ctap2DataException">
+        /// The encoding is not a correct COSE key encoding, or it is missing the
+        /// key type or the algorithm.
+        /// </exception>
+        internal static CoseKey CreateOrUnsupported(ReadOnlyMemory<byte> coseEncodedKey)
+        {
+            // Build the map outside the try, so that the only
+            // NotSupportedException the catch below can observe is the one the
+            // algorithm dispatch raises. CborMap also throws
+            // NotSupportedException for an indefinite-length map; that path is
+            // currently unreachable because the Ctap2Canonical reader rejects
+            // indefinite-length items first, but decoding failures are malformed
+            // data rather than an unrecognized algorithm, and must not be
+            // absorbed into an unsupported key if that ever changes.
+            var cborMap = new CborMap<int>(coseEncodedKey);
+
+            try
+            {
+                return CreateFromMap(cborMap, coseEncodedKey);
+            }
+            catch (NotSupportedException)
+            {
+                // Reaching here means CreateFromMap dispatched on an algorithm
+                // this SDK does not model, so GetAlgorithm already ran and the
+                // algorithm is present.
+                var algorithm = (CoseAlgorithmIdentifier)cborMap.ReadInt32(TagAlgorithm);
+
+                // The key type is not read on the unsupported algorithm path,
+                // because IsKeyType only runs for algorithms the SDK models.
+                // COSE requires it in every key, so a missing one is malformed;
+                // reject it here the same way IsKeyType would.
+                if (!cborMap.Contains(TagKeyType))
+                {
+                    throw new Ctap2DataException(
+                        string.Format(
+                            CultureInfo.CurrentCulture,
+                            ExceptionMessages.Ctap2MissingRequiredField));
+                }
+
+                var keyType = (CoseKeyType)cborMap.ReadInt32(TagKeyType);
+
+                return new CoseUnsupportedPublicKey(coseEncodedKey, keyType, algorithm);
+            }
         }
 
         private static CoseAlgorithmIdentifier GetAlgorithm(CborMap<int> map)

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
@@ -42,8 +42,11 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// than against named members.
     /// </para>
     /// <para>
-    /// Instances of this class are created only by the SDK while decoding a
-    /// response from a YubiKey; it cannot be constructed by callers.
+    /// This class has no public constructor. Instances are produced by the SDK
+    /// while decoding a response from a YubiKey, and by
+    /// <see cref="CoseKey.CreateOrUnsupported(System.ReadOnlyMemory{byte})"/>,
+    /// which callers can use to decode an encoding they hold themselves — for
+    /// example one their application persisted after an earlier registration.
     /// </para>
     /// <para>
     /// <see cref="EncodedKey"/> is fixed at construction. The inherited
@@ -57,9 +60,15 @@ namespace Yubico.YubiKey.Fido2.Cose
     public sealed class CoseUnsupportedPublicKey : CoseKey
     {
         /// <summary>
-        /// The original COSE encoding of the key, exactly as the YubiKey
-        /// returned it.
+        /// The original COSE encoding this key was decoded from, byte for byte.
         /// </summary>
+        /// <remarks>
+        /// When the key came from a YubiKey response this is exactly what the
+        /// YubiKey returned. When it came from
+        /// <see cref="CoseKey.CreateOrUnsupported(System.ReadOnlyMemory{byte})"/>
+        /// it is exactly the encoding the caller supplied, excluding any trailing
+        /// data that followed the key in the caller's buffer.
+        /// </remarks>
         public ReadOnlyMemory<byte> EncodedKey { get; }
 
         /// <summary>
@@ -95,7 +104,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// Because the SDK does not model this key's algorithm, it cannot
         /// re-encode the key from decoded components. This method returns a copy
         /// of <see cref="EncodedKey"/>, so the result is byte-for-byte identical
-        /// to what the YubiKey returned.
+        /// to the encoding this key was decoded from.
         /// </remarks>
         /// <returns>
         /// The encoded key.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
@@ -1,0 +1,105 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Yubico.YubiKey.Fido2.Cose
+{
+    /// <summary>
+    /// A COSE public key whose algorithm this SDK does not model, preserved in
+    /// its original encoded form.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The SDK returns an instance of this class when a YubiKey reports a public
+    /// key using a COSE algorithm that has no strongly-typed representation in
+    /// this version of the SDK. Rather than failing, the SDK preserves the
+    /// original encoding in <see cref="EncodedKey"/> along with the key type and
+    /// algorithm the YubiKey reported, so callers that understand the algorithm
+    /// can decode it themselves.
+    /// </para>
+    /// <para>
+    /// An example is the ARKG-P256 seed public key produced by the experimental
+    /// <c>previewSign</c> extension, which uses a COSE key type and algorithm
+    /// outside the set the SDK models.
+    /// </para>
+    /// <para>
+    /// Because the algorithm is not modeled, <see cref="CoseKey.Type"/> and
+    /// <see cref="CoseKey.Algorithm"/> will generally hold values that are not
+    /// defined members of <see cref="CoseKeyType"/> or
+    /// <see cref="CoseAlgorithmIdentifier"/>. Compare them numerically rather
+    /// than against named members.
+    /// </para>
+        /// <para>
+        /// Instances of this class are created only by the SDK while decoding a
+        /// response from a YubiKey; it cannot be constructed by callers.
+        /// </para>
+        /// <para>
+        /// <see cref="EncodedKey"/> is fixed at construction. The inherited
+        /// <see cref="CoseKey.Type"/> and <see cref="CoseKey.Algorithm"/>
+        /// properties are settable, but changing them does not alter
+        /// <see cref="EncodedKey"/> or the result of <see cref="Encode"/>, and
+        /// will make the reported metadata disagree with the encoded key. Treat
+        /// them as read-only.
+        /// </para>
+        /// </remarks>
+    public sealed class CoseUnsupportedPublicKey : CoseKey
+    {
+        /// <summary>
+        /// The original COSE encoding of the key, exactly as the YubiKey
+        /// returned it.
+        /// </summary>
+        public ReadOnlyMemory<byte> EncodedKey { get; }
+
+        /// <summary>
+        /// Build a new instance from the given encoded key and the key type and
+        /// algorithm reported within it.
+        /// </summary>
+        /// <param name="encodedKey">
+        /// The COSE encoding of the key. The data is copied.
+        /// </param>
+        /// <param name="type">
+        /// The key type (COSE label 1) reported by the encoding. COSE requires
+        /// this label, so callers reject an encoding that omits it rather than
+        /// passing a placeholder.
+        /// </param>
+        /// <param name="algorithm">
+        /// The algorithm (COSE label 3) reported by the encoding.
+        /// </param>
+        internal CoseUnsupportedPublicKey(
+            ReadOnlyMemory<byte> encodedKey,
+            CoseKeyType type,
+            CoseAlgorithmIdentifier algorithm)
+        {
+            EncodedKey = encodedKey.ToArray();
+            Type = type;
+            Algorithm = algorithm;
+        }
+
+        /// <summary>
+        /// Return a new byte array containing the original COSE encoding of the
+        /// key.
+        /// </summary>
+        /// <remarks>
+        /// Because the SDK does not model this key's algorithm, it cannot
+        /// re-encode the key from decoded components. This method returns a copy
+        /// of <see cref="EncodedKey"/>, so the result is byte-for-byte identical
+        /// to what the YubiKey returned.
+        /// </remarks>
+        /// <returns>
+        /// The encoded key.
+        /// </returns>
+        public override byte[] Encode() => EncodedKey.ToArray();
+    }
+}

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
@@ -17,17 +17,17 @@ using System;
 namespace Yubico.YubiKey.Fido2.Cose
 {
     /// <summary>
-    /// A COSE public key whose algorithm this SDK does not model, preserved in
-    /// its original encoded form.
+    /// A COSE public key whose algorithm this SDK cannot decode into a strongly
+    /// typed key representation, preserved in its original encoded form.
     /// </summary>
     /// <remarks>
     /// <para>
     /// The SDK returns an instance of this class when a YubiKey reports a public
-    /// key using a COSE algorithm that has no strongly-typed representation in
-    /// this version of the SDK. Rather than failing, the SDK preserves the
-    /// original encoding in <see cref="EncodedKey"/> along with the key type and
-    /// algorithm the YubiKey reported, so callers that understand the algorithm
-    /// can decode it themselves.
+    /// key using an algorithm that its strongly typed COSE key decoder does not
+    /// implement. Rather than failing, the SDK preserves the original encoding
+    /// in <see cref="EncodedKey"/> along with the key type and algorithm the
+    /// YubiKey reported, so callers that understand the representation can
+    /// decode it themselves.
     /// </para>
     /// <para>
     /// This typically arises with a credential created by an extension that
@@ -35,11 +35,13 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// version of the SDK was released.
     /// </para>
     /// <para>
-    /// Because the algorithm is not modeled, <see cref="CoseKey.Type"/> and
-    /// <see cref="CoseKey.Algorithm"/> will generally hold values that are not
-    /// defined members of <see cref="CoseKeyType"/> or
-    /// <see cref="CoseAlgorithmIdentifier"/>. Compare them numerically rather
-    /// than against named members.
+    /// <see cref="CoseKey.Type"/> and <see cref="CoseKey.Algorithm"/> preserve
+    /// the values from the encoding. Either value may still be a named member
+    /// of <see cref="CoseKeyType"/> or <see cref="CoseAlgorithmIdentifier"/>;
+    /// do not assume that both values are unrecognized merely because the full
+    /// algorithm is not implemented by the typed decoder.
+    /// Check whether a decoded key is an instance of this class rather than inferring support from
+    /// whether the reported enum values are named.
     /// </para>
     /// <para>
     /// This class has no public constructor. Instances are produced by the SDK
@@ -101,10 +103,10 @@ namespace Yubico.YubiKey.Fido2.Cose
         /// key.
         /// </summary>
         /// <remarks>
-        /// Because the SDK does not model this key's algorithm, it cannot
-        /// re-encode the key from decoded components. This method returns a copy
-        /// of <see cref="EncodedKey"/>, so the result is byte-for-byte identical
-        /// to the encoding this key was decoded from.
+        /// Because the SDK does not implement this key's algorithm, it cannot
+        /// re-encode the key from decoded components. This method returns a
+        /// copy of <see cref="EncodedKey"/>, so the result is byte-for-byte
+        /// identical to the encoding this key was decoded from.
         /// </remarks>
         /// <returns>
         /// The encoded key.

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/Cose/CoseUnsupportedPublicKey.cs
@@ -30,9 +30,9 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// can decode it themselves.
     /// </para>
     /// <para>
-    /// An example is the ARKG-P256 seed public key produced by the experimental
-    /// <c>previewSign</c> extension, which uses a COSE key type and algorithm
-    /// outside the set the SDK models.
+    /// This typically arises with a credential created by an extension that
+    /// introduces its own key type, or with an algorithm registered after this
+    /// version of the SDK was released.
     /// </para>
     /// <para>
     /// Because the algorithm is not modeled, <see cref="CoseKey.Type"/> and
@@ -41,19 +41,19 @@ namespace Yubico.YubiKey.Fido2.Cose
     /// <see cref="CoseAlgorithmIdentifier"/>. Compare them numerically rather
     /// than against named members.
     /// </para>
-        /// <para>
-        /// Instances of this class are created only by the SDK while decoding a
-        /// response from a YubiKey; it cannot be constructed by callers.
-        /// </para>
-        /// <para>
-        /// <see cref="EncodedKey"/> is fixed at construction. The inherited
-        /// <see cref="CoseKey.Type"/> and <see cref="CoseKey.Algorithm"/>
-        /// properties are settable, but changing them does not alter
-        /// <see cref="EncodedKey"/> or the result of <see cref="Encode"/>, and
-        /// will make the reported metadata disagree with the encoded key. Treat
-        /// them as read-only.
-        /// </para>
-        /// </remarks>
+    /// <para>
+    /// Instances of this class are created only by the SDK while decoding a
+    /// response from a YubiKey; it cannot be constructed by callers.
+    /// </para>
+    /// <para>
+    /// <see cref="EncodedKey"/> is fixed at construction. The inherited
+    /// <see cref="CoseKey.Type"/> and <see cref="CoseKey.Algorithm"/>
+    /// properties are settable, but changing them does not alter
+    /// <see cref="EncodedKey"/> or the result of <see cref="Encode"/>, and
+    /// will make the reported metadata disagree with the encoded key. Treat
+    /// them as read-only.
+    /// </para>
+    /// </remarks>
     public sealed class CoseUnsupportedPublicKey : CoseKey
     {
         /// <summary>

--- a/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialUserInfo.cs
+++ b/Yubico.YubiKey/src/Yubico/YubiKey/Fido2/CredentialUserInfo.cs
@@ -55,6 +55,12 @@ namespace Yubico.YubiKey.Fido2
         /// <summary>
         /// The public key for a credential returned.
         /// </summary>
+        /// <remarks>
+        /// If the credential's public key uses a COSE algorithm this SDK does
+        /// not model, this is a <see cref="CoseUnsupportedPublicKey"/> carrying
+        /// the original encoding. Enumeration does not fail in that case, so
+        /// callers can still read the other properties of every credential.
+        /// </remarks>
         public CoseKey CredentialPublicKey { get; private set; }
 
         /// <summary>
@@ -191,7 +197,7 @@ namespace Yubico.YubiKey.Fido2
             {
                 var user = new UserEntity(credentialManagementData.ReadEncodedValue(KeyUser), out int _);
                 var credentialId = new CredentialId(credentialManagementData.ReadEncodedValue(KeyCredentialId), out int _);
-                var credentialPublicKey = CoseKey.Create(credentialManagementData.ReadEncodedValue(KeyPublicKey), out int _);
+                var credentialPublicKey = CoseKey.CreateOrUnsupported(credentialManagementData.ReadEncodedValue(KeyPublicKey));
                 int credProtectPolicy = credentialManagementData.ReadInt32(KeyCredProtectPolicy);
                 ReadOnlyMemory<byte>? largeBlobKey = credentialManagementData.Contains(KeyLargeBlobKey)
                     ? credentialManagementData.ReadByteString(KeyLargeBlobKey)

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/AttestationObjectTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/AttestationObjectTests.cs
@@ -146,7 +146,9 @@ namespace Yubico.YubiKey.Fido2
 
             var obj = new AttestationObject(encoding);
 
-            Assert.Null(obj.AuthenticatorData.CredentialPublicKey);
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(
+                obj.AuthenticatorData.CredentialPublicKey);
+            Assert.Equal(coseKey, unsupported.EncodedKey.ToArray());
             Assert.Equal(coseKey, obj.AuthenticatorData.EncodedCredentialPublicKey!.Value.ToArray());
         }
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtDataTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtDataTests.cs
@@ -448,6 +448,73 @@ namespace Yubico.YubiKey.Fido2.Commands
             Assert.Throws<Ctap2DataException>(() => CredentialUserInfo.FromCredentialManagementData(map));
         }
 
+        [Fact]
+        public void CredMgm_Decode_UnsupportedPublicKey_PreservesRawKey()
+        {
+            byte[] publicKey = CredMgmtTestData.BuildUnsupportedCoseKey();
+            byte[] encodedData = CredMgmtTestData.BuildCredentialUserInfo(publicKey);
+
+            var mgmtData = new CredentialManagementData(encodedData);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(mgmtData.CredentialPublicKey);
+            Assert.Equal(publicKey, unsupported.EncodedKey.ToArray());
+            Assert.NotNull(mgmtData.CredentialId);
+            Assert.NotNull(mgmtData.User);
+        }
+
+        [Fact]
+        public void CredentialUserInfo_FromCredentialManagementData_UnsupportedPublicKey_PreservesRawKey()
+        {
+            byte[] publicKey = CredMgmtTestData.BuildUnsupportedCoseKey();
+            byte[] encodedData = CredMgmtTestData.BuildCredentialUserInfo(publicKey);
+            var map = new CborMap<int>(encodedData);
+
+            var userInfo = CredentialUserInfo.FromCredentialManagementData(map);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(userInfo.CredentialPublicKey);
+            Assert.Equal(publicKey, unsupported.EncodedKey.ToArray());
+        }
+
+        [Fact]
+        public void CredentialUserInfo_FromCredentialManagementData_UnsupportedPublicKey_StillDecodesOtherFields()
+        {
+            byte[] encodedData = CredMgmtTestData.BuildCredentialUserInfo(
+                CredMgmtTestData.BuildUnsupportedCoseKey());
+            var map = new CborMap<int>(encodedData);
+
+            var userInfo = CredentialUserInfo.FromCredentialManagementData(map);
+
+            Assert.Equal(CredMgmtTestData.CredentialIdBytes, userInfo.CredentialId.Id.ToArray());
+            Assert.Equal(CredMgmtTestData.UserIdBytes, userInfo.User.Id.ToArray());
+            Assert.Equal(CredMgmtTestData.UserName, userInfo.User.Name);
+            Assert.Equal(CredProtectPolicy.UserVerificationOptional, userInfo.CredProtectPolicy);
+        }
+
+        [Fact]
+        public void CredentialUserInfo_FromCredentialManagementData_SupportedPublicKey_ReturnsModeledKey()
+        {
+            byte[] encodedData = CredMgmtTestData.BuildCredentialUserInfo(
+                CredMgmtTestData.BuildEs256CoseKey());
+            var map = new CborMap<int>(encodedData);
+
+            var userInfo = CredentialUserInfo.FromCredentialManagementData(map);
+
+            var ecKey = Assert.IsType<CoseEcPublicKey>(userInfo.CredentialPublicKey);
+            Assert.Equal(CoseAlgorithmIdentifier.ES256, ecKey.Algorithm);
+        }
+
+        [Fact]
+        public void CredentialUserInfo_FromCredentialManagementData_MismatchedPublicKey_ThrowsCtap2DataException()
+        {
+            // A modeled algorithm paired with the wrong key type is corrupt data
+            // and must still fail rather than degrade to an unsupported key.
+            byte[] encodedData = CredMgmtTestData.BuildCredentialUserInfo(
+                CredMgmtTestData.BuildMismatchedEs256OkpCoseKey());
+            var map = new CborMap<int>(encodedData);
+
+            _ = Assert.Throws<Ctap2DataException>(() => CredentialUserInfo.FromCredentialManagementData(map));
+        }
+
         private CredentialManagementData GetFullCredMgmtData(out Dictionary<int, object> expectedValues)
         {
             expectedValues = new Dictionary<int, object>(20);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
@@ -25,16 +25,21 @@ namespace Yubico.YubiKey.Fido2.Commands
     internal static class CredMgmtTestData
     {
         /// <summary>
-        /// The COSE key type reported by an ARKG-pub key, as used by the
-        /// experimental previewSign extension. Not a value this SDK models.
+        /// A COSE key type this SDK does not model.
         /// </summary>
-        public const int ArkgPubKeyType = -65537;
+        /// <remarks>
+        /// Taken from a real extension-defined key type rather than invented, so
+        /// the fixtures exercise a shape a YubiKey can actually return. The
+        /// specific value does not matter to these tests; what matters is that
+        /// it is outside the set the SDK models.
+        /// </remarks>
+        public const int UnmodeledKeyType = -65537;
 
         /// <summary>
-        /// The COSE algorithm reported by an ARKG-P256 key, as used by the
-        /// experimental previewSign extension. Not a value this SDK models.
+        /// A COSE algorithm this SDK does not model. See
+        /// <see cref="UnmodeledKeyType"/> for why these values were chosen.
         /// </summary>
-        public const int ArkgP256Algorithm = -65700;
+        public const int UnmodeledAlgorithm = -65700;
 
         public static readonly byte[] UserIdBytes = { 0x75, 0x73, 0x65, 0x72, 0x49, 0x64 };
         public static readonly byte[] CredentialIdBytes = { 0x31, 0x32, 0x33, 0x34 };
@@ -80,17 +85,19 @@ namespace Yubico.YubiKey.Fido2.Commands
             BuildEc2Key((int)CoseKeyType.Ec2, -70000);
 
         /// <summary>
-        /// An ARKG-P256 seed key, matching the shape produced by the
-        /// experimental previewSign extension.
+        /// A key whose type and algorithm are both outside the set this SDK
+        /// models, and whose value is itself structured (two nested EC2 points).
+        /// Mirrors the shape of a real extension-defined key rather than a
+        /// trivially malformed one.
         /// </summary>
-        public static byte[] BuildArkgSeedCoseKey()
+        public static byte[] BuildUnmodeledStructuredCoseKey()
         {
             var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
             cbor.WriteStartMap(4);
             cbor.WriteInt32(1);
-            cbor.WriteInt32(ArkgPubKeyType);
+            cbor.WriteInt32(UnmodeledKeyType);
             cbor.WriteInt32(3);
-            cbor.WriteInt32(ArkgP256Algorithm);
+            cbor.WriteInt32(UnmodeledAlgorithm);
             cbor.WriteInt32(-1);
             cbor.WriteEncodedValue(BuildEc2Key((int)CoseKeyType.Ec2, (int)CoseAlgorithmIdentifier.ES256, 0x44));
             cbor.WriteInt32(-2);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
@@ -1,0 +1,155 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Formats.Cbor;
+using System.Linq;
+using Yubico.YubiKey.Fido2.Cose;
+
+namespace Yubico.YubiKey.Fido2.Commands
+{
+    /// <summary>
+    /// Builders for <c>authenticatorCredentialManagement</c> response encodings
+    /// used by credential-management decoding tests.
+    /// </summary>
+    internal static class CredMgmtTestData
+    {
+        /// <summary>
+        /// The COSE key type reported by an ARKG-pub key, as used by the
+        /// experimental previewSign extension. Not a value this SDK models.
+        /// </summary>
+        public const int ArkgPubKeyType = -65537;
+
+        /// <summary>
+        /// The COSE algorithm reported by an ARKG-P256 key, as used by the
+        /// experimental previewSign extension. Not a value this SDK models.
+        /// </summary>
+        public const int ArkgP256Algorithm = -65700;
+
+        public static readonly byte[] UserIdBytes = { 0x75, 0x73, 0x65, 0x72, 0x49, 0x64 };
+        public static readonly byte[] CredentialIdBytes = { 0x31, 0x32, 0x33, 0x34 };
+        public const string UserName = "userName";
+        public const string UserDisplayName = "User Name";
+
+        /// <summary>
+        /// Builds a credential-management response containing a single
+        /// credential: user (0x06), credential ID (0x07), public key (0x08),
+        /// total credentials (0x09) and credProtect (0x0A).
+        /// </summary>
+        public static byte[] BuildCredentialUserInfo(
+            byte[] encodedPublicKey,
+            int totalCredentials = 1,
+            int credProtectPolicy = 1)
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(5);
+
+            cbor.WriteInt32(6);
+            WriteUserEntity(cbor);
+
+            cbor.WriteInt32(7);
+            WriteCredentialId(cbor);
+
+            cbor.WriteInt32(8);
+            cbor.WriteEncodedValue(encodedPublicKey);
+
+            cbor.WriteInt32(9);
+            cbor.WriteInt32(totalCredentials);
+
+            cbor.WriteInt32(10);
+            cbor.WriteInt32(credProtectPolicy);
+
+            cbor.WriteEndMap();
+            return cbor.Encode();
+        }
+
+        /// <summary>
+        /// An EC2 P-256 key using an algorithm this SDK does not model.
+        /// </summary>
+        public static byte[] BuildUnsupportedCoseKey() =>
+            BuildEc2Key((int)CoseKeyType.Ec2, -70000);
+
+        /// <summary>
+        /// An ARKG-P256 seed key, matching the shape produced by the
+        /// experimental previewSign extension.
+        /// </summary>
+        public static byte[] BuildArkgSeedCoseKey()
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(4);
+            cbor.WriteInt32(1);
+            cbor.WriteInt32(ArkgPubKeyType);
+            cbor.WriteInt32(3);
+            cbor.WriteInt32(ArkgP256Algorithm);
+            cbor.WriteInt32(-1);
+            cbor.WriteEncodedValue(BuildEc2Key((int)CoseKeyType.Ec2, (int)CoseAlgorithmIdentifier.ES256, 0x44));
+            cbor.WriteInt32(-2);
+            cbor.WriteEncodedValue(BuildEc2Key((int)CoseKeyType.Ec2, (int)CoseAlgorithmIdentifier.ES256, 0x55));
+            cbor.WriteEndMap();
+            return cbor.Encode();
+        }
+
+        /// <summary>
+        /// A well-formed ES256 EC2 key.
+        /// </summary>
+        public static byte[] BuildEs256CoseKey() =>
+            BuildEc2Key((int)CoseKeyType.Ec2, (int)CoseAlgorithmIdentifier.ES256);
+
+        /// <summary>
+        /// A modeled algorithm paired with the wrong key type. This is corrupt
+        /// data, not a future algorithm.
+        /// </summary>
+        public static byte[] BuildMismatchedEs256OkpCoseKey() =>
+            BuildEc2Key((int)CoseKeyType.Okp, (int)CoseAlgorithmIdentifier.ES256);
+
+        private static byte[] BuildEc2Key(int keyType, int algorithm, byte fill = 0x11)
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(5);
+            cbor.WriteInt32(1);
+            cbor.WriteInt32(keyType);
+            cbor.WriteInt32(3);
+            cbor.WriteInt32(algorithm);
+            cbor.WriteInt32(-1);
+            cbor.WriteInt32((int)CoseEcCurve.P256);
+            cbor.WriteInt32(-2);
+            cbor.WriteByteString(Enumerable.Repeat(fill, 32).ToArray());
+            cbor.WriteInt32(-3);
+            cbor.WriteByteString(Enumerable.Repeat((byte)(fill + 1), 32).ToArray());
+            cbor.WriteEndMap();
+            return cbor.Encode();
+        }
+
+        private static void WriteUserEntity(CborWriter cbor)
+        {
+            cbor.WriteStartMap(3);
+            cbor.WriteTextString("id");
+            cbor.WriteByteString(UserIdBytes);
+            cbor.WriteTextString("name");
+            cbor.WriteTextString(UserName);
+            cbor.WriteTextString("displayName");
+            cbor.WriteTextString(UserDisplayName);
+            cbor.WriteEndMap();
+        }
+
+        private static void WriteCredentialId(CborWriter cbor)
+        {
+            cbor.WriteStartMap(2);
+            cbor.WriteTextString("id");
+            cbor.WriteByteString(CredentialIdBytes);
+            cbor.WriteTextString("type");
+            cbor.WriteTextString("public-key");
+            cbor.WriteEndMap();
+        }
+    }
+}

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/CredMgmtTestData.cs
@@ -28,16 +28,14 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// A COSE key type this SDK does not model.
         /// </summary>
         /// <remarks>
-        /// Taken from a real extension-defined key type rather than invented, so
-        /// the fixtures exercise a shape a YubiKey can actually return. The
-        /// specific value does not matter to these tests; what matters is that
-        /// it is outside the set the SDK models.
+        /// Exercises an extension-defined value outside the set this SDK
+        /// models. Its exact numeric value is not significant to these tests.
         /// </remarks>
         public const int UnmodeledKeyType = -65537;
 
         /// <summary>
-        /// A COSE algorithm this SDK does not model. See
-        /// <see cref="UnmodeledKeyType"/> for why these values were chosen.
+        /// A COSE algorithm this SDK does not model. Its exact numeric value is
+        /// not significant to these tests.
         /// </summary>
         public const int UnmodeledAlgorithm = -65700;
 
@@ -87,8 +85,8 @@ namespace Yubico.YubiKey.Fido2.Commands
         /// <summary>
         /// A key whose type and algorithm are both outside the set this SDK
         /// models, and whose value is itself structured (two nested EC2 points).
-        /// Mirrors the shape of a real extension-defined key rather than a
-        /// trivially malformed one.
+        /// Exercises a valid structured representation rather than a trivially
+        /// malformed value.
         /// </summary>
         public static byte[] BuildUnmodeledStructuredCoseKey()
         {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
@@ -1,0 +1,133 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using Xunit;
+using Yubico.Core.Iso7816;
+using Yubico.YubiKey.Fido2.Cose;
+
+namespace Yubico.YubiKey.Fido2.Commands
+{
+    public class EnumerateCredentialsResponseTests
+    {
+        [Fact]
+        public void BeginResponse_GetData_SupportedPublicKey_ReturnsModeledKey()
+        {
+            var response = new EnumerateCredentialsBeginResponse(
+                BuildApdu(CredMgmtTestData.BuildEs256CoseKey(), totalCredentials: 3));
+
+            (int credentialCount, CredentialUserInfo userInfo) = response.GetData();
+
+            Assert.Equal(3, credentialCount);
+            _ = Assert.IsType<CoseEcPublicKey>(userInfo.CredentialPublicKey);
+        }
+
+        [Fact]
+        public void BeginResponse_GetData_UnsupportedPublicKey_ReturnsCredentialWithRawKey()
+        {
+            byte[] publicKey = CredMgmtTestData.BuildArkgSeedCoseKey();
+            var response = new EnumerateCredentialsBeginResponse(
+                BuildApdu(publicKey, totalCredentials: 2));
+
+            (int credentialCount, CredentialUserInfo userInfo) = response.GetData();
+
+            Assert.Equal(2, credentialCount);
+            Assert.Equal(CredMgmtTestData.CredentialIdBytes, userInfo.CredentialId.Id.ToArray());
+            Assert.Equal(CredMgmtTestData.UserIdBytes, userInfo.User.Id.ToArray());
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(userInfo.CredentialPublicKey);
+            Assert.Equal(publicKey, unsupported.EncodedKey.ToArray());
+            Assert.Equal(CredMgmtTestData.ArkgPubKeyType, (int)unsupported.Type);
+            Assert.Equal(CredMgmtTestData.ArkgP256Algorithm, (int)unsupported.Algorithm);
+        }
+
+        [Fact]
+        public void GetNextResponse_GetData_SupportedPublicKey_ReturnsModeledKey()
+        {
+            var response = new EnumerateCredentialsGetNextResponse(
+                BuildApdu(CredMgmtTestData.BuildEs256CoseKey()));
+
+            CredentialUserInfo userInfo = response.GetData();
+
+            _ = Assert.IsType<CoseEcPublicKey>(userInfo.CredentialPublicKey);
+        }
+
+        [Fact]
+        public void GetNextResponse_GetData_UnsupportedPublicKey_ReturnsCredentialWithRawKey()
+        {
+            byte[] publicKey = CredMgmtTestData.BuildArkgSeedCoseKey();
+            var response = new EnumerateCredentialsGetNextResponse(BuildApdu(publicKey));
+
+            CredentialUserInfo userInfo = response.GetData();
+
+            Assert.Equal(CredMgmtTestData.CredentialIdBytes, userInfo.CredentialId.Id.ToArray());
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(userInfo.CredentialPublicKey);
+            Assert.Equal(publicKey, unsupported.EncodedKey.ToArray());
+        }
+
+        /// <summary>
+        /// This is the reported bug. Enumerating a relying party issues one
+        /// Begin response followed by one GetNext response per remaining
+        /// credential, and a single credential whose public key this SDK does
+        /// not model previously aborted the whole enumeration.
+        /// </summary>
+        /// <remarks>
+        /// This mirrors the response-decoding loop in
+        /// <c>Fido2Session.EnumerateCredentialsForRelyingParty</c>, driving the
+        /// GetNext count off the credential count returned by Begin. It stops at
+        /// the response boundary: exercising the session method itself would
+        /// require a mocked key-agreement exchange and a PIN/UV auth token
+        /// encrypted under the negotiated shared secret, for which the unit test
+        /// project currently has no harness.
+        /// </remarks>
+        [Fact]
+        public void EnumerateSequence_MiddleCredentialUnsupported_AllCredentialsReadable()
+        {
+            var getNextResponses = new Queue<EnumerateCredentialsGetNextResponse>(
+                new[]
+                {
+                    new EnumerateCredentialsGetNextResponse(BuildApdu(CredMgmtTestData.BuildArkgSeedCoseKey())),
+                    new EnumerateCredentialsGetNextResponse(BuildApdu(CredMgmtTestData.BuildEs256CoseKey())),
+                });
+
+            var beginResponse = new EnumerateCredentialsBeginResponse(
+                BuildApdu(CredMgmtTestData.BuildEs256CoseKey(), totalCredentials: 3));
+
+            (int credentialCount, CredentialUserInfo firstInfo) = beginResponse.GetData();
+            var credentials = new List<CredentialUserInfo>(credentialCount) { firstInfo };
+
+            for (int index = 1; index < credentialCount; index++)
+            {
+                credentials.Add(getNextResponses.Dequeue().GetData());
+            }
+
+            Assert.Equal(3, credentials.Count);
+            _ = Assert.IsType<CoseEcPublicKey>(credentials[0].CredentialPublicKey);
+            _ = Assert.IsType<CoseUnsupportedPublicKey>(credentials[1].CredentialPublicKey);
+            _ = Assert.IsType<CoseEcPublicKey>(credentials[2].CredentialPublicKey);
+
+            Assert.All(
+                credentials,
+                credential => Assert.Equal(
+                    CredMgmtTestData.CredentialIdBytes,
+                    credential.CredentialId.Id.ToArray()));
+        }
+
+        private static ResponseApdu BuildApdu(byte[] encodedPublicKey, int totalCredentials = 1) =>
+            new ResponseApdu(
+                CredMgmtTestData.BuildCredentialUserInfo(encodedPublicKey, totalCredentials),
+                SWConstants.Success);
+    }
+}

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
@@ -78,13 +78,12 @@ namespace Yubico.YubiKey.Fido2.Commands
         }
 
         /// <summary>
-        /// This is the reported bug. Enumerating a relying party issues one
-        /// Begin response followed by one GetNext response per remaining
-        /// credential, and a single credential whose public key this SDK does
-        /// not model previously aborted the whole enumeration.
+        /// Verifies that a credential with an unsupported public-key
+        /// representation does not prevent the complete enumeration sequence
+        /// from being decoded.
         /// </summary>
         /// <remarks>
-        /// This mirrors the response-decoding loop in
+        /// Mirrors the response-decoding loop in
         /// <c>Fido2Session.EnumerateCredentialsForRelyingParty</c>, driving the
         /// GetNext count off the credential count returned by Begin. It stops at
         /// the response boundary: exercising the session method itself would

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Commands/EnumerateCredentialsResponseTests.cs
@@ -36,7 +36,7 @@ namespace Yubico.YubiKey.Fido2.Commands
         [Fact]
         public void BeginResponse_GetData_UnsupportedPublicKey_ReturnsCredentialWithRawKey()
         {
-            byte[] publicKey = CredMgmtTestData.BuildArkgSeedCoseKey();
+            byte[] publicKey = CredMgmtTestData.BuildUnmodeledStructuredCoseKey();
             var response = new EnumerateCredentialsBeginResponse(
                 BuildApdu(publicKey, totalCredentials: 2));
 
@@ -48,8 +48,8 @@ namespace Yubico.YubiKey.Fido2.Commands
 
             var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(userInfo.CredentialPublicKey);
             Assert.Equal(publicKey, unsupported.EncodedKey.ToArray());
-            Assert.Equal(CredMgmtTestData.ArkgPubKeyType, (int)unsupported.Type);
-            Assert.Equal(CredMgmtTestData.ArkgP256Algorithm, (int)unsupported.Algorithm);
+            Assert.Equal(CredMgmtTestData.UnmodeledKeyType, (int)unsupported.Type);
+            Assert.Equal(CredMgmtTestData.UnmodeledAlgorithm, (int)unsupported.Algorithm);
         }
 
         [Fact]
@@ -66,7 +66,7 @@ namespace Yubico.YubiKey.Fido2.Commands
         [Fact]
         public void GetNextResponse_GetData_UnsupportedPublicKey_ReturnsCredentialWithRawKey()
         {
-            byte[] publicKey = CredMgmtTestData.BuildArkgSeedCoseKey();
+            byte[] publicKey = CredMgmtTestData.BuildUnmodeledStructuredCoseKey();
             var response = new EnumerateCredentialsGetNextResponse(BuildApdu(publicKey));
 
             CredentialUserInfo userInfo = response.GetData();
@@ -98,7 +98,7 @@ namespace Yubico.YubiKey.Fido2.Commands
             var getNextResponses = new Queue<EnumerateCredentialsGetNextResponse>(
                 new[]
                 {
-                    new EnumerateCredentialsGetNextResponse(BuildApdu(CredMgmtTestData.BuildArkgSeedCoseKey())),
+                    new EnumerateCredentialsGetNextResponse(BuildApdu(CredMgmtTestData.BuildUnmodeledStructuredCoseKey())),
                     new EnumerateCredentialsGetNextResponse(BuildApdu(CredMgmtTestData.BuildEs256CoseKey())),
                 });
 

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
@@ -94,25 +94,25 @@ namespace Yubico.YubiKey.Fido2.Cose
         }
 
         [Fact]
-        public void CreateOrUnsupported_ArkgSeedKey_ReturnsUnsupportedKeyWithReportedTypeAndAlgorithm()
+        public void CreateOrUnsupported_UnmodeledStructuredKey_ReturnsUnsupportedKeyWithReportedTypeAndAlgorithm()
         {
-            // The shape produced by the experimental previewSign extension: an
-            // ARKG-P256 seed, whose key type and algorithm are both outside the
-            // set this SDK models.
-            byte[] encodedKey = BuildArkgSeedKey();
+            // A key whose type and algorithm are both outside the set this SDK
+            // models, and whose value is itself structured rather than a flat
+            // point. Mirrors the shape of a real extension-defined key.
+            byte[] encodedKey = BuildUnmodeledStructuredKey();
 
             CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
 
             var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(key);
-            Assert.Equal(ArkgPubKeyType, (int)unsupported.Type);
-            Assert.Equal(ArkgP256Algorithm, (int)unsupported.Algorithm);
+            Assert.Equal(UnmodeledKeyType, (int)unsupported.Type);
+            Assert.Equal(UnmodeledAlgorithm, (int)unsupported.Algorithm);
             Assert.Equal(encodedKey, unsupported.EncodedKey.ToArray());
         }
 
         [Fact]
         public void CreateOrUnsupported_UnsupportedAlgorithm_EncodeRoundTripsOriginalBytes()
         {
-            byte[] encodedKey = BuildArkgSeedKey();
+            byte[] encodedKey = BuildUnmodeledStructuredKey();
 
             CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
 
@@ -186,8 +186,12 @@ namespace Yubico.YubiKey.Fido2.Cose
             _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(cbor.Encode()));
         }
 
-        private const int ArkgPubKeyType = -65537;
-        private const int ArkgP256Algorithm = -65700;
+        // Taken from a real extension-defined key type rather than invented, so
+        // the fixtures exercise a shape a YubiKey can actually return. The
+        // specific values do not matter; what matters is that they are outside
+        // the set the SDK models.
+        private const int UnmodeledKeyType = -65537;
+        private const int UnmodeledAlgorithm = -65700;
 
         private static byte[] BuildIndefiniteLengthMap()
         {
@@ -207,14 +211,14 @@ namespace Yubico.YubiKey.Fido2.Cose
             return cbor.Encode();
         }
 
-        private static byte[] BuildArkgSeedKey()
+        private static byte[] BuildUnmodeledStructuredKey()
         {
             var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
             cbor.WriteStartMap(4);
             cbor.WriteInt32(1);
-            cbor.WriteInt32(ArkgPubKeyType);
+            cbor.WriteInt32(UnmodeledKeyType);
             cbor.WriteInt32(3);
-            cbor.WriteInt32(ArkgP256Algorithm);
+            cbor.WriteInt32(UnmodeledAlgorithm);
             cbor.WriteInt32(-1);
             WriteEc2Point(cbor, 0x44);
             cbor.WriteInt32(-2);

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
@@ -98,7 +98,7 @@ namespace Yubico.YubiKey.Fido2.Cose
         {
             // A key whose type and algorithm are both outside the set this SDK
             // models, and whose value is itself structured rather than a flat
-            // point. Mirrors the shape of a real extension-defined key.
+            // point, exercising a valid unsupported representation.
             byte[] encodedKey = BuildUnmodeledStructuredKey();
 
             CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
@@ -122,9 +122,8 @@ namespace Yubico.YubiKey.Fido2.Cose
         [Fact]
         public void Create_RealWorldUnmodeledKey_ThrowsNotSupportedException()
         {
-            // Captured from a firmware 5.8.0 YubiKey. Pins the failure a caller
-            // reported when reloading a persisted key and parsing it with the
-            // strict public entry point.
+            // The strict entry point must reject an authenticator key whose
+            // algorithm this SDK does not model.
             byte[] encodedKey = Convert.FromHexString(RealWorldUnmodeledKeyHex);
 
             _ = Assert.Throws<NotSupportedException>(() => CoseKey.Create(encodedKey, out _));
@@ -147,10 +146,8 @@ namespace Yubico.YubiKey.Fido2.Cose
         [Fact]
         public void CreateOrUnsupported_PersistAndReloadUnmodeledKey_RoundTrips()
         {
-            // The reported workflow: store a key returned by the authenticator,
-            // then reload and parse it in a later process. The application never
-            // holds an SDK response object, only the bytes, so the whole
-            // round-trip has to work through the public surface.
+            // An unsupported authenticator key must remain decodable through
+            // the public tolerant entry point after an encode/reload cycle.
             byte[] fromAuthenticator = Convert.FromHexString(RealWorldUnmodeledKeyHex);
 
             byte[] persisted = CoseKey.CreateOrUnsupported(fromAuthenticator).Encode();
@@ -256,14 +253,13 @@ namespace Yubico.YubiKey.Fido2.Cose
             _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(cbor.Encode()));
         }
 
-        // Taken from a real extension-defined key type rather than invented, so
-        // the fixtures exercise a shape a YubiKey can actually return. The
-        // specific values do not matter; what matters is that they are outside
-        // the set the SDK models.
+        // Exercise extension-defined values outside the ranges this SDK models.
+        // Their exact numeric values are not significant to these tests.
         private const int UnmodeledKeyType = -65537;
         private const int UnmodeledAlgorithm = -65700;
 
-        // A verbatim 172-byte key captured from a firmware 5.8.0 YubiKey:
+        // Real-world structured key fixture with two nested EC2 points. The
+        // tests use it to exercise an unsupported key representation:
         //   map(5) {
         //     1:  -65537,          key type this SDK does not model
         //     3:  -65700,          algorithm this SDK does not model
@@ -271,9 +267,8 @@ namespace Yubico.YubiKey.Fido2.Cose
         //     -2: EC2 P-256 key,   alg ECDH-ES+HKDF-256 (-25)
         //     -3: -9
         //   }
-        // Kept verbatim rather than rebuilt from a writer so that the test
-        // exercises real authenticator bytes, including the nested structure
-        // and the trailing scalar that the synthetic fixtures above omit.
+        // Keep this as a literal encoding because it includes a trailing scalar omitted by the
+        // generated fixtures.
         private const string RealWorldUnmodeledKeyHex =
             "a5013a00010000033a000100a320a501020326200121582030cda7a5e32646f7ed" +
             "318725c47847d7c2af80794d76bf758e46bf4a5efa22b4225820b2c65e2789bed6" +

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
@@ -58,6 +58,187 @@ namespace Yubico.YubiKey.Fido2.Cose
             _ = Assert.Throws<NotSupportedException>(() => CoseKey.Create(encodedKey, out _));
         }
 
+        [Fact]
+        public void CreateOrUnsupported_Es256Ec2Key_ReturnsEcPublicKey()
+        {
+            byte[] encodedKey = BuildEc2Key(CoseAlgorithmIdentifier.ES256);
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            var ecKey = Assert.IsType<CoseEcPublicKey>(key);
+            Assert.Equal(CoseKeyType.Ec2, ecKey.Type);
+            Assert.Equal(CoseAlgorithmIdentifier.ES256, ecKey.Algorithm);
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_EdDsaOkpKey_ReturnsEdDsaPublicKey()
+        {
+            byte[] encodedKey = BuildOkpKey(CoseAlgorithmIdentifier.EdDSA);
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            _ = Assert.IsType<CoseEdDsaPublicKey>(key);
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_UnsupportedAlgorithm_ReturnsUnsupportedKey()
+        {
+            byte[] encodedKey = BuildEc2Key((CoseAlgorithmIdentifier)(-70000));
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(key);
+            Assert.Equal(CoseKeyType.Ec2, unsupported.Type);
+            Assert.Equal((CoseAlgorithmIdentifier)(-70000), unsupported.Algorithm);
+            Assert.Equal(encodedKey, unsupported.EncodedKey.ToArray());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_ArkgSeedKey_ReturnsUnsupportedKeyWithReportedTypeAndAlgorithm()
+        {
+            // The shape produced by the experimental previewSign extension: an
+            // ARKG-P256 seed, whose key type and algorithm are both outside the
+            // set this SDK models.
+            byte[] encodedKey = BuildArkgSeedKey();
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(key);
+            Assert.Equal(ArkgPubKeyType, (int)unsupported.Type);
+            Assert.Equal(ArkgP256Algorithm, (int)unsupported.Algorithm);
+            Assert.Equal(encodedKey, unsupported.EncodedKey.ToArray());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_UnsupportedAlgorithm_EncodeRoundTripsOriginalBytes()
+        {
+            byte[] encodedKey = BuildArkgSeedKey();
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            Assert.Equal(encodedKey, key.Encode());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_UnsupportedAlgorithm_EncodedKeyIsDefensiveCopy()
+        {
+            byte[] encodedKey = BuildEc2Key((CoseAlgorithmIdentifier)(-70000));
+            byte[] original = encodedKey.ToArray();
+
+            var key = Assert.IsType<CoseUnsupportedPublicKey>(CoseKey.CreateOrUnsupported(encodedKey));
+            encodedKey[0] = 0xFF;
+
+            Assert.Equal(original, key.EncodedKey.ToArray());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_UnsupportedAlgorithmNoKeyType_ThrowsCtap2DataException()
+        {
+            // COSE requires the key type in every key, so its absence is
+            // malformed data rather than an unrecognized algorithm. Create
+            // rejects this for modeled algorithms; CreateOrUnsupported must
+            // reject it for unmodeled ones too.
+            byte[] encodedKey = BuildAlgorithmOnlyKey((CoseAlgorithmIdentifier)(-70000));
+
+            _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(encodedKey));
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_IndefiniteLengthMap_ThrowsSameAsCreate()
+        {
+            // An indefinite-length map is malformed under Ctap2Canonical, not an
+            // unrecognized algorithm, so decoding it must fail identically
+            // whether the caller went through Create or CreateOrUnsupported.
+            byte[] encodedKey = BuildIndefiniteLengthMap();
+
+            _ = Assert.Throws<CborContentException>(() => CoseKey.Create(encodedKey, out _));
+            _ = Assert.Throws<CborContentException>(() => CoseKey.CreateOrUnsupported(encodedKey));
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_NotAMap_ThrowsCtap2DataException()
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteInt32(7);
+
+            _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(cbor.Encode()));
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_Es256WithOkpKeyType_ThrowsCtap2DataException()
+        {
+            // A modeled algorithm paired with the wrong key type is corrupt
+            // data, not a future algorithm, so it must not be tolerated.
+            byte[] encodedKey = BuildOkpKey(CoseAlgorithmIdentifier.ES256);
+
+            _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(encodedKey));
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_MissingAlgorithm_ThrowsCtap2DataException()
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(1);
+            cbor.WriteInt32(1);
+            cbor.WriteInt32((int)CoseKeyType.Ec2);
+            cbor.WriteEndMap();
+
+            _ = Assert.Throws<Ctap2DataException>(() => CoseKey.CreateOrUnsupported(cbor.Encode()));
+        }
+
+        private const int ArkgPubKeyType = -65537;
+        private const int ArkgP256Algorithm = -65700;
+
+        private static byte[] BuildIndefiniteLengthMap()
+        {
+            // System.Formats.Cbor will not emit an indefinite-length map in
+            // Ctap2Canonical mode, so write the encoding directly:
+            // 0xBF <start indefinite map> 01 02 <kty: Ec2> 03 39 01 0F <alg: -272> 0xFF <break>
+            return new byte[] { 0xBF, 0x01, 0x02, 0x03, 0x39, 0x01, 0x0F, 0xFF };
+        }
+
+        private static byte[] BuildAlgorithmOnlyKey(CoseAlgorithmIdentifier algorithm)
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(1);
+            cbor.WriteInt32(3);
+            cbor.WriteInt32((int)algorithm);
+            cbor.WriteEndMap();
+            return cbor.Encode();
+        }
+
+        private static byte[] BuildArkgSeedKey()
+        {
+            var cbor = new CborWriter(CborConformanceMode.Ctap2Canonical, convertIndefiniteLengthEncodings: true);
+            cbor.WriteStartMap(4);
+            cbor.WriteInt32(1);
+            cbor.WriteInt32(ArkgPubKeyType);
+            cbor.WriteInt32(3);
+            cbor.WriteInt32(ArkgP256Algorithm);
+            cbor.WriteInt32(-1);
+            WriteEc2Point(cbor, 0x44);
+            cbor.WriteInt32(-2);
+            WriteEc2Point(cbor, 0x55);
+            cbor.WriteEndMap();
+            return cbor.Encode();
+        }
+
+        private static void WriteEc2Point(CborWriter cbor, byte fill)
+        {
+            cbor.WriteStartMap(5);
+            cbor.WriteInt32(1);
+            cbor.WriteInt32((int)CoseKeyType.Ec2);
+            cbor.WriteInt32(3);
+            cbor.WriteInt32((int)CoseAlgorithmIdentifier.ES256);
+            cbor.WriteInt32(-1);
+            cbor.WriteInt32((int)CoseEcCurve.P256);
+            cbor.WriteInt32(-2);
+            cbor.WriteByteString(Enumerable.Repeat(fill, 32).ToArray());
+            cbor.WriteInt32(-3);
+            cbor.WriteByteString(Enumerable.Repeat((byte)(fill + 1), 32).ToArray());
+            cbor.WriteEndMap();
+        }
+
         private static byte[] BuildOkpKey(CoseAlgorithmIdentifier algorithm)
         {
             byte[] publicKey = Enumerable.Repeat((byte)0x33, 32).ToArray();

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/Cose/CoseKeyTests.cs
@@ -120,6 +120,76 @@ namespace Yubico.YubiKey.Fido2.Cose
         }
 
         [Fact]
+        public void Create_RealWorldUnmodeledKey_ThrowsNotSupportedException()
+        {
+            // Captured from a firmware 5.8.0 YubiKey. Pins the failure a caller
+            // reported when reloading a persisted key and parsing it with the
+            // strict public entry point.
+            byte[] encodedKey = Convert.FromHexString(RealWorldUnmodeledKeyHex);
+
+            _ = Assert.Throws<NotSupportedException>(() => CoseKey.Create(encodedKey, out _));
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_RealWorldUnmodeledKey_ReturnsUnsupportedKey()
+        {
+            byte[] encodedKey = Convert.FromHexString(RealWorldUnmodeledKeyHex);
+
+            CoseKey key = CoseKey.CreateOrUnsupported(encodedKey);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(key);
+            Assert.Equal(UnmodeledKeyType, (int)unsupported.Type);
+            Assert.Equal(UnmodeledAlgorithm, (int)unsupported.Algorithm);
+            Assert.Equal(encodedKey, unsupported.EncodedKey.ToArray());
+            Assert.Equal(encodedKey, key.Encode());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_PersistAndReloadUnmodeledKey_RoundTrips()
+        {
+            // The reported workflow: store a key returned by the authenticator,
+            // then reload and parse it in a later process. The application never
+            // holds an SDK response object, only the bytes, so the whole
+            // round-trip has to work through the public surface.
+            byte[] fromAuthenticator = Convert.FromHexString(RealWorldUnmodeledKeyHex);
+
+            byte[] persisted = CoseKey.CreateOrUnsupported(fromAuthenticator).Encode();
+            var reloaded = Assert.IsType<CoseUnsupportedPublicKey>(CoseKey.CreateOrUnsupported(persisted));
+
+            Assert.Equal(fromAuthenticator, reloaded.EncodedKey.ToArray());
+            Assert.Equal(UnmodeledKeyType, (int)reloaded.Type);
+            Assert.Equal(UnmodeledAlgorithm, (int)reloaded.Algorithm);
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_UnmodeledKeyFollowedByOtherData_ReportsBytesRead()
+        {
+            byte[] encodedKey = Convert.FromHexString(RealWorldUnmodeledKeyHex);
+            byte[] buffer = encodedKey.Concat(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF }).ToArray();
+
+            CoseKey key = CoseKey.CreateOrUnsupported(buffer, out int bytesRead);
+
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(key);
+            Assert.Equal(encodedKey.Length, bytesRead);
+
+            // The preserved bytes must be the key alone, not the key plus
+            // whatever followed it in the caller's buffer.
+            Assert.Equal(encodedKey, unsupported.EncodedKey.ToArray());
+            Assert.Equal(encodedKey, key.Encode());
+        }
+
+        [Fact]
+        public void CreateOrUnsupported_ModeledKey_ReportsSameBytesReadAsCreate()
+        {
+            byte[] encodedKey = BuildEc2Key(CoseAlgorithmIdentifier.ES256);
+
+            _ = CoseKey.Create(encodedKey, out int createBytesRead);
+            _ = CoseKey.CreateOrUnsupported(encodedKey, out int lenientBytesRead);
+
+            Assert.Equal(createBytesRead, lenientBytesRead);
+        }
+
+        [Fact]
         public void CreateOrUnsupported_UnsupportedAlgorithm_EncodedKeyIsDefensiveCopy()
         {
             byte[] encodedKey = BuildEc2Key((CoseAlgorithmIdentifier)(-70000));
@@ -192,6 +262,25 @@ namespace Yubico.YubiKey.Fido2.Cose
         // the set the SDK models.
         private const int UnmodeledKeyType = -65537;
         private const int UnmodeledAlgorithm = -65700;
+
+        // A verbatim 172-byte key captured from a firmware 5.8.0 YubiKey:
+        //   map(5) {
+        //     1:  -65537,          key type this SDK does not model
+        //     3:  -65700,          algorithm this SDK does not model
+        //     -1: EC2 P-256 key,   alg ES256 (-7)
+        //     -2: EC2 P-256 key,   alg ECDH-ES+HKDF-256 (-25)
+        //     -3: -9
+        //   }
+        // Kept verbatim rather than rebuilt from a writer so that the test
+        // exercises real authenticator bytes, including the nested structure
+        // and the trailing scalar that the synthetic fixtures above omit.
+        private const string RealWorldUnmodeledKeyHex =
+            "a5013a00010000033a000100a320a501020326200121582030cda7a5e32646f7ed" +
+            "318725c47847d7c2af80794d76bf758e46bf4a5efa22b4225820b2c65e2789bed6" +
+            "ac7c8f34f77a9ecbfcc8bf672b62271c12ecc0673e923002c321a5010203381820" +
+            "01215820ec9822dbff8eaa4f37d5879cafddf063af6c15ce9a4fe600b79424382a" +
+            "b029e22258206d2a9669f5aae87be629938a06c8be9eb0a8f0cf9e45800f08be2f" +
+            "0a64ceec992228";
 
         private static byte[] BuildIndefiniteLengthMap()
         {

--- a/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/MakeCredentialDataTests.cs
+++ b/Yubico.YubiKey/tests/unit/Yubico/YubiKey/Fido2/MakeCredentialDataTests.cs
@@ -218,7 +218,9 @@ namespace Yubico.YubiKey.Fido2
 
             var data = new MakeCredentialData(ctapResponse);
 
-            Assert.Null(data.AuthenticatorData.CredentialPublicKey);
+            var unsupported = Assert.IsType<CoseUnsupportedPublicKey>(
+                data.AuthenticatorData.CredentialPublicKey);
+            Assert.Equal(coseKey, unsupported.EncodedKey.ToArray());
             Assert.Equal(coseKey, data.AuthenticatorData.EncodedCredentialPublicKey!.Value.ToArray());
         }
 

--- a/contributordocs/fido2-forward-compatibility-audit.md
+++ b/contributordocs/fido2-forward-compatibility-audit.md
@@ -1,0 +1,397 @@
+<!-- Copyright 2026 Yubico AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. -->
+
+# FIDO2 forward-compatibility audit and handoff
+
+**Date:** 2026-08-25
+**Branch:** `bugfix/fido2-credmgmt-unsupported-cose-key`
+**Open PR:** <https://github.com/Yubico/Yubico.NET.SDK/pull/585>
+**Status:** one fix shipped to that PR; 12 further defects identified, none built.
+
+This document exists so the remaining work can be picked up cold. It records
+what was fixed, what was found, what was decided and why, and what was
+deliberately *not* done. The design-rationale sections exist to stop decisions
+being relitigated.
+
+---
+
+## 1. Origin
+
+Reported by Jonas Markström: `Fido2Session.EnumerateCredentialsForRelyingParty`
+throws and aborts enumeration of *all* credentials for a relying party when any
+one credential's public key uses a COSE algorithm the SDK does not model.
+
+Two corrections to the original report, both confirmed by reading the code:
+
+- The exception is `System.NotSupportedException` ("The requested algorithm is
+  not supported"), **not** `Ctap2DataException`.
+- The message quoted in the report — `Ctap2CborUnexpectedKey`, *"An unexpected
+  key was encountered in a CBOR map; expected to find {0} (name '{1}')"* — is
+  thrown from exactly one place in the SDK: `Fido2/RelyingParty.cs:128`. That is
+  **not** on the reported code path. See defect D1 in section 5.
+
+The report quoted the unformatted resx template (`{0}`, `{1}`), which suggests
+source analysis rather than a captured stack trace. **A stack trace was
+requested and had not arrived when this document was written.** Whoever picks
+this up should chase it — it determines whether the user's actual problem is D1
+rather than the COSE issue.
+
+---
+
+## 2. What shipped (PR #585)
+
+Two commits on `bugfix/fido2-credmgmt-unsupported-cose-key`:
+
+- `89effa2b` — `fix(fido2): tolerate unmodeled COSE key types when enumerating credentials`
+- `94093fd9` — `docs(fido2): generalize wording for unmodeled COSE key types`
+
+**Change:** added `CoseUnsupportedPublicKey` (sealed, internal constructor,
+carries the original encoding plus the reported key type and algorithm) and an
+internal `CoseKey.CreateOrUnsupported`. Applied at all three data-bearing
+`CoseKey.Create` call sites: `CredentialUserInfo.cs`,
+`Commands/CredentialManagementData.cs`, and `AuthenticatorData.cs`.
+`Commands/ClientPinResponse.cs` was deliberately left on strict `Create`.
+
+**Behavior change shipped:** `AuthenticatorData.CredentialPublicKey` now returns
+the sentinel instead of `null` for an unmodeled key. Code detecting such a
+credential via a null check must test for `CoseUnsupportedPublicKey` instead.
+`null` on that property now means unambiguously "no attested credential data".
+
+**Known incomplete:** see D7/D8 in section 5. PR #585 as it stands does not
+fully deliver its own guarantee.
+
+---
+
+## 3. Hardware findings — the reported scenario did NOT reproduce
+
+Run against three connected devices. **This section exists so nobody repeats
+the experiment.**
+
+| Serial | Firmware | Extensions | credMgmt |
+|---|---|---|---|
+| 25555459 | 5.4.3 | credProtect, hmac-secret | NotSupported |
+| 103 | 5.8.0 | ..., **previewSign** | True |
+| 125 | 5.8.0 | ..., **`sign`** | True |
+
+**Note serials 103 and 125: same firmware version, different extension name.**
+`previewSign` has already been partly renamed to `sign` in the field. This is
+why the documentation shipped in PR #585 describes the *mechanism* rather than
+naming the extension. Do not reintroduce extension names into permanent API
+documentation.
+
+What the hardware confirmed:
+
+- A previewSign-generated key **is** an unmodeled COSE key:
+  `kty = -65537, alg = -65700`. After the fix it decodes to
+  `CoseUnsupportedPublicKey` with byte-exact raw preservation. The sentinel is
+  therefore validated against real authenticator bytes, not just synthetic CBOR.
+
+What the hardware **disproved**:
+
+- `EnumerateCredentialsForRelyingParty` returned the credential cleanly, with
+  `CoseEcPublicKey kty=2 alg=-7`. The ARKG key rides inside the *extension
+  output*; it is **not** stored as its own discoverable credential.
+- The other route is closed too: requesting the unmodeled algorithm as the
+  credential's own algorithm (`alg = -65539`, `rk = true`) is **rejected by the
+  YubiKey** with `Fido2Exception`.
+- `AddPreviewSignGenerateKeyExtension` has no discoverability flag — its
+  `PreviewSignOptions` are user-presence/user-verification policy only.
+
+**Conclusion:** on firmware 5.8.0 there is no route via the public SDK API to a
+discoverable credential whose own public key is an unmodeled COSE type. The code
+defect is real and worth fixing regardless, but it is probably not what the
+reporter hit. D1 is the stronger candidate.
+
+**Safety note for anyone re-running this:** `FidoSessionIntegrationTestBase`'s
+constructor (`Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs`)
+**deletes every discoverable credential on the device** and asserts the PIN is
+the integration-test PIN. Do not point it at a personal key. The probes used for
+the results above deliberately did not inherit it, restricted writes to a serial
+allowlist, and cleaned up after themselves. They were not committed.
+
+---
+
+## 4. Audit scope and method
+
+139 `.cs` files under `Yubico.YubiKey/src/Yubico/YubiKey/Fido2/` were enumerated
+and every decoding file read. `Yubico.Core` was searched — **no FIDO2 response
+decoding exists there**; all CBOR parsing uses `System.Formats.Cbor` from
+`Yubico.YubiKey`.
+
+**A defect** is code that decodes data *received from a YubiKey* and hard-fails
+on something it does not recognize, when the data it *does* recognize would have
+been sufficient for the caller.
+
+**Not defects** (explicitly considered and rejected): validation of
+caller-supplied input; genuinely malformed CBOR; missing *required* fields; a
+recognized discriminator paired with a structurally wrong payload; and `default`
+arms over `CtapStatus`, which correctly funnel into a `Fido2Exception` carrying
+the raw code.
+
+**Exemplary patterns already in the codebase** — use these as templates:
+
+- `Fido2/AuthenticatorOptions.cs` — `default: return OptionValue.Unknown`.
+- `Fido2/Cbor/CborMap.cs` — `default` arms fall back to `RawCborValue`.
+- `Fido2/UserEntity.cs` and `Fido2/CredentialId.cs` — `CborMap<string>`, unknown
+  keys silently ignored.
+- `Fido2/Commands/CredentialManagementData.cs` — `RawData` + `UnknownFields`
+  (PR #508).
+- `Fido2/CredentialUserInfo.cs` — `TryGetCredentialManagementField` (PR #508).
+- `Fido2/AuthenticatorData.cs` — `EncodedCredentialPublicKey` (PR #468).
+
+**Not audited:** CTAPHID transport framing in
+`Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/`. Explicitly out of scope by
+decision. An unrecognized CTAPHID command byte has not been assessed.
+
+---
+
+## 5. Defects
+
+The **Confirmed** column records how the finding was checked. `direct` means the
+file and line were read and the defect confirmed by hand. Every line reference
+below was verified against the tree at commit `94093fd9`; re-check them if the
+files have moved since.
+
+| ID | Confirmed | Location | Defect | Severity |
+|---|---|---|---|---|
+| D1 | direct | `Fido2/RelyingParty.cs:124` | `default: throw` on any relying-party map key but `id`/`name`. Kills `EnumerateRelyingParties()`. **Only site emitting the message in the bug report.** | HIGH |
+| D2 | direct | `Fido2/Commands/ClientPinResponse.cs:97` | `default: throw` on any clientPIN response key but `0x01`–`0x05`. Breaks **every** PIN/UV path, and therefore MakeCredential, GetAssertions, and all credential management | HIGH |
+| D3 | direct | `Fido2/MakeCredentialData.cs:188` | `Statement as PackedAttestationStatement ?? throw`. Any non-`packed` `fmt` breaks `MakeCredential` | HIGH\* |
+| D4 | direct | `Fido2/AttestationStatement.cs:136` | `ContainsOnlyKeys` rejects a `packed` attestation statement carrying any extra key, degrading it to `UnknownAttestationStatement`, which then trips D3 | HIGH |
+| D5 | direct | `Fido2/AttestationStatement.cs:181,214,236` | `ContainsExactKeys` does the same for `fido-u2f`, `apple`, and `none`. Silent loss of the typed properties rather than a throw | LOW–MED |
+| D6 | direct | `Fido2/Fido2Session.Pin.cs:1422` | Three separate bugs in one line — see section 6 | HIGH |
+| D7 | direct | `Fido2/Cose/CoseEcPublicKey.cs:211-220` | The decode constructor assigns through the public property setters, which run `ValidateCurve`/`ValidateLength` and throw `ArgumentException`. **This escapes `CreateOrUnsupported`, whose catch is `NotSupportedException`-only** — a hole in the PR #585 fix | MED |
+| D8 | direct | `Fido2/Cose/CoseEdDsaPublicKey.cs:128-129` | Same pattern for non-Ed25519 OKP curves. `Ed448` is already a `CoseEcCurve` member but is rejected | MED |
+| D9 | direct | `Fido2/Commands/ClientPinResponse.cs:78` | Still uses strict `CoseKey.Create` for the `keyAgreement` field | MED |
+| D10 | direct | `Fido2/AuthenticatorData.cs:408` | `GetCredProtectExtension()` rejects credProtect values outside 1–3 | MED |
+| D11 | direct | `Fido2/AuthenticatorInfo.cs:460,520` | `AsDictionary<bool>()` is all-or-nothing; a single non-boolean `options` value throws `InvalidCastException` from the **session constructor** | MED |
+| D12 | direct | `Fido2/Cbor/CborMap.cs:162-189` | `ReadArray<T>` rejects the whole array when one element does not convert (throw at line 189); 13 call sites | LOW |
+| D13 | direct | `Fido2/Commands/GetKeyAgreementResponse.cs:53` | Misleading `Ctap2MissingRequiredField` for a field that is present but not an EC key | LOW |
+| D14 | direct | `Fido2/PinProtocols/PinUvAuthProtocolBase.cs:177` | Duplicate of D13 one layer down; line 184 also hard-codes P-256 regardless of what the device reported | LOW |
+
+\* **D3's severity is unconfirmed.** Nobody has established whether YubiKey
+firmware ever returns a non-`packed` `fmt`. `MakeCredentialParameters` has no
+attestation-format preference input, so the format is entirely the
+authenticator's choice today. The presence of
+`AuthenticatorInfo.AttestationFormats` (getInfo key `0x16`) and four modeled
+format classes is circumstantial evidence that non-packed is expected. **A
+firmware owner must confirm before this is scheduled.**
+
+---
+
+## 6. D6 in detail
+
+```csharp
+// Fido2Session.Pin.cs:1422 — called unconditionally from the constructor (Fido2Session.cs:273)
+var protocol = AuthenticatorInfo.PinUvAuthProtocols?[0] ?? PinUvAuthProtocol.ProtocolOne;
+```
+
+Three separate defects:
+
+1. **It only inspects index 0.** CTAP 2.1 defines `pinUvAuthProtocols` as a list
+   *in order of decreasing authenticator preference*. A device advertising
+   `[3, 2, 1]` means "I prefer 3, but I also support 2 and 1." The SDK throws and
+   refuses to construct a session against a device that supports both protocols
+   the SDK implements. Unambiguously a bug.
+2. **`?[0]` does not guard against an empty list.** The null-conditional operator
+   guards null only. A non-null empty list yields `ArgumentOutOfRangeException`
+   rather than the intended `NotSupportedException`. Only reachable on a device
+   that does not conform to CTAP, which requires the array to be non-empty when
+   present.
+3. **It throws from the constructor**, which is disproportionate *and* defeats
+   the SDK's own escape hatch. `AuthProtocol` is consumed only by PIN/UV paths;
+   reading `AuthenticatorInfo`, calling `Reset`, and a non-UV `GetAssertion`
+   never need it. Worse, `SetAuthProtocol(PinUvAuthProtocolBase)` exists and is
+   documented as *"Overrides the default PIN/UV Auth protocol"* — but it is an
+   **instance method**. If the constructor throws you never obtain an instance,
+   so the designed override is unreachable in exactly the scenario it exists for.
+
+**Chosen remedy** (see section 7 for the reasoning): walk the list for the first
+implemented protocol; handle the empty case; and when the device advertises only
+unmodeled protocols, assign an **internal**
+`UnsupportedPinUvAuthProtocol : PinUvAuthProtocolBase` sentinel that reports the
+advertised protocol number and throws a precise `NotSupportedException` from each
+of its eight abstract members. The session then constructs, non-PIN work
+proceeds, `SetAuthProtocol` becomes reachable, and `AuthProtocol` stays
+non-nullable.
+
+---
+
+## 7. Decisions already made — do not relitigate without new information
+
+**Sentinel over nullable.** For `CredentialUserInfo.CredentialPublicKey`,
+nullable was rejected. The property is non-nullable and CTAP mandates field
+`0x08` for `enumerateCredentials`, so nullable is both the wrong model and a
+source-breaking annotation change that would force null checks on 100% of
+callers to guard a case that fires for a fraction of a percent of credentials.
+The sentinel costs nothing unless you meet an unmodeled key, and it degrades
+better: `is CoseEcPublicKey` skips gracefully, `.Algorithm`/`.Type` return the
+real reported values instead of a `NullReferenceException`, a hard cast fails
+with a message naming the actual type, and consumers building with nullable
+reference types disabled would get no warning at all under the nullable design.
+The same reasoning drives the D6 remedy.
+
+**`CreateOrUnsupported` catches only `NotSupportedException`** — to be widened to
+`ArgumentException` for D7/D8, and nothing else. `Ctap2DataException` must keep
+propagating: malformed CBOR, a missing key type or algorithm, and a modeled
+algorithm paired with the wrong key type are corrupt data, not future values.
+
+**Public `CoseKey.Create` stays strict.** Making it return the sentinel would
+silently change a documented public throw contract. `Create` is strict;
+`CreateOrUnsupported` is lenient.
+
+**No `TryCreate`.** With a sentinel the method cannot fail, so the boolean would
+duplicate `key is CoseUnsupportedPublicKey`; none of the three call sites branch
+on it; and every `Try*` method in this codebase pairs `false` with a null or
+default out-parameter, several of them annotated `[MaybeNullWhen(false)]`, which
+an always-populated out-parameter would invert.
+
+**Decode-side tolerance must never become encode-side fabrication.** Preserved
+unknown fields must **not** be re-emitted from any `CborEncode()`.
+`RelyingParty.CborEncode()` is fed to the authenticator from
+`MakeCredentialParameters`; re-emitting authenticator-originated keys during
+registration is wrong, and CTAP2 canonical ordering makes it fiddly besides.
+
+**`whats-new.md` is release-time only.** Every edit to it comes from a release
+commit. Do not touch it in a feature or bugfix PR; put behavior-change notes in
+the PR body for the release manager to pick up.
+
+**Hard constraint set by the owner: no breaking changes, and nothing becomes
+nullable.** This is what blocks D3, and what forces remedy (a) over remedy (b)
+for D7.
+
+---
+
+## 8. Proposed remaining work
+
+Three stacked PRs. **None of this has been built.**
+
+```text
+develop
+ └─ bugfix/fido2-credmgmt-unsupported-cose-key   → PR #585 (open) + amendment
+     └─ bugfix/fido2-unknown-map-keys             → D1, D2, D4, D5, D9
+         └─ bugfix/fido2-pinuvauth-protocol       → D6
+```
+
+### Stack 1 — amend PR #585 (D7, D8)
+
+Widen `CreateOrUnsupported`'s catch to absorb `ArgumentException` and return the
+sentinel.
+
+Two remedies were considered; **only (a) is permitted under the
+no-breaking-changes constraint**:
+
+- **(a) widen the catch.** Confines the change to the tolerant path;
+  `CoseEcPublicKey`, `CoseEdDsaPublicKey`, and public `Create` are untouched.
+  **Chosen.**
+- (b) stop the decode constructors running their validators. This changes decode
+  behavior for every caller including direct `Create` users, and would permit a
+  `CoseEcPublicKey` to exist with an out-of-range `Curve`. **Rejected.**
+
+Consequence: `CoseUnsupportedPublicKey`'s XML documentation must widen from
+"algorithm this SDK does not model" to "cannot be represented by a modeled type",
+because you can now receive it for a modeled algorithm on an unmodeled curve.
+
+Criteria: an unmodeled curve, an unmodeled coordinate length, and a non-Ed25519
+OKP curve each yield the sentinel with raw bytes preserved; enumeration returns
+all credentials when one is affected; **anti:** public `Create` still throws for
+all three; **anti:** `CoseEcPublicKey.cs` and `CoseEdDsaPublicKey.cs` are
+unmodified; **anti:** null input still throws `ArgumentNullException` rather than
+being absorbed into a sentinel.
+
+### Stack 2 — unknown map keys (D1, D2, D4, D5, D9)
+
+- **D1** — rewrite `RelyingParty`'s decode constructor onto `CborMap<string>`,
+  matching `UserEntity` and `CredentialId`, and add
+  `TryGetUnknownField(string, out ReadOnlyMemory<byte>)` mirroring
+  `CredentialUserInfo.TryGetCredentialManagementField`.
+  **`RelyingParty` has no unit tests today** — a new `RelyingPartyTests.cs` is
+  required, as is `EnumerateRpsResponseTests.cs`.
+  Note that `RelyingParty` is decoded at exactly one site, in
+  `Commands/CredentialManagementData.cs`, so a single fix covers
+  `EnumerateRpsBeginResponse`, `EnumerateRpsGetNextResponse`, and
+  `CredentialManagementResponse`.
+- **D2** — have the `default:` arm collect into an unknown-fields dictionary, and
+  add `RawData` and `UnknownFields` to the public `ClientPinData`, exactly as
+  `CredentialManagementData` does.
+- **D4/D5** — drop `ContainsOnlyKeys`/`ContainsExactKeys` and keep only the
+  `Contains(...)` required-field checks. Then **delete both helpers from
+  `CborMap`**, along with their unit test in `CborMapTests.cs` — they are used
+  nowhere else, so this removes the hazard from the toolkit permanently.
+  `CborMap<TKey>` is `internal`, so this is not a public API change.
+- **D9** — swap the `keyAgreement` decode in `ClientPinResponse` to
+  `CreateOrUnsupported`.
+
+**Anti-criteria:** `RelyingParty.CborEncode()` on a decoded relying party that
+carried unknown fields must emit **only** `id` and `name`; and `CborEncode()` for
+`new RelyingParty("x")` must remain byte-identical to its current output.
+
+### Stack 3 — PIN/UV protocol selection (D6)
+
+As described in section 6. The key criterion, and the point of the exercise: with
+a device advertising only unmodeled protocols, `SetAuthProtocol(myProtocol)` must
+succeed and subsequent PIN operations must use it. **Anti:** `AuthProtocol`
+remains non-nullable; the sentinel type is `internal`; and `Dispose` on a session
+holding the sentinel does not throw.
+
+### Not scheduled
+
+| ID | Disposition |
+|---|---|
+| D3 | **Blocked twice.** The fix makes three public properties nullable, which violates the constraint, and reachability needs a firmware owner |
+| D10, D11, D12, D13, D14 | All non-breaking and buildable. Deferred only on reviewer-load grounds. Pull them forward freely |
+
+---
+
+## 9. Open items
+
+1. **Jonas's stack trace** — outstanding. It determines whether the real fault is
+   D1 rather than the COSE issue. Chase it before promising that PR #585 solves
+   his problem.
+2. **D3 reachability** — needs a firmware owner to confirm whether a non-`packed`
+   attestation format is ever returned.
+3. **D6 tail case** — the sentinel approach was chosen, but "device advertises
+   only unmodeled protocols" is product-visible behavior; confirm before building.
+4. **CTAPHID transport** (`Pipelines/`) has never been assessed for this class of
+   defect.
+5. **Version** — PR #585 adds a public type and changes shipped behavior. A minor
+   bump (1.18.0) was recommended over a patch release; not yet ratified.
+
+---
+
+## 10. Reproducing the audit
+
+Sweep for the two throwing patterns:
+
+```bash
+grep -rn "Ctap2CborUnexpectedKey\|CborUnexpectedMapTag" --include='*.cs' Yubico.YubiKey/src/
+grep -rn "ContainsExactKeys\|ContainsOnlyKeys" --include='*.cs' Yubico.YubiKey/src/
+```
+
+Both were exhaustive at the time of writing: two `default: throw` sites (D1 and
+D2) and four `Contains*Keys` sites, all four in `AttestationStatement.cs`.
+
+---
+
+## Glossary
+
+- **ARKG** — Asynchronous Remote Key Generation.
+- **CBOR** — Concise Binary Object Representation (RFC 8949).
+- **COSE** — CBOR Object Signing and Encryption (RFC 8152).
+- **CTAP / CTAP2** — Client to Authenticator Protocol.
+- **CTAPHID** — CTAP over the USB Human Interface Device transport.
+- **OKP** — Octet Key Pair, the COSE key type used for Edwards curves.
+- **PIN/UV** — Personal Identification Number / User Verification.
+- **RP** — Relying Party.
+- **SDK** — Software Development Kit.

--- a/contributordocs/fido2-forward-compatibility-audit.md
+++ b/contributordocs/fido2-forward-compatibility-audit.md
@@ -12,490 +12,184 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License. -->
 
-# FIDO2 forward-compatibility audit and handoff
+# FIDO2 forward-compatibility audit
 
-**Date:** 2026-08-25
-**Branch:** `bugfix/fido2-credmgmt-unsupported-cose-key`
-**Open PR:** <https://github.com/Yubico/Yubico.NET.SDK/pull/585>
-**Status:** one fix shipped to that PR; 12 further defects identified, none built.
+This audit identifies FIDO2 response-decoding paths where an authenticator can
+return valid data that the SDK does not yet model. Its purpose is to distinguish
+forward-compatibility limitations from required protocol validation and
+malformed-data handling.
 
-This document exists so the remaining work can be picked up cold. It records
-what was fixed, what was found, what was decided and why, and what was
-deliberately *not* done. The design-rationale sections exist to stop decisions
-being relitigated.
+## Scope
 
----
+The audit covers CBOR response decoding under
+`Yubico.YubiKey/src/Yubico/YubiKey/Fido2/`. It does not cover caller-supplied
+request validation. CTAPHID transport framing under `Pipelines/` has not been
+assessed for this class of defect.
 
-## 1. Origin
+A forward-compatibility finding requires all of the following:
 
-Reported by Jonas Markström: `Fido2Session.EnumerateCredentialsForRelyingParty`
-throws and aborts enumeration of *all* credentials for a relying party when any
-one credential's public key uses a COSE algorithm the SDK does not model.
+- The data was received from an authenticator.
+- The data is valid under the applicable CTAP structure.
+- The SDK does not recognize an optional value, field, or representation.
+- The recognized data would still be useful to the caller.
 
-Two corrections to the original report, both confirmed by reading the code and
-later by the reporter's stack trace:
+The following are not forward-compatibility findings:
 
-- The exception is `System.NotSupportedException` ("The requested algorithm is
-  not supported"), **not** `Ctap2DataException`.
-- The message quoted in the report — `Ctap2CborUnexpectedKey`, *"An unexpected
-  key was encountered in a CBOR map; expected to find {0} (name '{1}')"* — is
-  thrown from exactly one place in the SDK: `Fido2/RelyingParty.cs:128`. That is
-  **not** on the reported code path, and was a red herring.
+- malformed CBOR or a violation of CTAP canonical encoding;
+- a missing required field;
+- a recognized discriminator paired with an invalid payload; or
+- a protocol field whose exact algorithm, key type, or curve is required for
+  interoperability or security.
 
-### The stack trace, and what it actually showed
+Existing tolerant patterns include `AuthenticatorOptions`, which maps unknown
+option values to `OptionValue.Unknown`; `CborMap`, which preserves values it
+cannot model as `RawCborValue`; and response types that expose raw encoded data
+alongside typed properties.
 
-```text
-Yubico.YubiKey 1.17.2.0 · .NET 10.0.9 · YubiKey firmware 5.8.0
+## COSE key decoding
 
-System.NotSupportedException: The requested algorithm is not supported.
-   at Yubico.YubiKey.Fido2.Cose.CoseKey.Create(ReadOnlyMemory`1 coseEncodedKey, Int32& bytesRead)
-   at powershellYK.Cmdlets.Fido.TraceYubiKeyFIDO2CredentialManagementCommand.TryCoseKeyCreate(...)
-```
+`CoseKey.Create` is the strict public decoder. It returns a modeled key or
+throws. `CoseKey.CreateOrUnsupported` is the tolerant decoder for contexts in
+which an otherwise valid key representation must be preserved even when the SDK
+cannot provide a strongly typed key. It returns `CoseUnsupportedPublicKey` for
+an algorithm unsupported by the strongly typed decoder and preserves the
+original encoded key, reported key type, and reported algorithm.
 
-**The fault is not in enumeration at all.** The caller had persisted an ARKG
-seed to disk (`previewsign-<serial>.json`) during an earlier previewSign
-registration, and on reload was calling the **public** `CoseKey.Create` on those
-bytes directly. No SDK response object is involved anywhere in that path.
+The numeric type and algorithm on `CoseUnsupportedPublicKey` may or may not
+correspond to named `CoseKeyType` and `CoseAlgorithmIdentifier` members. The
+unsupported part is the complete key representation, not necessarily both
+metadata values.
 
-This matters for two reasons:
+The tolerant decoder still rejects malformed encodings, missing type or
+algorithm labels, and modeled algorithms paired with the wrong key type. It
+also currently rejects a modeled algorithm with an unsupported curve or invalid
+coordinate length. This avoids treating corrupted modeled keys as merely
+unsupported.
 
-1. It **confirms** the hardware non-reproduction in section 3. Enumeration was
-   never the failing path, which is why it could not be reproduced.
-2. It **refuted** the working hypothesis that D1 (`RelyingParty`) was the real
-   fault. It is not. D1 remains a genuine HIGH defect worth fixing, but it is
-   unrelated to this report.
+Credential-management and authenticator-data response decoders use
+`CreateOrUnsupported` because an unsupported credential public-key
+representation must not discard the surrounding credential or response.
+Applications that persist such keys can use the same decoder when loading them
+and inspect `CoseUnsupportedPublicKey.EncodedKey`.
 
-The reported 172-byte key is captured verbatim as a regression vector in
-`CoseKeyTests` (`RealWorldUnmodeledKeyHex`). Decoded:
+### Strict PIN/UV key agreement
 
-```text
-map(5) {
-   1: -65537,          key type this SDK does not model
-   3: -65700,          algorithm this SDK does not model
-  -1: EC2 P-256 key,   alg ES256 (-7)
-  -2: EC2 P-256 key,   alg ECDH-ES+HKDF-256 (-25)
-  -3: -9
-}
-```
+The `keyAgreement` field returned by `authenticatorClientPIN` is not an open
+algorithm-negotiation point. PIN/UV auth protocols one and two define the
+returned `COSE_Key` as:
 
----
+- key type `EC2` (`kty = 2`);
+- algorithm `ECDH-ES + HKDF-256` (`alg = -25`); and
+- curve NIST P-256 (`crv = 1`).
 
-## 2. What shipped (PR #585)
+Consequently, `ClientPinResponse` must continue to decode this field with the
+strict `CoseKey.Create` path. Accepting an unsupported key representation here
+would only postpone failure until key agreement and could obscure a protocol
+violation. Future PIN/UV auth protocols that define another key agreement
+scheme require explicit protocol support rather than tolerant decoding of this
+field.
 
-Two commits on `bugfix/fido2-credmgmt-unsupported-cose-key`:
+## Forward-compatibility findings
 
-- `89effa2b` — `fix(fido2): tolerate unmodeled COSE key types when enumerating credentials`
-- `94093fd9` — `docs(fido2): generalize wording for unmodeled COSE key types`
+Locations identify symbols rather than line numbers so that the audit remains
+useful as files evolve.
 
-**Change:** added `CoseUnsupportedPublicKey` (sealed, internal constructor,
-carries the original encoding plus the reported key type and algorithm) and a
-public `CoseKey.CreateOrUnsupported`. Applied at all three data-bearing
-`CoseKey.Create` call sites: `CredentialUserInfo.cs`,
-`Commands/CredentialManagementData.cs`, and `AuthenticatorData.cs`.
-`Commands/ClientPinResponse.cs` was deliberately left on strict `Create`.
-
-**Behavior change shipped:** `AuthenticatorData.CredentialPublicKey` now returns
-the sentinel instead of `null` for an unmodeled key. Code detecting such a
-credential via a null check must test for `CoseUnsupportedPublicKey` instead.
-`null` on that property now means unambiguously "no attested credential data".
-
-**Known incomplete:** see D7/D8 in section 5. PR #585 as it stands does not
-fully deliver its own guarantee.
-
----
-
-## 3. Hardware findings — the reported scenario did NOT reproduce
-
-Run against three connected devices. **This section exists so nobody repeats
-the experiment.**
-
-| Serial | Firmware | Extensions | credMgmt |
+| ID | Location | Finding | Impact |
 |---|---|---|---|
-| 25555459 | 5.4.3 | credProtect, hmac-secret | NotSupported |
-| 103 | 5.8.0 | ..., **previewSign** | True |
-| 125 | 5.8.0 | ..., **`sign`** | True |
-
-**Note serials 103 and 125: same firmware version, different extension name.**
-`previewSign` has already been partly renamed to `sign` in the field. This is
-why the documentation shipped in PR #585 describes the *mechanism* rather than
-naming the extension. Do not reintroduce extension names into permanent API
-documentation.
-
-What the hardware confirmed:
-
-- A previewSign-generated key **is** an unmodeled COSE key:
-  `kty = -65537, alg = -65700`. After the fix it decodes to
-  `CoseUnsupportedPublicKey` with byte-exact raw preservation. The sentinel is
-  therefore validated against real authenticator bytes, not just synthetic CBOR.
-
-What the hardware **disproved**:
-
-- `EnumerateCredentialsForRelyingParty` returned the credential cleanly, with
-  `CoseEcPublicKey kty=2 alg=-7`. The ARKG key rides inside the *extension
-  output*; it is **not** stored as its own discoverable credential.
-- The other route is closed too: requesting the unmodeled algorithm as the
-  credential's own algorithm (`alg = -65539`, `rk = true`) is **rejected by the
-  YubiKey** with `Fido2Exception`.
-- `AddPreviewSignGenerateKeyExtension` has no discoverability flag — its
-  `PreviewSignOptions` are user-presence/user-verification policy only.
-
-**Conclusion:** on firmware 5.8.0 there is no route via the public SDK API to a
-discoverable credential whose own public key is an unmodeled COSE type. The code
-defect is real and worth fixing regardless, but it is not what the reporter hit.
-The stack trace in section 1 later confirmed this: the failure was the strict
-public `CoseKey.Create` applied to a persisted key, with enumeration never
-involved.
-
-**Safety note for anyone re-running this:** `FidoSessionIntegrationTestBase`'s
-constructor (`Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs`)
-**deletes every discoverable credential on the device** and asserts the PIN is
-the integration-test PIN. Do not point it at a personal key. The probes used for
-the results above deliberately did not inherit it, restricted writes to a serial
-allowlist, and cleaned up after themselves. They were not committed.
-
----
-
-## 4. Audit scope and method
-
-139 `.cs` files under `Yubico.YubiKey/src/Yubico/YubiKey/Fido2/` were enumerated
-and every decoding file read. `Yubico.Core` was searched — **no FIDO2 response
-decoding exists there**; all CBOR parsing uses `System.Formats.Cbor` from
-`Yubico.YubiKey`.
-
-**A defect** is code that decodes data *received from a YubiKey* and hard-fails
-on something it does not recognize, when the data it *does* recognize would have
-been sufficient for the caller.
-
-**Not defects** (explicitly considered and rejected): validation of
-caller-supplied input; genuinely malformed CBOR; missing *required* fields; a
-recognized discriminator paired with a structurally wrong payload; and `default`
-arms over `CtapStatus`, which correctly funnel into a `Fido2Exception` carrying
-the raw code.
-
-**Exemplary patterns already in the codebase** — use these as templates:
-
-- `Fido2/AuthenticatorOptions.cs` — `default: return OptionValue.Unknown`.
-- `Fido2/Cbor/CborMap.cs` — `default` arms fall back to `RawCborValue`.
-- `Fido2/UserEntity.cs` and `Fido2/CredentialId.cs` — `CborMap<string>`, unknown
-  keys silently ignored.
-- `Fido2/Commands/CredentialManagementData.cs` — `RawData` + `UnknownFields`
-  (PR #508).
-- `Fido2/CredentialUserInfo.cs` — `TryGetCredentialManagementField` (PR #508).
-- `Fido2/AuthenticatorData.cs` — `EncodedCredentialPublicKey` (PR #468).
-
-**Not audited:** CTAPHID transport framing in
-`Yubico.YubiKey/src/Yubico/YubiKey/Pipelines/`. Explicitly out of scope by
-decision. An unrecognized CTAPHID command byte has not been assessed.
-
----
-
-## 5. Defects
-
-The **Confirmed** column records how the finding was checked. `direct` means the
-file and line were read and the defect confirmed by hand. Every line reference
-below was verified against the tree at commit `94093fd9`; re-check them if the
-files have moved since.
-
-| ID | Confirmed | Location | Defect | Severity |
-|---|---|---|---|---|
-| D1 | direct | `Fido2/RelyingParty.cs:124` | `default: throw` on any relying-party map key but `id`/`name`. Kills `EnumerateRelyingParties()`. **Only site emitting the message in the bug report.** | HIGH |
-| D2 | direct | `Fido2/Commands/ClientPinResponse.cs:97` | `default: throw` on any clientPIN response key but `0x01`–`0x05`. Breaks **every** PIN/UV path, and therefore MakeCredential, GetAssertions, and all credential management | HIGH |
-| D3 | direct | `Fido2/MakeCredentialData.cs:188` | `Statement as PackedAttestationStatement ?? throw`. Any non-`packed` `fmt` breaks `MakeCredential` | HIGH\* |
-| D4 | direct | `Fido2/AttestationStatement.cs:136` | `ContainsOnlyKeys` rejects a `packed` attestation statement carrying any extra key, degrading it to `UnknownAttestationStatement`, which then trips D3 | HIGH |
-| D5 | direct | `Fido2/AttestationStatement.cs:181,214,236` | `ContainsExactKeys` does the same for `fido-u2f`, `apple`, and `none`. Silent loss of the typed properties rather than a throw | LOW–MED |
-| D6 | direct | `Fido2/Fido2Session.Pin.cs:1422` | Three separate bugs in one line — see section 6 | HIGH |
-| D7 | direct | `Fido2/Cose/CoseEcPublicKey.cs:211-220` | The decode constructor assigns through the public property setters, which run `ValidateCurve`/`ValidateLength` and throw `ArgumentException`. **This escapes `CreateOrUnsupported`, whose catch is `NotSupportedException`-only** — a hole in the PR #585 fix | MED |
-| D8 | direct | `Fido2/Cose/CoseEdDsaPublicKey.cs:126-131` | Similar, but NOT the same pattern: the object initializer sets `PublicKey` **before** `Curve`, so an Ed448 key (57-byte public key) is rejected by the 32-byte `PublicKey` length check before curve validation ever runs. For OKP, "future curve" and "corrupt Ed25519" are the same wrong-length check — they cannot be told apart at the validator level | MED |
-| D9 | direct | `Fido2/Commands/ClientPinResponse.cs:78` | Still uses strict `CoseKey.Create` for the `keyAgreement` field | MED |
-| D10 | direct | `Fido2/AuthenticatorData.cs:408` | `GetCredProtectExtension()` rejects credProtect values outside 1–3 | MED |
-| D11 | direct | `Fido2/AuthenticatorInfo.cs:460,520` | `AsDictionary<bool>()` is all-or-nothing; a single non-boolean `options` value throws `InvalidCastException` from the **session constructor** | MED |
-| D12 | direct | `Fido2/Cbor/CborMap.cs:162-189` | `ReadArray<T>` rejects the whole array when one element does not convert (throw at line 189); 13 call sites | LOW |
-| D13 | direct | `Fido2/Commands/GetKeyAgreementResponse.cs:53` | Misleading `Ctap2MissingRequiredField` for a field that is present but not an EC key | LOW |
-| D14 | direct | `Fido2/PinProtocols/PinUvAuthProtocolBase.cs:177` | Duplicate of D13 one layer down; line 184 also hard-codes P-256 regardless of what the device reported | LOW |
-| D15 | doc | `Fido2/Cose/CoseEcPublicKey.cs:78`, `Fido2/Cose/CoseEdDsaPublicKey.cs:46` | Both `Curve` property docs promise `NotSupportedException` on set; `ValidateCurve` actually throws `ArgumentException` in both files. Pre-existing code/contract mismatch, discovered during D7 re-analysis | LOW |
-| D16 | direct | `Fido2/Cose/CoseEcPublicKey.cs:156,159` | `throw new ArgumentException(nameof(curve), "Unknown curve")` — arguments swapped; the signature is `(message, paramName)`, so the message renders as "curve" and the parameter name as "Unknown curve". Cosmetic | LOW |
-
-\* **D3's severity is unconfirmed.** Nobody has established whether YubiKey
-firmware ever returns a non-`packed` `fmt`. `MakeCredentialParameters` has no
-attestation-format preference input, so the format is entirely the
-authenticator's choice today. The presence of
-`AuthenticatorInfo.AttestationFormats` (getInfo key `0x16`) and four modeled
-format classes is circumstantial evidence that non-packed is expected. **A
-firmware owner must confirm before this is scheduled.**
-
----
-
-## 6. D6 in detail
-
-```csharp
-// Fido2Session.Pin.cs:1422 — called unconditionally from the constructor (Fido2Session.cs:273)
-var protocol = AuthenticatorInfo.PinUvAuthProtocols?[0] ?? PinUvAuthProtocol.ProtocolOne;
-```
-
-Three separate defects:
-
-1. **It only inspects index 0.** CTAP 2.1 defines `pinUvAuthProtocols` as a list
-   *in order of decreasing authenticator preference*. A device advertising
-   `[3, 2, 1]` means "I prefer 3, but I also support 2 and 1." The SDK throws and
-   refuses to construct a session against a device that supports both protocols
-   the SDK implements. Unambiguously a bug.
-2. **`?[0]` does not guard against an empty list.** The null-conditional operator
-   guards null only. A non-null empty list yields `ArgumentOutOfRangeException`
-   rather than the intended `NotSupportedException`. Only reachable on a device
-   that does not conform to CTAP, which requires the array to be non-empty when
-   present.
-3. **It throws from the constructor**, which is disproportionate *and* defeats
-   the SDK's own escape hatch. `AuthProtocol` is consumed only by PIN/UV paths;
-   reading `AuthenticatorInfo`, calling `Reset`, and a non-UV `GetAssertion`
-   never need it. Worse, `SetAuthProtocol(PinUvAuthProtocolBase)` exists and is
-   documented as *"Overrides the default PIN/UV Auth protocol"* — but it is an
-   **instance method**. If the constructor throws you never obtain an instance,
-   so the designed override is unreachable in exactly the scenario it exists for.
-
-**Chosen remedy** (see section 7 for the reasoning): walk the list for the first
-implemented protocol; handle the empty case; and when the device advertises only
-unmodeled protocols, assign an **internal**
-`UnsupportedPinUvAuthProtocol : PinUvAuthProtocolBase` sentinel that reports the
-advertised protocol number and throws a precise `NotSupportedException` from each
-of its eight abstract members. The session then constructs, non-PIN work
-proceeds, `SetAuthProtocol` becomes reachable, and `AuthProtocol` stays
-non-nullable.
-
----
-
-## 7. Decisions already made — do not relitigate without new information
-
-**Sentinel over nullable.** For `CredentialUserInfo.CredentialPublicKey`,
-nullable was rejected. The property is non-nullable and CTAP mandates field
-`0x08` for `enumerateCredentials`, so nullable is both the wrong model and a
-source-breaking annotation change that would force null checks on 100% of
-callers to guard a case that fires for a fraction of a percent of credentials.
-The sentinel costs nothing unless you meet an unmodeled key, and it degrades
-better: `is CoseEcPublicKey` skips gracefully, `.Algorithm`/`.Type` return the
-real reported values instead of a `NullReferenceException`, a hard cast fails
-with a message naming the actual type, and consumers building with nullable
-reference types disabled would get no warning at all under the nullable design.
-The same reasoning drives the D6 remedy.
-
-**`CreateOrUnsupported` catches only `NotSupportedException`, and stays that
-way for now.** An earlier draft prescribed widening the catch to
-`ArgumentException` for D7/D8; that prescription was **retracted** after
-re-analysis (see Stack 1) because it would absorb genuine corruption — a
-32-coordinate on a 48-curve, a truncated Ed25519 key — into the sentinel.
-`Ctap2DataException` must keep propagating: malformed CBOR, a missing key type
-or algorithm, and a modeled algorithm paired with the wrong key type are
-corrupt data, not future values.
-
-**Public `CoseKey.Create` stays strict.** Making it return the sentinel would
-silently change a documented public throw contract. `Create` is strict;
-`CreateOrUnsupported` is lenient.
-
-**`CreateOrUnsupported` is public — this reverses an earlier decision.** It was
-originally `internal`, on the reasoning that callers obtain the sentinel through
-SDK response objects and therefore never need to invoke the lenient parse
-themselves. **The reporter's stack trace refuted that.** An application that
-persists a key and reloads it later holds only raw bytes; there is no SDK
-response object in that path, and the only public entry point available was the
-strict `Create`, which throws. Corroborating evidence that the surface was
-missing something: the SDK's own test utility
-`PreviewSignGeneratedKeyExtensions.ParseArkgCoseKey` hand-rolls roughly sixty
-lines of CBOR parsing, which at the time it was written was the only way to
-parse one of these keys. A caller can now use `CreateOrUnsupported` and read
-`CoseUnsupportedPublicKey.EncodedKey` instead; that utility could be simplified
-to match, though doing so is not required and is out of scope here.
-
-Both overloads are public: the plain form, and a `out int bytesRead` form for
-parity with `Create` so callers can parse a key embedded in a larger buffer.
-
-**No `TryCreate`.** With a sentinel the method cannot fail, so the boolean would
-duplicate `key is CoseUnsupportedPublicKey`; none of the three call sites branch
-on it; and every `Try*` method in this codebase pairs `false` with a null or
-default out-parameter, several of them annotated `[MaybeNullWhen(false)]`, which
-an always-populated out-parameter would invert.
-
-**Decode-side tolerance must never become encode-side fabrication.** Preserved
-unknown fields must **not** be re-emitted from any `CborEncode()`.
-`RelyingParty.CborEncode()` is fed to the authenticator from
-`MakeCredentialParameters`; re-emitting authenticator-originated keys during
-registration is wrong, and CTAP2 canonical ordering makes it fiddly besides.
-
-**`whats-new.md` is release-time only.** Every edit to it comes from a release
-commit. Do not touch it in a feature or bugfix PR; put behavior-change notes in
-the PR body for the release manager to pick up.
-
-**Hard constraint set by the owner: no breaking changes, and nothing becomes
-nullable.** This is what blocks D3. It also ruled out remedy (b) for D7;
-remedy (a) was later found independently defective — see Stack 1.
-
----
-
-## 8. Proposed remaining work
-
-Three stacked PRs. **None of this has been built.**
-
-```text
-develop
- └─ bugfix/fido2-credmgmt-unsupported-cose-key   → PR #585 (open; ships with D7/D8 documented-open)
-     └─ bugfix/fido2-unknown-map-keys             → D1, D2, D4, D5, D9
-         └─ bugfix/fido2-pinuvauth-protocol       → D6
-```
-
-### Stack 1 — D7/D8 follow-up (NOT an amendment to PR #585)
-
-**Status: no known-correct remedy. All three candidates analyzed to date are
-defective. PR #585 ships with D7/D8 open and documented on the API surface.**
-Whoever picks this up: read this whole section first — two independent reviews
-(the original handoff and a later Opus pass) each proposed a fix here that
-detailed re-analysis then killed. The failure modes below are the trap record.
-
-**Remedies considered and rejected:**
-
-- **(a) widen the catch to `ArgumentException`.** Originally chosen; now
-  **rejected**. `ValidateLength` rejecting a 31-byte coordinate on a P-256 key,
-  or `PublicKey` rejecting a truncated Ed25519 key, is corruption detection —
-  the exact thing the sentinel design promised never to absorb.
-  `CreateOrUnsupported`'s own XML doc says so: "corrupt data rather than a
-  future algorithm... not tolerated." D7 and D8 want opposite answers; one
-  catch cannot give both.
-- **(b) stop the decode constructors running their validators.** Rejected as
-  before: changes decode behavior for every caller including strict `Create`,
-  and permits a `CoseEcPublicKey` with an out-of-range `Curve`.
-- **(c) change `ValidateCurve` to throw `NotSupportedException`,** aligning the
-  code with the exception both `Curve` property docs already promise (D15), so
-  the existing catch absorbs unmodeled curves with no widening. Attractive —
-  and **rejected as proposed**, for two reasons found on close reading:
-  1. **It does nothing for EdDSA.** The `CreateFromEncodedKey` object
-     initializer sets `PublicKey` before `Curve` (D8's corrected entry in
-     section 5), so an Ed448 key dies on the 32-byte length check before curve
-     validation runs. And for OKP, future-curve and corrupt-key are the *same*
-     length check — the D7/D8 separation this remedy depends on does not exist
-     in that file.
-  2. **It is not one line even for EC.** A `NotSupportedException` from inside
-     the constructor reaches the catch and produces a sentinel whose
-     `Algorithm` is a **modeled** value (e.g. ES256). That falsifies two
-     shipped contracts: `CreateOrUnsupported`'s "when the algorithm is one
-     this SDK models, the behavior is identical to `Create`", and the
-     load-bearing comment above the try block stating the only observable
-     `NotSupportedException` is the dispatch's. Both must be redesigned, not
-     merely edited.
-
-**The actual open design question**, which must be answered before any code:
-*may a `CoseUnsupportedPublicKey` ever carry a modeled algorithm?* If yes, the
-sentinel's meaning widens from "algorithm this SDK does not model" to "key this
-SDK cannot represent", every consumer switching on `.Algorithm` must be
-reconsidered, and both documents above must be rewritten to match. If no, D7
-requires a second sentinel or a different mechanism entirely. Decide this
-first; the diff is downstream of the decision.
-
-Also fold in when this is picked up: D15 (align `ValidateCurve`'s exception
-with the documented contract — in whichever direction the design decision
-implies) and D16 (swapped `ArgumentException` arguments), both trivial once
-the direction is fixed.
-
-Criteria for whatever remedy survives: an unmodeled EC curve yields the
-sentinel with raw bytes preserved; enumeration returns all credentials when one
-is affected; **anti:** a wrong-length coordinate on a *modeled* curve still
-throws; **anti:** a truncated Ed25519 key still throws; **anti:** public
-`Create` still throws for all of these; **anti:** every malformed-encoding
-rejection in `CreateOrUnsupported`'s documented exception contract still
-throws. Ed448 tolerance may prove unachievable without redesigning
-`CoseEdDsaPublicKey` validation order — if so, document it as out of scope
-rather than forcing it.
-
-Note that `ArgumentException` is currently documented on both
-`CreateOrUnsupported` overloads as the outcome for a modeled algorithm on an
-unmodeled curve. That documentation is **accurate today** and must stay until a
-remedy ships; the earlier instruction to remove it belonged to rejected
-remedy (a).
-
-Do not write a criterion about null input. `ReadOnlyMemory<byte>` is a struct and
-neither `Create` nor `CborMap` performs a null check, so `ArgumentNullException`
-is unreachable on these entry points — an earlier draft of this document claimed
-otherwise, and `Create`'s XML documentation carried the same false claim until it
-was removed.
-
-### Stack 2 — unknown map keys (D1, D2, D4, D5, D9)
-
-- **D1** — rewrite `RelyingParty`'s decode constructor onto `CborMap<string>`,
-  matching `UserEntity` and `CredentialId`, and add
-  `TryGetUnknownField(string, out ReadOnlyMemory<byte>)` mirroring
-  `CredentialUserInfo.TryGetCredentialManagementField`.
-  **`RelyingParty` has no unit tests today** — a new `RelyingPartyTests.cs` is
-  required, as is `EnumerateRpsResponseTests.cs`.
-  Note that `RelyingParty` is decoded at exactly one site, in
-  `Commands/CredentialManagementData.cs`, so a single fix covers
-  `EnumerateRpsBeginResponse`, `EnumerateRpsGetNextResponse`, and
-  `CredentialManagementResponse`.
-- **D2** — have the `default:` arm collect into an unknown-fields dictionary, and
-  add `RawData` and `UnknownFields` to the public `ClientPinData`, exactly as
-  `CredentialManagementData` does.
-- **D4/D5** — drop `ContainsOnlyKeys`/`ContainsExactKeys` and keep only the
-  `Contains(...)` required-field checks. Then **delete both helpers from
-  `CborMap`**, along with their unit test in `CborMapTests.cs` — they are used
-  nowhere else, so this removes the hazard from the toolkit permanently.
-  `CborMap<TKey>` is `internal`, so this is not a public API change.
-- **D9** — swap the `keyAgreement` decode in `ClientPinResponse` to
-  `CreateOrUnsupported`.
-
-**Anti-criteria:** `RelyingParty.CborEncode()` on a decoded relying party that
-carried unknown fields must emit **only** `id` and `name`; and `CborEncode()` for
-`new RelyingParty("x")` must remain byte-identical to its current output.
-
-### Stack 3 — PIN/UV protocol selection (D6)
-
-As described in section 6. The key criterion, and the point of the exercise: with
-a device advertising only unmodeled protocols, `SetAuthProtocol(myProtocol)` must
-succeed and subsequent PIN operations must use it. **Anti:** `AuthProtocol`
-remains non-nullable; the sentinel type is `internal`; and `Dispose` on a session
-holding the sentinel does not throw.
-
-### Not scheduled
-
-| ID | Disposition |
-|---|---|
-| D3 | **Blocked twice.** The fix makes three public properties nullable, which violates the constraint, and reachability needs a firmware owner |
-| D10, D11, D12, D13, D14 | All non-breaking and buildable. Deferred only on reviewer-load grounds. Pull them forward freely |
-
----
-
-## 9. Open items
-
-1. ~~Jonas's stack trace~~ — **received and resolved.** See section 1. The fault
-   was the strict public `CoseKey.Create` applied to a persisted key, not
-   enumeration and not D1. Addressed by making `CreateOrUnsupported` public.
-2. **D3 reachability** — needs a firmware owner to confirm whether a non-`packed`
-   attestation format is ever returned.
-3. **D6 tail case** — the sentinel approach was chosen, but "device advertises
-   only unmodeled protocols" is product-visible behavior; confirm before building.
-4. **CTAPHID transport** (`Pipelines/`) has never been assessed for this class of
-   defect.
-5. **Version** — PR #585 adds a public type and changes shipped behavior. A minor
-   bump (1.18.0) was recommended over a patch release; not yet ratified.
-
----
-
-## 10. Reproducing the audit
-
-Sweep for the two throwing patterns:
-
-```bash
-grep -rn "Ctap2CborUnexpectedKey\|CborUnexpectedMapTag" --include='*.cs' Yubico.YubiKey/src/
-grep -rn "ContainsExactKeys\|ContainsOnlyKeys" --include='*.cs' Yubico.YubiKey/src/
-```
-
-Both were exhaustive at the time of writing: two `default: throw` sites (D1 and
-D2) and four `Contains*Keys` sites, all four in `AttestationStatement.cs`.
-
----
+| F1 | `Fido2/RelyingParty.cs`, encoded-value constructor | Any relying-party map key other than `id` or `name` causes a throw instead of being ignored or preserved. | High: credential-management relying-party enumeration can fail on an added field. |
+| F2 | `Fido2/Commands/ClientPinResponse.cs`, `GetData` | An unknown top-level response key causes a throw even when all fields needed for the selected subcommand are present. | High: PIN/UV operations can fail on an additive response field. This does not apply to the strictly defined contents of `keyAgreement`. |
+| F3 | `Fido2/MakeCredentialData.cs`, constructor | The response requires a `PackedAttestationStatement`; another valid attestation format is rejected after it has been decoded. | Potentially high, but reachability depends on which formats supported authenticators return. |
+| F4 | `Fido2/AttestationStatement.cs`, `PackedAttestationStatement.FromCbor` | `ContainsOnlyKeys` rejects a packed attestation statement with an additional field. | High when an authenticator extends a packed statement. |
+| F5 | `Fido2/AttestationStatement.cs`, `FidoU2fAttestationStatement.FromCbor`, `AppleAttestationStatement.FromCbor`, and `NoneAttestationStatement.FromCbor` | `ContainsExactKeys` rejects otherwise valid statements with additional fields. | Low to medium: typed attestation data is lost. |
+| F6 | `Fido2/Fido2Session.Pin.cs`, `GetPreferredPinProtocol` | Selection inspects only the first advertised protocol, indexing an empty list throws the wrong exception, and an unsupported first protocol prevents construction even when a supported protocol appears later. The configuration escape hatch is an instance method, so constructor failure prevents callers from reaching it. | High: session construction can fail despite a mutually supported protocol. |
+| F7 | `Fido2/Cose/CoseEcPublicKey.cs`, encoded-value constructor | Validation of an unsupported curve throws `ArgumentException`, so `CreateOrUnsupported` cannot preserve a key that uses a modeled algorithm with a future EC curve. | Medium: a future key representation is rejected. Any remedy must continue rejecting invalid coordinate lengths for modeled curves. |
+| F8 | `Fido2/Cose/CoseEdDsaPublicKey.cs`, `CreateFromEncodedKey` | Public-key length is validated before the curve, making an unsupported OKP curve indistinguishable from a malformed Ed25519 key at that point. | Medium: future OKP representations cannot be preserved without restructuring validation. |
+| F9 | `Fido2/AuthenticatorData.cs`, `GetCredProtectExtension` | Values outside the currently modeled range are rejected. | Medium: a future credProtect policy cannot be inspected through this helper. |
+| F10 | `Fido2/AuthenticatorInfo.cs`, `Options` decoding | `AsDictionary<bool>()` rejects the entire options map when one value is not Boolean. | Medium: session construction can fail instead of preserving recognized options. |
+| F11 | `Fido2/Cbor/CborMap.cs`, `ReadArray<TValue>` | One unconvertible array element rejects the complete array. | Low: callers cannot retain recognized elements where the protocol permits future values. Each call site must be assessed because some arrays are homogeneous by contract. |
+
+`AuthenticatorInfo.Certifications` also uses an all-or-nothing dictionary
+conversion. It is excluded from F10 because the current CTAP schema requires
+integer certification values; a noninteger value is malformed rather than an
+unrecognized extension.
+
+## Related contract and diagnostic findings
+
+These issues were identified in related COSE key handling code but do not meet
+the forward-compatibility criteria above.
+
+| ID | Location | Finding | Impact |
+|---|---|---|---|
+| F12 | `Fido2/Commands/GetKeyAgreementResponse.cs`, `GetData`, and `Fido2/PinProtocols/PinUvAuthProtocolBase.cs`, `Encapsulate` | A present but invalid key-agreement key is reported as a missing field at the response boundary, while the protocol layer reports a different generic key error. | Low: diagnostics do not clearly identify a protocol-invalid key. Requiring EC2, P-256, and algorithm `-25` remains correct. |
+| F13 | `Fido2/Cose/CoseEcPublicKey.cs` and `Fido2/Cose/CoseEdDsaPublicKey.cs`, `Curve` properties | The property documentation names `NotSupportedException`, but unsupported curves currently produce `ArgumentException`. Correct the property documentation; do not change `ValidateCurve` while `CreateOrUnsupported` catches `NotSupportedException` (see the constraints below). | Low: the documented exception contract is inaccurate. |
+| F14 | `Fido2/Cose/CoseEcPublicKey.cs`, curve-based constructor | Two `ArgumentException` calls pass message and parameter name in the wrong order. | Low: exception diagnostics are misleading. |
+
+## Design constraints for remediation
+
+Do not change `ValidateCurve` to throw `NotSupportedException` while `CreateOrUnsupported` catches
+that exception type. Doing so would convert a modeled algorithm with an invalid or unsupported curve
+into the forward-compatible sentinel, conflating malformed modeled data with an unmodeled algorithm.
+
+Likewise, do not bypass the typed key constructors' curve and coordinate validation. The tolerant
+path is for algorithms the typed decoder does not implement, not for structurally invalid data using
+a modeled algorithm. Whether a future sentinel should ever represent a modeled algorithm is a
+separate API decision and is not established by this audit.
+
+Any remediation of these findings should retain these boundaries:
+
+- Decode-side tolerance must not fabricate or re-emit authenticator-originated
+  unknown fields in request encodings.
+- Required fields and malformed CBOR must remain errors.
+- Modeled algorithms with structurally invalid keys must remain errors.
+- `CoseKey.Create` must remain strict; tolerant behavior belongs in
+  `CreateOrUnsupported` and response decoders where surrounding data remains
+  useful.
+- PIN/UV key agreement must remain strict for protocols one and two: EC2,
+  P-256, and algorithm `-25` are required.
+- Public nullability and existing public property types should not be changed
+  merely to represent an unsupported value when a preserving representation is
+  available.
+
+For F7 and F8, broadening a catch from `NotSupportedException` to
+`ArgumentException` is unsafe because the same exception also represents
+corrupt modeled keys. A solution must distinguish unsupported representation
+from invalid data before changing tolerant-decoder behavior.
+
+For F3, confirm that supported firmware can return a non-packed attestation
+format before assigning priority. The SDK models multiple attestation statement
+formats, but that alone does not establish current device behavior.
+
+## Verification targets
+
+Tests for tolerant COSE decoding should continue to establish that:
+
+- modeled keys produce their modeled key types;
+- unsupported representations preserve the complete original encoding and the
+  reported metadata;
+- persisted unsupported keys can be decoded again through the public tolerant
+  API;
+- trailing data is excluded from `EncodedKey` and `bytesRead` identifies only
+  the key;
+- malformed CBOR, missing required labels, wrong key-type pairings, and invalid
+  modeled-key lengths still throw; and
+- credential enumeration returns all entries when one credential uses an
+  unsupported public-key representation.
+
+## References
+
+- CTAP PIN/UV auth protocol definitions, including the required key-agreement
+  COSE key parameters.
+- RFC 8949, Concise Binary Object Representation.
+- RFC 9052, CBOR Object Signing and Encryption structures.
+- RFC 9053, CBOR Object Signing and Encryption algorithms.
 
 ## Glossary
 
-- **ARKG** — Asynchronous Remote Key Generation.
-- **CBOR** — Concise Binary Object Representation (RFC 8949).
-- **COSE** — CBOR Object Signing and Encryption (RFC 8152).
-- **CTAP / CTAP2** — Client to Authenticator Protocol.
-- **CTAPHID** — CTAP over the USB Human Interface Device transport.
-- **OKP** — Octet Key Pair, the COSE key type used for Edwards curves.
-- **PIN/UV** — Personal Identification Number / User Verification.
-- **RP** — Relying Party.
-- **SDK** — Software Development Kit.
+- **CBOR**: Concise Binary Object Representation.
+- **COSE**: CBOR Object Signing and Encryption.
+- **CTAP**: Client to Authenticator Protocol.
+- **CTAPHID**: CTAP over the USB Human Interface Device transport.
+- **EC2**: COSE key type for elliptic-curve keys with x- and y-coordinates.
+- **OKP**: Octet Key Pair.
+- **PIN/UV**: Personal Identification Number / User Verification.
+- **SDK**: Software Development Kit.

--- a/contributordocs/fido2-forward-compatibility-audit.md
+++ b/contributordocs/fido2-forward-compatibility-audit.md
@@ -205,13 +205,15 @@ files have moved since.
 | D5 | direct | `Fido2/AttestationStatement.cs:181,214,236` | `ContainsExactKeys` does the same for `fido-u2f`, `apple`, and `none`. Silent loss of the typed properties rather than a throw | LOW–MED |
 | D6 | direct | `Fido2/Fido2Session.Pin.cs:1422` | Three separate bugs in one line — see section 6 | HIGH |
 | D7 | direct | `Fido2/Cose/CoseEcPublicKey.cs:211-220` | The decode constructor assigns through the public property setters, which run `ValidateCurve`/`ValidateLength` and throw `ArgumentException`. **This escapes `CreateOrUnsupported`, whose catch is `NotSupportedException`-only** — a hole in the PR #585 fix | MED |
-| D8 | direct | `Fido2/Cose/CoseEdDsaPublicKey.cs:128-129` | Same pattern for non-Ed25519 OKP curves. `Ed448` is already a `CoseEcCurve` member but is rejected | MED |
+| D8 | direct | `Fido2/Cose/CoseEdDsaPublicKey.cs:126-131` | Similar, but NOT the same pattern: the object initializer sets `PublicKey` **before** `Curve`, so an Ed448 key (57-byte public key) is rejected by the 32-byte `PublicKey` length check before curve validation ever runs. For OKP, "future curve" and "corrupt Ed25519" are the same wrong-length check — they cannot be told apart at the validator level | MED |
 | D9 | direct | `Fido2/Commands/ClientPinResponse.cs:78` | Still uses strict `CoseKey.Create` for the `keyAgreement` field | MED |
 | D10 | direct | `Fido2/AuthenticatorData.cs:408` | `GetCredProtectExtension()` rejects credProtect values outside 1–3 | MED |
 | D11 | direct | `Fido2/AuthenticatorInfo.cs:460,520` | `AsDictionary<bool>()` is all-or-nothing; a single non-boolean `options` value throws `InvalidCastException` from the **session constructor** | MED |
 | D12 | direct | `Fido2/Cbor/CborMap.cs:162-189` | `ReadArray<T>` rejects the whole array when one element does not convert (throw at line 189); 13 call sites | LOW |
 | D13 | direct | `Fido2/Commands/GetKeyAgreementResponse.cs:53` | Misleading `Ctap2MissingRequiredField` for a field that is present but not an EC key | LOW |
 | D14 | direct | `Fido2/PinProtocols/PinUvAuthProtocolBase.cs:177` | Duplicate of D13 one layer down; line 184 also hard-codes P-256 regardless of what the device reported | LOW |
+| D15 | doc | `Fido2/Cose/CoseEcPublicKey.cs:78`, `Fido2/Cose/CoseEdDsaPublicKey.cs:46` | Both `Curve` property docs promise `NotSupportedException` on set; `ValidateCurve` actually throws `ArgumentException` in both files. Pre-existing code/contract mismatch, discovered during D7 re-analysis | LOW |
+| D16 | direct | `Fido2/Cose/CoseEcPublicKey.cs:156,159` | `throw new ArgumentException(nameof(curve), "Unknown curve")` — arguments swapped; the signature is `(message, paramName)`, so the message renders as "curve" and the parameter name as "Unknown curve". Cosmetic | LOW |
 
 \* **D3's severity is unconfirmed.** Nobody has established whether YubiKey
 firmware ever returns a non-`packed` `fmt`. `MakeCredentialParameters` has no
@@ -275,10 +277,14 @@ with a message naming the actual type, and consumers building with nullable
 reference types disabled would get no warning at all under the nullable design.
 The same reasoning drives the D6 remedy.
 
-**`CreateOrUnsupported` catches only `NotSupportedException`** — to be widened to
-`ArgumentException` for D7/D8, and nothing else. `Ctap2DataException` must keep
-propagating: malformed CBOR, a missing key type or algorithm, and a modeled
-algorithm paired with the wrong key type are corrupt data, not future values.
+**`CreateOrUnsupported` catches only `NotSupportedException`, and stays that
+way for now.** An earlier draft prescribed widening the catch to
+`ArgumentException` for D7/D8; that prescription was **retracted** after
+re-analysis (see Stack 1) because it would absorb genuine corruption — a
+32-coordinate on a 48-curve, a truncated Ed25519 key — into the sentinel.
+`Ctap2DataException` must keep propagating: malformed CBOR, a missing key type
+or algorithm, and a modeled algorithm paired with the wrong key type are
+corrupt data, not future values.
 
 **Public `CoseKey.Create` stays strict.** Making it return the sentinel would
 silently change a documented public throw contract. `Create` is strict;
@@ -318,8 +324,8 @@ commit. Do not touch it in a feature or bugfix PR; put behavior-change notes in
 the PR body for the release manager to pick up.
 
 **Hard constraint set by the owner: no breaking changes, and nothing becomes
-nullable.** This is what blocks D3, and what forces remedy (a) over remedy (b)
-for D7.
+nullable.** This is what blocks D3. It also ruled out remedy (b) for D7;
+remedy (a) was later found independently defective — see Stack 1.
 
 ---
 
@@ -329,42 +335,78 @@ Three stacked PRs. **None of this has been built.**
 
 ```text
 develop
- └─ bugfix/fido2-credmgmt-unsupported-cose-key   → PR #585 (open) + amendment
+ └─ bugfix/fido2-credmgmt-unsupported-cose-key   → PR #585 (open; ships with D7/D8 documented-open)
      └─ bugfix/fido2-unknown-map-keys             → D1, D2, D4, D5, D9
          └─ bugfix/fido2-pinuvauth-protocol       → D6
 ```
 
-### Stack 1 — amend PR #585 (D7, D8)
+### Stack 1 — D7/D8 follow-up (NOT an amendment to PR #585)
 
-Widen `CreateOrUnsupported`'s catch to absorb `ArgumentException` and return the
-sentinel.
+**Status: no known-correct remedy. All three candidates analyzed to date are
+defective. PR #585 ships with D7/D8 open and documented on the API surface.**
+Whoever picks this up: read this whole section first — two independent reviews
+(the original handoff and a later Opus pass) each proposed a fix here that
+detailed re-analysis then killed. The failure modes below are the trap record.
 
-Two remedies were considered; **only (a) is permitted under the
-no-breaking-changes constraint**:
+**Remedies considered and rejected:**
 
-- **(a) widen the catch.** Confines the change to the tolerant path;
-  `CoseEcPublicKey`, `CoseEdDsaPublicKey`, and public `Create` are untouched.
-  **Chosen.**
-- (b) stop the decode constructors running their validators. This changes decode
-  behavior for every caller including direct `Create` users, and would permit a
-  `CoseEcPublicKey` to exist with an out-of-range `Curve`. **Rejected.**
+- **(a) widen the catch to `ArgumentException`.** Originally chosen; now
+  **rejected**. `ValidateLength` rejecting a 31-byte coordinate on a P-256 key,
+  or `PublicKey` rejecting a truncated Ed25519 key, is corruption detection —
+  the exact thing the sentinel design promised never to absorb.
+  `CreateOrUnsupported`'s own XML doc says so: "corrupt data rather than a
+  future algorithm... not tolerated." D7 and D8 want opposite answers; one
+  catch cannot give both.
+- **(b) stop the decode constructors running their validators.** Rejected as
+  before: changes decode behavior for every caller including strict `Create`,
+  and permits a `CoseEcPublicKey` with an out-of-range `Curve`.
+- **(c) change `ValidateCurve` to throw `NotSupportedException`,** aligning the
+  code with the exception both `Curve` property docs already promise (D15), so
+  the existing catch absorbs unmodeled curves with no widening. Attractive —
+  and **rejected as proposed**, for two reasons found on close reading:
+  1. **It does nothing for EdDSA.** The `CreateFromEncodedKey` object
+     initializer sets `PublicKey` before `Curve` (D8's corrected entry in
+     section 5), so an Ed448 key dies on the 32-byte length check before curve
+     validation runs. And for OKP, future-curve and corrupt-key are the *same*
+     length check — the D7/D8 separation this remedy depends on does not exist
+     in that file.
+  2. **It is not one line even for EC.** A `NotSupportedException` from inside
+     the constructor reaches the catch and produces a sentinel whose
+     `Algorithm` is a **modeled** value (e.g. ES256). That falsifies two
+     shipped contracts: `CreateOrUnsupported`'s "when the algorithm is one
+     this SDK models, the behavior is identical to `Create`", and the
+     load-bearing comment above the try block stating the only observable
+     `NotSupportedException` is the dispatch's. Both must be redesigned, not
+     merely edited.
 
-Consequence: `CoseUnsupportedPublicKey`'s XML documentation must widen from
-"algorithm this SDK does not model" to "cannot be represented by a modeled type",
-because you can now receive it for a modeled algorithm on an unmodeled curve.
+**The actual open design question**, which must be answered before any code:
+*may a `CoseUnsupportedPublicKey` ever carry a modeled algorithm?* If yes, the
+sentinel's meaning widens from "algorithm this SDK does not model" to "key this
+SDK cannot represent", every consumer switching on `.Algorithm` must be
+reconsidered, and both documents above must be rewritten to match. If no, D7
+requires a second sentinel or a different mechanism entirely. Decide this
+first; the diff is downstream of the decision.
 
-Criteria: an unmodeled curve, an unmodeled coordinate length, and a non-Ed25519
-OKP curve each yield the sentinel with raw bytes preserved; enumeration returns
-all credentials when one is affected; **anti:** public `Create` still throws for
-all three; **anti:** `CoseEcPublicKey.cs` and `CoseEdDsaPublicKey.cs` are
-unmodified; **anti:** every malformed-encoding rejection listed in
-`CreateOrUnsupported`'s exception contract still throws, so widening the catch
-absorbs the curve and coordinate-length cases only.
+Also fold in when this is picked up: D15 (align `ValidateCurve`'s exception
+with the documented contract — in whichever direction the design decision
+implies) and D16 (swapped `ArgumentException` arguments), both trivial once
+the direction is fixed.
+
+Criteria for whatever remedy survives: an unmodeled EC curve yields the
+sentinel with raw bytes preserved; enumeration returns all credentials when one
+is affected; **anti:** a wrong-length coordinate on a *modeled* curve still
+throws; **anti:** a truncated Ed25519 key still throws; **anti:** public
+`Create` still throws for all of these; **anti:** every malformed-encoding
+rejection in `CreateOrUnsupported`'s documented exception contract still
+throws. Ed448 tolerance may prove unachievable without redesigning
+`CoseEdDsaPublicKey` validation order — if so, document it as out of scope
+rather than forcing it.
 
 Note that `ArgumentException` is currently documented on both
 `CreateOrUnsupported` overloads as the outcome for a modeled algorithm on an
-unmodeled curve. That documentation must be removed as part of this work, since
-the whole point of the change is that those cases stop throwing.
+unmodeled curve. That documentation is **accurate today** and must stay until a
+remedy ships; the earlier instruction to remove it belonged to rejected
+remedy (a).
 
 Do not write a criterion about null input. `ReadOnlyMemory<byte>` is a struct and
 neither `Create` nor `CborMap` performs a null check, so `ArgumentNullException`

--- a/contributordocs/fido2-forward-compatibility-audit.md
+++ b/contributordocs/fido2-forward-compatibility-audit.md
@@ -32,20 +32,51 @@ Reported by Jonas Markström: `Fido2Session.EnumerateCredentialsForRelyingParty`
 throws and aborts enumeration of *all* credentials for a relying party when any
 one credential's public key uses a COSE algorithm the SDK does not model.
 
-Two corrections to the original report, both confirmed by reading the code:
+Two corrections to the original report, both confirmed by reading the code and
+later by the reporter's stack trace:
 
 - The exception is `System.NotSupportedException` ("The requested algorithm is
   not supported"), **not** `Ctap2DataException`.
 - The message quoted in the report — `Ctap2CborUnexpectedKey`, *"An unexpected
   key was encountered in a CBOR map; expected to find {0} (name '{1}')"* — is
   thrown from exactly one place in the SDK: `Fido2/RelyingParty.cs:128`. That is
-  **not** on the reported code path. See defect D1 in section 5.
+  **not** on the reported code path, and was a red herring.
 
-The report quoted the unformatted resx template (`{0}`, `{1}`), which suggests
-source analysis rather than a captured stack trace. **A stack trace was
-requested and had not arrived when this document was written.** Whoever picks
-this up should chase it — it determines whether the user's actual problem is D1
-rather than the COSE issue.
+### The stack trace, and what it actually showed
+
+```text
+Yubico.YubiKey 1.17.2.0 · .NET 10.0.9 · YubiKey firmware 5.8.0
+
+System.NotSupportedException: The requested algorithm is not supported.
+   at Yubico.YubiKey.Fido2.Cose.CoseKey.Create(ReadOnlyMemory`1 coseEncodedKey, Int32& bytesRead)
+   at powershellYK.Cmdlets.Fido.TraceYubiKeyFIDO2CredentialManagementCommand.TryCoseKeyCreate(...)
+```
+
+**The fault is not in enumeration at all.** The caller had persisted an ARKG
+seed to disk (`previewsign-<serial>.json`) during an earlier previewSign
+registration, and on reload was calling the **public** `CoseKey.Create` on those
+bytes directly. No SDK response object is involved anywhere in that path.
+
+This matters for two reasons:
+
+1. It **confirms** the hardware non-reproduction in section 3. Enumeration was
+   never the failing path, which is why it could not be reproduced.
+2. It **refuted** the working hypothesis that D1 (`RelyingParty`) was the real
+   fault. It is not. D1 remains a genuine HIGH defect worth fixing, but it is
+   unrelated to this report.
+
+The reported 172-byte key is captured verbatim as a regression vector in
+`CoseKeyTests` (`RealWorldUnmodeledKeyHex`). Decoded:
+
+```text
+map(5) {
+   1: -65537,          key type this SDK does not model
+   3: -65700,          algorithm this SDK does not model
+  -1: EC2 P-256 key,   alg ES256 (-7)
+  -2: EC2 P-256 key,   alg ECDH-ES+HKDF-256 (-25)
+  -3: -9
+}
+```
 
 ---
 
@@ -57,8 +88,8 @@ Two commits on `bugfix/fido2-credmgmt-unsupported-cose-key`:
 - `94093fd9` — `docs(fido2): generalize wording for unmodeled COSE key types`
 
 **Change:** added `CoseUnsupportedPublicKey` (sealed, internal constructor,
-carries the original encoding plus the reported key type and algorithm) and an
-internal `CoseKey.CreateOrUnsupported`. Applied at all three data-bearing
+carries the original encoding plus the reported key type and algorithm) and a
+public `CoseKey.CreateOrUnsupported`. Applied at all three data-bearing
 `CoseKey.Create` call sites: `CredentialUserInfo.cs`,
 `Commands/CredentialManagementData.cs`, and `AuthenticatorData.cs`.
 `Commands/ClientPinResponse.cs` was deliberately left on strict `Create`.
@@ -110,8 +141,10 @@ What the hardware **disproved**:
 
 **Conclusion:** on firmware 5.8.0 there is no route via the public SDK API to a
 discoverable credential whose own public key is an unmodeled COSE type. The code
-defect is real and worth fixing regardless, but it is probably not what the
-reporter hit. D1 is the stronger candidate.
+defect is real and worth fixing regardless, but it is not what the reporter hit.
+The stack trace in section 1 later confirmed this: the failure was the strict
+public `CoseKey.Create` applied to a persisted key, with enumeration never
+involved.
 
 **Safety note for anyone re-running this:** `FidoSessionIntegrationTestBase`'s
 constructor (`Yubico.YubiKey/tests/integration/Yubico/YubiKey/Fido2/FidoIntegrationTestBase.cs`)
@@ -251,6 +284,23 @@ algorithm paired with the wrong key type are corrupt data, not future values.
 silently change a documented public throw contract. `Create` is strict;
 `CreateOrUnsupported` is lenient.
 
+**`CreateOrUnsupported` is public — this reverses an earlier decision.** It was
+originally `internal`, on the reasoning that callers obtain the sentinel through
+SDK response objects and therefore never need to invoke the lenient parse
+themselves. **The reporter's stack trace refuted that.** An application that
+persists a key and reloads it later holds only raw bytes; there is no SDK
+response object in that path, and the only public entry point available was the
+strict `Create`, which throws. Corroborating evidence that the surface was
+missing something: the SDK's own test utility
+`PreviewSignGeneratedKeyExtensions.ParseArkgCoseKey` hand-rolls roughly sixty
+lines of CBOR parsing, which at the time it was written was the only way to
+parse one of these keys. A caller can now use `CreateOrUnsupported` and read
+`CoseUnsupportedPublicKey.EncodedKey` instead; that utility could be simplified
+to match, though doing so is not required and is out of scope here.
+
+Both overloads are public: the plain form, and a `out int bytesRead` form for
+parity with `Create` so callers can parse a key embedded in a larger buffer.
+
 **No `TryCreate`.** With a sentinel the method cannot fail, so the boolean would
 duplicate `key is CoseUnsupportedPublicKey`; none of the three call sites branch
 on it; and every `Try*` method in this codebase pairs `false` with a null or
@@ -307,8 +357,20 @@ Criteria: an unmodeled curve, an unmodeled coordinate length, and a non-Ed25519
 OKP curve each yield the sentinel with raw bytes preserved; enumeration returns
 all credentials when one is affected; **anti:** public `Create` still throws for
 all three; **anti:** `CoseEcPublicKey.cs` and `CoseEdDsaPublicKey.cs` are
-unmodified; **anti:** null input still throws `ArgumentNullException` rather than
-being absorbed into a sentinel.
+unmodified; **anti:** every malformed-encoding rejection listed in
+`CreateOrUnsupported`'s exception contract still throws, so widening the catch
+absorbs the curve and coordinate-length cases only.
+
+Note that `ArgumentException` is currently documented on both
+`CreateOrUnsupported` overloads as the outcome for a modeled algorithm on an
+unmodeled curve. That documentation must be removed as part of this work, since
+the whole point of the change is that those cases stop throwing.
+
+Do not write a criterion about null input. `ReadOnlyMemory<byte>` is a struct and
+neither `Create` nor `CborMap` performs a null check, so `ArgumentNullException`
+is unreachable on these entry points — an earlier draft of this document claimed
+otherwise, and `Create`'s XML documentation carried the same false claim until it
+was removed.
 
 ### Stack 2 — unknown map keys (D1, D2, D4, D5, D9)
 
@@ -356,9 +418,9 @@ holding the sentinel does not throw.
 
 ## 9. Open items
 
-1. **Jonas's stack trace** — outstanding. It determines whether the real fault is
-   D1 rather than the COSE issue. Chase it before promising that PR #585 solves
-   his problem.
+1. ~~Jonas's stack trace~~ — **received and resolved.** See section 1. The fault
+   was the strict public `CoseKey.Create` applied to a persisted key, not
+   enumeration and not D1. Addressed by making `CreateOrUnsupported` public.
 2. **D3 reachability** — needs a firmware owner to confirm whether a non-`packed`
    attestation format is ever returned.
 3. **D6 tail case** — the sentinel approach was chosen, but "device advertises

--- a/docs/users-manual/application-fido2/fido2-cred-mgmt.md
+++ b/docs/users-manual/application-fido2/fido2-cred-mgmt.md
@@ -157,6 +157,32 @@ the specified relying party. You specify which relying party you are interested 
 supplying the `RelyingParty` object, which you likely retrieved during a call to obtain a
 list of relying parties.
 
+### Credentials with an unrecognized public key type
+
+A credential's public key can use a COSE algorithm that this SDK does not model. This
+happens with credentials created by the experimental `previewSign` extension, whose public
+key is an ARKG-P256 seed.
+
+Enumeration does not fail in that case. The credential's `CredentialPublicKey` will be a
+[CoseUnsupportedPublicKey](xref:Yubico.YubiKey.Fido2.Cose.CoseUnsupportedPublicKey), which
+carries the original COSE encoding in its `EncodedKey` property along with the key type
+and algorithm the YubiKey reported. Every other property of that credential, and every
+other credential belonging to the relying party, is returned as normal.
+
+```csharp
+    foreach (CredentialUserInfo info in credentialList)
+    {
+        if (info.CredentialPublicKey is CoseUnsupportedPublicKey unsupportedKey)
+        {
+            // This SDK has no strongly-typed representation for this key. Decode
+            // unsupportedKey.EncodedKey yourself, or skip the credential.
+            continue;
+        }
+
+        // ... use info.CredentialPublicKey normally
+    }
+```
+
 If you use the commands, you will need to use the `EnumerateCredentialsBeginCommand`
 command to obtain the first credential and the total count of credentials available, and
 then the `EnumerateCredentialsGetNextCommand` to get each successive credential.

--- a/docs/users-manual/application-fido2/fido2-cred-mgmt.md
+++ b/docs/users-manual/application-fido2/fido2-cred-mgmt.md
@@ -160,8 +160,8 @@ list of relying parties.
 ### Credentials with an unrecognized public key type
 
 A credential's public key can use a COSE algorithm that this SDK does not model. This
-happens with credentials created by the experimental `previewSign` extension, whose public
-key is an ARKG-P256 seed.
+happens with credentials created by an extension that introduces its own key type, and
+with algorithms registered after the version of the SDK you are using was released.
 
 Enumeration does not fail in that case. The credential's `CredentialPublicKey` will be a
 [CoseUnsupportedPublicKey](xref:Yubico.YubiKey.Fido2.Cose.CoseUnsupportedPublicKey), which

--- a/docs/users-manual/application-fido2/fido2-cred-mgmt.md
+++ b/docs/users-manual/application-fido2/fido2-cred-mgmt.md
@@ -157,16 +157,18 @@ the specified relying party. You specify which relying party you are interested 
 supplying the `RelyingParty` object, which you likely retrieved during a call to obtain a
 list of relying parties.
 
-### Credentials with an unrecognized public key type
+### Credentials with an unimplemented public key algorithm
 
-A credential's public key can use a COSE algorithm that this SDK does not model. This
-happens with credentials created by an extension that introduces its own key type, and
-with algorithms registered after the version of the SDK you are using was released.
+A credential's public key can use a COSE algorithm for which this SDK has no strongly
+typed key representation. This can happen with credentials created by an extension that
+uses its own algorithm, or with algorithms registered after the SDK version was released.
 
 Enumeration does not fail in that case. The credential's `CredentialPublicKey` will be a
 [CoseUnsupportedPublicKey](xref:Yubico.YubiKey.Fido2.Cose.CoseUnsupportedPublicKey), which
 carries the original COSE encoding in its `EncodedKey` property along with the key type
-and algorithm the YubiKey reported. Every other property of that credential, and every
+and algorithm the YubiKey reported. The type or algorithm may still correspond to a
+named SDK value; the sentinel indicates that the typed decoder does not implement the
+reported algorithm. Every other property of that credential, and every
 other credential belonging to the relying party, is returned as normal.
 
 ```csharp


### PR DESCRIPTION
Fixes unsupported-algorithm decoding in credential-management responses and adds a public tolerant COSE-key parser for callers that need to preserve unknown keys.

## Current scope

- `CoseKey.Create` remains strict for protocol paths that require a modeled key, including PIN/UV key agreement.
- `CoseKey.CreateOrUnsupported` preserves the exact encoded key in `CoseUnsupportedPublicKey` when the algorithm is unknown. Its `bytesRead` overload slices the preserved encoding correctly when the key is embedded in a larger buffer.
- Credential-management and authenticator-data decode paths use the tolerant parser only where an unsupported key can be retained without losing the surrounding credential.
- Modeled algorithms with malformed data, incompatible key types, or unsupported curves still fail rather than being mislabeled as future algorithms.

The reporter later supplied a stack trace showing an application reloading persisted raw key bytes through strict `CoseKey.Create`, rather than a failure inside credential enumeration. The public tolerant overload supplies that missing caller path; the response-decoding changes remain forward-compatibility hardening.

## Audit document

`contributordocs/fido2-forward-compatibility-audit.md` is a durable, symbol-referenced snapshot of CBOR response decoding under `Fido2`. It records findings `F1` through `F14`, distinguishes required strict decoding from preservable optional data, and does not claim to assess CTAPHID transport framing.

## Verification

- Legacy Yubico.YubiKey and Yubico.Core unit suites passed during implementation.
- Hardware on firmware 5.8.0 confirmed byte-exact preservation of an unmodeled previewSign key; credential enumeration itself did not reproduce the original report.
- Separate cross-vendor remediation review confirmed strict key agreement and the durable audit scope.

Abbreviations: CBOR means Concise Binary Object Representation; COSE means CBOR Object Signing and Encryption; CTAPHID means Client to Authenticator Protocol over Human Interface Device; PIN means personal identification number; UV means user verification.