### PR TITLE
docs: add v2 highlights and v1-to-v2 comparison

### DIFF
--- a/docs/v1-to-v2-comparison.md
+++ b/docs/v1-to-v2-comparison.md
@@ -1,0 +1,123 @@
+# V1 to V2 Comparison
+
+Last updated: 2026-08-31
+
+This document exists to answer one question precisely: for each difference
+between v1 and v2, is it a deliberate design decision, a deferred/undecided
+question, something decided against, a genuine open gap, or something
+already restored?
+
+It is a manually curated synthesis, built for developers and stakeholders
+who need the "why," not a replacement for the automated migration lane.
+
+**For code-level before/after migration recipes**, use
+[`docs/migration/v1-to-v2.md`](migration/v1-to-v2.md) — that document is
+maintained by automation on every merge to `yubikit` and is the canonical
+API mapping reference. This document does not duplicate its recipes.
+
+**Source material**: this synthesis is built from
+`docs/migration/v1-to-v2-gaps.md` (a point-in-time gap analysis dated
+2026-07-21), `docs/migration/v1-to-v2-changelog.md` (automated updates
+through 2026-08-24), and direct verification against current source. Per the
+governance in `docs/live-documentation-governance.md`, `docs/migration/**` is
+an automation-owned lane; this document lives outside it and should be
+refreshed manually rather than assumed to track automatically.
+
+## Design Decisions (Not Regressions)
+
+These are intentional. Framing them as bugs in developer-facing
+communication would be inaccurate and would undersell the reasoning behind
+the breaking changes.
+
+| V1 capability | V2 status | Why |
+|---|---|---|
+| `TlvReader`/`TlvWriter` typed, sequential TLV parsing | Replaced by a thinner `Tlv`/`TlvHelper`/`DisposableTlvList` surface — tag/value containers and static helpers only | V1's public typed TLV API was a broad extensibility surface; every change to it was a breaking change |
+| `Base16`/`Base32`/`Bcd`/`ModHex` standalone codecs | No longer public | Same reasoning — general-purpose public utilities constrained internal iteration |
+| Pluggable crypto primitives (`IAesGcmPrimitives`, `IEcdhPrimitives`, `ICmacPrimitives`) | No longer public extension points | Same reasoning; AES-CMAC is now hardcoded internal to SCP code |
+
+Net effect: v1 shipped a very large public surface, and nearly everything in
+it was a compatibility promise the team had to keep. V2 intentionally keeps
+low-level primitives internal so the SDK can keep evolving without repeating
+that pattern.
+
+## Deferred / Under Evaluation
+
+Not decided either way yet. Do not commit to a date or an outcome for these
+in external communication.
+
+- **Unified credential-collection pattern**: v1's `KeyCollector` delegate
+  (one callback shape shared across PIV/FIDO2/OATH/U2F/YubiHSM Auth) has no
+  v2 replacement. Each applet currently handles PIN/PUK/touch collection with
+  its own bespoke shape. Whether v2 gets a unified pattern is under
+  evaluation.
+
+## Decided Against
+
+- **Meta-package**: v1 was effectively one "install everything" package.
+  V2 will not add an equivalent bundling package. Compartmentalization —
+  installing only the applets an application uses — is the only supported
+  install path, by design, to preserve the smaller-footprint benefit.
+
+## Still Open
+
+These have not been addressed and are not currently planned as design
+decisions — they are real functionality differences a migrating developer
+will hit.
+
+| Gap | Impact |
+|---|---|
+| No .NET Framework / netstandard support — v2 targets `net10.0` only | Blocker for any consumer on .NET Framework, netstandard2.0 library authors, or older .NET (Core 3.1/5/6/8) until their host app is on .NET 10 |
+| U2F/CTAP1 protocol removed entirely — no `U2fSession` equivalent | Blocker for U2F-only relying parties or non-CTAP2 browsers/servers |
+| Logging silent by default | `YubiKitLogging.LoggerFactory` defaults to `NullLoggerFactory`; v1 auto-configured console logging at Error level. Apps that don't call `YubiKitLogging.Configure(...)` silently lose diagnostics they got for free in v1 |
+| Exception hierarchy reduced (10 v1 types → 8 v2 types) | No v2 equivalent for `TlvException` or `KeyboardConnectionException`; consumers catching specific v1 exception types fall back to broader catches |
+| Legacy pre-firmware-5 mode switching removed from the public Management surface | YubiKey NEO / YubiKey 4 (pre-5.0 firmware) users cannot reconfigure enabled USB interfaces through the public API |
+
+Lower-severity items (MSROOTS support, NDEF read-back, `FromStaticKeys`
+convenience factories, and similar cosmetic/niche API removals) are tracked
+in the full point-in-time detail in `docs/migration/v1-to-v2-gaps.md` and are
+not repeated here.
+
+## Restored Since the 2026-07-21 Gap Analysis
+
+The gap analysis above already reflects the current state — these items were
+found missing on 2026-07-21 and have since been closed, per
+`docs/migration/v1-to-v2-changelog.md` (2026-07-30 entry):
+
+- PIV PIN-only (`PinProtected`) management-key mode, plus typed
+  CHUID/CCC/AdminData/KeyHistory data objects.
+- OATH `IsPasswordProtected` and `AuthenticateAndRetryAsync`, plus a
+  dedicated `OathException`.
+- YubiHSM Auth's `HsmAuthRetryException`, `OnTouchRequired` callback, and the
+  hardware-verified `Counter` → `RetriesRemaining` rename.
+- YubiOTP keyboard-layout-aware static passwords and Yubico-OTP-algorithm
+  challenge-response.
+- Dedicated exception types for SecurityDomain (`SecureChannelException`) and
+  OpenPGP (`OpenPgpInvalidPinException`).
+
+Note: v1's PIN-*derived* management-key mode (as opposed to PIN-*protected*)
+remains deprecated and cannot be newly enabled in v2, though v2 can still
+detect and recover an existing PIN-derived configuration.
+
+## New in V2 (No V1 Comparison Applies)
+
+These aren't v1-to-v2 differences at all — v1 never had them:
+
+- **WebAuthn** (`Yubico.YubiKit.WebAuthn`) — a new client package for the
+  FIDO ceremony.
+- **OpenPGP** (`Yubico.YubiKit.OpenPgp`) — new applet support.
+
+See [`docs/v2-highlights.md`](v2-highlights.md) for the developer-outreach
+framing of both.
+
+## Verified Strong/Full Parity (No Action Needed)
+
+Per the 2026-07-21 gap analysis, these areas were verified as full parity or
+improvements, not gaps: device discovery/hot-plug, HID/CCID/NFC transports,
+Windows/macOS/Linux platform interop, PIV key management and algorithms
+(including new Ed25519/X25519 support and touch-notification callbacks),
+FIDO2 CTAP2 surface (GetInfo, PIN protocols, bio enrollment, credential
+management, config, largeBlob, extensions), SCP03/SCP11 core protocol and key
+management, Management device-info read/device-config write, OATH credential
+types and PBKDF2 handling, and YubiHSM Auth's new capabilities (password
+change, on-device EC key generation, derived credentials, zeroizing
+`SessionKeys`).

