### PR TITLE
fix(toolchain): repair coverage collection and add source-level CRAP scoring

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "coverlet.console": {
+      "version": "10.0.1",
+      "commands": [
+        "coverlet"
+      ],
+      "rollForward": false
+    },
+    "dotnet-reportgenerator-globaltool": {
+      "version": "5.5.11",
+      "commands": [
+        "reportgenerator"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -44,5 +44,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Bullseye" Version="5.0.0" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
+    <!-- Used by crap.cs for source-level cyclomatic complexity. Not referenced by any shipping project. -->
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
   </ItemGroup>
 </Project>

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -211,9 +211,38 @@ dotnet toolchain.cs -- crap --crap-args "--top 50 --min-crap 15"
 dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/crap.json"
 ```
 
-Verify the complexity rules against their golden fixtures with `dotnet crap.cs --self-check`.
+### Two complexity axes
 
-v1 reports only. There is no CI gate, no cognitive-complexity second axis, and no baseline ratchet yet; those wait until the baseline shows whether they are needed.
+CRAP is driven by cyclomatic complexity, which answers *how many paths* — not *how risky is this to change*. Those diverge badly on lookup tables, so the report also computes **cognitive complexity** (SonarSource rule S3776).
+
+| method | cyclomatic | cognitive | reading |
+|---|---:|---:|---|
+| `SCardException.GetErrorString` | 69 | 1 | a flat status-word table: large, obvious |
+| `LinuxHidIOReportConnection.ParseReportSizes` | 13 | 24 | a nested parser: small, genuinely hard |
+
+Cognitive complexity applies three rules that produce this split: a `switch` increments **once** regardless of arm count, nesting compounds, and readable shorthand (`??`, `??=`, `?.`) is ignored.
+
+Filter with both to get the actionable set, which avoids maintaining a hand-written ignore list of "big but harmless" methods:
+
+```bash
+dotnet toolchain.cs -- crap --crap-args "--min-crap 8 --min-cognitive 15"
+```
+
+`--min-cognitive` defaults to 15, which is Sonar's own threshold for S3776.
+
+### Cyclomatic complexity rules
+
+The rules follow the [SonarQube C# specification](https://docs.sonarsource.com/sonarqube-server/user-guide/code-metrics/metrics-definition), so the numbers are comparable to any SonarQube report: base 1 per member, plus one for each conditional expression, conditional access (`?.`), switch case or switch-expression arm, `and`/`or` pattern, `do`/`for`/`foreach`/`if`/`while`, and `??`/`??=`/`||`/`&&`.
+
+**One deliberate deviation:** `catch` clauses and `when` guards also increment. SonarQube's C# list omits them; textbook McCabe and the original crap4j both count them, and an exception handler is a real alternate path. This repo has 186 catch clauses, so the difference is material and is stated here rather than hidden.
+
+`default:` and the `_` switch-expression arm do not increment, since neither adds an independent path.
+
+Cognitive complexity does not implement the recursion increment, which needs a semantic model; directly recursive methods score one low.
+
+Verify every rule against its golden fixtures with `dotnet crap.cs --self-check` (51 fixtures, several taken from the SonarSource white paper).
+
+v1 reports only. There is no CI gate and no baseline ratchet yet; those wait until the thresholds are settled.
 
 ## xUnit v2 vs v3 Test Runner Detection
 

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -46,6 +46,7 @@ dotnet toolchain.cs -- build --project Piv --clean
 - **docs-inventory** - Generate the report-only active documentation inventory
 - **docs-architecture** - Validate architecture diagram evidence map and rendered-image freshness
 - **coverage** - Run tests with code coverage collection (depends on: restore, build)
+- **crap** - Compute CRAP scores from collected coverage (requires: coverage)
 - **pack** - Create NuGet packages (depends on: restore, build)
 - **setup-feed** - Configure local NuGet feed
 - **publish** - Publish packages to local feed (depends on: pack, setup-feed)
@@ -92,8 +93,12 @@ dotnet toolchain.cs -- docs-inventory
 # Run tests for specific project with filter
 dotnet toolchain.cs -- test --project Piv --filter "Method~Sign"
 
-# Run tests with code coverage (xUnit v2 unit test projects only)
+# Run tests with code coverage (all unit test projects)
 dotnet toolchain.cs coverage
+
+# Rank methods by CRAP score using the collected coverage
+dotnet toolchain.cs crap
+dotnet toolchain.cs -- crap --crap-args "--top 50 --json artifacts/crap/crap.json"
 
 # Run integration tests for a specific module
 dotnet toolchain.cs -- test --integration --project Piv
@@ -130,6 +135,7 @@ clean  (standalone — must be specified explicitly)
 
 - **Packages**: `artifacts/packages/*.nupkg`
 - **Coverage reports**: `artifacts/coverage/**/coverage.cobertura.xml`
+- **CRAP report**: `artifacts/crap/crap.json` (when `--json` is passed)
 - **Local NuGet feed**: `artifacts/nuget-feed/`
 
 ## Analyzers and Formatting
@@ -171,7 +177,43 @@ This means you don't need to manually update the build script when adding new pr
 
 ## Code Coverage
 
-The `coverage` target collects coverage via `dotnet test` with the `coverlet` collector. Both xUnit v2 and v3 (MTP) projects are supported via the VSTest compatibility layer. Use `--project` to run coverage for a specific module.
+The `coverage` target picks a collector per project, because the two test platforms need different mechanisms:
+
+| Test platform | Mechanism | Why |
+|---|---|---|
+| xUnit v3 / Microsoft Testing Platform | `coverlet.console` against the test executable | `--collect:"XPlat Code Coverage"` is a VSTest data collector and requires `Microsoft.NET.Test.Sdk`, which MTP projects deliberately omit. Using it aborts the run with a missing `testhost.deps.json`. |
+| xUnit v2 | `dotnet test --collect:"XPlat Code Coverage"` | The VSTest data collector path. |
+
+All unit test projects currently use MTP, so the second row is not exercised today; it remains for xUnit v2 projects.
+
+`coverlet.runsettings.xml` is the single definition of coverage policy. The VSTest collector reads it directly, and `toolchain.cs` projects the same settings onto `coverlet.console` flags, so both paths filter identically. Change filters there, not in `toolchain.cs`.
+
+Use `--project` to run coverage for a specific module.
+
+`Microsoft.Testing.Extensions.CodeCoverage` is not used: it currently throws `TypeLoadException` against `xunit.v3` 3.0.0, whose `Microsoft.Testing.Platform.MSBuild` 1.7.3 dependency is not binary compatible with `Microsoft.Testing.Platform` 2.3.3. It also does not emit the per-method complexity that CRAP analysis reads.
+
+## CRAP Scores
+
+The `crap` target ranks methods by the CRAP (Change Risk Anti-Patterns) metric:
+
+```
+CRAP(m) = cc(m)^2 * (1 - cov(m))^3 + cc(m)
+```
+
+It runs `crap.cs`, which computes **source-level cyclomatic complexity** with Roslyn and takes only coverage from the Cobertura reports.
+
+This deliberately differs from the "crap score" ReportGenerator shows for the same reports. ReportGenerator reads coverlet's `complexity` attribute, which is `Math.Max(1, branches.Count)` over recorded IL branch outcomes — a single `if` contributes 2. Measured on this repo the ratio to source complexity ranges from 0.5x to 6x with no stable multiplier, and it follows Roslyn codegen, so an SDK upgrade can move the numbers with no source change.
+
+Pass script options through `--crap-args`:
+
+```bash
+dotnet toolchain.cs -- crap --crap-args "--top 50 --min-crap 15"
+dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/crap.json"
+```
+
+Verify the complexity rules against their golden fixtures with `dotnet crap.cs --self-check`.
+
+v1 reports only. There is no CI gate, no cognitive-complexity second axis, and no baseline ratchet yet; those wait until the baseline shows whether they are needed.
 
 ## xUnit v2 vs v3 Test Runner Detection
 

--- a/coverlet.runsettings.xml
+++ b/coverlet.runsettings.xml
@@ -5,6 +5,10 @@
       <DataCollector friendlyName="XPlat code coverage">
         <Configuration>
           <Format>cobertura</Format>
+          <!-- This file is the single definition of coverage policy. The VSTest data collector
+               reads it directly; for Microsoft Testing Platform projects, toolchain.cs projects
+               these same settings onto coverlet.console flags. Change filters here, not there. -->
+          <Exclude>[*.UnitTests]*,[*.IntegrationTests]*,[*Tests.Shared]*</Exclude>
           <ExcludeByFile>**/tests/**/*.cs</ExcludeByFile> <!-- Globbing filter -->
           <ExcludeByAttribute>Obsolete,GeneratedCodeAttribute,CompilerGeneratedAttribute</ExcludeByAttribute>
           <IncludeTestAssembly>false</IncludeTestAssembly>

--- a/crap.cs
+++ b/crap.cs
@@ -1,0 +1,934 @@
+#!/usr/bin/env dotnet run
+
+#:package Microsoft.CodeAnalysis.CSharp
+
+/*
+ * Yubico.YubiKit CRAP Metrics Script
+ * ===================================
+ *
+ * Computes the CRAP (Change Risk Anti-Patterns) metric per method:
+ *
+ *     CRAP(m) = cc(m)^2 * (1 - cov(m))^3 + cc(m)
+ *
+ * WHY THIS SCRIPT EXISTS
+ * ----------------------
+ * ReportGenerator already reports a "crap score" from the Cobertura files that
+ * `dotnet toolchain.cs coverage` produces, but it reads coverlet's `complexity`
+ * attribute, which is NOT cyclomatic complexity. coverlet computes it as
+ * `Math.Max(1, branches.Count)` over recorded IL branch outcomes, so a single
+ * `if` contributes 2. Measured against source-level cyclomatic complexity on
+ * this repo, the ratio ranges from 0.5x to 6x with no stable multiplier, and it
+ * tracks Roslyn codegen rather than the source, so an SDK upgrade can move the
+ * numbers with no source change.
+ *
+ * This script therefore computes cyclomatic complexity from the syntax tree and
+ * takes only coverage from the Cobertura reports.
+ *
+ * USAGE:
+ *   dotnet crap.cs [options]
+ *
+ * OPTIONS:
+ *   --coverage <dir>    Directory searched recursively for coverage.cobertura.xml.
+ *                       Default: artifacts/coverage
+ *   --source <dir>      Source root to analyze. Repeatable. Default: src
+ *   --min-crap <n>      Only report methods at or above this CRAP score. Default: 8
+ *   --top <n>           Rows in the console table. Default: 25
+ *   --json <path>       Write the full ranked result as JSON.
+ *   --no-conditional-access
+ *                       Exclude `?.` / `?[]` from cyclomatic complexity.
+ *   --self-check        Run the built-in golden fixtures and exit.
+ *
+ * EXIT CODES:
+ *   0  success
+ *   1  usage / IO error, or a self-check fixture failed
+ *   2  coverage could not be reconciled with the source tree
+ *
+ * NOT IMPLEMENTED IN v1 (deliberately):
+ *   - cognitive complexity as a second gate
+ *   - CI gate / threshold exit code
+ *   - baseline ratchet
+ *   These wait until the source-CC baseline shows whether they are needed.
+ *
+ * See TOOLCHAIN.md and docs/TESTING.md.
+ */
+
+using System.Globalization;
+using System.Text.Json;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+var options = CrapOptions.Parse(args);
+if (options is null)
+    return 1;
+
+if (options.SelfCheck)
+    return SelfCheck.Run(options);
+
+return CrapAnalysis.Run(options);
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+sealed record CrapOptions
+{
+    public required string RepoRoot { get; init; }
+    public required IReadOnlyList<string> SourceRoots { get; init; }
+    public required string CoverageGlob { get; init; }
+    public double MinCrap { get; init; } = 8;
+    public int Top { get; init; } = 25;
+    public string? JsonPath { get; init; }
+    public bool CountConditionalAccess { get; init; } = true;
+    public bool SelfCheck { get; init; }
+
+    public static CrapOptions? Parse(string[] args)
+    {
+        var repoRoot = FindRepoRoot();
+        if (repoRoot is null)
+        {
+            Console.Error.WriteLine("error: could not locate repo root (no toolchain.cs found in any parent directory)");
+            return null;
+        }
+
+        var sources = new List<string>();
+        string? coverageGlob = null;
+        double minCrap = 8;
+        var top = 25;
+        string? json = null;
+        var countConditionalAccess = true;
+        var selfCheck = false;
+
+        for (var i = 0; i < args.Length; i++)
+        {
+            switch (args[i])
+            {
+                case "--source" when i + 1 < args.Length:
+                    sources.Add(args[++i]);
+                    break;
+                case "--coverage" when i + 1 < args.Length:
+                    coverageGlob = args[++i];
+                    break;
+                case "--min-crap" when i + 1 < args.Length:
+                    if (!double.TryParse(args[++i], NumberStyles.Float, CultureInfo.InvariantCulture, out minCrap))
+                    {
+                        Console.Error.WriteLine($"error: --min-crap expects a number, got '{args[i]}'");
+                        return null;
+                    }
+
+                    break;
+                case "--top" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out top))
+                    {
+                        Console.Error.WriteLine($"error: --top expects an integer, got '{args[i]}'");
+                        return null;
+                    }
+
+                    break;
+                case "--json" when i + 1 < args.Length:
+                    json = args[++i];
+                    break;
+                case "--no-conditional-access":
+                    countConditionalAccess = false;
+                    break;
+                case "--self-check":
+                    selfCheck = true;
+                    break;
+                case "--help" or "-h":
+                    PrintUsage();
+                    return null;
+                default:
+                    Console.Error.WriteLine($"error: unrecognized argument '{args[i]}' (try --help)");
+                    return null;
+            }
+        }
+
+        if (sources.Count == 0)
+            sources.Add("src");
+
+        return new CrapOptions
+        {
+            RepoRoot = repoRoot,
+            SourceRoots = sources,
+            CoverageGlob = coverageGlob ?? Path.Combine("artifacts", "coverage"),
+            MinCrap = minCrap,
+            Top = top,
+            JsonPath = json,
+            CountConditionalAccess = countConditionalAccess,
+            SelfCheck = selfCheck,
+        };
+    }
+
+    static void PrintUsage() =>
+        Console.WriteLine("""
+            dotnet crap.cs [options]
+
+              --coverage <dir>           Directory searched for coverage.cobertura.xml (default: artifacts/coverage)
+              --source <dir>             Source root to analyze, repeatable (default: src)
+              --min-crap <n>             Minimum CRAP score to report (default: 8)
+              --top <n>                  Rows in the console table (default: 25)
+              --json <path>              Write full ranked result as JSON
+              --no-conditional-access    Exclude ?. and ?[] from cyclomatic complexity
+              --self-check               Run built-in golden fixtures and exit
+            """);
+
+    static string? FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(Directory.GetCurrentDirectory());
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "toolchain.cs")))
+            dir = dir.Parent;
+
+        return dir?.FullName;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Source model
+// ---------------------------------------------------------------------------
+
+sealed record SourceMethod
+{
+    public required string FilePath { get; init; }
+    public required string TypeName { get; init; }
+    public required string MethodName { get; init; }
+    public required int StartLine { get; init; }
+    public required int EndLine { get; init; }
+    public required int Cyclomatic { get; init; }
+
+    /// <summary>False for abstract, interface, extern, and auto-property members, which emit no code.</summary>
+    public required bool HasImplementation { get; init; }
+
+    public string Display => $"{TypeName}.{MethodName}";
+}
+
+/// <summary>
+/// Extracts every method-like declaration with its source span and cyclomatic complexity.
+/// </summary>
+/// <remarks>
+/// Lambdas and local functions are deliberately folded into their enclosing member so that
+/// complexity and coverage describe the same unit: coverlet attributes a lambda's lines to
+/// the file region of its parent, so splitting them would desynchronize the two halves of
+/// the CRAP formula.
+/// </remarks>
+static class MethodExtractor
+{
+    public static List<SourceMethod> Extract(string filePath, string text, bool countConditionalAccess)
+    {
+        var tree = CSharpSyntaxTree.ParseText(text, path: filePath);
+        var root = tree.GetRoot();
+        var results = new List<SourceMethod>();
+
+        foreach (var node in root.DescendantNodes())
+        {
+            if (!IsMemberDeclaration(node))
+                continue;
+
+            // A local function is part of its parent member's complexity, not its own entry.
+            if (node.Ancestors().Any(IsMemberDeclaration))
+                continue;
+
+            var span = tree.GetLineSpan(node.Span);
+            results.Add(new SourceMethod
+            {
+                FilePath = filePath,
+                TypeName = TypeNameOf(node),
+                MethodName = MemberNameOf(node),
+                StartLine = span.StartLinePosition.Line + 1,
+                EndLine = span.EndLinePosition.Line + 1,
+                Cyclomatic = CyclomaticComplexity.Compute(node, countConditionalAccess),
+                HasImplementation = HasImplementation(node),
+            });
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// True for any node that owns a body worth measuring, including local functions.
+    /// </summary>
+    /// <remarks>
+    /// This is the single definition of "member" for the whole script.
+    /// <see cref="CyclomaticComplexity"/> derives its own narrower notion from it rather
+    /// than repeating the list, so the two cannot drift apart and silently mis-count.
+    /// </remarks>
+    public static bool IsMemberDeclaration(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax or
+        ConstructorDeclarationSyntax or
+        DestructorDeclarationSyntax or
+        OperatorDeclarationSyntax or
+        ConversionOperatorDeclarationSyntax or
+        AccessorDeclarationSyntax or
+        LocalFunctionStatementSyntax => true,
+
+        // An expression-bodied property or indexer has no AccessorDeclarationSyntax, so it
+        // would otherwise be skipped entirely. One with an accessor list is not itself a
+        // member here — its accessors are picked up individually.
+        PropertyDeclarationSyntax p => p.ExpressionBody is not null,
+        IndexerDeclarationSyntax i => i.ExpressionBody is not null,
+
+        _ => false,
+    };
+
+    /// <summary>
+    /// True when the member has a body the compiler can instrument.
+    /// </summary>
+    /// <remarks>
+    /// Abstract, interface, extern, and partial declarations, and auto-property accessors,
+    /// emit no code, so coverage tools never report them. Distinguishing these from members
+    /// that are simply absent from the coverage data is what lets the report treat the
+    /// latter as genuinely untested rather than silently dropping them.
+    /// </remarks>
+    public static bool HasImplementation(SyntaxNode node) => node switch
+    {
+        BaseMethodDeclarationSyntax m => m.Body is not null || m.ExpressionBody is not null,
+        AccessorDeclarationSyntax a => a.Body is not null || a.ExpressionBody is not null,
+        LocalFunctionStatementSyntax l => l.Body is not null || l.ExpressionBody is not null,
+        PropertyDeclarationSyntax p => p.ExpressionBody is not null,
+        IndexerDeclarationSyntax i => i.ExpressionBody is not null,
+        _ => false,
+    };
+
+    static string MemberNameOf(SyntaxNode node) => node switch
+    {
+        MethodDeclarationSyntax m => m.Identifier.ValueText,
+        ConstructorDeclarationSyntax c => c.Identifier.ValueText,
+        DestructorDeclarationSyntax d => "~" + d.Identifier.ValueText,
+        OperatorDeclarationSyntax o => "operator " + o.OperatorToken.ValueText,
+        ConversionOperatorDeclarationSyntax => "operator",
+        LocalFunctionStatementSyntax l => l.Identifier.ValueText,
+        AccessorDeclarationSyntax a => AccessorName(a),
+        PropertyDeclarationSyntax p => p.Identifier.ValueText,
+        IndexerDeclarationSyntax => "this[]",
+        _ => "?",
+    };
+
+    static string AccessorName(AccessorDeclarationSyntax accessor)
+    {
+        var owner = accessor.Ancestors()
+            .OfType<BasePropertyDeclarationSyntax>()
+            .FirstOrDefault();
+
+        var ownerName = owner switch
+        {
+            PropertyDeclarationSyntax p => p.Identifier.ValueText,
+            EventDeclarationSyntax e => e.Identifier.ValueText,
+            IndexerDeclarationSyntax => "this[]",
+            _ => "?",
+        };
+
+        return $"{accessor.Keyword.ValueText}_{ownerName}";
+    }
+
+    static string TypeNameOf(SyntaxNode node)
+    {
+        var type = node.Ancestors().OfType<BaseTypeDeclarationSyntax>().FirstOrDefault();
+        if (type is null)
+            return "<global>";
+
+        var names = new Stack<string>();
+        for (var current = type; current is not null; current = current.Ancestors().OfType<BaseTypeDeclarationSyntax>().FirstOrDefault())
+            names.Push(current.Identifier.ValueText);
+
+        var ns = node.Ancestors().OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();
+        var prefix = ns is null ? string.Empty : ns.Name.ToString() + ".";
+
+        return prefix + string.Join(".", names);
+    }
+}
+
+/// <summary>
+/// Source-level McCabe cyclomatic complexity: one plus the number of decision points.
+/// </summary>
+/// <remarks>
+/// Counted: if, the four loop forms, each non-default switch case / switch-expression arm,
+/// each catch clause, the short-circuiting and null-coalescing operators (&amp;&amp;, ||, ??, ??=),
+/// conditional access (?. and ?[], unless disabled), the ternary conditional, `when` guards,
+/// and each `and`/`or` pattern combinator.
+///
+/// `else` is not counted: it adds no independent path beyond the `if` that introduced it.
+/// `default:` and the `_` switch arm are not counted for the same reason.
+/// </remarks>
+static class CyclomaticComplexity
+{
+    public static int Compute(SyntaxNode member, bool countConditionalAccess)
+    {
+        var complexity = 1;
+
+        foreach (var node in member.DescendantNodes())
+        {
+            // Nested members carry their own complexity except local functions and lambdas,
+            // which are intentionally folded into the enclosing member.
+            if (IsSeparatelyCountedMember(node))
+                continue;
+
+            complexity += Increment(node, countConditionalAccess);
+        }
+
+        return complexity;
+    }
+
+    // Derived from the single member definition rather than restating it: every member kind
+    // gets its own entry except local functions, which fold into their enclosing member.
+    static bool IsSeparatelyCountedMember(SyntaxNode node) =>
+        MethodExtractor.IsMemberDeclaration(node) && node is not LocalFunctionStatementSyntax;
+
+    static int Increment(SyntaxNode node, bool countConditionalAccess) => node switch
+    {
+        IfStatementSyntax => 1,
+        WhileStatementSyntax => 1,
+        DoStatementSyntax => 1,
+        ForStatementSyntax => 1,
+        ForEachStatementSyntax or ForEachVariableStatementSyntax => 1,
+        CaseSwitchLabelSyntax => 1,
+        CasePatternSwitchLabelSyntax => 1,
+        CatchClauseSyntax => 1,
+        ConditionalExpressionSyntax => 1,
+
+        // `case x when guard:` — a switch-label guard.
+        WhenClauseSyntax => 1,
+
+        // `catch (E e) when (filter)` — a distinct node type from the switch-label guard.
+        CatchFilterClauseSyntax => 1,
+
+        // `default:` adds no independent path.
+        DefaultSwitchLabelSyntax => 0,
+
+        // The discard arm `_ =>` is the switch-expression equivalent of `default:`.
+        SwitchExpressionArmSyntax arm => arm.Pattern is DiscardPatternSyntax ? 0 : 1,
+
+        BinaryExpressionSyntax b when b.IsKind(SyntaxKind.LogicalAndExpression)
+                                   || b.IsKind(SyntaxKind.LogicalOrExpression)
+                                   || b.IsKind(SyntaxKind.CoalesceExpression) => 1,
+
+        AssignmentExpressionSyntax a when a.IsKind(SyntaxKind.CoalesceAssignmentExpression) => 1,
+
+        ConditionalAccessExpressionSyntax => countConditionalAccess ? 1 : 0,
+
+        // `x is A or B` introduces one extra path per combinator.
+        BinaryPatternSyntax => 1,
+
+        _ => 0,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// Self-check: golden fixtures for the complexity rules
+// ---------------------------------------------------------------------------
+
+static class SelfCheck
+{
+    public static int Run(CrapOptions options)
+    {
+        var failures = 0;
+        var passes = 0;
+
+        foreach (var (name, source, expected) in Fixtures())
+        {
+            var methods = MethodExtractor.Extract("fixture.cs", Wrap(source), countConditionalAccess: true);
+            var actual = methods.Count == 1 ? methods[0].Cyclomatic : -methods.Count;
+
+            if (actual == expected)
+            {
+                passes++;
+            }
+            else
+            {
+                failures++;
+                Console.Error.WriteLine($"FAIL {name}: expected cc={expected}, got {actual}");
+            }
+        }
+
+        foreach (var (name, source, expected) in ImplementationFixtures())
+        {
+            var methods = MethodExtractor.Extract("fixture.cs", source, countConditionalAccess: true);
+            var actual = methods.Count > 0 && methods.All(m => m.HasImplementation == expected);
+
+            if (actual && methods.Count > 0)
+            {
+                passes++;
+            }
+            else
+            {
+                failures++;
+                Console.Error.WriteLine(
+                    $"FAIL {name}: expected HasImplementation={expected} on all {methods.Count} extracted member(s)");
+            }
+        }
+
+        // Anchor against a real method whose complexity was derived by hand.
+        var anchor = Path.Combine(options.RepoRoot, "src", "Piv", "src", "Metadata", "PivMetadataProtocol.cs");
+        if (File.Exists(anchor))
+        {
+            var target = MethodExtractor
+                .Extract(anchor, File.ReadAllText(anchor), countConditionalAccess: true)
+                .FirstOrDefault(m => m.MethodName == "GetSlotMetadataAsync");
+
+            const int expectedAnchor = 15;
+            if (target is null)
+            {
+                failures++;
+                Console.Error.WriteLine("FAIL anchor: GetSlotMetadataAsync not found in PivMetadataProtocol.cs");
+            }
+            else if (target.Cyclomatic != expectedAnchor)
+            {
+                failures++;
+                Console.Error.WriteLine(
+                    $"FAIL anchor GetSlotMetadataAsync: expected cc={expectedAnchor}, got {target.Cyclomatic}. " +
+                    "If the method changed, re-derive the expected value by hand before editing this number.");
+            }
+            else
+            {
+                passes++;
+            }
+        }
+
+        Console.WriteLine($"self-check: {passes} passed, {failures} failed");
+        return failures == 0 ? 0 : 1;
+    }
+
+    static string Wrap(string body) => $$"""
+        namespace Fixture;
+        internal sealed class C
+        {
+        {{body}}
+        }
+        """;
+
+    /// <summary>
+    /// Members that emit no code must be distinguishable from members that were simply
+    /// never exercised, otherwise untested code is silently dropped from the report.
+    /// </summary>
+    static IEnumerable<(string Name, string Source, bool Expected)> ImplementationFixtures()
+    {
+        yield return ("abstract-method-has-no-implementation",
+            "namespace F; internal abstract class A { public abstract void M(); }", false);
+        yield return ("interface-method-has-no-implementation",
+            "namespace F; internal interface I { void M(); }", false);
+        yield return ("extern-method-has-no-implementation",
+            "namespace F; internal static class E { public static extern void M(); }", false);
+        yield return ("auto-property-accessors-have-no-implementation",
+            "namespace F; internal sealed class C { public int P { get; set; } }", false);
+        yield return ("concrete-method-has-implementation",
+            "namespace F; internal sealed class C { public void M() { } }", true);
+        yield return ("expression-bodied-property-has-implementation",
+            "namespace F; internal sealed class C { public int P => 1; }", true);
+    }
+
+    static IEnumerable<(string Name, string Source, int Expected)> Fixtures()
+    {
+        yield return ("straight-line", "void M() { var x = 1; }", 1);
+        yield return ("single-if", "void M(int a) { if (a > 0) { } }", 2);
+        yield return ("if-else-counts-once", "void M(int a) { if (a > 0) { } else { } }", 2);
+        yield return ("else-if-chain", "void M(int a) { if (a > 0) { } else if (a < 0) { } else { } }", 3);
+        yield return ("three-sequential-ifs", "void M(int a) { if (a>0){} if (a>1){} if (a>2){} }", 4);
+        yield return ("while", "void M(bool b) { while (b) { } }", 2);
+        yield return ("do-while", "void M(bool b) { do { } while (b); }", 2);
+        yield return ("for", "void M() { for (var i = 0; i < 3; i++) { } }", 2);
+        yield return ("foreach", "void M(int[] xs) { foreach (var x in xs) { } }", 2);
+        yield return ("logical-and", "bool M(bool a, bool b) => a && b;", 2);
+        yield return ("logical-or", "bool M(bool a, bool b) => a || b;", 2);
+        yield return ("two-ands", "bool M(bool a, bool b, bool c) => a && b && c;", 3);
+        yield return ("coalesce", "string M(string? a) => a ?? \"x\";", 2);
+        yield return ("coalesce-assign", "void M(ref string? a) { a ??= \"x\"; }", 2);
+        yield return ("ternary", "int M(bool b) => b ? 1 : 2;", 2);
+        yield return ("conditional-access", "int? M(string? s) => s?.Length;", 2);
+        yield return ("catch-single", "void M() { try { } catch { } }", 2);
+        yield return ("catch-multiple", "void M() { try { } catch (System.IO.IOException) { } catch { } }", 3);
+        yield return ("catch-when-filter", "void M() { try { } catch (System.Exception e) when (e.Message.Length > 0) { } }", 3);
+        yield return ("switch-statement-three-cases",
+            "void M(int a) { switch (a) { case 1: break; case 2: break; default: break; } }", 3);
+        yield return ("switch-expression-three-arms",
+            "string M(int a) => a switch { 1 => \"a\", 2 => \"b\", _ => \"c\" };", 3);
+        // `is` alone is not a branch; only the `or` combinator adds a path.
+        yield return ("pattern-or-combinator", "bool M(int a) => a is 1 or 2;", 2);
+        yield return ("pattern-two-combinators", "bool M(int a) => a is 1 or 2 or 3;", 3);
+        yield return ("local-function-folds-into-parent",
+            "void M(int a) { Inner(); void Inner() { if (a > 0) { } } }", 2);
+
+        // Introducing a lambda is not itself a branch; only the decisions inside it count.
+        yield return ("lambda-folds-into-parent",
+            "void M(System.Collections.Generic.List<int> xs) { xs.RemoveAll(x => x > 0 && x < 9); }", 2);
+
+        // Expression-bodied members have no AccessorDeclarationSyntax and were once skipped.
+        yield return ("expression-bodied-property", "int P => 1;", 1);
+        yield return ("expression-bodied-property-ternary",
+            "int P => System.Environment.TickCount > 0 ? 1 : 2;", 2);
+        yield return ("expression-bodied-indexer", "int this[int i] => i > 0 ? 1 : 2;", 2);
+        yield return ("expression-bodied-method-coalesce", "string M(string? s) => s ?? \"x\";", 2);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Coverage ingest and CRAP analysis
+// ---------------------------------------------------------------------------
+
+sealed record CrapRow
+{
+    public required SourceMethod Method { get; init; }
+    public required int CoveredLines { get; init; }
+    public required int TotalLines { get; init; }
+
+    /// <summary>True when no coverage report mentioned this member at all.</summary>
+    public bool NeverObserved => TotalLines == 0;
+
+    public double Coverage => TotalLines == 0 ? 0 : (double)CoveredLines / TotalLines;
+
+    public double Crap
+    {
+        get
+        {
+            var cc = (double)Method.Cyclomatic;
+            var uncovered = 1 - Coverage;
+            return (cc * cc * uncovered * uncovered * uncovered) + cc;
+        }
+    }
+}
+
+static class CrapAnalysis
+{
+    public static int Run(CrapOptions options)
+    {
+        var methods = LoadSourceMethods(options);
+        if (methods.Count == 0)
+        {
+            Console.Error.WriteLine("error: no source methods found; check --source");
+            return 1;
+        }
+
+        var reports = DiscoverReports(options);
+        if (reports.Count == 0)
+        {
+            Console.Error.WriteLine(
+                $"error: no coverage.cobertura.xml under '{options.CoverageGlob}'. " +
+                "Run 'dotnet toolchain.cs coverage' first.");
+            return 1;
+        }
+
+        var hits = LoadCoverage(reports);
+        var rows = Correlate(methods, hits, out var unmatchedCoverage, out var uninstrumented);
+
+        Report(options, rows, methods.Count, reports.Count, unmatchedCoverage, uninstrumented);
+
+        // Coverage that cannot be tied back to a source method means the two halves of the
+        // formula disagree about the code under analysis. Reporting a number anyway is how
+        // other CRAP tools silently produce wrong answers, so this is a hard failure.
+        var orphanRatio = hits.Count == 0 ? 1.0 : (double)unmatchedCoverage / hits.Count;
+        if (orphanRatio > 0.10)
+        {
+            Console.Error.WriteLine();
+            Console.Error.WriteLine(
+                $"error: {unmatchedCoverage} of {hits.Count} covered lines ({orphanRatio:P1}) " +
+                "could not be matched to a source method. Coverage is likely stale — re-run " +
+                "'dotnet toolchain.cs coverage'. Refusing to report CRAP scores built on it.");
+            return 2;
+        }
+
+        return 0;
+    }
+
+    static List<SourceMethod> LoadSourceMethods(CrapOptions options)
+    {
+        var methods = new List<SourceMethod>();
+
+        foreach (var root in options.SourceRoots)
+        {
+            var full = Path.IsPathRooted(root) ? root : Path.Combine(options.RepoRoot, root);
+            if (!Directory.Exists(full))
+            {
+                Console.Error.WriteLine($"warning: source root not found: {full}");
+                continue;
+            }
+
+            foreach (var file in Directory.EnumerateFiles(full, "*.cs", SearchOption.AllDirectories))
+            {
+                if (IsExcluded(file))
+                    continue;
+
+                methods.AddRange(MethodExtractor.Extract(
+                    Path.GetFullPath(file),
+                    File.ReadAllText(file),
+                    options.CountConditionalAccess));
+            }
+        }
+
+        return methods;
+    }
+
+    // Scope is the shipping SDK. Each module is laid out as src/<Module>/{src,tests,examples},
+    // and only the inner src/ ships: tests are not the subject of the metric, and examples are
+    // sample apps outside the solution. Shared test infrastructure sits directly under src/ as
+    // src/Tests.Shared and src/Tests.TestProject, which have no "tests" path segment, so those
+    // are matched by name. Build output and generated files are never source.
+    static bool IsExcluded(string path)
+    {
+        var normalized = path.Replace('\\', '/');
+
+        if (normalized.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase)
+            || normalized.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase))
+        {
+            return true;
+        }
+
+        foreach (var segment in normalized.Split('/'))
+        {
+            if (segment is "obj" or "bin" or "tests" or "examples")
+                return true;
+
+            if (segment.StartsWith("Tests.", StringComparison.Ordinal))
+                return true;
+        }
+
+        return false;
+    }
+
+    static List<string> DiscoverReports(CrapOptions options)
+    {
+        var dir = Path.IsPathRooted(options.CoverageGlob)
+            ? options.CoverageGlob
+            : Path.Combine(options.RepoRoot, options.CoverageGlob);
+
+        return Directory.Exists(dir)
+            ? [.. Directory.EnumerateFiles(dir, "coverage.cobertura.xml", SearchOption.AllDirectories).Order()]
+            : [];
+    }
+
+    /// <summary>
+    /// Reads every Cobertura report into a merged (absolute path, line) -> hits map.
+    /// </summary>
+    /// <remarks>
+    /// Each report's <c>&lt;sources&gt;</c> root must be applied to that report's own
+    /// <c>filename</c> values. coverlet derives the root from the common prefix of the
+    /// assemblies it instrumented, so a project that only touches Core emits
+    /// <c>Protocols/.../SWConstants.cs</c> while every other project emits
+    /// <c>Core/src/Protocols/.../SWConstants.cs</c> for the same file. Keying on the raw
+    /// relative path therefore double-counts shared code.
+    ///
+    /// Hits are accumulated rather than overwritten so a line executed by any one test
+    /// project counts as covered overall.
+    /// </remarks>
+    static Dictionary<(string Path, int Line), int> LoadCoverage(List<string> reports)
+    {
+        var hits = new Dictionary<(string, int), int>();
+
+        foreach (var report in reports)
+        {
+            var doc = XDocument.Load(report);
+            var roots = doc.Descendants("source")
+                .Select(s => s.Value.Trim())
+                .Where(s => s.Length > 0)
+                .ToList();
+
+            foreach (var cls in doc.Descendants("class"))
+            {
+                var filename = cls.Attribute("filename")?.Value;
+                if (string.IsNullOrEmpty(filename))
+                    continue;
+
+                var resolved = ResolveAgainstRoots(roots, filename);
+                if (resolved is null)
+                    continue;
+
+                foreach (var line in cls.Descendants("line"))
+                {
+                    if (!int.TryParse(line.Attribute("number")?.Value, out var number))
+                        continue;
+                    if (!int.TryParse(line.Attribute("hits")?.Value, out var count))
+                        continue;
+
+                    var key = (resolved, number);
+                    hits[key] = hits.TryGetValue(key, out var existing) ? existing + count : count;
+                }
+            }
+        }
+
+        return hits;
+    }
+
+    static string? ResolveAgainstRoots(List<string> roots, string filename)
+    {
+        foreach (var root in roots)
+        {
+            var candidate = Path.GetFullPath(Path.Combine(root, filename));
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Assigns each covered line to the innermost source method whose span contains it.
+    /// </summary>
+    /// <remarks>
+    /// Matching on spans rather than names is what makes async work. coverlet records an
+    /// async body under the compiler-generated <c>&lt;Name&gt;d__N::MoveNext</c>, but it
+    /// keeps the original file and line numbers, so the lines fall inside the source
+    /// method's span. Name-based matching misses this and scores every async method 0%.
+    /// </remarks>
+    static List<CrapRow> Correlate(
+        List<SourceMethod> methods,
+        Dictionary<(string Path, int Line), int> hits,
+        out int unmatchedCoverage,
+        out int uninstrumented)
+    {
+        var byFile = methods
+            .GroupBy(m => m.FilePath)
+            .ToDictionary(g => g.Key, g => g.OrderBy(m => m.EndLine - m.StartLine).ToList());
+
+        var covered = new Dictionary<SourceMethod, (int Covered, int Total)>();
+        unmatchedCoverage = 0;
+
+        foreach (var ((path, line), count) in hits)
+        {
+            if (!byFile.TryGetValue(path, out var candidates))
+            {
+                unmatchedCoverage++;
+                continue;
+            }
+
+            // Candidates are ordered narrowest-first, so the first containing span is innermost.
+            var owner = candidates.FirstOrDefault(m => line >= m.StartLine && line <= m.EndLine);
+            if (owner is null)
+            {
+                unmatchedCoverage++;
+                continue;
+            }
+
+            var entry = covered.TryGetValue(owner, out var e) ? e : (0, 0);
+            covered[owner] = (entry.Item1 + (count > 0 ? 1 : 0), entry.Item2 + 1);
+        }
+
+        var rows = covered.Select(kv => new CrapRow
+        {
+            Method = kv.Key,
+            CoveredLines = kv.Value.Covered,
+            TotalLines = kv.Value.Total,
+        }).ToList();
+
+        // A member with a body that never appeared in any coverage report was not exercised
+        // at all — most often because its assembly has no unit test project. That is the
+        // most dangerous code in the repo, so it must be reported as 0% covered rather than
+        // dropped. Only members that emit no code are genuinely unmeasurable.
+        uninstrumented = 0;
+        foreach (var method in methods)
+        {
+            if (covered.ContainsKey(method))
+                continue;
+
+            if (!method.HasImplementation)
+            {
+                uninstrumented++;
+                continue;
+            }
+
+            rows.Add(new CrapRow { Method = method, CoveredLines = 0, TotalLines = 0 });
+        }
+
+        return rows;
+    }
+
+    static void Report(
+        CrapOptions options,
+        List<CrapRow> rows,
+        int methodCount,
+        int reportCount,
+        int unmatchedCoverage,
+        int uninstrumented)
+    {
+        var ranked = rows.OrderByDescending(r => r.Crap).ToList();
+        var flagged = ranked.Where(r => r.Crap >= options.MinCrap).ToList();
+
+        Console.WriteLine();
+        Console.WriteLine("CRAP report (source-level cyclomatic complexity)");
+        Console.WriteLine(new string('=', 96));
+        Console.WriteLine($"  coverage reports    {reportCount}");
+        Console.WriteLine($"  source methods      {methodCount}");
+        var neverObserved = rows.Count(r => r.NeverObserved);
+        Console.WriteLine($"  with coverage data  {rows.Count - neverObserved}");
+        Console.WriteLine($"  never exercised     {neverObserved}  (implemented but absent from every report; scored 0%)");
+        Console.WriteLine($"  not measurable      {uninstrumented}  (abstract, interface, extern, or auto-property)");
+        Console.WriteLine($"  unmatched lines     {unmatchedCoverage}");
+        Console.WriteLine($"  CRAP >= {options.MinCrap,-11:0.##}{flagged.Count}");
+        Console.WriteLine($"  conditional access  {(options.CountConditionalAccess ? "counted" : "not counted")}");
+        Console.WriteLine();
+
+        if (flagged.Count > 0)
+        {
+            Console.WriteLine($"{"CRAP",10}  {"cc",4}  {"cov",7}  method");
+            Console.WriteLine(new string('-', 96));
+            foreach (var row in flagged.Take(options.Top))
+            {
+                var coverage = row.NeverObserved ? "  n/a" : row.Coverage.ToString("P1");
+                Console.WriteLine(
+                    $"{row.Crap,10:F1}  {row.Method.Cyclomatic,4}  {coverage,7}  {row.Method.Display}");
+            }
+
+            if (flagged.Count > options.Top)
+                Console.WriteLine($"... and {flagged.Count - options.Top} more (raise --top or use --json)");
+        }
+
+        if (options.JsonPath is not null)
+            WriteJson(options, ranked, methodCount, reportCount, unmatchedCoverage, uninstrumented);
+    }
+
+    // Written with Utf8JsonWriter rather than JsonSerializer: the repo enables the trim and
+    // AOT analyzers as errors, and reflection-based serialization of anonymous types trips
+    // IL2026/IL3050.
+    static void WriteJson(
+        CrapOptions options,
+        List<CrapRow> ranked,
+        int methodCount,
+        int reportCount,
+        int unmatchedCoverage,
+        int uninstrumented)
+    {
+        var path = Path.IsPathRooted(options.JsonPath!)
+            ? options.JsonPath!
+            : Path.Combine(options.RepoRoot, options.JsonPath!);
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrEmpty(directory))
+            Directory.CreateDirectory(directory);
+
+        using var stream = File.Create(path);
+        using var writer = new Utf8JsonWriter(stream, new JsonWriterOptions { Indented = true });
+
+        writer.WriteStartObject();
+        writer.WriteString("generatedOn", DateTimeOffset.UtcNow);
+        writer.WriteString("complexityMetric", "source-cyclomatic");
+        writer.WriteBoolean("countsConditionalAccess", options.CountConditionalAccess);
+        writer.WriteNumber("reportCount", reportCount);
+        writer.WriteNumber("methodCount", methodCount);
+        writer.WriteNumber("methodsWithCoverage", ranked.Count(r => !r.NeverObserved));
+        writer.WriteNumber("neverExercised", ranked.Count(r => r.NeverObserved));
+        writer.WriteNumber("uninstrumented", uninstrumented);
+        writer.WriteNumber("unmatchedCoverage", unmatchedCoverage);
+
+        writer.WriteStartArray("methods");
+        foreach (var row in ranked)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("type", row.Method.TypeName);
+            writer.WriteString("method", row.Method.MethodName);
+            writer.WriteString("file", Path.GetRelativePath(options.RepoRoot, row.Method.FilePath));
+            writer.WriteNumber("startLine", row.Method.StartLine);
+            writer.WriteNumber("endLine", row.Method.EndLine);
+            writer.WriteNumber("cyclomatic", row.Method.Cyclomatic);
+            writer.WriteNumber("coveredLines", row.CoveredLines);
+            writer.WriteNumber("totalLines", row.TotalLines);
+            writer.WriteNumber("coverage", Math.Round(row.Coverage, 4));
+            writer.WriteBoolean("neverObserved", row.NeverObserved);
+            writer.WriteNumber("crap", Math.Round(row.Crap, 2));
+            writer.WriteEndObject();
+        }
+
+        writer.WriteEndArray();
+        writer.WriteEndObject();
+        writer.Flush();
+
+        Console.WriteLine();
+        Console.WriteLine($"JSON written to {path}");
+    }
+}

--- a/crap.cs
+++ b/crap.cs
@@ -32,6 +32,8 @@
  *                       Default: artifacts/coverage
  *   --source <dir>      Source root to analyze. Repeatable. Default: src
  *   --min-crap <n>      Only report methods at or above this CRAP score. Default: 8
+ *   --min-cognitive <n> Cognitive-complexity threshold used to separate genuinely
+ *                       hard code from large-but-flat code. Default: 15 (Sonar's own).
  *   --top <n>           Rows in the console table. Default: 25
  *   --json <path>       Write the full ranked result as JSON.
  *   --no-conditional-access
@@ -44,10 +46,9 @@
  *   2  coverage could not be reconciled with the source tree
  *
  * NOT IMPLEMENTED IN v1 (deliberately):
- *   - cognitive complexity as a second gate
  *   - CI gate / threshold exit code
  *   - baseline ratchet
- *   These wait until the source-CC baseline shows whether they are needed.
+ *   These wait until the thresholds are settled against the baseline.
  *
  * See TOOLCHAIN.md and docs/TESTING.md.
  */
@@ -78,6 +79,9 @@ sealed record CrapOptions
     public required IReadOnlyList<string> SourceRoots { get; init; }
     public required string CoverageGlob { get; init; }
     public double MinCrap { get; init; } = 8;
+
+    /// <summary>Sonar's own default threshold for rule S3776 is 15.</summary>
+    public int MinCognitive { get; init; } = 15;
     public int Top { get; init; } = 25;
     public string? JsonPath { get; init; }
     public bool CountConditionalAccess { get; init; } = true;
@@ -95,6 +99,7 @@ sealed record CrapOptions
         var sources = new List<string>();
         string? coverageGlob = null;
         double minCrap = 8;
+        var minCognitive = 15;
         var top = 25;
         string? json = null;
         var countConditionalAccess = true;
@@ -114,6 +119,14 @@ sealed record CrapOptions
                     if (!double.TryParse(args[++i], NumberStyles.Float, CultureInfo.InvariantCulture, out minCrap))
                     {
                         Console.Error.WriteLine($"error: --min-crap expects a number, got '{args[i]}'");
+                        return null;
+                    }
+
+                    break;
+                case "--min-cognitive" when i + 1 < args.Length:
+                    if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out minCognitive))
+                    {
+                        Console.Error.WriteLine($"error: --min-cognitive expects an integer, got '{args[i]}'");
                         return null;
                     }
 
@@ -153,6 +166,7 @@ sealed record CrapOptions
             SourceRoots = sources,
             CoverageGlob = coverageGlob ?? Path.Combine("artifacts", "coverage"),
             MinCrap = minCrap,
+            MinCognitive = minCognitive,
             Top = top,
             JsonPath = json,
             CountConditionalAccess = countConditionalAccess,
@@ -167,6 +181,7 @@ sealed record CrapOptions
               --coverage <dir>           Directory searched for coverage.cobertura.xml (default: artifacts/coverage)
               --source <dir>             Source root to analyze, repeatable (default: src)
               --min-crap <n>             Minimum CRAP score to report (default: 8)
+              --min-cognitive <n>        Cognitive-complexity threshold for the risk column (default: 15)
               --top <n>                  Rows in the console table (default: 25)
               --json <path>              Write full ranked result as JSON
               --no-conditional-access    Exclude ?. and ?[] from cyclomatic complexity
@@ -195,6 +210,9 @@ sealed record SourceMethod
     public required int StartLine { get; init; }
     public required int EndLine { get; init; }
     public required int Cyclomatic { get; init; }
+
+    /// <summary>SonarSource cognitive complexity: how hard the control flow is to follow.</summary>
+    public required int Cognitive { get; init; }
 
     /// <summary>False for abstract, interface, extern, and auto-property members, which emit no code.</summary>
     public required bool HasImplementation { get; init; }
@@ -237,6 +255,7 @@ static class MethodExtractor
                 StartLine = span.StartLinePosition.Line + 1,
                 EndLine = span.EndLinePosition.Line + 1,
                 Cyclomatic = CyclomaticComplexity.Compute(node, countConditionalAccess),
+                Cognitive = CognitiveComplexity.Compute(node),
                 HasImplementation = HasImplementation(node),
             });
         }
@@ -413,6 +432,193 @@ static class CyclomaticComplexity
     };
 }
 
+/// <summary>
+/// Cognitive complexity: how hard the control flow is to follow, per the SonarSource
+/// specification (rule S3776, white paper Appendix B).
+/// </summary>
+/// <remarks>
+/// This exists because cyclomatic complexity answers "how many paths", which is not the
+/// same question as "how risky is this to change". A flat 63-arm switch that maps status
+/// words to strings has very high cyclomatic complexity and almost no cognitive
+/// complexity; a short method nested four levels deep is the reverse. Gating on both
+/// separates large-but-obvious code from genuinely difficult code without anyone
+/// maintaining a hand-written ignore list.
+///
+/// Three rules from the specification drive the difference:
+///   1. A `switch` increments once, no matter how many arms it has.
+///   2. Nesting compounds: a structure inside N nesting structures costs 1 + N.
+///   3. Readable shorthand is ignored, so `??`, `??=`, and `?.` cost nothing.
+///
+/// Not implemented: the recursion increment, which needs a semantic model to resolve call
+/// targets. Scores for directly recursive methods are therefore low by one.
+/// </remarks>
+static class CognitiveComplexity
+{
+    public static int Compute(SyntaxNode member)
+    {
+        var score = 0;
+
+        foreach (var child in BodyOf(member))
+            Walk(child, nesting: 0, ref score);
+
+        return score;
+    }
+
+    static IEnumerable<SyntaxNode> BodyOf(SyntaxNode member) => member switch
+    {
+        BaseMethodDeclarationSyntax m => Bodies(m.Body, m.ExpressionBody),
+        AccessorDeclarationSyntax a => Bodies(a.Body, a.ExpressionBody),
+        LocalFunctionStatementSyntax l => Bodies(l.Body, l.ExpressionBody),
+        PropertyDeclarationSyntax p => Bodies(null, p.ExpressionBody),
+        IndexerDeclarationSyntax i => Bodies(null, i.ExpressionBody),
+        _ => [],
+    };
+
+    static IEnumerable<SyntaxNode> Bodies(SyntaxNode? body, ArrowExpressionClauseSyntax? arrow)
+    {
+        if (body is not null)
+            yield return body;
+
+        if (arrow?.Expression is not null)
+            yield return arrow.Expression;
+    }
+
+    static void Walk(SyntaxNode node, int nesting, ref int score)
+    {
+        switch (node)
+        {
+            // Structural increments: cost one, plus one per enclosing nesting level, and
+            // raise the nesting level for whatever they contain.
+            case IfStatementSyntax ifStatement:
+                score += 1 + nesting;
+                Walk(ifStatement.Condition, nesting, ref score);
+                Walk(ifStatement.Statement, nesting + 1, ref score);
+                WalkElse(ifStatement.Else, nesting, ref score);
+                return;
+
+            case SwitchStatementSyntax switchStatement:
+                // One increment for the whole switch regardless of arm count.
+                score += 1 + nesting;
+                Walk(switchStatement.Expression, nesting, ref score);
+                foreach (var section in switchStatement.Sections)
+                    WalkChildren(section, nesting + 1, ref score);
+                return;
+
+            case SwitchExpressionSyntax switchExpression:
+                score += 1 + nesting;
+                Walk(switchExpression.GoverningExpression, nesting, ref score);
+                foreach (var arm in switchExpression.Arms)
+                    WalkChildren(arm, nesting + 1, ref score);
+                return;
+
+            case WhileStatementSyntax or DoStatementSyntax or ForStatementSyntax
+                or ForEachStatementSyntax or ForEachVariableStatementSyntax:
+                score += 1 + nesting;
+                WalkChildren(node, nesting + 1, ref score);
+                return;
+
+            case CatchClauseSyntax:
+                // try and finally are free; only the handler is a flow break.
+                score += 1 + nesting;
+                WalkChildren(node, nesting + 1, ref score);
+                return;
+
+            case ConditionalExpressionSyntax conditional:
+                score += 1 + nesting;
+                Walk(conditional.Condition, nesting, ref score);
+                Walk(conditional.WhenTrue, nesting + 1, ref score);
+                Walk(conditional.WhenFalse, nesting + 1, ref score);
+                return;
+
+            // Fundamental increment, no nesting cost: a labelled jump.
+            case GotoStatementSyntax:
+                score += 1;
+                WalkChildren(node, nesting, ref score);
+                return;
+
+            // Lambdas and local functions raise the nesting level but cost nothing
+            // themselves, because extracting code into a named unit aids readability.
+            case AnonymousFunctionExpressionSyntax or LocalFunctionStatementSyntax:
+                WalkChildren(node, nesting + 1, ref score);
+                return;
+
+            // A run of the same logical operator reads as one condition, so a sequence
+            // costs one regardless of length. Only the root of the tree is scored.
+            case BinaryExpressionSyntax binary when IsLogical(binary) && !IsLogical(node.Parent):
+                score += CountOperatorRuns(binary);
+                WalkChildren(node, nesting, ref score);
+                return;
+
+            default:
+                WalkChildren(node, nesting, ref score);
+                return;
+        }
+    }
+
+    static void WalkElse(ElseClauseSyntax? elseClause, int nesting, ref int score)
+    {
+        if (elseClause is null)
+            return;
+
+        // `else` and `else if` are hybrid increments: they cost one but take no nesting
+        // increment, because the reader already paid that cost at the opening `if`.
+        score += 1;
+
+        if (elseClause.Statement is IfStatementSyntax elseIf)
+        {
+            Walk(elseIf.Condition, nesting, ref score);
+            Walk(elseIf.Statement, nesting + 1, ref score);
+            WalkElse(elseIf.Else, nesting, ref score);
+            return;
+        }
+
+        Walk(elseClause.Statement, nesting + 1, ref score);
+    }
+
+    static void WalkChildren(SyntaxNode node, int nesting, ref int score)
+    {
+        foreach (var child in node.ChildNodes())
+            Walk(child, nesting, ref score);
+    }
+
+    static bool IsLogical(SyntaxNode? node) =>
+        node is BinaryExpressionSyntax b
+        && (b.IsKind(SyntaxKind.LogicalAndExpression) || b.IsKind(SyntaxKind.LogicalOrExpression));
+
+    /// <summary>
+    /// Counts maximal runs of the same logical operator, left to right.
+    /// </summary>
+    /// <remarks>
+    /// <c>a &amp;&amp; b &amp;&amp; c</c> is one run and costs 1;
+    /// <c>a &amp;&amp; b || c &amp;&amp; d</c> is three runs and costs 3, because mixing
+    /// operators is what makes a condition hard to read.
+    /// </remarks>
+    static int CountOperatorRuns(BinaryExpressionSyntax root)
+    {
+        var kinds = new List<SyntaxKind>();
+        Flatten(root, kinds);
+
+        var runs = 0;
+        for (var i = 0; i < kinds.Count; i++)
+        {
+            if (i == 0 || kinds[i] != kinds[i - 1])
+                runs++;
+        }
+
+        return runs;
+
+        static void Flatten(SyntaxNode node, List<SyntaxKind> kinds)
+        {
+            if (node is not BinaryExpressionSyntax b || !IsLogical(b))
+                return;
+
+            Flatten(b.Left, kinds);
+            kinds.Add(b.Kind());
+            Flatten(b.Right, kinds);
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Self-check: golden fixtures for the complexity rules
 // ---------------------------------------------------------------------------
@@ -437,6 +643,22 @@ static class SelfCheck
             {
                 failures++;
                 Console.Error.WriteLine($"FAIL {name}: expected cc={expected}, got {actual}");
+            }
+        }
+
+        foreach (var (name, source, expected) in CognitiveFixtures())
+        {
+            var methods = MethodExtractor.Extract("fixture.cs", Wrap(source), countConditionalAccess: true);
+            var actual = methods.Count == 1 ? methods[0].Cognitive : -methods.Count;
+
+            if (actual == expected)
+            {
+                passes++;
+            }
+            else
+            {
+                failures++;
+                Console.Error.WriteLine($"FAIL cognitive/{name}: expected {expected}, got {actual}");
             }
         }
 
@@ -514,6 +736,48 @@ static class SelfCheck
             "namespace F; internal sealed class C { public void M() { } }", true);
         yield return ("expression-bodied-property-has-implementation",
             "namespace F; internal sealed class C { public int P => 1; }", true);
+    }
+
+    /// <summary>
+    /// Cognitive complexity fixtures, several taken directly from the SonarSource white
+    /// paper so the implementation can be checked against the published specification.
+    /// </summary>
+    static IEnumerable<(string Name, string Source, int Expected)> CognitiveFixtures()
+    {
+        yield return ("straight-line-is-zero", "void M() { var x = 1; }", 0);
+
+        // White paper: a switch costs one increment regardless of arm count. This is the
+        // rule that stops flat lookup tables from dominating the report.
+        yield return ("switch-counts-once-not-per-case",
+            "string M(int n) { switch (n) { case 1: return \"one\"; case 2: return \"two\"; " +
+            "case 3: return \"three\"; default: return \"lots\"; } }", 1);
+        yield return ("switch-expression-counts-once",
+            "string M(int n) => n switch { 1 => \"a\", 2 => \"b\", 3 => \"c\", _ => \"d\" };", 1);
+
+        // Nesting compounds; a flat sequence does not.
+        yield return ("three-sequential-ifs", "void M(int a) { if (a>0){} if (a>1){} if (a>2){} }", 3);
+        yield return ("nested-if-costs-one-plus-depth",
+            "void M(int a, int b) { if (a > 0) { if (b > 0) { } } }", 3);
+        yield return ("triple-nested",
+            "void M(int a, int b, int c) { if (a>0) { if (b>0) { if (c>0) { } } } }", 6);
+
+        // else and else if are hybrid: +1 each, no nesting increment.
+        yield return ("if-else", "void M(int a) { if (a > 0) { } else { } }", 2);
+        yield return ("if-elseif-else", "void M(int a) { if (a>0) { } else if (a<0) { } else { } }", 3);
+
+        // White paper: a run of one operator costs 1; mixing operators costs per run.
+        yield return ("uniform-operator-sequence-costs-one", "bool M(bool a, bool b, bool c, bool d) => a && b && c && d;", 1);
+        yield return ("mixed-operator-sequence-costs-per-run", "bool M(bool a, bool b, bool c, bool d) => a && b || c && d;", 3);
+
+        // Appendix A: readable shorthand is ignored.
+        yield return ("null-coalescing-ignored", "string M(string? a) => a ?? \"x\";", 0);
+        yield return ("conditional-access-ignored", "int? M(string? s) => s?.Length;", 0);
+
+        yield return ("loop-with-nested-if",
+            "void M(int[] xs) { foreach (var x in xs) { if (x > 0) { } } }", 3);
+        yield return ("catch-costs-one-try-is-free", "void M() { try { } catch { } }", 1);
+        yield return ("lambda-adds-nesting-but-no-increment",
+            "void M(System.Collections.Generic.List<int> xs) { xs.RemoveAll(x => { if (x > 0) { return true; } return false; }); }", 2);
     }
 
     static IEnumerable<(string Name, string Source, int Expected)> Fixtures()
@@ -851,18 +1115,19 @@ static class CrapAnalysis
         Console.WriteLine($"  not measurable      {uninstrumented}  (abstract, interface, extern, or auto-property)");
         Console.WriteLine($"  unmatched lines     {unmatchedCoverage}");
         Console.WriteLine($"  CRAP >= {options.MinCrap,-11:0.##}{flagged.Count}");
+        Console.WriteLine($"  of those, cognitive > {options.MinCognitive,-4}{flagged.Count(r => r.Method.Cognitive > options.MinCognitive)}");
         Console.WriteLine($"  conditional access  {(options.CountConditionalAccess ? "counted" : "not counted")}");
         Console.WriteLine();
 
         if (flagged.Count > 0)
         {
-            Console.WriteLine($"{"CRAP",10}  {"cc",4}  {"cov",7}  method");
+            Console.WriteLine($"{"CRAP",10}  {"cc",4}  {"cog",4}  {"cov",7}  method");
             Console.WriteLine(new string('-', 96));
             foreach (var row in flagged.Take(options.Top))
             {
                 var coverage = row.NeverObserved ? "  n/a" : row.Coverage.ToString("P1");
                 Console.WriteLine(
-                    $"{row.Crap,10:F1}  {row.Method.Cyclomatic,4}  {coverage,7}  {row.Method.Display}");
+                    $"{row.Crap,10:F1}  {row.Method.Cyclomatic,4}  {row.Method.Cognitive,4}  {coverage,7}  {row.Method.Display}");
             }
 
             if (flagged.Count > options.Top)
@@ -916,6 +1181,7 @@ static class CrapAnalysis
             writer.WriteNumber("startLine", row.Method.StartLine);
             writer.WriteNumber("endLine", row.Method.EndLine);
             writer.WriteNumber("cyclomatic", row.Method.Cyclomatic);
+            writer.WriteNumber("cognitive", row.Method.Cognitive);
             writer.WriteNumber("coveredLines", row.CoveredLines);
             writer.WriteNumber("totalLines", row.TotalLines);
             writer.WriteNumber("coverage", Math.Round(row.Coverage, 4));

--- a/src/Core/src/Native/Linux/Libc/LibcHelpers.cs
+++ b/src/Core/src/Native/Linux/Libc/LibcHelpers.cs
@@ -19,7 +19,10 @@ namespace Yubico.YubiKit.Core.Native.Linux.Libc;
 public static class LibcHelpers
 {
     public static string GetErrnoString() =>
-        Marshal.GetLastWin32Error() switch
+        GetErrnoString(Marshal.GetLastWin32Error());
+
+    internal static string GetErrnoString(int errno) =>
+        errno switch
         {
             7 => "E2BIG(7): Argument list too long",
             13 => "EACCES(13): Permission denied",

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/OidsTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/OidsTests.cs
@@ -1,0 +1,49 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+public class OidsTests
+{
+    [Theory]
+    [InlineData(KeyType.RSA1024, Oids.RSA, null)]
+    [InlineData(KeyType.RSA2048, Oids.RSA, null)]
+    [InlineData(KeyType.RSA3072, Oids.RSA, null)]
+    [InlineData(KeyType.RSA4096, Oids.RSA, null)]
+    [InlineData(KeyType.ECP256, Oids.ECDSA, Oids.ECP256)]
+    [InlineData(KeyType.ECP384, Oids.ECDSA, Oids.ECP384)]
+    [InlineData(KeyType.ECP521, Oids.ECDSA, Oids.ECP521)]
+    [InlineData(KeyType.X25519, Oids.X25519, null)]
+    [InlineData(KeyType.Ed25519, Oids.Ed25519, null)]
+    [InlineData(KeyType.AES128, Oids.AES128Cbc, null)]
+    [InlineData(KeyType.AES192, Oids.AES192Cbc, null)]
+    [InlineData(KeyType.AES256, Oids.AES256Cbc, null)]
+    [InlineData(KeyType.TripleDES, Oids.TripleDESCbc, null)]
+    public void GetOidsByKeyType_MappedKeyType_ReturnsExpectedOidPair(
+        KeyType keyType,
+        string expectedAlgorithmOid,
+        string? expectedCurveOid)
+    {
+        (string AlgorithmOid, string? Curveoid) result = Oids.GetOidsByKeyType(keyType);
+
+        Assert.Equal(expectedAlgorithmOid, result.AlgorithmOid);
+        Assert.Equal(expectedCurveOid, result.Curveoid);
+    }
+
+    [Fact]
+    public void GetOidsByKeyType_UnsupportedKeyType_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() => Oids.GetOidsByKeyType(KeyType.None));
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Linux/LibcHelpersTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Linux/LibcHelpersTests.cs
@@ -1,0 +1,69 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Native.Linux.Libc;
+
+namespace Yubico.YubiKit.Core.UnitTests.Native.Linux;
+
+public class LibcHelpersTests
+{
+    [Theory]
+    [InlineData(7, "E2BIG(7): Argument list too long")]
+    [InlineData(13, "EACCES(13): Permission denied")]
+    [InlineData(11, "EAGAIN(11): No more processes or not enough memory or maximum nesting level reached.")]
+    [InlineData(9,
+        "EBADF(9): Bad file number. Either the file descriptor is invalid or does not refer to a file, or an attempt to write to a read-only file was made.")]
+    [InlineData(16, "EBUSY(16): Device or resource is busy.")]
+    [InlineData(10, "ECHILD(10): No spawned processes.")]
+    [InlineData(36, "EDEADLK(36): Resource deadlock would occur.")]
+    [InlineData(33, "EDOM(33): The argument to a math function is not in the domain of the function.")]
+    [InlineData(17, "EEXIST(17): The file or resource already exists.")]
+    [InlineData(14, "EFAULT(14): Bad address.")]
+    [InlineData(27, "EFBIG(27): File too large.")]
+    [InlineData(42, "EILSEQ(42): Illegal sequence of bytes (for example, in an MBCS string).")]
+    [InlineData(4, "EINTR(4): Interrupted function.")]
+    [InlineData(22, "EINVAL(22): Invalid argument.")]
+    [InlineData(5, "EIO(5): I/O error.")]
+    [InlineData(21, "EISDIR(21): Object is a directory.")]
+    [InlineData(24, "EMFILE(24): Too many open files.")]
+    [InlineData(31, "EMLINK(31): Too many links.")]
+    [InlineData(38, "ENAMETOOLONG(38): Filename is too long.")]
+    [InlineData(23, "ENFILE(23): Too many files open on the system.")]
+    [InlineData(19, "ENODEV(19): No such device.")]
+    [InlineData(2, "ENOENT(2): No such file or directory.")]
+    [InlineData(8, "ENOEXEC(8): Exec format error")]
+    [InlineData(39, "ENOLCK(39): No locks available.")]
+    [InlineData(12, "ENOMEM(12): Not enough memory is available for the attempted operation.")]
+    [InlineData(28, "ENOSPC(28): No space left on the device.")]
+    [InlineData(40, "ENOSYS(40): Function not supported.")]
+    [InlineData(20, "ENOTDIR(20): Not a directory.")]
+    [InlineData(41, "ENOTDIR(41): Directory is not empty.")]
+    [InlineData(25, "ENOTTY(25): Inappropriate I/O control operation.")]
+    [InlineData(6, "ENXIO(6): No such device or address.")]
+    [InlineData(1, "EPERM(1): Operation not permitted.")]
+    [InlineData(32, "EPIPE(32): Broken pipe.")]
+    [InlineData(34, "ERANGE(34): Result too large.")]
+    [InlineData(30, "EROFS(30): Read only file system.")]
+    [InlineData(29, "ESPIPE(29): Invalid seek.")]
+    [InlineData(3, "ESRCH(3): No such process.")]
+    [InlineData(18, "EXDEV(18): An attempt was made to move a file to a different device.")]
+    [InlineData(80, "STRUNCATE(80): A string copy or concatenation resulted in a truncated string.")]
+    [InlineData(9999, "Unmapped error")]
+    public void GetErrnoString_ReturnsExpectedMappingForErrno(int errno, string expected)
+    {
+        string actual = LibcHelpers.GetErrnoString(errno);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Piv/src/Certificates/PivCertificateProtocol.cs
+++ b/src/Piv/src/Certificates/PivCertificateProtocol.cs
@@ -167,7 +167,7 @@ internal static class PivCertificateProtocol
         await PivDataObjectProtocol.PutObjectAsync(backend, isAuthenticated, objectId, null, cancellationToken).ConfigureAwait(false);
     }
 
-    private static int GetCertificateObjectId(PivSlot slot)
+    internal static int GetCertificateObjectId(PivSlot slot)
     {
         return slot switch
         {

--- a/src/Piv/tests/Yubico.YubiKit.Piv.UnitTests/Certificates/PivCertificateObjectIdTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.UnitTests/Certificates/PivCertificateObjectIdTests.cs
@@ -1,0 +1,70 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Piv.Certificates;
+
+namespace Yubico.YubiKit.Piv.UnitTests.Certificates;
+
+/// <summary>
+/// Exact-value coverage for the <c>PivSlot</c> to PIV certificate data-object-id mapping in
+/// <see cref="PivCertificateProtocol.GetCertificateObjectId(PivSlot)"/>. Each mapped slot arm
+/// asserts the specific <see cref="PivDataObject"/> constant it must resolve to, so that changing
+/// any single arm's mapping fails a test.
+/// </summary>
+public class PivCertificateObjectIdTests
+{
+    [Theory]
+    [InlineData(PivSlot.Authentication, PivDataObject.Authentication)]
+    [InlineData(PivSlot.Signature, PivDataObject.Signature)]
+    [InlineData(PivSlot.KeyManagement, PivDataObject.KeyManagement)]
+    [InlineData(PivSlot.CardAuthentication, PivDataObject.CardAuthentication)]
+    [InlineData(PivSlot.Attestation, PivDataObject.Attestation)]
+    [InlineData(PivSlot.Retired1, PivDataObject.Retired1)]
+    [InlineData(PivSlot.Retired2, PivDataObject.Retired2)]
+    [InlineData(PivSlot.Retired3, PivDataObject.Retired3)]
+    [InlineData(PivSlot.Retired4, PivDataObject.Retired4)]
+    [InlineData(PivSlot.Retired5, PivDataObject.Retired5)]
+    [InlineData(PivSlot.Retired6, PivDataObject.Retired6)]
+    [InlineData(PivSlot.Retired7, PivDataObject.Retired7)]
+    [InlineData(PivSlot.Retired8, PivDataObject.Retired8)]
+    [InlineData(PivSlot.Retired9, PivDataObject.Retired9)]
+    [InlineData(PivSlot.Retired10, PivDataObject.Retired10)]
+    [InlineData(PivSlot.Retired11, PivDataObject.Retired11)]
+    [InlineData(PivSlot.Retired12, PivDataObject.Retired12)]
+    [InlineData(PivSlot.Retired13, PivDataObject.Retired13)]
+    [InlineData(PivSlot.Retired14, PivDataObject.Retired14)]
+    [InlineData(PivSlot.Retired15, PivDataObject.Retired15)]
+    [InlineData(PivSlot.Retired16, PivDataObject.Retired16)]
+    [InlineData(PivSlot.Retired17, PivDataObject.Retired17)]
+    [InlineData(PivSlot.Retired18, PivDataObject.Retired18)]
+    [InlineData(PivSlot.Retired19, PivDataObject.Retired19)]
+    [InlineData(PivSlot.Retired20, PivDataObject.Retired20)]
+    public void GetCertificateObjectId_MappedSlot_ReturnsExpectedObjectId(PivSlot slot, int expectedObjectId)
+    {
+        int actual = PivCertificateProtocol.GetCertificateObjectId(slot);
+
+        Assert.Equal(expectedObjectId, actual);
+    }
+
+    [Fact]
+    public void GetCertificateObjectId_UnmappedSlot_ThrowsArgumentExceptionWithSlotSpecificMessage()
+    {
+        var slot = (PivSlot)0x00;
+
+        var exception = Assert.Throws<ArgumentException>(() => PivCertificateProtocol.GetCertificateObjectId(slot));
+
+        Assert.Equal("slot", exception.ParamName);
+        Assert.StartsWith("Slot 0x00 does not support certificates", exception.Message);
+    }
+}

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -765,7 +765,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// CredentialExcluded and previewSign-specific statuses are handled by their own catch arms
     /// upstream and never reach this mapper.
     /// </summary>
-    private static WebAuthnClientError MapCtapStatusToWebAuthnError(CtapException ex) =>
+    internal static WebAuthnClientError MapCtapStatusToWebAuthnError(CtapException ex) =>
         ex.Status switch
         {
             CtapStatus.PinAuthInvalid or CtapStatus.PinInvalid or CtapStatus.PinAuthBlocked

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CtapStatusMappingTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CtapStatusMappingTests.cs
@@ -1,0 +1,75 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Fido2.Ctap;
+using Yubico.YubiKit.WebAuthn.Client;
+
+namespace Yubico.YubiKit.WebAuthn.UnitTests.Client;
+
+public class CtapStatusMappingTests
+{
+    [Theory]
+    // NotAllowed group
+    [InlineData(CtapStatus.PinAuthInvalid, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinInvalid, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinAuthBlocked, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinBlocked, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinPolicyViolation, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PuatRequired, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinTokenExpired, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.NotAllowed, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.OperationDenied, WebAuthnClientErrorCode.NotAllowed)]
+    // Constraint group
+    [InlineData(CtapStatus.KeyStoreFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.LargeBlobStorageFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.FpDatabaseFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.LimitExceeded, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.RequestTooLarge, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.UserActionTimeout, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.ActionTimeout, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.Timeout, WebAuthnClientErrorCode.Constraint)]
+    // NotSupported group
+    [InlineData(CtapStatus.UnsupportedAlgorithm, WebAuthnClientErrorCode.NotSupported)]
+    [InlineData(CtapStatus.UnsupportedOption, WebAuthnClientErrorCode.NotSupported)]
+    [InlineData(CtapStatus.InvalidOption, WebAuthnClientErrorCode.NotSupported)]
+    // Security group
+    [InlineData(CtapStatus.PinNotSet, WebAuthnClientErrorCode.Security)]
+    [InlineData(CtapStatus.UpRequired, WebAuthnClientErrorCode.Security)]
+    // InvalidState group
+    [InlineData(CtapStatus.NoCredentials, WebAuthnClientErrorCode.InvalidState)]
+    [InlineData(CtapStatus.InvalidCredential, WebAuthnClientErrorCode.InvalidState)]
+    // Default group (not a member of any arm above)
+    [InlineData(CtapStatus.Other, WebAuthnClientErrorCode.Unknown)]
+    public void MapCtapStatusToWebAuthnError_MapsStatusToExpectedCode(
+        CtapStatus status,
+        WebAuthnClientErrorCode expectedCode)
+    {
+        var ctapException = new CtapException(status, "ctap failure message");
+
+        var result = WebAuthnClient.MapCtapStatusToWebAuthnError(ctapException);
+
+        Assert.Equal(expectedCode, result.Code);
+    }
+
+    [Fact]
+    public void MapCtapStatusToWebAuthnError_PropagatesMessageAndInnerException()
+    {
+        var ctapException = new CtapException(CtapStatus.PinInvalid, "specific ctap message");
+
+        var result = WebAuthnClient.MapCtapStatusToWebAuthnError(ctapException);
+
+        Assert.Equal("specific ctap message", result.Message);
+        Assert.Same(ctapException, result.InnerException);
+    }
+}

--- a/toolchain.cs
+++ b/toolchain.cs
@@ -106,12 +106,16 @@
  */
 
 using System.Diagnostics;
+using System.Text;
 using System.Text.RegularExpressions;
+using System.Xml.Linq;
 using static Bullseye.Targets;
 using static SimpleExec.Command;
 
 // Configuration
 const string ProjectPrefix = "Yubico.YubiKit.";
+// Matches <TargetFramework> in Directory.Build.props; used to locate MTP test executables.
+const string TestTargetFramework = "net10.0";
 var repoRoot = GetRepoRoot();
 var solutionFile = "Yubico.YubiKit.sln";
 var configuration = "Release";
@@ -130,6 +134,7 @@ var includeIntegration = HasFlag("--integration");
 var smokeTest = HasFlag("--smoke");
 var fastMode = HasFlag("--fast");
 var benchmarkArgs = GetArgument("--benchmark-args") ?? "";
+var crapArgs = GetArgument("--crap-args") ?? "";
 
 // --smoke injects trait filters to skip slow and user-presence tests
 if (smokeTest)
@@ -273,25 +278,48 @@ Target("coverage", () =>
 {
     PrintHeader("Running tests with coverage");
 
-    // Coverage uses dotnet test with coverlet. Both xUnit v2 and v3 (MTP) projects support
-    // this via the VSTest compatibility layer, so all unit test projects are included.
+    // Coverage collection differs per test platform:
+    //
+    //   xUnit v3 / MTP  -> coverlet.console (out of process).
+    //                      --collect:"XPlat Code Coverage" is a VSTest data collector and needs
+    //                      Microsoft.NET.Test.Sdk, which MTP projects deliberately omit, so it
+    //                      aborts with a missing testhost.deps.json. The MTP-native alternative,
+    //                      Microsoft.Testing.Extensions.CodeCoverage, currently throws
+    //                      TypeLoadException against xunit.v3 3.0.0 (its Microsoft.Testing.Platform.MSBuild
+    //                      1.7.3 dependency is not binary compatible with Microsoft.Testing.Platform 2.3.3).
+    //   xUnit v2        -> the existing VSTest data collector path.
+    //
+    // coverlet is also required for CRAP analysis: it is the only one of these that writes a
+    // per-method `complexity` attribute into the Cobertura XML, which ReportGenerator's risk
+    // hotspots and any CRAP tooling read. See docs/TESTING.md.
     var coverageResultsDir = Path.Combine(artifactsDir, "coverage");
     Directory.CreateDirectory(coverageResultsDir);
 
-    var projectsToCover = FilterProjectsByName(unitTestProjects, projectFilter);
+    var projectsToCover = FilterToProject(
+        unitTestProjects
+            .Select(p => (ProjectPath: p, UsesTestingPlatformRunner: UsesMicrosoftTestingPlatformRunner(repoRoot, p)))
+            .ToArray(),
+        projectFilter);
     if (projectsToCover is null)
         return;
 
+    if (projectsToCover.Any(p => p.UsesTestingPlatformRunner))
+        Run("dotnet", "tool restore");
+
     var results = new List<(string Project, bool Passed, string? Error, bool Skipped)>();
 
-    foreach (var project in projectsToCover)
+    foreach (var (project, usesTestingPlatformRunner) in projectsToCover)
     {
         var projectName = Path.GetFileNameWithoutExtension(project);
         PrintProjectHeader("Coverage", projectName);
 
         try
         {
-            Run("dotnet", $"test {project} -c {configuration} --settings coverlet.runsettings.xml --collect:\"XPlat Code Coverage\" --results-directory {coverageResultsDir}");
+            if (usesTestingPlatformRunner)
+                CollectMtpCoverage(project, projectName, coverageResultsDir);
+            else
+                Run("dotnet", $"test {project} -c {configuration} --settings coverlet.runsettings.xml --collect:\"XPlat Code Coverage\" --results-directory {coverageResultsDir}");
+
             results.Add((projectName, true, null, false));
             PrintColored($"✓ {projectName} - Coverage collected", ConsoleColor.Green);
         }
@@ -317,6 +345,21 @@ Target("coverage", () =>
     var failCount = results.Count(r => !r.Passed);
     if (failCount > 0)
         throw new InvalidOperationException($"{failCount} test project(s) failed during coverage collection");
+});
+
+Target("crap", () =>
+{
+    // The analysis itself lives in crap.cs so it stays independently runnable and
+    // self-checkable; this target exists because CRAP consumes the reports that the
+    // coverage target produces, so it belongs on the same discovery surface.
+    PrintHeader("Computing CRAP scores");
+
+    var coverageResultsDir = Path.Combine(artifactsDir, "coverage");
+    if (!Directory.Exists(coverageResultsDir))
+        throw new InvalidOperationException(
+            "No coverage results found. Run 'dotnet toolchain.cs coverage' first.");
+
+    Run("dotnet", $"crap.cs {crapArgs}".TrimEnd(), workingDirectory: repoRoot);
 });
 
 Target("resilience", () =>
@@ -525,7 +568,7 @@ if (args.Contains("--help") || args.Contains("-h"))
 // Run Bullseye — strip all custom args so Bullseye only sees target names and its own flags
 var bullseyeArgs = FilterBullseyeArgs(args,
     optionsWithValues: ["--project", "--filter", "--package-version", "--nuget-feed-name", "--nuget-feed-path",
-                        "--nuget-feed-url", "--nuget-api-key", "--benchmark-args"],
+                        "--nuget-feed-url", "--nuget-api-key", "--benchmark-args", "--crap-args"],
     flags: ["--integration", "--include-docs", "--embed-symbols", "--dry-run", "--clean", "--smoke", "--fast"]);
 await RunTargetsAndExitAsync(bullseyeArgs);
 
@@ -698,6 +741,97 @@ List<(string Project, bool Passed, string? Error, bool Skipped)> RunTestProjects
 
     return results;
 }
+
+// Collects coverage for a Microsoft Testing Platform (xUnit v3) test project.
+//
+// MTP test projects are plain executables, so coverlet.console can instrument the output
+// directory and launch the test binary directly.
+void CollectMtpCoverage(string projectPath, string projectName, string coverageResultsDir)
+{
+    Run("dotnet", $"build {projectPath} -c {configuration}");
+
+    var projectDir = Path.GetDirectoryName(Path.Combine(repoRoot, projectPath))!;
+    var outputDir = Path.Combine(projectDir, "bin", configuration, TestTargetFramework);
+    // Windows appends .exe to the apphost; Linux and macOS do not.
+    var testExecutable = Path.Combine(outputDir, projectName);
+    if (!File.Exists(testExecutable) && File.Exists(testExecutable + ".exe"))
+        testExecutable += ".exe";
+
+    if (!File.Exists(testExecutable))
+        throw new FileNotFoundException(
+            $"MTP test executable not found at {testExecutable}. Expected an OutputType=Exe test project.",
+            testExecutable);
+
+    var outputFile = Path.Combine(coverageResultsDir, projectName, "coverage.cobertura.xml");
+    Directory.CreateDirectory(Path.GetDirectoryName(outputFile)!);
+
+    var coverletArgs = new StringBuilder();
+    coverletArgs.Append($"coverlet \"{outputDir}\"");
+    coverletArgs.Append($" --target \"{testExecutable}\"");
+    coverletArgs.Append(" --format cobertura");
+    coverletArgs.Append($" --output \"{outputFile}\"");
+    coverletArgs.Append(TranslateRunsettingsToCoverletArgs());
+
+    Run("dotnet", coverletArgs.ToString());
+}
+
+// Translates coverlet.runsettings.xml into coverlet.console command-line flags.
+//
+// The VSTest data collector reads the runsettings file directly; coverlet.console cannot.
+// Rather than restating the filters here, the runsettings file stays the single definition
+// of coverage policy and this function projects it onto the CLI, so both collection paths
+// cannot drift apart.
+string TranslateRunsettingsToCoverletArgs()
+{
+    var settingsPath = Path.Combine(repoRoot, "coverlet.runsettings.xml");
+    if (!File.Exists(settingsPath))
+        throw new FileNotFoundException(
+            $"coverlet.runsettings.xml not found at {settingsPath}; it defines the coverage filters.",
+            settingsPath);
+
+    var settings = XDocument.Load(settingsPath)
+        .Descendants("Configuration")
+        .FirstOrDefault()
+        ?? throw new InvalidOperationException(
+            "coverlet.runsettings.xml has no <Configuration> element.");
+
+    var args = new StringBuilder();
+
+    foreach (var (element, flag) in new[]
+             {
+                 ("Exclude", "--exclude"),
+                 ("Include", "--include"),
+                 ("ExcludeByFile", "--exclude-by-file"),
+                 ("ExcludeByAttribute", "--exclude-by-attribute"),
+             })
+    {
+        foreach (var value in SplitSettingList(settings.Element(element)?.Value))
+            args.Append($" {flag} \"{value}\"");
+    }
+
+    if (IsSettingTrue(settings.Element("SkipAutoProps")?.Value))
+        args.Append(" --skipautoprops");
+
+    if (IsSettingTrue(settings.Element("SingleHit")?.Value))
+        args.Append(" --single-hit");
+
+    if (IsSettingTrue(settings.Element("UseSourceLink")?.Value))
+        args.Append(" --use-source-link");
+
+    // coverlet.console omits the test assembly unless asked; VSTest needs it stated.
+    if (IsSettingTrue(settings.Element("IncludeTestAssembly")?.Value))
+        args.Append(" --include-test-assembly");
+
+    return args.ToString();
+}
+
+static IEnumerable<string> SplitSettingList(string? value) =>
+    string.IsNullOrWhiteSpace(value)
+        ? []
+        : value.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+static bool IsSettingTrue(string? value) =>
+    string.Equals(value?.Trim(), "true", StringComparison.OrdinalIgnoreCase);
 
 void PrintTestSummary(List<(string Project, bool Passed, string? Error, bool Skipped)> results, string label)
 {
@@ -1236,13 +1370,6 @@ static bool ShouldSkipMarkdownLink(string target)
 }
 
 static bool IsCodeFenceLine(string line) => Regex.IsMatch(line, @"^\s*```");
-
-// Returns null when no projects matched and an error was already printed (caller should return early).
-List<string>? FilterProjectsByName(string[] projects, string? filter)
-{
-    var matched = FilterProjectPaths(projects, filter, "No projects match");
-    return matched is null ? null : [..matched];
-}
 
 string[] FilterBullseyeArgs(string[] args, string[] optionsWithValues, string[] flags)
 {


### PR DESCRIPTION
## What this fixes

`dotnet toolchain.cs coverage` was broken for every unit test project. It used `dotnet test --collect:"XPlat Code Coverage"`, a VSTest data collector that requires `Microsoft.NET.Test.Sdk`. All 12 unit test projects run on Microsoft Testing Platform and deliberately omit that package (the csproj files even say so), so every run aborted:

```
Testhost process exited with error:
  package: 'testhost', version: '18.0.1-release-25523-111'
  path: 'testhost.dll'
Test Run Aborted.
```

The comment in `toolchain.cs` claiming the VSTest compatibility layer covered both platforms was not accurate, and `TOOLCHAIN.md` repeated it. Both are corrected here.

## Why coverlet.console

I tried the MTP-native route first. `Microsoft.Testing.Extensions.CodeCoverage` throws `TypeLoadException` against `xunit.v3` 3.0.0 — its `Microsoft.Testing.Platform.MSBuild` 1.7.3 dependency is not binary compatible with `Microsoft.Testing.Platform` 2.3.3. That is a latent problem in the xunit.v3 dependency graph; adding the coverage extension just activates it.

`coverlet.console` instruments out of process and never loads into the MTP extension graph. It is also the only option that writes a per-method `complexity` attribute into the Cobertura output, which any coverage-risk reporting needs.

`coverlet.runsettings.xml` is now the single definition of coverage policy. The VSTest collector reads it directly; `toolchain.cs` projects the same settings onto `coverlet.console` flags so the two paths cannot drift.

## New: `dotnet toolchain.cs crap`

Ranks methods by CRAP (Change Risk Anti-Patterns):

```
CRAP(m) = cc(m)^2 * (1 - cov(m))^3 + cc(m)
```

Complexity is computed from the syntax tree with Roslyn, not read from coverlet. coverlet's `complexity` is `Math.Max(1, branches.Count)` over IL branch outcomes, so a single `if` counts 2. Measured across this repo the ratio to source-level complexity ranges from **0.5x to 6x** with no stable multiplier, and because it follows codegen an SDK upgrade can shift the numbers with no source change. That makes it unsuitable for a metric held over time.

Two correctness details worth calling out:

- **Coverage is matched by file and line range, never by name.** coverlet records an async body under `<Name>d__N::MoveNext` but keeps the original file and line numbers. Name matching scores every async method 0%; span matching reads `PivMetadataProtocol.GetSlotMetadataAsync` at its true 90.0%.
- **Implemented methods absent from all reports are scored 0%, not dropped.** Silently omitting them would hide the least-tested code in the repo. Only members that emit no code (abstract, interface, extern, auto-property) are excluded.

## Verification

| Check | Result |
|---|---|
| `dotnet toolchain.cs build` | Succeeded, 0 warnings |
| `dotnet toolchain.cs test` | 12/12 passed |
| `dotnet toolchain.cs coverage` | 12/12, ~1m28s |
| `dotnet crap.cs --self-check` | 36/36 golden fixtures |
| `dotnet toolchain.cs docs-qa` | Succeeded |
| `dotnet format --verify-no-changes` | clean |

The self-check pins every complexity rule with inline fixtures and anchors one case to a hand-derived real method, so the rules cannot drift silently.

## Current baseline

427 methods at CRAP >= 8.

| module | >=8 | worst | | module | >=8 | worst |
|---|---:|---:|---|---|---:|---:|
| Core | 157 | 1640 | | Cli.Shared | 16 | 72 |
| Cli.Commands | 87 | 600 | | Oath | 8 | 30 |
| Fido2 | 44 | 928 | | SecurityDomain | 7 | 110 |
| Piv | 44 | 702 | | YubiHsm | 4 | 42 |
| WebAuthn | 33 | 650 | | Management | 3 | 17 |
| OpenPgp | 21 | 90 | | YubiOtp | 3 | 12 |

Bands: 8-15 → 183 · 15-30 → 132 · 30-100 → 85 · >100 → 27

## Scope

v1 reports only. No CI gate, no cognitive-complexity second axis, no baseline ratchet — those are deliberately deferred until the baseline shows whether they are needed. Nothing in this PR changes CI behavior.

One caveat for reviewers: most of the methods above CRAP 100 are flat status-word and error-string lookup tables. They are large but not nested, so they are poor refactoring targets despite topping the list. The 15-30 band is the more useful place to look.

## Dependency note

Adds `Microsoft.CodeAnalysis.CSharp` to `Directory.Packages.props`, used only by `crap.cs`. No shipping project references it.
