### PR TITLE
fix(fido): send CTAPHID_CANCEL when a ceremony awaiting touch is abandoned

### DIFF
--- a/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
+++ b/src/Core/src/Protocols/Fido/Hid/FidoHidProtocol.cs
@@ -80,7 +80,8 @@ internal class FidoHidProtocol(
                             _channelId!.Value,
                             command,
                             data,
-                            exchangeToken)
+                            exchangeToken,
+                            cancellationToken)
                         .ConfigureAwait(false);
                 },
                 cancellationToken)
@@ -166,10 +167,11 @@ internal class FidoHidProtocol(
         uint channelId,
         byte command,
         ReadOnlyMemory<byte> data,
-        CancellationToken cancellationToken)
+        CancellationToken exchangeToken,
+        CancellationToken callerToken = default)
     {
-        await SendRequest(channelId, command, data, cancellationToken).ConfigureAwait(false);
-        return await ReceiveResponse(channelId, command, cancellationToken).ConfigureAwait(false);
+        await SendRequest(channelId, command, data, exchangeToken).ConfigureAwait(false);
+        return await ReceiveResponse(channelId, command, exchangeToken, callerToken).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -230,20 +232,42 @@ internal class FidoHidProtocol(
     /// <summary>
     /// Receives a CTAP HID response, handling keep-alive and multi-packet responses.
     /// </summary>
+    /// <remarks>
+    /// <paramref name="exchangeToken"/> governs the reads and is uncancellable inside an
+    /// exchange, so a partially framed response is never stranded. <paramref name="callerToken"/>
+    /// is signal-only: it never aborts a read, it makes this method send CTAPHID_CANCEL.
+    /// </remarks>
     private async Task<ReadOnlyMemory<byte>> ReceiveResponse(
         uint channelId,
         byte expectedCommand,
-        CancellationToken cancellationToken)
+        CancellationToken exchangeToken,
+        CancellationToken callerToken)
     {
         _logger.LogTrace("Receiving CTAP HID response");
 
+        var cancelRequested = false;
+
         // Get initialization packet, handling keep-alive
-        var initPacket = await _connection.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+        var initPacket = await _connection.ReceiveAsync(exchangeToken).ConfigureAwait(false);
         while (IsKeepAlivePacket(initPacket.Span))
         {
             ValidateInitPacket(initPacket.Span, channelId);
+
+            // Abandoning a ceremony without telling the authenticator leaves it holding a
+            // user-presence request on a channel nobody is servicing: the key keeps asking for a
+            // touch that can no longer be consumed, and the busy channel blocks later opens until
+            // the key is physically re-plugged. CTAPHID_CANCEL is the protocol's way out, and is
+            // only meaningful while the authenticator is still working (that is, right here).
+            if (!cancelRequested && callerToken.IsCancellationRequested)
+            {
+                _logger.LogDebug("Operation abandoned during keep-alive; sending CTAPHID_CANCEL");
+                await SendRequest(channelId, CtapConstants.CtapHidCancel, ReadOnlyMemory<byte>.Empty, exchangeToken)
+                    .ConfigureAwait(false);
+                cancelRequested = true;
+            }
+
             _logger.LogTrace("Received keep-alive, waiting for response");
-            initPacket = await _connection.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+            initPacket = await _connection.ReceiveAsync(exchangeToken).ConfigureAwait(false);
         }
 
         ValidateInitPacket(initPacket.Span, channelId);
@@ -280,7 +304,7 @@ internal class FidoHidProtocol(
             byte expectedSequence = 0;
             while (bytesReceived < responseLength)
             {
-                var contPacket = await _connection.ReceiveAsync(cancellationToken).ConfigureAwait(false);
+                var contPacket = await _connection.ReceiveAsync(exchangeToken).ConfigureAwait(false);
                 ValidateContinuationPacket(contPacket.Span, channelId, expectedSequence);
                 var contDataLength = Math.Min(
                     responseLength - bytesReceived,
@@ -294,6 +318,17 @@ internal class FidoHidProtocol(
             }
 
             _logger.LogTrace("Received {Length} bytes in response", responseLength);
+
+            // Only here is the channel provably clean. Throwing any earlier would strand the
+            // remaining frames for the next exchange to misread — the very failure this cancel
+            // exists to prevent — because a touch landing as the caller abandons makes the
+            // answer a real multi-packet response, not the one-byte cancel acknowledgement.
+            // Ownership stays untransferred, so the discarded buffer is zeroed by the finally.
+            if (cancelRequested)
+            {
+                callerToken.ThrowIfCancellationRequested();
+            }
+
             ownershipTransferred = true;
             return responseData;
         }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Protocols/Fido/Hid/FidoHidProtocolTests.cs
@@ -426,6 +426,144 @@ public class FidoHidProtocolTests
         Assert.Equal(responsePayload, response.ToArray());
     }
 
+    /// <summary>
+    /// Abandoning a ceremony while the authenticator is asking for a touch must tell the
+    /// authenticator, or it keeps that request pending on a channel nobody is servicing and the
+    /// key stays unusable until it is physically re-plugged. The cancel is sent once, not on
+    /// every keep-alive frame that follows it, and the channel is left immediately reusable.
+    /// </summary>
+    /// <remarks>
+    /// The caller is abandoned mid-exchange rather than up front: <see cref="ExchangeGuard"/>
+    /// rejects an already-cancelled token before the exchange is admitted, so a pre-cancelled
+    /// token would never reach the keep-alive loop this covers.
+    /// </remarks>
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task SendVendorCommandAsync_AbandonedDuringKeepAlive_SendsExactlyOneCancelAndLeavesChannelUsable(
+        int keepAliveCount)
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        using var cts = new CancellationTokenSource();
+
+        // The authenticator reports it is waiting for a touch, then answers the cancel with
+        // CTAP2_ERR_KEEPALIVE_CANCEL (0x2D).
+        connection.QueueResponsePackets([
+            .. Enumerable.Range(0, keepAliveCount).Select(_ =>
+                CreateInitPacket(0x01020304, CtapConstants.CtapHidKeepAlive, [KeepAliveUpNeeded])),
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0x2D])
+        ]);
+
+        // Abandon the moment the authenticator says it is waiting for a touch.
+        connection.OnResponseDequeued = packet =>
+        {
+            if (IsCommand(packet, CtapConstants.CtapHidKeepAlive))
+                cts.Cancel();
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            protocol.SendVendorCommandAsync(
+                CtapConstants.CtapVendorFirst,
+                ReadOnlyMemory<byte>.Empty,
+                cts.Token));
+
+        Assert.Equal(
+            1,
+            connection.SentPacketSnapshots.Count(packet => IsCommand(packet, CtapConstants.CtapHidCancel)));
+
+        // The symptom the fix exists to prevent: before it, the abandoned user-presence request
+        // left the channel busy and the next exchange failed until the key was re-plugged.
+        connection.OnResponseDequeued = null;
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0xAA]));
+
+        var afterCancel = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(0xAA, afterCancel.Span[0]);
+    }
+
+    /// <summary>
+    /// A touch landing at the same moment the caller abandons makes the authenticator's answer a
+    /// real multi-packet response rather than the one-byte cancel acknowledgement. Every
+    /// continuation frame must still be drained before cancellation is surfaced, or the next
+    /// exchange reads the leftovers as its own response.
+    /// </summary>
+    [Fact]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task SendVendorCommandAsync_AbandonedWhenAnswerIsMultiPacket_DrainsEveryFrame()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+        using var cts = new CancellationTokenSource();
+
+        var racedPayload = new byte[CtapConstants.InitDataSize + 20];
+        racedPayload.AsSpan().Fill(0x5A);
+
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapHidKeepAlive, [KeepAliveUpNeeded]),
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, racedPayload),
+            CreateContinuationPacket(0x01020304, sequence: 0, racedPayload.AsSpan(CtapConstants.InitDataSize)));
+
+        connection.OnResponseDequeued = packet =>
+        {
+            if (IsCommand(packet, CtapConstants.CtapHidKeepAlive))
+                cts.Cancel();
+        };
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            protocol.SendVendorCommandAsync(
+                CtapConstants.CtapVendorFirst,
+                ReadOnlyMemory<byte>.Empty,
+                cts.Token));
+
+        // The continuation frame was consumed, so the next exchange sees its own response rather
+        // than the tail of the abandoned one.
+        connection.OnResponseDequeued = null;
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0xAA]));
+
+        var afterCancel = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(1, afterCancel.Length);
+        Assert.Equal(0xAA, afterCancel.Span[0]);
+    }
+
+    [Fact]
+    [Trait("Category", "RuntimeResilience")]
+    public async Task SendVendorCommandAsync_NotAbandoned_DoesNotSendCtapHidCancel()
+    {
+        var connection = new FakeFidoHidConnection();
+        var protocol = new FidoHidProtocol(connection);
+
+        connection.QueueResponsePackets(
+            CreateInitPacket(0x01020304, CtapConstants.CtapHidKeepAlive, [KeepAliveUpNeeded]),
+            CreateInitPacket(0x01020304, CtapConstants.CtapVendorFirst, [0xAA]));
+
+        var response = await protocol.SendVendorCommandAsync(
+            CtapConstants.CtapVendorFirst,
+            ReadOnlyMemory<byte>.Empty,
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(0xAA, response.Span[0]);
+        Assert.DoesNotContain(
+            connection.SentPacketSnapshots,
+            packet => IsCommand(packet, CtapConstants.CtapHidCancel));
+    }
+
+    /// <summary>CTAP HID keep-alive status byte meaning a touch is awaited.</summary>
+    private const byte KeepAliveUpNeeded = 0x02;
+
+    private static bool IsCommand(byte[] packet, byte command) =>
+        (packet[4] & ~CtapConstants.InitPacketMask) == command;
+
     private static byte[] CreateInitPacket(uint channelId, byte command, ReadOnlySpan<byte> payload)
     {
         var packet = new byte[CtapConstants.PacketSize];
@@ -460,6 +598,14 @@ public class FidoHidProtocolTests
 
         public int InitRequestCount { get; private set; }
         public bool ThrowOnNextSend { get; set; }
+
+        /// <summary>
+        /// Invoked as each queued packet is handed to the protocol, letting a test act at a
+        /// precise point mid-exchange — notably abandoning the caller while a keep-alive is
+        /// being processed.
+        /// </summary>
+        public Action<byte[]>? OnResponseDequeued { get; set; }
+
         public List<ReadOnlyMemory<byte>> RetainedSentPackets { get; } = [];
         public List<byte[]> SentPacketSnapshots { get; } = [];
 
@@ -507,7 +653,9 @@ public class FidoHidProtocolTests
                 return Task.FromResult<ReadOnlyMemory<byte>>(CreateInitResponse());
             }
 
-            return Task.FromResult<ReadOnlyMemory<byte>>(_responsePackets.Dequeue());
+            var packet = _responsePackets.Dequeue();
+            OnResponseDequeued?.Invoke(packet);
+            return Task.FromResult<ReadOnlyMemory<byte>>(packet);
         }
 
         public void Dispose()