--- a/docs/v2-highlights.md
+++ b/docs/v2-highlights.md
@@ -1,0 +1,153 @@
+# V2 Highlights
+
+Last updated: 2026-08-31
+
+This is the source-of-truth feature summary for developer outreach, the Early
+Access program, and launch communications. It is written to be handed to
+developer relations, product, and documentation stakeholders without
+additional interpretation.
+
+Every claim below is grounded in current source, merged automation records,
+or explicitly named pull requests. Where a capability is not yet true today,
+it is labeled as such rather than implied.
+
+## New Applet Support
+
+V2 adds application support that v1 never had at all. These are not rewrites
+of existing v1 capability — they are new YubiKey applications the SDK did not
+previously speak to.
+
+### WebAuthn (primary highlight)
+
+`Yubico.YubiKit.WebAuthn` is a client package that encapsulates the FIDO
+ceremony end to end: preparing payloads, building `clientDataJSON`, formatting
+requests, making credentials, and getting assertions. This directly answers
+the most common developer question about v1 — which data fields belong where
+in a WebAuthn ceremony. The design is deliberately consistent with the
+Android, Python, and Rust SDKs so behavior transfers across platforms.
+
+There is no plan to ship a server-side validation component alongside this
+client. Scope is the client ceremony only.
+
+### OpenPGP
+
+`Yubico.YubiKit.OpenPgp` is new applet support with no v1 equivalent.
+Per-applet documentation covers supported operations and any firmware
+constraints; this summary intentionally does not restate applet-specific
+compatibility details.
+
+## Async-First Architecture
+
+Every v2 public API is `async`/`await`. There are no synchronous facades
+anywhere in the SDK. This is a deliberate architectural choice, not a partial
+port: it optimizes for how the SDK actually spends time waiting on the
+YubiKey, at the cost of requiring async adoption even for simple
+console-app or script use cases that v1 didn't require.
+
+## Compartmentalized Packaging
+
+V1 shipped as two packages (`Yubico.Core`, `Yubico.YubiKey`) that pulled in
+every applet whether an application used it or not. V2 splits into 10 focused
+packages:
+
+`Yubico.YubiKit.Core`, `.Management`, `.Piv`, `.Fido2`, `.WebAuthn`, `.Oath`,
+`.YubiOtp`, `.OpenPgp`, `.SecurityDomain`, `.YubiHsm`.
+
+Applications install only the applets they use, which keeps deployed size
+down — this matters for enterprise and CLI/agent tooling scenarios in
+particular.
+
+**There is no meta-package.** This is a deliberate decision, not an
+oversight: bundling "install everything" back into one package would
+undercut the footprint benefit compartmentalization is meant to deliver.
+Consumers who genuinely need every applet add all 10 package references
+explicitly.
+
+## Native AOT Support
+
+V2 SDK libraries compile to a single self-contained native binary with
+`PublishAot=true` and run without a .NET runtime installed on the host
+machine. All 10 SDK libraries are covered.
+
+This work landed through a reviewed, evidence-backed PR stack
+(`#592` → `#578` → `#587`, plus the native packaging prerequisite `#586`):
+
+- Zero AOT/trimming analyzer warnings, no suppressions, across all 10
+  libraries.
+- Verified with real physical YubiKey hardware on macOS arm64, Windows x64,
+  and Linux x64.
+- A companion native-packaging effort is closing the last rough edge: today's
+  public NativeShims package still ships a shared-library sidecar next to an
+  AOT executable; a self-contained static NativeShims package removing that
+  sidecar is in progress and expected shortly.
+
+Deeper protocol-level runtime testing under AOT currently covers Core device
+discovery, Management, and PIV most thoroughly. FIDO2/WebAuthn and YubiOTP
+HID exchanges, and OATH/OpenPGP/SecurityDomain/YubiHSM session operations,
+are confirmed to link and run under AOT but have less exhaustive
+protocol-level runtime coverage than PIV. This is expected to deepen before
+general availability, not a known defect.
+
+## Why V2 Breaks So Much, On Purpose
+
+V1 shipped a large public surface — typed TLV readers/writers, general-purpose
+codecs (`Base16`, `Base32`, `Bcd`, `ModHex`), and pluggable low-level crypto
+primitive interfaces. Because all of it was public, almost any internal
+change became a breaking change, which made the SDK slow to evolve.
+
+V2 deliberately keeps this class of low-level primitive internal:
+
+- `TlvReader`/`TlvWriter` (typed, sequential parsing) are gone. They are
+  replaced by a much thinner `Tlv`/`TlvHelper`/`DisposableTlvList` surface —
+  simple tag/value containers and static encode/decode helpers, not a public
+  extensibility point.
+- `Base16`/`Base32`/`Bcd`/`ModHex` standalone codecs are no longer public.
+- Pluggable crypto primitive interfaces (`IAesGcmPrimitives`,
+  `IEcdhPrimitives`, `ICmacPrimitives`) are no longer public extension points.
+
+This is intentional API discipline, not an oversight. A smaller, more
+deliberate public surface means v2 can keep evolving without repeating v1's
+pattern of constant breaking changes. Application code that depended on these
+utilities directly needs its own replacement; see
+[`docs/v1-to-v2-comparison.md`](v1-to-v2-comparison.md) for the breakdown.
+
+## Restored From V1 (Since Initial Gap Analysis)
+
+An initial v1/v2 gap analysis (2026-07-21) flagged several v1 capabilities
+that were missing in early v2. Several of these have since been restored:
+
+- PIV PIN-only (`PinProtected`) management-key mode, plus typed
+  CHUID/CCC/AdminData/KeyHistory data objects.
+- OATH `IsPasswordProtected` and `AuthenticateAndRetryAsync`, plus a
+  dedicated `OathException`.
+- YubiHSM Auth's `HsmAuthRetryException`, `OnTouchRequired` callback, and the
+  hardware-verified `Counter` → `RetriesRemaining` rename.
+- YubiOTP keyboard-layout-aware static passwords and Yubico-OTP-algorithm
+  challenge-response.
+- Dedicated exception types for SecurityDomain (`SecureChannelException`) and
+  OpenPGP (`OpenPgpInvalidPinException`).
+
+See [`docs/v1-to-v2-comparison.md`](v1-to-v2-comparison.md) for what remains
+open, deferred, or intentionally decided against.
+
+## Not Yet Supported
+
+- **Post-quantum algorithms (ML-DSA, ML-KEM):** not implemented in the .NET
+  SDK today. Feature-parity timing across SDKs is being coordinated
+  separately; do not commit to a date for this in external communication
+  until that's resolved.
+
+## Near-Term Roadmap
+
+- **Unified credential-collection pattern:** v1's `KeyCollector` delegate is
+  not replaced by an equivalent in v2 — each applet currently handles
+  PIN/PUK/touch collection independently. Whether to add a unified pattern is
+  under evaluation, not committed.
+
+## Current Release State
+
+V2 ships today as `2.0.0-alpha.2` from a public, anonymous, unsigned NuGet
+feed. It has **not yet completed Yubico's formal security audit** and is
+explicitly marked not for production use. This is a real gap against the
+"audited, fully functional release by end of year" commitment and needs an
+explicit timeline decision, not just documentation work.