### PR DESCRIPTION
## What this fixes

`CtapHidCancel = 0x11` has been sitting in `CtapConstants` without a single caller anywhere in the SDK. That meant abandoning a ceremony never told the authenticator anything, so it kept holding a user-presence request on a channel nobody was servicing.

Symptoms, seen twice on a 5.8.0 key:

- rapid blinking, unresponsive to touch (not the normal awaiting-touch blink)
- `CTAP1_ERR_CHANNEL_BUSY` (0x06) on later opens
- identity reads stop resolving, so the key enumerates under a PID fallback id instead of its serial
- only a physical re-plug recovers it

Canonical Rust sends the cancel from inside the keep-alive loop (`crates/yubikit/src/platform/hidapi.rs:335`), so this is really just restoring parity.

## How it works

The caller's token is threaded into the keep-alive loop **for signalling only**. Reads keep using the exchange token, so `ExchangeGuard`'s guarantee that a partially framed exchange is never stranded still holds. On abandonment the protocol sends `CTAPHID_CANCEL` once, however many keep-alives follow.

One subtlety worth calling out for review: cancellation is surfaced only *after* the authenticator's answer has been read in full, continuation frames included. Throwing earlier would strand those frames for the next exchange to misread — which is precisely the failure this cancel exists to prevent. If a touch lands at the same moment the caller abandons, that answer is a real multi-packet response rather than the one-byte acknowledgement. There's a dedicated test for that case.