### PR DESCRIPTION
## Summary

Adds two developer-facing documents supporting the v2 launch, requested out of the Aug 25 SDK v2 rollout planning meeting (action items: "List V2 Features," "Provide Feature List," "Compare SDK Versions").

- **`docs/v2-highlights.md`** — the source-of-truth feature summary for developer outreach, the Early Access program, and launch communications. Covers new applet support (WebAuthn, OpenPGP), async-first architecture, compartmentalized packaging (and why there's deliberately no meta-package), Native AOT support (grounded in PRs #592/#578/#587/#586), the design-philosophy rationale for why v2 has so many breaking changes, parity items restored since the initial gap analysis, what's explicitly not yet supported (PQC/ML-DSA/ML-KEM), and the current alpha/pre-audit release state.

- **`docs/v1-to-v2-comparison.md`** — a curated synthesis distinguishing:
  - deliberate design decisions (TLV/codec/crypto-primitive surface reduction) from regressions
  - deferred/under-evaluation items (unified KeyCollector-equivalent pattern)
  - decisions made against (meta-package)
  - genuinely open gaps (.NET Framework support, U2F/CTAP1, silent-by-default logging, exception hierarchy)
  - items already restored since the 2026-07-21 gap analysis

  This lives outside `docs/migration/**` intentionally, per the automation-owned lane boundary documented in `docs/live-documentation-governance.md` — that directory's source of truth is the v1 `develop` vs v2 `yubikit` diff automation, and this is a manually curated document that shouldn't be assumed to track it automatically.

## Validation

```
dotnet toolchain.cs -- docs-qa
```

Both files pass; confirmed included in the active documentation set via `dotnet toolchain.cs -- docs-list-active`.

## Notes for reviewers

- Native AOT is described as shipping, on the basis that the #592 → #578 → #587 PR stack (plus native-packaging prerequisite #586) is expected to merge and be ready by end of year.
- The "audited, fully functional release by end of year" commitment from the meeting is flagged in `v2-highlights.md` as an open item against the current alpha/pre-audit state — this doc doesn't resolve that, it surfaces it for the Dane conversation.