While in here, the two tokens on the private path are now named `exchangeToken` and `callerToken`. The one previously called `cancellationToken` is the one that never cancels, which was a bit of a trap.

## Scope

Core only — `FidoHidProtocol` and its tests. An earlier revision of this branch also threaded an optional keep-alive status observer through Fido2 and `IFidoSession`, but that has no production consumer here and belongs with the WebAuthn credential-prompt work that actually uses it, so it has moved to that branch.

## Known limitation

A hard process kill cannot notify the authenticator and still needs a re-plug. That's inherent to the transport.

## Testing

No-hardware `RuntimeResilience` coverage:

- cancel sent exactly once across one and three keep-alives, and the channel is usable immediately afterwards
- a multi-packet answer is drained in full, so the next exchange reads its own response
- no cancel is sent when the caller doesn't abandon

Verified load-bearing by mutation — removing the cancel send, or moving the throw before the drain, fails exactly the tests that should catch it.

Gates run locally:

- `dotnet toolchain.cs build` — clean
- `dotnet toolchain.cs test` — 12/12 projects
- `dotnet toolchain.cs -- resilience --fast` — 74/74 (required, this touches a Core runtime loop)
- `dotnet toolchain.cs -- test --integration --project Fido2 --smoke` — 30/30 on serial 103 / 5.8.0, HID FIDO and SmartCard
- `dotnet toolchain.cs -- test --integration --project WebAuthn` — 11/11

Still outstanding: a hardware regression test for the cancel itself (start a ceremony, don't touch, cancel, assert the key is immediately reusable). It's deliberately a no-touch test, so it should be automatable — happy to add it here or as a follow-up, whichever reviewers prefer.