### PR TITLE
feat(credentials): add ICredentialPrompt and adopt it in WebAuthn

### DIFF
--- a/docs/migration/v1-to-v2-gaps.md
+++ b/docs/migration/v1-to-v2-gaps.md
@@ -136,9 +136,9 @@ v2 locations: `src/Fido2/src/**`, `src/WebAuthn/src/**`
   **Severity**: Major (Blocker for U2F-only consumers) | **Confidence**: High
 
 - **Feature/API**: `KeyCollector` delegate for PIN/touch/UV prompts on `Fido2Session`
-  **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns the retry loop itself (fresh prompt per attempt, rejected secrets zeroed and never resubmitted, attempts capped so a buggy prompt cannot burn the retry counter).
+  **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns a bounded retry loop with a fresh, zeroed secret for each attempt.
   `IAsyncEnumerable<WebAuthnStatus>` is **not** the replacement — it is observation-only ceremony progress (`Processing`, `Finished`, `Failed`) and never gathers input. Abandonment is via the cancellation token, not a stream state.
-  Remaining gap: v1's `KeyCollector` also signalled touch. WebAuthn has no touch notification yet, so a UI can only prompt speculatively before a ceremony. PIV and YubiHsm expose `OnTouchRequired`; a unified cross-applet mechanism is deferred by design (see `src/WebAuthn/CLAUDE.md`, "Touch notification").
+  Touch remains a gap: WebAuthn has no dedicated in-flight touch signal, so UI can only prompt speculatively while a ceremony may be waiting for user presence.
   No 1:1 analog; arguably more explicit/testable, but requires a rewrite.
   **Severity**: Minor (migration friction, not capability loss) | **Confidence**: High
 
@@ -359,7 +359,7 @@ v2 location: `src/Management/src/**`
   **User impact**: Simple synchronous console-app/script consumers must adopt async/await throughout, including `await using` for disposal — a non-trivial rewrite for straightforward use cases v1 didn't require.
   **Severity**: Major (understandable architecturally, but a real DX cost) | **Confidence**: High
 
-- **`KeyCollector` delegate pattern**: removed entirely. v1 had one callback shape shared across Piv/Fido2/Oath/U2f/YubiHsmAuth (31 files reference it). v2 has zero matches for `KeyCollector`/`IAsyncKeyCollector`/`PinCollector`/`IPinProvider`/`IUserVerifier` — most applets take credentials as direct parameters. Confirmed deliberate per `docs/migration/v1-to-v2.md`.
+- **`KeyCollector` delegate pattern**: removed entirely. v1 had one callback shape shared across Piv/Fido2/Oath/U2f/YubiHsmAuth (31 files reference it). v2 has zero matches for `KeyCollector`/`IAsyncKeyCollector`/`PinCollector`/`IPinProvider`/`IUserVerifier` — most applets take credentials as direct parameters.
   Partially addressed: `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`) is a shared async, context-carrying, cancellable prompt primitive intended as the one reusable shape. It is currently consumed only by `WebAuthnClient`; other applets remain direct-parameter and would adopt the same interface if they grow interactive needs.
   **User impact**: A caller cannot yet wire one prompt across all applets. Prompting patterns still differ per applet outside WebAuthn.
   **Severity**: Major | **Confidence**: High

--- a/docs/migration/v1-to-v2-gaps.md
+++ b/docs/migration/v1-to-v2-gaps.md
@@ -26,7 +26,7 @@ Ranked roughly by blast radius. Full detail for each is in the module sections b
 | 1 | No .NET Framework/netstandard support — v2 is net10.0-only, v1 supported net472/netstandard2.0/2.1 | Cross-cutting | Blocker (for that consumer segment) |
 | 2 | U2F protocol entirely removed — no register/authenticate, no `U2fSession` equivalent | FIDO2 | Major/Blocker for U2F-only consumers |
 | 3 | PIV PIN-only mode gone — `PivSession.Pinonly.cs`/PIN-derived management key has no v2 equivalent | PIV | Major |
-| 4 | `KeyCollector` delegate pattern removed everywhere — each applet (Piv/Oath/Fido2/YubiHsm) handles PIN/PUK/touch with direct parameters. A shared async prompt primitive, `ICredentialPrompt`, now exists in Core but is adopted only by WebAuthn so far | Cross-cutting | Major |
+| 4 | `KeyCollector` delegate pattern removed everywhere — each applet (Piv/Oath/Fido2/YubiHsm) handles PIN/PUK/touch with direct parameters. A shared async SDK-to-application prompt primitive, `ICredentialPrompt`, now exists in Core but is adopted only by WebAuthn so far; the application-initiated `ISecureCredentialReader` terminal helper serves a different role | Cross-cutting | Major |
 | 5 | Legacy pre-5.0 firmware mode switching removed from public API (`SetLegacyDeviceConfiguration`) — YubiKey NEO/4 users can't reconfigure interfaces at all | Management | Major |
 | 6 | Pluggable crypto primitives gone (`IAesGcmPrimitives`/`IEcdhPrimitives`/`ICmacPrimitives` extension points) | Core | Major |
 | 7 | `TlvReader`/`TlvWriter` typed sequential API gone, replaced by a much thinner `Tlv`/`TlvHelper` | Core | Major |
@@ -136,7 +136,7 @@ v2 locations: `src/Fido2/src/**`, `src/WebAuthn/src/**`
   **Severity**: Major (Blocker for U2F-only consumers) | **Confidence**: High
 
 - **Feature/API**: `KeyCollector` delegate for PIN/touch/UV prompts on `Fido2Session`
-  **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns a bounded retry loop with a fresh, zeroed secret for each attempt.
+  **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async SDK-to-application prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns a bounded retry loop with a fresh, zeroed secret for each attempt. The synchronous `ISecureCredentialReader` is instead an application-initiated terminal input helper and does not replace this callback.
   `IAsyncEnumerable<WebAuthnStatus>` is **not** the replacement — it is observation-only ceremony progress (`Processing`, `Finished`, `Failed`) and never gathers input. Abandonment is via the cancellation token, not a stream state.
   Touch remains a gap: WebAuthn has no dedicated in-flight touch signal, so UI can only prompt speculatively while a ceremony may be waiting for user presence.
   No 1:1 analog; arguably more explicit/testable, but requires a rewrite.
@@ -360,7 +360,7 @@ v2 location: `src/Management/src/**`
   **Severity**: Major (understandable architecturally, but a real DX cost) | **Confidence**: High
 
 - **`KeyCollector` delegate pattern**: removed entirely. v1 had one callback shape shared across Piv/Fido2/Oath/U2f/YubiHsmAuth (31 files reference it). v2 has zero matches for `KeyCollector`/`IAsyncKeyCollector`/`PinCollector`/`IPinProvider`/`IUserVerifier` — most applets take credentials as direct parameters.
-  Partially addressed: `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`) is a shared async, context-carrying, cancellable prompt primitive intended as the one reusable shape. It is currently consumed only by `WebAuthnClient`; other applets remain direct-parameter and would adopt the same interface if they grow interactive needs.
+  Partially addressed: `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`) is a shared async, context-carrying, cancellable SDK-to-application prompt primitive intended as the one reusable callback shape. It is currently consumed only by `WebAuthnClient`; other applets remain direct-parameter and would adopt the same interface if they grow interactive needs. `ISecureCredentialReader` remains a separate synchronous, application-initiated terminal helper.
   **User impact**: A caller cannot yet wire one prompt across all applets. Prompting patterns still differ per applet outside WebAuthn.
   **Severity**: Major | **Confidence**: High
 

--- a/docs/migration/v1-to-v2-gaps.md
+++ b/docs/migration/v1-to-v2-gaps.md
@@ -137,7 +137,8 @@ v2 locations: `src/Fido2/src/**`, `src/WebAuthn/src/**`
 
 - **Feature/API**: `KeyCollector` delegate for PIN/touch/UV prompts on `Fido2Session`
   **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns the retry loop itself (fresh prompt per attempt, rejected secrets zeroed and never resubmitted, attempts capped so a buggy prompt cannot burn the retry counter).
-  `IAsyncEnumerable<WebAuthnStatus>` is **not** the replacement — it is observation-only ceremony progress (`Processing`, `WaitingForUser`, `Finished`, `Failed`) and never gathers input. Abandonment is via the cancellation token, not a stream state.
+  `IAsyncEnumerable<WebAuthnStatus>` is **not** the replacement — it is observation-only ceremony progress (`Processing`, `Finished`, `Failed`) and never gathers input. Abandonment is via the cancellation token, not a stream state.
+  Remaining gap: v1's `KeyCollector` also signalled touch. WebAuthn has no touch notification yet, so a UI can only prompt speculatively before a ceremony. PIV and YubiHsm expose `OnTouchRequired`; a unified cross-applet mechanism is deferred by design (see `src/WebAuthn/CLAUDE.md`, "Touch notification").
   No 1:1 analog; arguably more explicit/testable, but requires a rewrite.
   **Severity**: Minor (migration friction, not capability loss) | **Confidence**: High
 

--- a/docs/migration/v1-to-v2-gaps.md
+++ b/docs/migration/v1-to-v2-gaps.md
@@ -26,7 +26,7 @@ Ranked roughly by blast radius. Full detail for each is in the module sections b
 | 1 | No .NET Framework/netstandard support — v2 is net10.0-only, v1 supported net472/netstandard2.0/2.1 | Cross-cutting | Blocker (for that consumer segment) |
 | 2 | U2F protocol entirely removed — no register/authenticate, no `U2fSession` equivalent | FIDO2 | Major/Blocker for U2F-only consumers |
 | 3 | PIV PIN-only mode gone — `PivSession.Pinonly.cs`/PIN-derived management key has no v2 equivalent | PIV | Major |
-| 4 | `KeyCollector` delegate pattern removed everywhere, no unified replacement — each applet (Piv/Oath/Fido2/YubiHsm) now handles PIN/PUK/touch differently | Cross-cutting | Major |
+| 4 | `KeyCollector` delegate pattern removed everywhere — each applet (Piv/Oath/Fido2/YubiHsm) handles PIN/PUK/touch with direct parameters. A shared async prompt primitive, `ICredentialPrompt`, now exists in Core but is adopted only by WebAuthn so far | Cross-cutting | Major |
 | 5 | Legacy pre-5.0 firmware mode switching removed from public API (`SetLegacyDeviceConfiguration`) — YubiKey NEO/4 users can't reconfigure interfaces at all | Management | Major |
 | 6 | Pluggable crypto primitives gone (`IAesGcmPrimitives`/`IEcdhPrimitives`/`ICmacPrimitives` extension points) | Core | Major |
 | 7 | `TlvReader`/`TlvWriter` typed sequential API gone, replaced by a much thinner `Tlv`/`TlvHelper` | Core | Major |
@@ -136,7 +136,9 @@ v2 locations: `src/Fido2/src/**`, `src/WebAuthn/src/**`
   **Severity**: Major (Blocker for U2F-only consumers) | **Confidence**: High
 
 - **Feature/API**: `KeyCollector` delegate for PIN/touch/UV prompts on `Fido2Session`
-  **v2 status**: Present-but-renamed/Behavior-changed — v2 exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback; WebAuthn layer adds an `IAsyncEnumerable<WebAuthnStatus>` streaming model instead. No 1:1 analog; arguably more explicit/testable, but requires a rewrite.
+  **v2 status**: Present-but-renamed/Behavior-changed — `Fido2Session` exposes explicit async methods (`SetPinAsync`, `ChangePinAsync`, `GetPinUvAuthTokenUsingPinAsync/UsingUvAsync`) with no callback. At the WebAuthn layer the closest analog is `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`), an optional async prompt supplied to `WebAuthnClient`: the SDK calls it when a ceremony needs a PIN and owns the retry loop itself (fresh prompt per attempt, rejected secrets zeroed and never resubmitted, attempts capped so a buggy prompt cannot burn the retry counter).
+  `IAsyncEnumerable<WebAuthnStatus>` is **not** the replacement — it is observation-only ceremony progress (`Processing`, `WaitingForUser`, `Finished`, `Failed`) and never gathers input. Abandonment is via the cancellation token, not a stream state.
+  No 1:1 analog; arguably more explicit/testable, but requires a rewrite.
   **Severity**: Minor (migration friction, not capability loss) | **Confidence**: High
 
 - **Feature/API**: COSE named constants `ES512` (-36) and `ECDHwHKDF256` (-25)
@@ -356,8 +358,9 @@ v2 location: `src/Management/src/**`
   **User impact**: Simple synchronous console-app/script consumers must adopt async/await throughout, including `await using` for disposal — a non-trivial rewrite for straightforward use cases v1 didn't require.
   **Severity**: Major (understandable architecturally, but a real DX cost) | **Confidence**: High
 
-- **`KeyCollector` delegate pattern**: removed entirely, with no unified replacement. v1 had one callback shape shared across Piv/Fido2/Oath/U2f/YubiHsmAuth (31 files reference it). v2 has zero matches for `KeyCollector`/`IAsyncKeyCollector`/`PinCollector`/`IPinProvider`/`IUserVerifier` — each applet now has its own bespoke credential-handling shape. Confirmed deliberate per `docs/migration/v1-to-v2.md`.
-  **User impact**: No single reusable PIN/PUK/touch-prompt callback wireable once across all applets; inconsistent prompting patterns per applet.
+- **`KeyCollector` delegate pattern**: removed entirely. v1 had one callback shape shared across Piv/Fido2/Oath/U2f/YubiHsmAuth (31 files reference it). v2 has zero matches for `KeyCollector`/`IAsyncKeyCollector`/`PinCollector`/`IPinProvider`/`IUserVerifier` — most applets take credentials as direct parameters. Confirmed deliberate per `docs/migration/v1-to-v2.md`.
+  Partially addressed: `ICredentialPrompt` (`Yubico.YubiKit.Core.Credentials`) is a shared async, context-carrying, cancellable prompt primitive intended as the one reusable shape. It is currently consumed only by `WebAuthnClient`; other applets remain direct-parameter and would adopt the same interface if they grow interactive needs.
+  **User impact**: A caller cannot yet wire one prompt across all applets. Prompting patterns still differ per applet outside WebAuthn.
   **Severity**: Major | **Confidence**: High
 
 - **Logging**: not a regression — both v1 and v2 use a global static logger factory (no per-instance DI). v2 additionally adds `UseTemporary(ILoggerFactory)` for test isolation. (Separate from the "silent by default" finding under Core above, which is a real behavior change in default output, not architecture.)

--- a/src/Core/src/Credentials/ICredentialPrompt.cs
+++ b/src/Core/src/Credentials/ICredentialPrompt.cs
@@ -1,0 +1,194 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Buffers;
+using Yubico.YubiKit.Core.Utilities;
+
+namespace Yubico.YubiKit.Core.Credentials;
+
+/// <summary>
+/// Supplies secrets (PINs, passwords, keys) to SDK components on demand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Implementations decide how a secret is obtained: console input, a graphical
+/// dialog, a secret vault, or a test fake. The SDK calls this interface only
+/// when it needs a secret it was not given explicitly, so an application that
+/// passes secrets directly never needs an implementation.
+/// </para>
+/// <para><b>Contract</b></para>
+/// <list type="bullet">
+/// <item>
+/// Returning <c>null</c> means exactly one thing: the user declined. It never
+/// signals cancellation, an input error, or a retry request.
+/// </item>
+/// <item>
+/// Cancellation is reported by throwing <see cref="OperationCanceledException"/>.
+/// </item>
+/// <item>
+/// The returned <see cref="IMemoryOwner{T}"/> must expose a
+/// <see cref="IMemoryOwner{T}.Memory"/> sized <b>exactly</b> to the secret.
+/// Pool-rented buffers are frequently larger than requested, and the SDK
+/// transmits the whole of <c>Memory</c>; an over-sized buffer therefore sends
+/// trailing padding as part of the secret. Use
+/// <see cref="DisposableArrayPoolBuffer.CreateFromSpan"/>, which slices to the
+/// exact length, rather than handing back a raw rented buffer.
+/// </item>
+/// <item>
+/// Ownership of the returned buffer transfers to the SDK, which disposes it
+/// (and thereby zeroes it) once the secret has been used.
+/// </item>
+/// </list>
+/// <para><b>Guarantees the SDK provides to implementations</b></para>
+/// <list type="bullet">
+/// <item>
+/// Prompt invocations are bounded by the caller's cancellation token even if an
+/// implementation ignores the token it is given, so a slow or stuck prompt
+/// cannot strand an SDK operation.
+/// </item>
+/// <item>
+/// Retry loops are owned by the SDK: after a rejected secret the SDK calls
+/// again with <see cref="CredentialPromptContext.IsRetry"/> set and an updated
+/// <see cref="CredentialPromptContext.RetriesRemaining"/>. A cached secret is
+/// never resubmitted on the application's behalf.
+/// </item>
+/// </list>
+/// <para><b>Example</b></para>
+/// <code>
+/// internal sealed class DialogPrompt : ICredentialPrompt
+/// {
+///     public async ValueTask&lt;IMemoryOwner&lt;byte&gt;?&gt; RequestSecretAsync(
+///         CredentialPromptContext context, CancellationToken cancellationToken)
+///     {
+///         var title = context.IsRetry
+///             ? $"Incorrect PIN - {context.RetriesRemaining} attempts remaining"
+///             : $"Enter PIN for {context.Scope}";
+///
+///         byte[]? entered = await ShowPinDialogAsync(title, cancellationToken);
+///         return entered is null
+///             ? null
+///             : DisposableArrayPoolBuffer.CreateFromSpan(entered);
+///     }
+/// }
+/// </code>
+/// </remarks>
+public interface ICredentialPrompt
+{
+    /// <summary>
+    /// Requests a secret from the user or another source.
+    /// </summary>
+    /// <param name="context">Describes what is being requested and why.</param>
+    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <returns>
+    /// The secret bytes in a buffer whose <see cref="IMemoryOwner{T}.Memory"/> is
+    /// sized exactly to the secret and whose ownership transfers to the caller,
+    /// or <c>null</c> if the user declined to supply one.
+    /// </returns>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when cancellation is requested through <paramref name="cancellationToken"/>.
+    /// </exception>
+    ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+        CredentialPromptContext context,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The kind of secret being requested by an <see cref="ICredentialPrompt"/>.
+/// </summary>
+/// <remarks>
+/// Implementations should treat an unrecognized value as a generic secret
+/// request rather than failing, so that new kinds can be added without
+/// breaking existing implementations.
+/// </remarks>
+public enum CredentialKind
+{
+    /// <summary>A PIN (personal identification number).</summary>
+    Pin,
+
+    /// <summary>A PUK (PIN unblocking key).</summary>
+    Puk,
+
+    /// <summary>A password or passphrase.</summary>
+    Password,
+
+    /// <summary>A management key, conventionally entered as hexadecimal.</summary>
+    ManagementKey,
+
+    /// <summary>A new PIN being established by a change or initialize flow.</summary>
+    NewPin,
+
+    /// <summary>A new PUK being established.</summary>
+    NewPuk,
+
+    /// <summary>A new password being established.</summary>
+    NewPassword,
+
+    /// <summary>A reset code, for example the OpenPGP resetting code.</summary>
+    ResetCode
+}
+
+/// <summary>
+/// Describes a single credential request made through <see cref="ICredentialPrompt"/>.
+/// </summary>
+/// <remarks>
+/// This is a non-positional record so that optional properties can be added in
+/// later releases without breaking implementations or callers. Implementations
+/// should ignore properties they do not use.
+/// </remarks>
+public record CredentialPromptContext
+{
+    /// <summary>Gets the kind of secret being requested.</summary>
+    public required CredentialKind Kind { get; init; }
+
+    /// <summary>
+    /// Gets a display-oriented description of what the secret unlocks, such as
+    /// a relying-party identifier (<c>"example.com"</c>) for WebAuthn or an
+    /// application name (<c>"PIV"</c>) elsewhere. May be <c>null</c> when no
+    /// meaningful scope exists.
+    /// </summary>
+    public string? Scope { get; init; }
+
+    /// <summary>
+    /// Gets the number of attempts remaining before the credential is blocked,
+    /// when the protocol reports it; otherwise <c>null</c>.
+    /// </summary>
+    public int? RetriesRemaining { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this request follows a rejected attempt.
+    /// </summary>
+    public bool IsRetry { get; init; }
+
+    /// <summary>
+    /// Gets the minimum acceptable secret length, measured in encoded bytes.
+    /// </summary>
+    /// <remarks>
+    /// Lengths are expressed in bytes rather than characters because protocol
+    /// limits are defined over the encoded form; a multi-byte character can
+    /// consume more than one byte of the allowance.
+    /// </remarks>
+    public int MinLengthBytes { get; init; }
+
+    /// <summary>
+    /// Gets the maximum acceptable secret length, measured in encoded bytes.
+    /// </summary>
+    public int MaxLengthBytes { get; init; } = 255;
+
+    /// <summary>
+    /// Gets a value indicating whether the implementation should ask for the
+    /// secret twice and confirm the entries match, which is conventional when
+    /// establishing a new secret.
+    /// </summary>
+    public bool RequiresConfirmation { get; init; }
+}

--- a/src/Core/src/Credentials/ICredentialPrompt.cs
+++ b/src/Core/src/Credentials/ICredentialPrompt.cs
@@ -27,6 +27,13 @@ namespace Yubico.YubiKit.Core.Credentials;
 /// when it needs a secret it was not given explicitly, so an application that
 /// passes secrets directly never needs an implementation.
 /// </para>
+/// <para>
+/// This is an SDK-to-application callback with protocol context and asynchronous cancellation.
+/// It is distinct from <see cref="ISecureCredentialReader"/>, which is a synchronous,
+/// application-initiated terminal input helper with display and encoding options. An implementation
+/// may delegate to any credential acquisition mechanism, including a secure reader, provided it
+/// returns promptly without blocking the calling thread and honors the cancellation token.
+/// </para>
 /// <para><b>Contract</b></para>
 /// <list type="bullet">
 /// <item>
@@ -177,14 +184,13 @@ public record CredentialPromptContext
     public bool IsRetry { get; init; }
 
     /// <summary>
-    /// Gets the minimum acceptable secret length, measured in encoded bytes.
+    /// Gets the minimum acceptable secret length, measured in Unicode code points.
     /// </summary>
     /// <remarks>
-    /// Lengths are expressed in bytes rather than characters because protocol
-    /// limits are defined over the encoded form; a multi-byte character can
-    /// consume more than one byte of the allowance.
+    /// Protocols that define their minimum over encoded bytes should set this only
+    /// when every accepted code point encodes to one byte.
     /// </remarks>
-    public int MinLengthBytes { get; init; }
+    public int MinLengthCodePoints { get; init; }
 
     /// <summary>
     /// Gets the maximum acceptable secret length, measured in encoded bytes.

--- a/src/Core/src/Credentials/ICredentialPrompt.cs
+++ b/src/Core/src/Credentials/ICredentialPrompt.cs
@@ -34,6 +34,8 @@ namespace Yubico.YubiKit.Core.Credentials;
 /// signals cancellation, an input error, or a retry request.
 /// </item>
 /// <item>
+/// The method must return a <see cref="ValueTask{TResult}"/> promptly, must not block the calling
+/// thread while obtaining the secret, and must honor the supplied cancellation token.
 /// Cancellation is reported by throwing <see cref="OperationCanceledException"/>.
 /// </item>
 /// <item>
@@ -46,22 +48,15 @@ namespace Yubico.YubiKit.Core.Credentials;
 /// exact length, rather than handing back a raw rented buffer.
 /// </item>
 /// <item>
-/// Ownership of the returned buffer transfers to the SDK, which disposes it
-/// (and thereby zeroes it) once the secret has been used.
-/// </item>
-/// </list>
-/// <para><b>Guarantees the SDK provides to implementations</b></para>
-/// <list type="bullet">
-/// <item>
-/// Prompt invocations are bounded by the caller's cancellation token even if an
-/// implementation ignores the token it is given, so a slow or stuck prompt
-/// cannot strand an SDK operation.
+/// The implementation owns the buffer until the returned <see cref="ValueTask{TResult}"/>
+/// completes successfully. At that point ownership transfers to the SDK. The implementation must
+/// not access or dispose the buffer after successful completion. A null, faulted, or cancelled
+/// result transfers no buffer ownership.
 /// </item>
 /// <item>
-/// Retry loops are owned by the SDK: after a rejected secret the SDK calls
-/// again with <see cref="CredentialPromptContext.IsRetry"/> set and an updated
-/// <see cref="CredentialPromptContext.RetriesRemaining"/>. A cached secret is
-/// never resubmitted on the application's behalf.
+/// Implementations must not retry credential verification internally. The SDK component using the
+/// prompt owns any retry policy so each authenticator submission is represented by a separate
+/// prompt invocation and context.
 /// </item>
 /// </list>
 /// <para><b>Example</b></para>
@@ -76,9 +71,19 @@ namespace Yubico.YubiKit.Core.Credentials;
 ///             : $"Enter PIN for {context.Scope}";
 ///
 ///         byte[]? entered = await ShowPinDialogAsync(title, cancellationToken);
-///         return entered is null
-///             ? null
-///             : DisposableArrayPoolBuffer.CreateFromSpan(entered);
+///         if (entered is null)
+///         {
+///             return null;
+///         }
+///
+///         try
+///         {
+///             return DisposableArrayPoolBuffer.CreateFromSpan(entered);
+///         }
+///         finally
+///         {
+///             System.Security.Cryptography.CryptographicOperations.ZeroMemory(entered);
+///         }
 ///     }
 /// }
 /// </code>
@@ -89,11 +94,12 @@ public interface ICredentialPrompt
     /// Requests a secret from the user or another source.
     /// </summary>
     /// <param name="context">Describes what is being requested and why.</param>
-    /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+    /// <param name="cancellationToken">Token that the implementation must monitor for cancellation requests.</param>
     /// <returns>
     /// The secret bytes in a buffer whose <see cref="IMemoryOwner{T}.Memory"/> is
-    /// sized exactly to the secret and whose ownership transfers to the caller,
-    /// or <c>null</c> if the user declined to supply one.
+    /// sized exactly to the secret, or <c>null</c> if the user declined to supply one. Ownership
+    /// transfers to the caller only when the returned task completes successfully with a non-null
+    /// owner.
     /// </returns>
     /// <exception cref="OperationCanceledException">
     /// Thrown when cancellation is requested through <paramref name="cancellationToken"/>.

--- a/src/Core/src/Credentials/ISecureCredentialReader.cs
+++ b/src/Core/src/Credentials/ISecureCredentialReader.cs
@@ -26,6 +26,11 @@ namespace Yubico.YubiKit.Core.Credentials;
 /// to ensure credentials are cleared as soon as possible.
 /// </para>
 /// <para>
+/// This is a synchronous, application-initiated terminal input helper with display and encoding
+/// options. It is distinct from <see cref="ICredentialPrompt"/>, which is an asynchronous
+/// SDK-to-application callback carrying protocol context for secrets requested during an operation.
+/// </para>
+/// <para>
 /// Example usage:
 /// <code>
 /// var reader = new ConsoleCredentialReader();

--- a/src/WebAuthn/CLAUDE.md
+++ b/src/WebAuthn/CLAUDE.md
@@ -17,11 +17,12 @@ The WebAuthn module implements the W3C Web Authentication API (Level 2/3) on top
 - **High-level WebAuthn API**: `WebAuthnClient` orchestrates credential registration and authentication
 - **Extension Framework**: Pluggable CTAP v4 extensions (e.g., `previewSign`)
 - **Backend Abstraction**: Transparently routes operations through `IFidoSession`
-- **Status Streaming**: Async enumerable for operation progress (`IAsyncEnumerable<WebAuthnStatus>`)
+- **Status Streaming**: Observation-only async enumerable for ceremony progress (`IAsyncEnumerable<WebAuthnStatus>`)
+- **Credential Prompting**: Optional `ICredentialPrompt` supplies a PIN on demand; the SDK owns the retry loop
 
 **Key Dependencies:**
 - **One-way dependency on Fido2**: WebAuthn builds on FIDO2/CTAP primitives but FIDO2 does NOT depend on WebAuthn
-- **Core**: Shared types, logging, memory management
+- **Core**: Shared types, logging, memory management, `ICredentialPrompt`
 
 **Key Directories:**
 ```
@@ -30,25 +31,38 @@ src/
 │   ├── WebAuthnClient.cs
 │   ├── PublicSuffixChecker.cs
 │   ├── FidoSessionWebAuthnBackend.cs
-│   └── WebAuthnStatus.cs
+│   ├── IWebAuthnBackend.cs
+│   ├── PinUvAuthTokenSession.cs
+│   ├── WebAuthnClientData.cs
+│   ├── WebAuthnOrigin.cs
+│   ├── Status/                   # Ceremony progress reporting
+│   │   ├── WebAuthnStatus.cs
+│   │   └── StatusChannel.cs
+│   ├── UserVerification/         # UV/PIN decision logic
+│   │   └── UvDecision.cs
+│   ├── Validation/
+│   │   └── RpIdValidator.cs
+│   ├── Registration/             # Registration options and responses
+│   │   ├── RegistrationOptions.cs
+│   │   └── RegistrationResponse.cs
+│   └── Authentication/           # Authentication options and responses
+│       ├── AuthenticationOptions.cs
+│       ├── AuthenticationResponse.cs
+│       ├── CredentialMatcher.cs
+│       └── MatchedCredential.cs
 ├── Attestation/                  # Attestation object types
-│   ├── WebAuthnAttestationObject.cs
-│   └── WebAuthnAuthenticatorData.cs
+│   └── WebAuthnAttestationObject.cs
 ├── Extensions/                   # CTAP v4 extension framework
-│   ├── Adapters/
-│   │   └── PreviewSignAdapter.cs  # WebAuthn-level adapter (translates to Fido2)
-│   ├── PreviewSign/              # previewSign extension
-│   │   ├── PreviewSignAuthenticationInput.cs
-│   │   ├── PreviewSignRegistrationInput.cs
-│   │   └── PreviewSignErrors.cs
-│   └── IExtensionAdapter.cs
-├── Client/Registration/          # Registration options and responses
-│   ├── RegistrationOptions.cs
-│   └── RegistrationResponse.cs
-├── Client/Authentication/        # Authentication options and responses
-│   ├── AuthenticationOptions.cs
-│   ├── AuthenticationResponse.cs
-│   └── MatchedCredential.cs
+│   ├── Adapters/                 # credBlob, credProps, credProtect, largeBlob,
+│   │                             # minPinLength, prf, previewSign
+│   ├── Inputs/  Outputs/
+│   ├── PreviewSign/              # previewSign extension types
+│   └── ExtensionPipeline.cs
+├── Internal/
+│   └── ExcludeListPreflight.cs
+├── Preferences/                  # AttestationPreference, ResidentKeyPreference,
+│                                 # UserVerificationPreference
+├── WebAuthnAuthenticatorData.cs
 └── WebAuthnClientError.cs        # Error handling
 ```
 
@@ -76,10 +90,13 @@ Logger.LogError(ex, "PreviewSign authentication failed");
 ```csharp
 // Create client from an existing FIDO2 session.
 // The PublicSuffixChecker should be backed by Public Suffix List data.
+// `prompt` is optional; supply one to let the SDK ask for a PIN when the ceremony needs it.
 await using var client = new WebAuthnClient(
     fidoSession,
     origin,
-    isPublicSuffix: domain => publicSuffixList.Contains(domain));
+    isPublicSuffix: domain => publicSuffixList.Contains(domain),
+    enterpriseRpIds: null,
+    prompt: myCredentialPrompt);
 
 // Or create the FIDO2 session and WebAuthn client from a YubiKey device.
 await using var clientFromDevice = await yubiKey.CreateWebAuthnClientAsync(
@@ -96,7 +113,8 @@ var createOptions = new RegistrationOptions
     Extensions = extensionInputs
 };
 
-var credential = await client.MakeCredentialAsync(createOptions, pin: null, useUv: false);
+// Pass pinBytes to supply a PIN directly, or leave it null to use the configured prompt.
+var credential = await client.MakeCredentialAsync(createOptions, pinBytes: null);
 
 // Authentication
 var requestOptions = new AuthenticationOptions
@@ -107,27 +125,93 @@ var requestOptions = new AuthenticationOptions
     Extensions = extensionInputs
 };
 
-var matches = await client.GetAssertionAsync(requestOptions, pin: null, useUv: false);
+var matches = await client.GetAssertionAsync(requestOptions, pinBytes: null);
 var assertion = await matches[0].SelectAsync();
 ```
 
-### Status Streaming
+### Credential Prompting
 
-WebAuthn operations expose progress via `IAsyncEnumerable<WebAuthnStatus>`:
+A PIN reaches the client one of two ways: the caller passes `pinBytes`, or the client was
+constructed with an `ICredentialPrompt` (from `Yubico.YubiKit.Core.Credentials`) and asks for one
+when the ceremony needs it. There is no callback on the status stream.
 
 ```csharp
-await foreach (var status in client.MakeCredentialStreamAsync(options))
+public interface ICredentialPrompt
+{
+    ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+        CredentialPromptContext context,
+        CancellationToken cancellationToken);
+}
+```
+
+Contract, in both directions:
+
+- Returning `null` means **the user declined**, and nothing else. It is not a channel for
+  "cancelled" or "failed" — cancellation throws, and failures throw.
+- The returned `Memory<byte>` must be **exactly** the secret's length. Use
+  `DisposableArrayPoolBuffer.CreateFromSpan`, whose `Memory` already slices exactly; a
+  pool-sized buffer with trailing slack will be read as part of the secret.
+- Ownership transfers to the SDK, which disposes and zeroes the buffer.
+- **The SDK owns the retry loop.** On a rejected PIN it zeroes the secret, never resubmits it, and
+  calls the prompt again with a fresh `CredentialPromptContext` carrying `IsRetry = true` and the
+  refreshed `RetriesRemaining`. Implementations must not retry internally.
+- `MaxPromptAttempts` (3) bounds a prompt that keeps answering wrongly, so a buggy implementation
+  cannot burn the PIN retry counter to zero.
+- The caller's `CancellationToken` is applied to the prompt call, so a prompt that never returns
+  cannot strand the ceremony.
+
+`CredentialPromptContext` carries `Kind`, `Scope` (the RP ID), `RetriesRemaining`, `IsRetry`,
+`MinLengthBytes`, `MaxLengthBytes`, and `RequiresConfirmation`. Note lengths here are **bytes**,
+not characters.
+
+### User Verification Decision
+
+`UvDecisionLogic.Decide` (`src/Client/UserVerification/UvDecision.cs`) answers two questions in
+order, and keeping them separate is the point: **whether** the ceremony needs a PIN/UV auth token,
+and only then **which** method supplies it. Collapsing them is what previously made `Discouraged`
+demand a PIN whenever one happened to be reachable.
+
+"Configured" throughout means the option is advertised **and** enabled. A YubiKey with no PIN set
+still advertises `clientPin: false`, so testing for the key's presence rather than its value reads
+as "verification is available" on a key that has none.
+
+| Preference | Needs a token? |
+|---|---|
+| `Required` | Always. Throws `NotAllowed` if nothing can satisfy it. |
+| `Preferred` | Only if verification is configured; otherwise degrades to an unverified credential. |
+| `Discouraged` | No — unless verification is configured AND one of: `alwaysUv` is enabled; this is a makeCredential and `makeCredUvNotRqd` is not enabled (pre-CTAP-2.1 keys); or the request needs a permission beyond makeCredential/getAssertion (e.g. `LargeBlobWrite`). |
+
+This mirrors the canonical Rust client's `should_use_uv` in
+`crates/yubikit/src/webauthn/client.rs`, with **one deliberate divergence**: canonical's `Preferred`
+arm tests whether the option is *advertised*, which on a PIN-less YubiKey decides verification is
+needed and then fails for want of a method. Since `preferred` is the WebAuthn default, that turns
+the most common request into a hard error, so this SDK gates `Preferred` on *configured* per
+WebAuthn L2 §5.4.2. **Do not "fix" this back to match Rust** without re-reading that clause.
+
+Backstop: if the client's model of the authenticator is wrong and the key answers
+`CTAP2_ERR_PUAT_REQUIRED` (0x36), `ShouldRetryWithRequiredUv` escalates to `Required` and retries the
+ceremony once.
+
+Known gap: extension-driven permissions are not aggregated before the decision, so a largeBlob
+write does not yet contribute `LargeBlobWrite` to `requestedPermissions`. The logic handles that
+permission correctly once something requests it.
+
+### Status Streaming
+
+WebAuthn operations report ceremony progress via `IAsyncEnumerable<WebAuthnStatus>`. The stream is
+**observation-only**: statuses never gather input and carry no callbacks. To abandon an operation,
+cancel the token you passed to it.
+
+```csharp
+await foreach (var status in client.MakeCredentialStreamAsync(options, cancellationToken: ct))
 {
     switch (status)
     {
         case WebAuthnStatusProcessing:
             Console.WriteLine("Processing WebAuthn ceremony...");
             break;
-        case WebAuthnStatusRequestingPin requestingPin:
-            await requestingPin.SubmitPin(pinBytes);
-            break;
-        case WebAuthnStatusRequestingUv requestingUv:
-            await requestingUv.SetUseUv(false);
+        case WebAuthnStatusWaitingForUser:
+            Console.WriteLine("Touch your YubiKey...");
             break;
         case WebAuthnStatusFinished<RegistrationResponse> finished:
             Console.WriteLine($"Created credential {Convert.ToHexString(finished.Result.CredentialId.Span)}");
@@ -140,10 +224,17 @@ await foreach (var status in client.MakeCredentialStreamAsync(options))
 
 **Status records:**
 - `WebAuthnStatusProcessing` — ceremony work is in progress
-- `WebAuthnStatusRequestingPin` — caller must supply PIN bytes or cancel
-- `WebAuthnStatusRequestingUv` — caller must opt in/out of UV
+- `WebAuthnStatusWaitingForUser` — the authenticator is awaiting a touch; show a touch prompt.
+  Driven by real CTAP HID keep-alive frames, so **only the HID transport emits it**. Over
+  SmartCard the ceremony appears as continuous `WebAuthnStatusProcessing`.
 - `WebAuthnStatusFinished<T>` — operation completed successfully
 - `WebAuthnStatusFailed` — operation completed with a typed WebAuthn error
+
+> **Removed in the `ICredentialPrompt` migration:** `WebAuthnStatusRequestingPin`,
+> `WebAuthnStatusRequestingUv`, and the `useUv` parameter. The first two smuggled response
+> callbacks into stream states, which deadlocked both a consumer that stopped enumerating and one
+> that merely cancelled its own token; `useUv` was a silent no-op. PIN acquisition now goes through
+> `ICredentialPrompt`, which makes those deadlocks structurally impossible rather than patched.
 
 ### RP ID Validation
 
@@ -308,3 +399,15 @@ dotnet toolchain.cs -- test --integration --project WebAuthn --smoke
 4. **No LoggingFactory** — Use `YubiKitLogging.CreateLogger<T>()` from Core
 5. **Status stream must be consumed** — `IAsyncEnumerable` won't advance unless caller enumerates
 6. **CBOR key constants are context-specific** — key `7` means authentication `additionalArgs` in GetAssertion input and attestation object in MakeCredential unsigned output; keep parsing paths context-specific
+7. **The status stream never asks for anything** — it reports only. Do not add a state that carries a
+   response callback; that is exactly what caused the two deadlocks the `ICredentialPrompt`
+   migration removed. Input comes from `pinBytes` or `ICredentialPrompt`; abandonment comes from
+   the cancellation token.
+8. **`WaitingForUser` is HID-only** — it is driven by CTAP HID keep-alive frames. No fake backend
+   produces them, so this state can only be observed on real hardware over HID. Over SmartCard a
+   touch wait looks like continuous `Processing`.
+9. **User presence and user verification are independent** — touch (UP) is always required for
+   makeCredential regardless of the UV preference. CTAP does not let a client set `up` on
+   makeCredential at all, so never send it; the authenticator's default of `true` applies. `up=false`
+   is legitimate only on the silent exclude-list pre-flight getAssertion probe
+   (`Internal/ExcludeListPreflight.cs`).

--- a/src/WebAuthn/CLAUDE.md
+++ b/src/WebAuthn/CLAUDE.md
@@ -164,6 +164,35 @@ Contract, in both directions:
 `MinLengthBytes`, `MaxLengthBytes`, and `RequiresConfirmation`. Note lengths here are **bytes**,
 not characters.
 
+### Touch notification — deliberately absent, deferred by design
+
+WebAuthn currently has **no way to tell a caller that the authenticator is waiting for a touch**.
+The status stream reports `Processing` → `Finished`/`Failed` and nothing in between, so a UI can
+only prompt speculatively before the call rather than at the moment the key actually asks.
+
+This is a known gap, not an oversight. An earlier iteration carried a `WebAuthnStatusWaitingForUser`
+state fed by CTAP HID keep-alive `0x02` frames, threaded as an `IProgress<CtapStatus>` through
+`IFidoHidProtocol` → `IFidoBackend` → `IFidoSession` → the WebAuthn backend. It worked and was
+validated on hardware, but it added an optional parameter to the two hottest methods on the
+**public** `IFidoSession` to serve a single consumer, so it was removed.
+
+Context for whoever picks this up:
+
+- **Canonical does have this.** The Rust client holds a `user_interaction` field and calls
+  `prompt_up()` from an `on_keepalive` closure when the status byte is `0x02`
+  (`crates/yubikit/src/webauthn/client.rs:356-361`). Note it scopes the handler at the *client*,
+  not as a per-call parameter.
+- **This repo already has a convention.** PIV and YubiHsm both expose
+  `public TouchNotificationCallback? OnTouchRequired { get; set; }` on the session
+  (`Piv/src/TouchNotification.cs`, `PivSession.cs:100`). FIDO2 — the applet where touch matters
+  most — is the one that lacks it.
+- **The intended direction is a unified cross-applet touch notification**, rather than a third
+  bespoke per-module callback. `ICredentialPrompt` is the natural place to look: it is already the
+  shared async, context-carrying prompt primitive, and "tell the user to touch" is the same class
+  of interaction as "ask the user for a PIN". Deferred pending that design.
+
+Until then, do not reintroduce a per-call `IProgress` parameter on public session methods.
+
 ### User Verification Decision
 
 `UvDecisionLogic.Decide` (`src/Client/UserVerification/UvDecision.cs`) answers two questions in
@@ -210,9 +239,6 @@ await foreach (var status in client.MakeCredentialStreamAsync(options, cancellat
         case WebAuthnStatusProcessing:
             Console.WriteLine("Processing WebAuthn ceremony...");
             break;
-        case WebAuthnStatusWaitingForUser:
-            Console.WriteLine("Touch your YubiKey...");
-            break;
         case WebAuthnStatusFinished<RegistrationResponse> finished:
             Console.WriteLine($"Created credential {Convert.ToHexString(finished.Result.CredentialId.Span)}");
             break;
@@ -224,9 +250,6 @@ await foreach (var status in client.MakeCredentialStreamAsync(options, cancellat
 
 **Status records:**
 - `WebAuthnStatusProcessing` — ceremony work is in progress
-- `WebAuthnStatusWaitingForUser` — the authenticator is awaiting a touch; show a touch prompt.
-  Driven by real CTAP HID keep-alive frames, so **only the HID transport emits it**. Over
-  SmartCard the ceremony appears as continuous `WebAuthnStatusProcessing`.
 - `WebAuthnStatusFinished<T>` — operation completed successfully
 - `WebAuthnStatusFailed` — operation completed with a typed WebAuthn error
 
@@ -403,9 +426,9 @@ dotnet toolchain.cs -- test --integration --project WebAuthn --smoke
    response callback; that is exactly what caused the two deadlocks the `ICredentialPrompt`
    migration removed. Input comes from `pinBytes` or `ICredentialPrompt`; abandonment comes from
    the cancellation token.
-8. **`WaitingForUser` is HID-only** — it is driven by CTAP HID keep-alive frames. No fake backend
-   produces them, so this state can only be observed on real hardware over HID. Over SmartCard a
-   touch wait looks like continuous `Processing`.
+8. **There is currently no touch notification** — the stream cannot tell a caller when the
+   authenticator is waiting for a touch, so a UI can only prompt speculatively before the call.
+   See "Touch notification" below.
 9. **User presence and user verification are independent** — touch (UP) is always required for
    makeCredential regardless of the UV preference. CTAP does not let a client set `up` on
    makeCredential at all, so never send it; the authenticator's default of `true` applies. `up=false`

--- a/src/WebAuthn/CLAUDE.md
+++ b/src/WebAuthn/CLAUDE.md
@@ -144,61 +144,36 @@ public interface ICredentialPrompt
 }
 ```
 
-Contract, in both directions:
+Contract:
 
 - Returning `null` means **the user declined**, and nothing else. It is not a channel for
   "cancelled" or "failed" — cancellation throws, and failures throw.
+- `RequestSecretAsync` returns its `ValueTask` promptly, never blocks the calling thread while
+  obtaining the secret, and honors the supplied cancellation token. `WaitAsync` bounds only the
+  SDK's wait after the task has been returned; it cannot bound synchronous work inside the call.
 - The returned `Memory<byte>` must be **exactly** the secret's length. Use
   `DisposableArrayPoolBuffer.CreateFromSpan`, whose `Memory` already slices exactly; a
   pool-sized buffer with trailing slack will be read as part of the secret.
-- Ownership transfers to the SDK, which disposes and zeroes the buffer.
+- The prompt owns a returned buffer until its task completes successfully. Ownership then transfers
+  to the SDK. A null, faulted, or cancelled result transfers no ownership.
 - **The SDK owns the retry loop.** On a rejected PIN it zeroes the secret, never resubmits it, and
   calls the prompt again with a fresh `CredentialPromptContext` carrying `IsRetry = true` and the
   refreshed `RetriesRemaining`. Implementations must not retry internally.
-- `MaxPromptAttempts` (3) bounds a prompt that keeps answering wrongly, so a buggy implementation
-  cannot burn the PIN retry counter to zero.
-- The caller's `CancellationToken` is applied to the prompt call, so a prompt that never returns
-  cannot strand the ceremony.
+- `MaxPromptAttempts` (3) limits SDK prompt attempts. The authenticator separately enforces and
+  reports its own retry state.
+- WebAuthn additionally zeroes and disposes late-returned PIN buffers after cancellation when the
+  prompt task eventually completes. There is no Core-wide tracking guarantee for a prompt that
+  never completes; implementations must honor cancellation.
 
 `CredentialPromptContext` carries `Kind`, `Scope` (the RP ID), `RetriesRemaining`, `IsRetry`,
 `MinLengthBytes`, `MaxLengthBytes`, and `RequiresConfirmation`. Note lengths here are **bytes**,
 not characters.
 
-### Touch notification — deliberately absent, deferred by design
-
-WebAuthn currently has **no way to tell a caller that the authenticator is waiting for a touch**.
-The status stream reports `Processing` → `Finished`/`Failed` and nothing in between, so a UI can
-only prompt speculatively before the call rather than at the moment the key actually asks.
-
-This is a known gap, not an oversight. An earlier iteration carried a `WebAuthnStatusWaitingForUser`
-state fed by CTAP HID keep-alive `0x02` frames, threaded as an `IProgress<CtapStatus>` through
-`IFidoHidProtocol` → `IFidoBackend` → `IFidoSession` → the WebAuthn backend. It worked and was
-validated on hardware, but it added an optional parameter to the two hottest methods on the
-**public** `IFidoSession` to serve a single consumer, so it was removed.
-
-Context for whoever picks this up:
-
-- **Canonical does have this.** The Rust client holds a `user_interaction` field and calls
-  `prompt_up()` from an `on_keepalive` closure when the status byte is `0x02`
-  (`crates/yubikit/src/webauthn/client.rs:356-361`). Note it scopes the handler at the *client*,
-  not as a per-call parameter.
-- **This repo already has a convention.** PIV and YubiHsm both expose
-  `public TouchNotificationCallback? OnTouchRequired { get; set; }` on the session
-  (`Piv/src/TouchNotification.cs`, `PivSession.cs:100`). FIDO2 — the applet where touch matters
-  most — is the one that lacks it.
-- **The intended direction is a unified cross-applet touch notification**, rather than a third
-  bespoke per-module callback. `ICredentialPrompt` is the natural place to look: it is already the
-  shared async, context-carrying prompt primitive, and "tell the user to touch" is the same class
-  of interaction as "ask the user for a PIN". Deferred pending that design.
-
-Until then, do not reintroduce a per-call `IProgress` parameter on public session methods.
-
 ### User Verification Decision
 
 `UvDecisionLogic.Decide` (`src/Client/UserVerification/UvDecision.cs`) answers two questions in
 order, and keeping them separate is the point: **whether** the ceremony needs a PIN/UV auth token,
-and only then **which** method supplies it. Collapsing them is what previously made `Discouraged`
-demand a PIN whenever one happened to be reachable.
+and only then **which** method supplies it.
 
 "Configured" throughout means the option is advertised **and** enabled. A YubiKey with no PIN set
 still advertises `clientPin: false`, so testing for the key's presence rather than its value reads
@@ -210,12 +185,7 @@ as "verification is available" on a key that has none.
 | `Preferred` | Only if verification is configured; otherwise degrades to an unverified credential. |
 | `Discouraged` | No — unless verification is configured AND one of: `alwaysUv` is enabled; this is a makeCredential and `makeCredUvNotRqd` is not enabled (pre-CTAP-2.1 keys); or the request needs a permission beyond makeCredential/getAssertion (e.g. `LargeBlobWrite`). |
 
-This mirrors the canonical Rust client's `should_use_uv` in
-`crates/yubikit/src/webauthn/client.rs`, with **one deliberate divergence**: canonical's `Preferred`
-arm tests whether the option is *advertised*, which on a PIN-less YubiKey decides verification is
-needed and then fails for want of a method. Since `preferred` is the WebAuthn default, that turns
-the most common request into a hard error, so this SDK gates `Preferred` on *configured* per
-WebAuthn L2 §5.4.2. **Do not "fix" this back to match Rust** without re-reading that clause.
+`Preferred` gates on verification being configured, as specified by WebAuthn L2 section 5.4.2.
 
 Backstop: if the client's model of the authenticator is wrong and the key answers
 `CTAP2_ERR_PUAT_REQUIRED` (0x36), `ShouldRetryWithRequiredUv` escalates to `Required` and retries the
@@ -230,6 +200,9 @@ permission correctly once something requests it.
 WebAuthn operations report ceremony progress via `IAsyncEnumerable<WebAuthnStatus>`. The stream is
 **observation-only**: statuses never gather input and carry no callbacks. To abandon an operation,
 cancel the token you passed to it.
+
+There is also no dedicated touch signal in the WebAuthn surface. If the authenticator needs user
+presence, UI can only prompt speculatively before or during the wait.
 
 ```csharp
 await foreach (var status in client.MakeCredentialStreamAsync(options, cancellationToken: ct))
@@ -252,12 +225,6 @@ await foreach (var status in client.MakeCredentialStreamAsync(options, cancellat
 - `WebAuthnStatusProcessing` — ceremony work is in progress
 - `WebAuthnStatusFinished<T>` — operation completed successfully
 - `WebAuthnStatusFailed` — operation completed with a typed WebAuthn error
-
-> **Removed in the `ICredentialPrompt` migration:** `WebAuthnStatusRequestingPin`,
-> `WebAuthnStatusRequestingUv`, and the `useUv` parameter. The first two smuggled response
-> callbacks into stream states, which deadlocked both a consumer that stopped enumerating and one
-> that merely cancelled its own token; `useUv` was a silent no-op. PIN acquisition now goes through
-> `ICredentialPrompt`, which makes those deadlocks structurally impossible rather than patched.
 
 ### RP ID Validation
 
@@ -422,15 +389,13 @@ dotnet toolchain.cs -- test --integration --project WebAuthn --smoke
 4. **No LoggingFactory** — Use `YubiKitLogging.CreateLogger<T>()` from Core
 5. **Status stream must be consumed** — `IAsyncEnumerable` won't advance unless caller enumerates
 6. **CBOR key constants are context-specific** — key `7` means authentication `additionalArgs` in GetAssertion input and attestation object in MakeCredential unsigned output; keep parsing paths context-specific
-7. **The status stream never asks for anything** — it reports only. Do not add a state that carries a
-   response callback; that is exactly what caused the two deadlocks the `ICredentialPrompt`
-   migration removed. Input comes from `pinBytes` or `ICredentialPrompt`; abandonment comes from
-   the cancellation token.
-8. **There is currently no touch notification** — the stream cannot tell a caller when the
-   authenticator is waiting for a touch, so a UI can only prompt speculatively before the call.
-   See "Touch notification" below.
-9. **User presence and user verification are independent** — touch (UP) is always required for
+7. **The status stream never asks for anything** — it reports only. Input comes from `pinBytes` or
+   `ICredentialPrompt`; abandonment comes from the cancellation token.
+8. **User presence and user verification are independent** — touch (UP) is always required for
    makeCredential regardless of the UV preference. CTAP does not let a client set `up` on
    makeCredential at all, so never send it; the authenticator's default of `true` applies. `up=false`
    is legitimate only on the silent exclude-list pre-flight getAssertion probe
    (`Internal/ExcludeListPreflight.cs`).
+9. **Touch guidance is speculative only** — WebAuthn exposes no dedicated "touch now" callback or
+   status. If UX needs a touch prompt, show concise factual guidance based on the ceremony shape,
+   not on an in-flight signal from the SDK.

--- a/src/WebAuthn/CLAUDE.md
+++ b/src/WebAuthn/CLAUDE.md
@@ -166,8 +166,8 @@ Contract:
   never completes; implementations must honor cancellation.
 
 `CredentialPromptContext` carries `Kind`, `Scope` (the RP ID), `RetriesRemaining`, `IsRetry`,
-`MinLengthBytes`, `MaxLengthBytes`, and `RequiresConfirmation`. Note lengths here are **bytes**,
-not characters.
+`MinLengthCodePoints`, `MaxLengthBytes`, and `RequiresConfirmation`. CTAP reports its minimum in
+Unicode code points while its encoded PIN limit is expressed in UTF-8 bytes.
 
 ### User Verification Decision
 

--- a/src/WebAuthn/CLAUDE.md
+++ b/src/WebAuthn/CLAUDE.md
@@ -228,25 +228,18 @@ await foreach (var status in client.MakeCredentialStreamAsync(options, cancellat
 
 ### RP ID Validation
 
-`WebAuthnClient` validates RP IDs against `WebAuthnOrigin` before CTAP operations. Public suffixes such as `com` and `co.uk` must be rejected for suffix matches, so production callers must provide a `PublicSuffixChecker` backed by Public Suffix List data.
-
-Cross-SDK alignment:
-- Swift uses the same caller-supplied public-suffix checker pattern for `WebAuthn.Client`.
-- Python `python-fido2` ships bundled PSL data and validates with `verify_rp_id`.
-- Android accepts caller-supplied `effectiveDomain`; .NET intentionally keeps the safer explicit suffix-checker model.
+`WebAuthnClient` enforces RP ID validity through `Client/Validation/RpIdValidator.cs` before CTAP
+operations. Public suffixes such as `com` and `co.uk` must be rejected for suffix matches, so
+production callers must provide a `PublicSuffixChecker` backed by Public Suffix List data. The
+explicit suffix checker is required; a caller-supplied effective-domain shortcut is not a substitute.
 
 ### Extension Adapter Pattern
 
-Extensions are implemented as `IExtensionAdapter<TInput, TOutput>`:
-
-```csharp
-public interface IExtensionAdapter<in TInput, out TOutput>
-{
-    string ExtensionIdentifier { get; }
-    void EncodeInput(TInput input, IDictionary<string, object> extensionsMap);
-    TOutput DecodeOutput(IDictionary<string, object> extensionsMap);
-}
-```
+Extensions use internal static adapters coordinated by `ExtensionPipeline`. Input methods are named
+`ApplyToBuilder` or `ApplyToBuilderForRegistration`/`ApplyToBuilderForAuthentication`. Output methods
+are generally named `ParseRegistrationOutput` and `ParseAuthenticationOutput`; `MinPinLengthAdapter`
+uses `ParseOutput`, and client-derived `CredPropsAdapter` uses `DeriveOutput`. Add each supported
+ceremony to `Extensions/ExtensionPipeline.cs` and cover its encoded map and parsed output.
 
 **previewSign Example:**
 ```csharp
@@ -384,7 +377,7 @@ dotnet toolchain.cs -- test --integration --project WebAuthn --smoke
 ## Known Gotchas
 
 1. **previewSign auth is single-credential only for now** — multi-credential probe-selection is not implemented yet
-2. **Extension passthrough bug (fixed in commit `95abc0c5`)** — Extensions were silently dropped at backend; now wired correctly
+2. **Extension inputs must reach the backend** — Assert on encoded extension maps because a missing adapter call can silently omit an extension
 3. **`flags` optional in previewSign registration output** — Some authenticators return only key 3 (algorithm)
 4. **No LoggingFactory** — Use `YubiKitLogging.CreateLogger<T>()` from Core
 5. **Status stream must be consumed** — `IAsyncEnumerable` won't advance unless caller enumerates

--- a/src/WebAuthn/src/Client/Authentication/CredentialMatcher.cs
+++ b/src/WebAuthn/src/Client/Authentication/CredentialMatcher.cs
@@ -32,6 +32,9 @@ internal sealed class CredentialMatcher
     /// <param name="backend">The WebAuthn backend to use.</param>
     /// <param name="request">The backend GetAssertion request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="keepAliveProgress">
+    /// Optional observer for authenticator-busy notifications while the assertion is pending.
+    /// </param>
     /// <returns>
     /// A list of tuples containing credential ID, optional user, and the GetAssertionResponse.
     /// May be empty if no credentials match.
@@ -40,13 +43,14 @@ internal sealed class CredentialMatcher
         MatchAsync(
             IWebAuthnBackend backend,
             BackendGetAssertionRequest request,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken,
+            IProgress<CtapStatus>? keepAliveProgress = null)
     {
         GetAssertionResponse firstResponse;
 
         try
         {
-            firstResponse = await backend.GetAssertionAsync(request, progress: null, cancellationToken);
+            firstResponse = await backend.GetAssertionAsync(request, keepAliveProgress, cancellationToken);
         }
         catch (CtapException ex) when (IsNoCredentialsError(ex.Status))
         {

--- a/src/WebAuthn/src/Client/Authentication/CredentialMatcher.cs
+++ b/src/WebAuthn/src/Client/Authentication/CredentialMatcher.cs
@@ -32,9 +32,6 @@ internal sealed class CredentialMatcher
     /// <param name="backend">The WebAuthn backend to use.</param>
     /// <param name="request">The backend GetAssertion request.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
-    /// <param name="keepAliveProgress">
-    /// Optional observer for authenticator-busy notifications while the assertion is pending.
-    /// </param>
     /// <returns>
     /// A list of tuples containing credential ID, optional user, and the GetAssertionResponse.
     /// May be empty if no credentials match.
@@ -43,14 +40,13 @@ internal sealed class CredentialMatcher
         MatchAsync(
             IWebAuthnBackend backend,
             BackendGetAssertionRequest request,
-            CancellationToken cancellationToken,
-            IProgress<CtapStatus>? keepAliveProgress = null)
+            CancellationToken cancellationToken)
     {
         GetAssertionResponse firstResponse;
 
         try
         {
-            firstResponse = await backend.GetAssertionAsync(request, keepAliveProgress, cancellationToken);
+            firstResponse = await backend.GetAssertionAsync(request, cancellationToken);
         }
         catch (CtapException ex) when (IsNoCredentialsError(ex.Status))
         {

--- a/src/WebAuthn/src/Client/FidoSessionWebAuthnBackend.cs
+++ b/src/WebAuthn/src/Client/FidoSessionWebAuthnBackend.cs
@@ -57,6 +57,18 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
     }
 
     /// <inheritdoc/>
+    public async Task<int?> GetPinRetriesAsync(CancellationToken cancellationToken)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+
+        EnsureProtocolInitialized();
+        var clientPin = new ClientPin(_session, _protocol!);
+
+        var (pinRetries, _) = await clientPin.GetPinRetriesAsync(cancellationToken).ConfigureAwait(false);
+        return pinRetries;
+    }
+
+    /// <inheritdoc/>
     public async Task<PinUvAuthTokenSession> GetPinUvTokenAsync(
         PinUvAuthMethod method,
         PinUvAuthTokenPermissions permissions,
@@ -132,7 +144,8 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
                 request.User,
                 request.PubKeyCredParams,
                 options,
-                cancellationToken
+                cancellationToken,
+                progress
             ).ConfigureAwait(false);
         }
         finally
@@ -189,7 +202,8 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
                 request.RpId,
                 request.ClientDataHash,
                 options,
-                cancellationToken).ConfigureAwait(false);
+                cancellationToken,
+                progress).ConfigureAwait(false);
         }
         finally
         {

--- a/src/WebAuthn/src/Client/FidoSessionWebAuthnBackend.cs
+++ b/src/WebAuthn/src/Client/FidoSessionWebAuthnBackend.cs
@@ -74,7 +74,6 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
         PinUvAuthTokenPermissions permissions,
         string? rpId,
         ReadOnlyMemory<byte>? pinBytes,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -104,7 +103,6 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
     /// <inheritdoc/>
     public async Task<MakeCredentialResponse> MakeCredentialAsync(
         BackendMakeCredentialRequest request,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -144,9 +142,7 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
                 request.User,
                 request.PubKeyCredParams,
                 options,
-                cancellationToken,
-                progress
-            ).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
         }
         finally
         {
@@ -157,7 +153,6 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
     /// <inheritdoc/>
     public async Task<GetAssertionResponse> GetAssertionAsync(
         BackendGetAssertionRequest request,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
@@ -202,8 +197,7 @@ internal sealed class FidoSessionWebAuthnBackend : IWebAuthnBackend
                 request.RpId,
                 request.ClientDataHash,
                 options,
-                cancellationToken,
-                progress).ConfigureAwait(false);
+                cancellationToken).ConfigureAwait(false);
         }
         finally
         {

--- a/src/WebAuthn/src/Client/IWebAuthnBackend.cs
+++ b/src/WebAuthn/src/Client/IWebAuthnBackend.cs
@@ -52,6 +52,17 @@ public interface IWebAuthnBackend : IAsyncDisposable
         CancellationToken cancellationToken);
 
     /// <summary>
+    /// Gets the number of PIN attempts remaining before the authenticator blocks the PIN.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>
+    /// The remaining attempt count, or <c>null</c> when the authenticator does not
+    /// report one. Used to populate credential prompts after a rejected PIN, so a
+    /// failure to read it must not fail the surrounding operation.
+    /// </returns>
+    Task<int?> GetPinRetriesAsync(CancellationToken cancellationToken);
+
+    /// <summary>
     /// Creates a new credential via CTAP2 MakeCredential.
     /// </summary>
     Task<MakeCredentialResponse> MakeCredentialAsync(

--- a/src/WebAuthn/src/Client/IWebAuthnBackend.cs
+++ b/src/WebAuthn/src/Client/IWebAuthnBackend.cs
@@ -40,7 +40,6 @@ public interface IWebAuthnBackend : IAsyncDisposable
     /// <param name="permissions">The requested token permissions.</param>
     /// <param name="rpId">Optional RP ID to bind the token to (required for some permissions).</param>
     /// <param name="pinBytes">PIN bytes (UTF-8 encoded) when method is PIN, otherwise null.</param>
-    /// <param name="progress">Optional progress reporter for CTAP status updates.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>A session holding the PIN/UV auth token and protocol instance.</returns>
     Task<PinUvAuthTokenSession> GetPinUvTokenAsync(
@@ -48,7 +47,6 @@ public interface IWebAuthnBackend : IAsyncDisposable
         PinUvAuthTokenPermissions permissions,
         string? rpId,
         ReadOnlyMemory<byte>? pinBytes,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -67,7 +65,6 @@ public interface IWebAuthnBackend : IAsyncDisposable
     /// </summary>
     Task<MakeCredentialResponse> MakeCredentialAsync(
         BackendMakeCredentialRequest request,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken);
 
     /// <summary>
@@ -76,7 +73,6 @@ public interface IWebAuthnBackend : IAsyncDisposable
     /// <remarks>Implemented in Phase 4.</remarks>
     Task<GetAssertionResponse> GetAssertionAsync(
         BackendGetAssertionRequest request,
-        IProgress<CtapStatus>? progress,
         CancellationToken cancellationToken);
 
     /// <summary>

--- a/src/WebAuthn/src/Client/Status/StatusChannel.cs
+++ b/src/WebAuthn/src/Client/Status/StatusChannel.cs
@@ -25,7 +25,6 @@ namespace Yubico.YubiKit.WebAuthn.Client.Status;
 /// This channel manages:
 /// - Unbounded status queue
 /// - Deduplication of consecutive identical statuses
-/// - Interactive responses (PIN submission, UV decision)
 /// - Graceful completion on success, cancellation, or error
 /// </remarks>
 internal sealed class StatusChannel<TResult> : IAsyncDisposable
@@ -33,7 +32,6 @@ internal sealed class StatusChannel<TResult> : IAsyncDisposable
     private readonly Channel<WebAuthnStatus> _channel;
     private WebAuthnStatus? _lastWritten;
     private bool _readerStarted;
-    private TaskCompletionSource<ReadOnlyMemory<byte>?>? _pinResponseTcs;
 
     public StatusChannel()
     {
@@ -86,35 +84,34 @@ internal sealed class StatusChannel<TResult> : IAsyncDisposable
     }
 
     /// <summary>
+    /// Writes a status update without blocking, discarding it if the channel is already complete.
+    /// </summary>
+    /// <param name="status">The status to write.</param>
+    /// <remarks>
+    /// For callers that must not block or throw, such as transport keep-alive notifications that
+    /// can arrive as a ceremony is finishing. Applies the same consecutive-duplicate suppression
+    /// as <see cref="WriteAsync"/>.
+    /// </remarks>
+    public void TryWrite(WebAuthnStatus status)
+    {
+        if (_lastWritten is not null && _lastWritten.Equals(status))
+        {
+            return;
+        }
+
+        if (_channel.Writer.TryWrite(status))
+        {
+            _lastWritten = status;
+        }
+    }
+
+    /// <summary>
     /// Completes the channel writer, signaling no more statuses will be written.
     /// </summary>
     /// <param name="error">Optional exception if the channel is being completed due to an error.</param>
     public void Complete(Exception? error = null)
     {
         _channel.Writer.Complete(error);
-    }
-
-    /// <summary>
-    /// Creates a PIN request status that the producer can await.
-    /// </summary>
-    /// <returns>A tuple of (status, response task).</returns>
-    public (WebAuthnStatusRequestingPin Status, Task<ReadOnlyMemory<byte>?> ResponseTask) CreatePinRequest()
-    {
-        _pinResponseTcs = new TaskCompletionSource<ReadOnlyMemory<byte>?>();
-
-        var status = new WebAuthnStatusRequestingPin(
-            SubmitPin: pinBytes =>
-            {
-                _pinResponseTcs?.TrySetResult(pinBytes);
-                return ValueTask.CompletedTask;
-            },
-            Cancel: () =>
-            {
-                _pinResponseTcs?.TrySetResult(null);
-                return ValueTask.CompletedTask;
-            });
-
-        return (status, _pinResponseTcs.Task);
     }
 
     /// <inheritdoc/>

--- a/src/WebAuthn/src/Client/Status/WebAuthnStatus.cs
+++ b/src/WebAuthn/src/Client/Status/WebAuthnStatus.cs
@@ -18,8 +18,16 @@ namespace Yubico.YubiKit.WebAuthn.Client.Status;
 /// Base type for WebAuthn operation status updates in a streaming context.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Discriminated status union for <see cref="WebAuthnClient"/> streaming operations.
 /// Consumers use pattern matching to handle each status variant.
+/// </para>
+/// <para>
+/// These statuses report progress; they never gather input. A PIN, when one is needed, comes
+/// from the PIN bytes passed to the operation or from the client's configured
+/// <see cref="Yubico.YubiKit.Core.Credentials.ICredentialPrompt"/>. To abandon an operation,
+/// cancel the token supplied to it.
+/// </para>
 /// </remarks>
 public abstract record WebAuthnStatus;
 
@@ -29,25 +37,14 @@ public abstract record WebAuthnStatus;
 public sealed record WebAuthnStatusProcessing : WebAuthnStatus;
 
 /// <summary>
-/// Waiting for user interaction (touch, biometric, or other authenticator prompt).
+/// The authenticator is waiting for the user to touch it.
 /// </summary>
-/// <param name="Cancel">Call to cancel the wait.</param>
-public sealed record WebAuthnStatusWaitingForUser(Func<ValueTask> Cancel) : WebAuthnStatus;
-
-/// <summary>
-/// The operation is requesting a decision on whether to use user verification.
-/// </summary>
-/// <param name="SetUseUv">Call with true to use UV, false to skip UV.</param>
-public sealed record WebAuthnStatusRequestingUv(Func<bool, ValueTask> SetUseUv) : WebAuthnStatus;
-
-/// <summary>
-/// The operation requires a PIN to proceed.
-/// </summary>
-/// <param name="SubmitPin">Submit PIN bytes (UTF-8 encoded) to continue.</param>
-/// <param name="Cancel">Call to cancel PIN entry and abort the operation.</param>
-public sealed record WebAuthnStatusRequestingPin(
-    Func<ReadOnlyMemory<byte>, ValueTask> SubmitPin,
-    Func<ValueTask> Cancel) : WebAuthnStatus;
+/// <remarks>
+/// Emitted when the authenticator reports that it is awaiting user presence, which is the moment
+/// to show a "touch your key" prompt. Only the HID transport signals this; over SmartCard the
+/// ceremony appears as continuous <see cref="WebAuthnStatusProcessing"/>.
+/// </remarks>
+public sealed record WebAuthnStatusWaitingForUser : WebAuthnStatus;
 
 /// <summary>
 /// The operation has finished successfully.

--- a/src/WebAuthn/src/Client/Status/WebAuthnStatus.cs
+++ b/src/WebAuthn/src/Client/Status/WebAuthnStatus.cs
@@ -37,16 +37,6 @@ public abstract record WebAuthnStatus;
 public sealed record WebAuthnStatusProcessing : WebAuthnStatus;
 
 /// <summary>
-/// The authenticator is waiting for the user to touch it.
-/// </summary>
-/// <remarks>
-/// Emitted when the authenticator reports that it is awaiting user presence, which is the moment
-/// to show a "touch your key" prompt. Only the HID transport signals this; over SmartCard the
-/// ceremony appears as continuous <see cref="WebAuthnStatusProcessing"/>.
-/// </remarks>
-public sealed record WebAuthnStatusWaitingForUser : WebAuthnStatus;
-
-/// <summary>
 /// The operation has finished successfully.
 /// </summary>
 /// <typeparam name="T">The result type (RegistrationResponse or IReadOnlyList&lt;MatchedCredential&gt;).</typeparam>

--- a/src/WebAuthn/src/Client/UserVerification/UvDecision.cs
+++ b/src/WebAuthn/src/Client/UserVerification/UvDecision.cs
@@ -37,19 +37,10 @@ internal readonly record struct UvDecision(
 /// User verification decision logic.
 /// </summary>
 /// <remarks>
-/// <para>
-/// Mirrors the canonical Rust client's <c>should_use_uv</c>
-/// (<c>crates/yubikit/src/webauthn/client.rs</c>): first decide <em>whether</em> user verification
-/// is needed at all, then decide <em>which</em> method satisfies it. Collapsing those two questions
-/// is what previously made <see cref="UserVerificationPreference.Discouraged"/> demand a PIN
-/// whenever one happened to be reachable.
-/// </para>
-/// <para>
-/// Throughout, "configured" means the authenticator advertises the option <em>and</em> has it
-/// enabled. That distinction matters: a YubiKey with no PIN set still advertises
-/// <c>clientPin: false</c>, so testing for the key's presence rather than its value would read as
-/// "user verification is available" on a key that has none.
-/// </para>
+/// First decides <em>whether</em> user verification is needed, then decides <em>which</em> method
+/// satisfies it. "Configured" means the option is both advertised and enabled: a YubiKey with no
+/// PIN set still advertises <c>clientPin: false</c>, and treating advertisement alone as available
+/// verification would request a token from a key that has no enabled verification method.
 /// </remarks>
 internal static class UvDecisionLogic
 {
@@ -149,12 +140,10 @@ internal static class UvDecisionLogic
         {
             UserVerificationPreference.Required => true,
 
-            // Deliberate divergence from canonical Rust, which uses "advertised" here and would
-            // therefore decide UV is needed on a PIN-less YubiKey (it still advertises
-            // clientPin: false) and then fail for want of a method. Since `preferred` is the
-            // WebAuthn default, that would turn the most common request into a hard error. WebAuthn
-            // L2 5.4.2 says preferred degrades to no verification when none is available, so gate on
-            // "configured". Do not "fix" this back to match Rust without re-reading that clause.
+            // WebAuthn L2 5.4.2 allows Preferred to proceed without verification when none is
+            // available, so only enabled verification methods count as configured here. This
+            // intentionally differs from implementations that treat an advertised false option as
+            // available verification.
             UserVerificationPreference.Preferred => uvConfigured,
 
             UserVerificationPreference.Discouraged =>

--- a/src/WebAuthn/src/Client/UserVerification/UvDecision.cs
+++ b/src/WebAuthn/src/Client/UserVerification/UvDecision.cs
@@ -36,14 +36,40 @@ internal readonly record struct UvDecision(
 /// <summary>
 /// User verification decision logic.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Mirrors the canonical Rust client's <c>should_use_uv</c>
+/// (<c>crates/yubikit/src/webauthn/client.rs</c>): first decide <em>whether</em> user verification
+/// is needed at all, then decide <em>which</em> method satisfies it. Collapsing those two questions
+/// is what previously made <see cref="UserVerificationPreference.Discouraged"/> demand a PIN
+/// whenever one happened to be reachable.
+/// </para>
+/// <para>
+/// Throughout, "configured" means the authenticator advertises the option <em>and</em> has it
+/// enabled. That distinction matters: a YubiKey with no PIN set still advertises
+/// <c>clientPin: false</c>, so testing for the key's presence rather than its value would read as
+/// "user verification is available" on a key that has none.
+/// </para>
+/// </remarks>
 internal static class UvDecisionLogic
 {
+    /// <summary>
+    /// Permissions that are part of an ordinary registration or authentication ceremony. Anything
+    /// beyond these (credential management, bio enrollment, large-blob write, authenticator config)
+    /// requires user verification even when the relying party discouraged it.
+    /// </summary>
+    private const PinUvAuthTokenPermissions CeremonyPermissions =
+        PinUvAuthTokenPermissions.MakeCredential | PinUvAuthTokenPermissions.GetAssertion;
+
     /// <summary>
     /// Determines how to handle user verification based on authenticator capabilities and preferences.
     /// </summary>
     /// <param name="info">The authenticator info.</param>
     /// <param name="preference">The user verification preference from the request.</param>
-    /// <param name="pinAvailable">Whether a PIN is available (caller has PIN bytes).</param>
+    /// <param name="pinAvailable">
+    /// Whether a PIN can be obtained — either the caller passed PIN bytes or the client has an
+    /// <c>ICredentialPrompt</c> configured.
+    /// </param>
     /// <param name="requestedPermissions">The permissions needed for the operation.</param>
     /// <returns>The UV decision.</returns>
     /// <exception cref="WebAuthnClientError">
@@ -57,27 +83,25 @@ internal static class UvDecisionLogic
     {
         ArgumentNullException.ThrowIfNull(info);
 
-        bool clientPinSet = info.Options.TryGetValue("clientPin", out var pinSet) && pinSet;
-        bool uvSupported = info.Options.TryGetValue("uv", out var uv) && uv;
+        bool clientPinConfigured = IsOptionEnabled(info, "clientPin");
+        bool builtInUvConfigured = IsOptionEnabled(info, "uv");
+        bool uvConfigured = clientPinConfigured || builtInUvConfigured || IsOptionEnabled(info, "bioEnroll");
 
-        // If UV is required, ensure at least one method is available
-        if (preference == UserVerificationPreference.Required)
+        var noUv = new UvDecision(
+            UseToken: false,
+            UseUv: false,
+            UvOption: null,
+            Method: null,
+            Permissions: requestedPermissions);
+
+        if (!ShouldUseUv(info, preference, requestedPermissions, uvConfigured))
         {
-            bool hasUvMethod = (clientPinSet && pinAvailable) || uvSupported;
-            if (!hasUvMethod)
-            {
-                throw new WebAuthnClientError(
-                    WebAuthnClientErrorCode.NotAllowed,
-                    "User verification is required but the authenticator does not support UV " +
-                    "and no PIN is available (or PIN is not set on the authenticator).");
-            }
+            return noUv;
         }
 
-        // Decide which method to use
-        // Priority: PIN (if available) > built-in UV > none
-        if (clientPinSet && pinAvailable)
+        // User verification is wanted. Pick a method: PIN first, then built-in UV.
+        if (clientPinConfigured && pinAvailable)
         {
-            // Use PIN method
             return new UvDecision(
                 UseToken: true,
                 UseUv: false,
@@ -86,9 +110,8 @@ internal static class UvDecisionLogic
                 Permissions: requestedPermissions);
         }
 
-        if (uvSupported)
+        if (builtInUvConfigured)
         {
-            // Use built-in UV (biometric, etc.)
             return new UvDecision(
                 UseToken: true,
                 UseUv: true,
@@ -97,21 +120,86 @@ internal static class UvDecisionLogic
                 Permissions: requestedPermissions);
         }
 
-        // No UV available - only allowed if preference is not Required
+        // Wanted, but nothing can satisfy it.
         if (preference == UserVerificationPreference.Required)
         {
-            // This shouldn't happen due to the check above, but defensively handle it
             throw new WebAuthnClientError(
                 WebAuthnClientErrorCode.NotAllowed,
-                "User verification is required but no UV method is available.");
+                "User verification is required but the authenticator does not support UV " +
+                "and no PIN is available (or PIN is not set on the authenticator).");
         }
 
-        // UV is Preferred or Discouraged, and no method available - proceed without UV
-        return new UvDecision(
-            UseToken: false,
-            UseUv: false,
-            UvOption: null,
-            Method: null,
-            Permissions: requestedPermissions);
+        // The relying party did not require verification, so try the ceremony without it rather
+        // than failing on our own reading of the authenticator's options. If the authenticator
+        // really does insist, it answers CTAP2_ERR_PUAT_REQUIRED and WebAuthnClient retries the
+        // whole ceremony with Required.
+        return noUv;
     }
+
+    /// <summary>
+    /// Decides whether a PIN/UV auth token is needed at all, before any question of which method
+    /// would provide it.
+    /// </summary>
+    private static bool ShouldUseUv(
+        AuthenticatorInfo info,
+        UserVerificationPreference preference,
+        PinUvAuthTokenPermissions requestedPermissions,
+        bool uvConfigured) =>
+        preference switch
+        {
+            UserVerificationPreference.Required => true,
+
+            // Deliberate divergence from canonical Rust, which uses "advertised" here and would
+            // therefore decide UV is needed on a PIN-less YubiKey (it still advertises
+            // clientPin: false) and then fail for want of a method. Since `preferred` is the
+            // WebAuthn default, that would turn the most common request into a hard error. WebAuthn
+            // L2 5.4.2 says preferred degrades to no verification when none is available, so gate on
+            // "configured". Do not "fix" this back to match Rust without re-reading that clause.
+            UserVerificationPreference.Preferred => uvConfigured,
+
+            UserVerificationPreference.Discouraged =>
+                RequiresUvDespiteDiscouraged(info, requestedPermissions, uvConfigured),
+
+            _ => false
+        };
+
+    /// <summary>
+    /// The relying party discouraged user verification, but the authenticator or the request may
+    /// still force it.
+    /// </summary>
+    private static bool RequiresUvDespiteDiscouraged(
+        AuthenticatorInfo info,
+        PinUvAuthTokenPermissions requestedPermissions,
+        bool uvConfigured)
+    {
+        // Every override below presupposes that verification is actually configured. A key with no
+        // PIN and no biometrics has nothing to force.
+        if (!uvConfigured)
+        {
+            return false;
+        }
+
+        // The authenticator is configured to always verify, which outranks the relying party.
+        if (IsOptionEnabled(info, "alwaysUv"))
+        {
+            return true;
+        }
+
+        // Pre-CTAP-2.1 authenticators with verification configured refuse an unverified
+        // makeCredential. CTAP 2.1 authenticators advertise makeCredUvNotRqd to opt out of that.
+        bool isMakeCredential = (requestedPermissions & PinUvAuthTokenPermissions.MakeCredential) != 0;
+        if (isMakeCredential && !IsOptionEnabled(info, "makeCredUvNotRqd"))
+        {
+            return true;
+        }
+
+        // Privileged permissions always need verification, whatever the relying party asked for.
+        return (requestedPermissions & ~CeremonyPermissions) != 0;
+    }
+
+    /// <summary>
+    /// Returns true only when the option is both advertised and enabled.
+    /// </summary>
+    private static bool IsOptionEnabled(AuthenticatorInfo info, string option) =>
+        info.Options.TryGetValue(option, out bool enabled) && enabled;
 }

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -360,7 +360,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// This method handles validation, UV/PIN decision, token acquisition, and CTAP execution.
-    /// It may write status updates to the channel (e.g., WaitingForUser) and awaits interactive
+    /// It may write status updates to the channel and awaits interactive
     /// responses when PIN/UV is needed.
     /// </remarks>
     private async Task<RegistrationResponse> MakeCredentialCoreAsync(
@@ -397,7 +397,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
         PinUvAuthTokenSession? tokenSession = null;
         IMemoryOwner<byte>? pinOwner = null;
         ReadOnlyMemory<byte>? pinBytes = callerPinBytes;
-        var keepAliveProgress = CreateKeepAliveObserver(channel);
 
         try
         {
@@ -426,7 +425,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
             MakeCredentialResponse ctapResponse;
             try
             {
-                ctapResponse = await ExecuteMakeCredentialAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
+                ctapResponse = await ExecuteMakeCredentialAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (CtapException ex) when (ShouldRetryWithRequiredUv(ex, options.UserVerification))
             {
@@ -457,7 +456,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 request = BuildMakeCredentialRequest(options, clientData, tokenSession, uvDecision, matchedExclude, preflightPerformed);
                 try
                 {
-                    ctapResponse = await ExecuteMakeCredentialAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
+                    ctapResponse = await ExecuteMakeCredentialAsync(request, cancellationToken).ConfigureAwait(false);
                 }
                 catch (CtapException retryEx)
                 {
@@ -504,7 +503,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// This method handles validation, UV/PIN decision, token acquisition, credential matching, and CTAP execution.
-    /// It may write status updates to the channel (e.g., WaitingForUser) and awaits interactive
+    /// It may write status updates to the channel and awaits interactive
     /// responses when PIN/UV is needed.
     /// </remarks>
     private async Task<IReadOnlyList<MatchedCredential>> GetAssertionCoreAsync(
@@ -541,7 +540,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
         PinUvAuthTokenSession? tokenSession = null;
         IMemoryOwner<byte>? pinOwner = null;
         ReadOnlyMemory<byte>? pinBytes = callerPinBytes;
-        var keepAliveProgress = CreateKeepAliveObserver(channel);
 
         try
         {
@@ -559,7 +557,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
             IReadOnlyList<(ReadOnlyMemory<byte> Id, PublicKeyCredentialUserEntity? User, GetAssertionResponse Response)> matches;
             try
             {
-                matches = await MatchCredentialsAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
+                matches = await MatchCredentialsAsync(request, cancellationToken).ConfigureAwait(false);
             }
             catch (CtapException ex) when (ShouldRetryWithRequiredUv(ex, options.UserVerification))
             {
@@ -582,7 +580,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 request = BuildGetAssertionRequest(options, clientData, tokenSession, uvDecision);
                 try
                 {
-                    matches = await MatchCredentialsAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
+                    matches = await MatchCredentialsAsync(request, cancellationToken).ConfigureAwait(false);
                 }
                 catch (CtapException retryEx)
                 {
@@ -734,47 +732,13 @@ public sealed class WebAuthnClient : IAsyncDisposable
         ex.Status == CtapStatus.PuatRequired &&
         userVerification != Preferences.UserVerificationPreference.Required;
 
-    /// <summary>
-    /// Builds an observer that republishes authenticator-busy notifications as ceremony statuses,
-    /// so a consumer learns the moment a touch is being awaited.
-    /// </summary>
-    /// <remarks>
-    /// Returns <c>null</c> when nobody is listening, which keeps the non-streaming path free of
-    /// per-keep-alive work. Duplicate statuses are collapsed by the channel.
-    /// </remarks>
-    private static IProgress<CtapStatus>? CreateKeepAliveObserver<T>(StatusChannel<T>? channel)
-    {
-        if (channel is null)
-        {
-            return null;
-        }
-
-        return new KeepAliveObserver<T>(channel);
-    }
-
-    /// <summary>
-    /// Republishes authenticator keep-alive notifications as ceremony statuses.
-    /// </summary>
-    /// <remarks>
-    /// Reports synchronously so a status cannot arrive after the ceremony has completed, and uses
-    /// the non-blocking write so transport notifications can never stall or fail the ceremony.
-    /// </remarks>
-    private sealed class KeepAliveObserver<T>(StatusChannel<T> channel) : IProgress<CtapStatus>
-    {
-        public void Report(CtapStatus value) =>
-            channel.TryWrite(value == CtapStatus.UserActionPending
-                ? new WebAuthnStatusWaitingForUser()
-                : new WebAuthnStatusProcessing());
-    }
-
     private async Task<MakeCredentialResponse> ExecuteMakeCredentialAsync(
         BackendMakeCredentialRequest request,
-        IProgress<CtapStatus>? keepAliveProgress,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await _backend.MakeCredentialAsync(request, keepAliveProgress, cancellationToken)
+            return await _backend.MakeCredentialAsync(request, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
@@ -785,12 +749,11 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
     private async Task<IReadOnlyList<(ReadOnlyMemory<byte> Id, PublicKeyCredentialUserEntity? User, GetAssertionResponse Response)>> MatchCredentialsAsync(
         BackendGetAssertionRequest request,
-        IProgress<CtapStatus>? keepAliveProgress,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await CredentialMatcher.MatchAsync(_backend, request, cancellationToken, keepAliveProgress)
+            return await CredentialMatcher.MatchAsync(_backend, request, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
@@ -937,7 +900,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 permissions,
                 rpId,
                 pinBytes,
-                progress: null,
                 cancellationToken).ConfigureAwait(false);
         }
         catch (CtapException ex) when (IsPinRejection(ex.Status))
@@ -1002,8 +964,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                     permissions,
                     rpId,
                     secret.Memory,
-                    progress: null,
-                    cancellationToken).ConfigureAwait(false);
+                        cancellationToken).ConfigureAwait(false);
 
                 return (tokenSession, secret);
             }

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -54,8 +54,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </remarks>
     public const int MaxPromptAttempts = 3;
 
-    /// <summary>CTAP 2.1 minimum PIN length in bytes, used when the authenticator reports none.</summary>
-    private const int Ctap2MinPinLengthBytes = 4;
+    /// <summary>CTAP 2.1 minimum PIN length in Unicode code points.</summary>
+    private const int Ctap2MinPinLengthCodePoints = 4;
 
     /// <summary>CTAP 2.1 maximum PIN length in bytes.</summary>
     private const int Ctap2MaxPinLengthBytes = 63;
@@ -920,7 +920,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
         var prompt = _prompt ?? throw new InvalidOperationException("No credential prompt configured.");
 
         var info = await _backend.GetCachedInfoAsync(cancellationToken).ConfigureAwait(false);
-        var minPinLength = info.MinPinLength ?? Ctap2MinPinLengthBytes;
+        var minPinLength = info.MinPinLength ?? Ctap2MinPinLengthCodePoints;
         int? retriesRemaining = null;
 
         for (var attempt = 0; attempt < MaxPromptAttempts; attempt++)
@@ -933,7 +933,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 Scope = rpId,
                 IsRetry = attempt > 0,
                 RetriesRemaining = retriesRemaining,
-                MinLengthBytes = minPinLength,
+                MinLengthCodePoints = minPinLength,
                 MaxLengthBytes = Ctap2MaxPinLengthBytes
             };
 
@@ -1023,7 +1023,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </summary>
     /// <remarks>
     /// Purely informational: a failure to read the counter must not replace the PIN rejection
-    /// the caller is actually dealing with, so all errors collapse to <c>null</c>.
+    /// the caller is actually dealing with, so failures collapse to <c>null</c>. Caller cancellation
+    /// still propagates.
     /// </remarks>
     private async Task<int?> TryGetPinRetriesAsync(CancellationToken cancellationToken)
     {
@@ -1031,11 +1032,11 @@ public sealed class WebAuthnClient : IAsyncDisposable
         {
             return await _backend.GetPinRetriesAsync(cancellationToken).ConfigureAwait(false);
         }
-        catch (CtapException)
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            return null;
+            throw;
         }
-        catch (InvalidOperationException)
+        catch
         {
             return null;
         }

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -49,10 +49,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// for a PIN during a single operation.
     /// </summary>
     /// <remarks>
-    /// The authenticator's own retry counter is the security boundary; this cap is a
-    /// blast-radius bound so that a prompt implementation which repeatedly returns the
-    /// same wrong secret cannot consume every hardware attempt and block the credential.
-    /// Reaching the cap fails the operation, which the user can simply retry.
+    /// Reaching the cap fails the operation. The authenticator independently enforces its own
+    /// retry limit and may report a terminal PIN state before this cap is reached.
     /// </remarks>
     public const int MaxPromptAttempts = 3;
 
@@ -136,10 +134,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The registration response with credential details.</returns>
     /// <exception cref="WebAuthnClientError">Thrown on validation or operation failure.</exception>
-    /// <remarks>
-    /// To observe ceremony progress (for example, to show a "touch your key" prompt), use
-    /// <see cref="MakeCredentialStreamAsync"/> instead.
-    /// </remarks>
     public async Task<RegistrationResponse> MakeCredentialAsync(
         RegistrationOptions options,
         ReadOnlyMemory<byte>? pinBytes = null,
@@ -163,10 +157,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// to complete the authentication and retrieve the assertion response.
     /// </returns>
     /// <remarks>
-    /// <para>
-    /// To observe ceremony progress (for example, to show a "touch your key" prompt), use
-    /// <see cref="GetAssertionStreamAsync"/> instead.
-    /// </para>
     /// <para>
     /// This method follows the deferred-selection pattern: the authenticator enumerates
     /// all matching credentials, and the caller can present a credential picker UI before
@@ -350,9 +340,14 @@ public sealed class WebAuthnClient : IAsyncDisposable
             return;
         }
 
-        // Zero entire rented buffer for defense-in-depth even though only the PIN prefix was written.
-        CryptographicOperations.ZeroMemory(owner.Memory.Span);
-        owner.Dispose();
+        try
+        {
+            CryptographicOperations.ZeroMemory(owner.Memory.Span);
+        }
+        finally
+        {
+            owner.Dispose();
+        }
     }
 
     /// <summary>
@@ -492,8 +487,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
             if (pinOwner is not null)
             {
-                CryptographicOperations.ZeroMemory(pinOwner.Memory.Span);
-                pinOwner.Dispose();
+                ZeroAndDispose(pinOwner);
             }
         }
     }
@@ -621,8 +615,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
             if (pinOwner is not null)
             {
-                CryptographicOperations.ZeroMemory(pinOwner.Memory.Span);
-                pinOwner.Dispose();
+                ZeroAndDispose(pinOwner);
             }
         }
     }
@@ -881,9 +874,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// Acquires a PIN/UV auth token from the backend using a secret the caller already supplied.
     /// </summary>
     /// <remarks>
-    /// A caller-supplied secret is never retried: resubmitting identical PIN bytes would burn
-    /// authenticator attempts without any chance of a different outcome. Deciding whether to ask
-    /// the user again belongs to the caller, or to the prompt-driven path in
+    /// A caller-supplied secret is never retried because the SDK has no replacement value to
+    /// submit. Deciding whether to ask the user again belongs to the caller, or to the prompt-driven path in
     /// <see cref="AcquireTokenViaPromptAsync"/>.
     /// </remarks>
     private async Task<PinUvAuthTokenSession> AcquirePinUvTokenAsync(
@@ -933,6 +925,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
         for (var attempt = 0; attempt < MaxPromptAttempts; attempt++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             var context = new CredentialPromptContext
             {
                 Kind = CredentialKind.Pin,
@@ -943,12 +937,17 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 MaxLengthBytes = Ctap2MaxPinLengthBytes
             };
 
-            // WaitAsync bounds the wait even if an implementation ignores the token it is handed,
-            // so a stuck prompt cannot strand the operation.
-            var secret = await prompt.RequestSecretAsync(context, cancellationToken)
-                .AsTask()
-                .WaitAsync(cancellationToken)
-                .ConfigureAwait(false);
+            var promptTask = prompt.RequestSecretAsync(context, cancellationToken).AsTask();
+            IMemoryOwner<byte>? secret;
+            try
+            {
+                secret = await promptTask.WaitAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                _ = DisposeLatePromptResultAsync(promptTask);
+                throw;
+            }
 
             if (secret is null)
             {
@@ -964,14 +963,19 @@ public sealed class WebAuthnClient : IAsyncDisposable
                     permissions,
                     rpId,
                     secret.Memory,
-                        cancellationToken).ConfigureAwait(false);
+                    cancellationToken).ConfigureAwait(false);
 
                 return (tokenSession, secret);
             }
-            catch (CtapException ex) when (ex.Status == CtapStatus.PinInvalid
-                                           && attempt + 1 < MaxPromptAttempts)
+            catch (CtapException ex) when (ex.Status == CtapStatus.PinInvalid)
             {
                 ZeroAndDispose(secret);
+
+                if (attempt + 1 >= MaxPromptAttempts)
+                {
+                    throw MapPinRejection(ex);
+                }
+
                 retriesRemaining = await TryGetPinRetriesAsync(cancellationToken).ConfigureAwait(false);
             }
             catch (CtapException ex) when (IsPinRejection(ex.Status))
@@ -988,7 +992,30 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
         throw new WebAuthnClientError(
             WebAuthnClientErrorCode.NotAllowed,
-            $"PIN was rejected on {MaxPromptAttempts} attempts.");
+            "PIN authentication did not complete within the prompt-attempt limit.");
+    }
+
+    private static async Task DisposeLatePromptResultAsync(Task<IMemoryOwner<byte>?> promptTask)
+    {
+        IMemoryOwner<byte>? owner;
+        try
+        {
+            owner = await promptTask.ConfigureAwait(false);
+        }
+        catch
+        {
+            // Observe a fault from work that completed after the operation was cancelled.
+            return;
+        }
+
+        try
+        {
+            ZeroAndDispose(owner);
+        }
+        catch
+        {
+            // Cleanup cannot be surfaced because the cancelled operation has already returned.
+        }
     }
 
     /// <summary>

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -17,6 +17,7 @@ using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 using System.Text;
+using Yubico.YubiKit.Core.Credentials;
 using Yubico.YubiKit.Core.Cryptography.Cose;
 using Yubico.YubiKit.Fido2;
 using Yubico.YubiKit.Fido2.Cose;
@@ -43,17 +44,30 @@ namespace Yubico.YubiKit.WebAuthn.Client;
 /// </remarks>
 public sealed class WebAuthnClient : IAsyncDisposable
 {
+    /// <summary>
+    /// The maximum number of times the client asks an <see cref="ICredentialPrompt"/>
+    /// for a PIN during a single operation.
+    /// </summary>
+    /// <remarks>
+    /// The authenticator's own retry counter is the security boundary; this cap is a
+    /// blast-radius bound so that a prompt implementation which repeatedly returns the
+    /// same wrong secret cannot consume every hardware attempt and block the credential.
+    /// Reaching the cap fails the operation, which the user can simply retry.
+    /// </remarks>
+    public const int MaxPromptAttempts = 3;
+
+    /// <summary>CTAP 2.1 minimum PIN length in bytes, used when the authenticator reports none.</summary>
+    private const int Ctap2MinPinLengthBytes = 4;
+
+    /// <summary>CTAP 2.1 maximum PIN length in bytes.</summary>
+    private const int Ctap2MaxPinLengthBytes = 63;
+
     private readonly IWebAuthnBackend _backend;
     private readonly WebAuthnOrigin _origin;
     private readonly Func<string, bool> _isPublicSuffix;
     private readonly IReadOnlySet<string> _enterpriseRpIds;
+    private readonly ICredentialPrompt? _prompt;
     private bool _disposed;
-
-    private enum MissingPinBehavior
-    {
-        ThrowAfterCancel,
-        DrainFailedStatus
-    }
 
     /// <summary>
     /// Initializes a new instance of <see cref="WebAuthnClient"/>.
@@ -62,11 +76,17 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// <param name="origin">The WebAuthn origin for this client.</param>
     /// <param name="isPublicSuffix">Checker used to reject public-suffix RP IDs.</param>
     /// <param name="enterpriseRpIds">Optional set of enterprise-allowed RP IDs.</param>
+    /// <param name="prompt">
+    /// Optional prompt used to obtain a PIN when an operation needs one and the caller
+    /// did not supply it. When omitted, such operations fail with
+    /// <see cref="WebAuthnClientErrorCode.NotAllowed"/> rather than prompting.
+    /// </param>
     public WebAuthnClient(
         IFidoSession fidoSession,
         WebAuthnOrigin origin,
         PublicSuffixChecker isPublicSuffix,
-        IReadOnlySet<string>? enterpriseRpIds = null)
+        IReadOnlySet<string>? enterpriseRpIds = null,
+        ICredentialPrompt? prompt = null)
     {
         ArgumentNullException.ThrowIfNull(fidoSession);
         _origin = origin ?? throw new ArgumentNullException(nameof(origin));
@@ -74,6 +94,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
         _backend = new FidoSessionWebAuthnBackend(fidoSession);
         _isPublicSuffix = domain => isPublicSuffix(domain);
         _enterpriseRpIds = enterpriseRpIds ?? new HashSet<string>();
+        _prompt = prompt;
     }
 
     /// <summary>
@@ -83,44 +104,52 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// <param name="origin">The WebAuthn origin for this client.</param>
     /// <param name="isPublicSuffix">Predicate to determine if a domain is a public suffix.</param>
     /// <param name="enterpriseRpIds">Optional set of enterprise-allowed RP IDs.</param>
+    /// <param name="prompt">
+    /// Optional prompt used to obtain a PIN when an operation needs one and the caller
+    /// did not supply it. When omitted, such operations fail with
+    /// <see cref="WebAuthnClientErrorCode.NotAllowed"/> rather than prompting.
+    /// </param>
     public WebAuthnClient(
         IWebAuthnBackend backend,
         WebAuthnOrigin origin,
         Func<string, bool> isPublicSuffix,
-        IReadOnlySet<string>? enterpriseRpIds = null)
+        IReadOnlySet<string>? enterpriseRpIds = null,
+        ICredentialPrompt? prompt = null)
     {
         _backend = backend ?? throw new ArgumentNullException(nameof(backend));
         _origin = origin ?? throw new ArgumentNullException(nameof(origin));
         _isPublicSuffix = isPublicSuffix ?? throw new ArgumentNullException(nameof(isPublicSuffix));
         _enterpriseRpIds = enterpriseRpIds ?? new HashSet<string>();
+        _prompt = prompt;
     }
 
     /// <summary>
     /// Creates a new WebAuthn credential via CTAP2 MakeCredential.
     /// </summary>
     /// <param name="options">The registration options.</param>
-    /// <param name="pinBytes">Optional PIN bytes (UTF-8 encoded). Caller owns and zeroes this memory.</param>
+    /// <param name="pinBytes">
+    /// Optional PIN bytes (UTF-8 encoded). The caller owns and zeroes this memory. When omitted
+    /// and the operation needs a PIN, the client asks the configured
+    /// <see cref="ICredentialPrompt"/>; if none is configured the operation fails with
+    /// <see cref="WebAuthnClientErrorCode.NotAllowed"/>.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>The registration response with credential details.</returns>
     /// <exception cref="WebAuthnClientError">Thrown on validation or operation failure.</exception>
     /// <remarks>
-    /// This overload is a convenience wrapper that drains the underlying stream and auto-responds
-    /// to PIN requests if pinBytes is provided. For manual control over PIN/UV interaction,
-    /// use <see cref="MakeCredentialStreamAsync"/>.
+    /// To observe ceremony progress (for example, to show a "touch your key" prompt), use
+    /// <see cref="MakeCredentialStreamAsync"/> instead.
     /// </remarks>
     public async Task<RegistrationResponse> MakeCredentialAsync(
         RegistrationOptions options,
-        ReadOnlyMemory<byte>? pinBytes,
+        ReadOnlyMemory<byte>? pinBytes = null,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(options);
 
-        return await DrainInteractiveStreamAsync<RegistrationResponse>(
-            MakeCredentialStreamAsync(options, cancellationToken),
-            pinBytes,
-            useUv: false,
-            MissingPinBehavior.ThrowAfterCancel).ConfigureAwait(false);
+        return await MakeCredentialCoreAsync(options, pinBytes, channel: null, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -135,9 +164,8 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </returns>
     /// <remarks>
     /// <para>
-    /// This overload is a convenience wrapper that drains the underlying stream and auto-responds
-    /// to PIN requests if pinBytes is provided. For manual control over PIN/UV interaction,
-    /// use <see cref="GetAssertionStreamAsync"/>.
+    /// To observe ceremony progress (for example, to show a "touch your key" prompt), use
+    /// <see cref="GetAssertionStreamAsync"/> instead.
     /// </para>
     /// <para>
     /// This method follows the deferred-selection pattern: the authenticator enumerates
@@ -151,17 +179,14 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </remarks>
     public async Task<IReadOnlyList<MatchedCredential>> GetAssertionAsync(
         AuthenticationOptions options,
-        ReadOnlyMemory<byte>? pinBytes,
+        ReadOnlyMemory<byte>? pinBytes = null,
         CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(options);
 
-        return await DrainInteractiveStreamAsync<IReadOnlyList<MatchedCredential>>(
-            GetAssertionStreamAsync(options, cancellationToken),
-            pinBytes,
-            useUv: false,
-            MissingPinBehavior.ThrowAfterCancel).ConfigureAwait(false);
+        return await GetAssertionCoreAsync(options, pinBytes, channel: null, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
     }
 
     /// <summary>
@@ -169,25 +194,35 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </summary>
     /// <param name="options">The registration options.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="pinBytes">
+    /// Optional PIN bytes (UTF-8 encoded). The caller owns and zeroes this memory. When omitted
+    /// and the operation needs a PIN, the client asks the configured
+    /// <see cref="ICredentialPrompt"/>.
+    /// </param>
     /// <returns>
-    /// An async enumerable of status updates. Terminal states are <see cref="WebAuthnStatusFinished{T}"/>
-    /// and <see cref="WebAuthnStatusFailed"/>. Interactive states like <see cref="WebAuthnStatusRequestingPin"/>
-    /// require consumer response to proceed.
+    /// An async enumerable of ceremony status updates. Terminal states are
+    /// <see cref="WebAuthnStatusFinished{T}"/> and <see cref="WebAuthnStatusFailed"/>.
     /// </returns>
     /// <remarks>
-    /// This is the underlying primitive for all MakeCredential operations. When PIN/UV is needed,
-    /// the stream emits <see cref="WebAuthnStatusRequestingPin"/> or <see cref="WebAuthnStatusRequestingUv"/>.
-    /// Consumers must call the provided callbacks to supply the required information.
+    /// <para>
+    /// The stream reports progress; it does not gather input. A PIN, when needed, comes from
+    /// <paramref name="pinBytes"/> or the configured <see cref="ICredentialPrompt"/>.
+    /// </para>
+    /// <para>
+    /// Enumerating the returned sequence starts a ceremony, so enumerating it a second time
+    /// starts another one. Abandoning enumeration early cancels the ceremony in progress.
+    /// </para>
     /// </remarks>
     public async IAsyncEnumerable<WebAuthnStatus> MakeCredentialStreamAsync(
         RegistrationOptions options,
+        ReadOnlyMemory<byte>? pinBytes = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(options);
 
         await foreach (var status in RunStatusStreamAsync<RegistrationResponse>(
-            (channel, producerCt) => MakeCredentialCoreAsync(options, channel, producerCt),
+            (channel, producerCt) => MakeCredentialCoreAsync(options, pinBytes, channel, producerCt),
             cancellationToken).ConfigureAwait(false))
         {
             yield return status;
@@ -198,99 +233,41 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// Authenticates using an existing credential (GetAssertion) with status streaming.
     /// </summary>
     /// <param name="options">The authentication options.</param>
+    /// <param name="pinBytes">
+    /// Optional PIN bytes (UTF-8 encoded). The caller owns and zeroes this memory. When omitted
+    /// and the operation needs a PIN, the client asks the configured
+    /// <see cref="ICredentialPrompt"/>.
+    /// </param>
     /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>
-    /// An async enumerable of status updates. Terminal states are <see cref="WebAuthnStatusFinished{T}"/>
-    /// and <see cref="WebAuthnStatusFailed"/>. Interactive states like <see cref="WebAuthnStatusRequestingPin"/>
-    /// require consumer response to proceed.
+    /// An async enumerable of ceremony status updates. Terminal states are
+    /// <see cref="WebAuthnStatusFinished{T}"/> and <see cref="WebAuthnStatusFailed"/>.
     /// </returns>
     /// <remarks>
-    /// This is the underlying primitive for all GetAssertion operations. The terminal result is a list
-    /// of <see cref="MatchedCredential"/> instances, each exposing <see cref="MatchedCredential.SelectAsync"/>
-    /// for deferred authentication.
+    /// <para>
+    /// The stream reports progress; it does not gather input. A PIN, when needed, comes from
+    /// <paramref name="pinBytes"/> or the configured <see cref="ICredentialPrompt"/>. The terminal
+    /// result is a list of <see cref="MatchedCredential"/> instances, each exposing
+    /// <see cref="MatchedCredential.SelectAsync"/> for deferred authentication.
+    /// </para>
+    /// <para>
+    /// Enumerating the returned sequence starts a ceremony, so enumerating it a second time
+    /// starts another one. Abandoning enumeration early cancels the ceremony in progress.
+    /// </para>
     /// </remarks>
     public async IAsyncEnumerable<WebAuthnStatus> GetAssertionStreamAsync(
         AuthenticationOptions options,
+        ReadOnlyMemory<byte>? pinBytes = null,
         [EnumeratorCancellation] CancellationToken cancellationToken = default)
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
         ArgumentNullException.ThrowIfNull(options);
 
         await foreach (var status in RunStatusStreamAsync<IReadOnlyList<MatchedCredential>>(
-            (channel, producerCt) => GetAssertionCoreAsync(options, channel, producerCt),
+            (channel, producerCt) => GetAssertionCoreAsync(options, pinBytes, channel, producerCt),
             cancellationToken).ConfigureAwait(false))
         {
             yield return status;
-        }
-    }
-
-    /// <summary>
-    /// Creates a new WebAuthn credential with automatic PIN/UV handling.
-    /// </summary>
-    /// <param name="options">The registration options.</param>
-    /// <param name="pin">Optional PIN string. If null and PIN is required, throws <see cref="WebAuthnClientError"/>.</param>
-    /// <param name="useUv">Whether to use user verification when requested.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>The registration response with credential details.</returns>
-    /// <exception cref="WebAuthnClientError">Thrown on validation or operation failure.</exception>
-    /// <remarks>
-    /// This is a convenience wrapper over <see cref="MakeCredentialStreamAsync"/> that automatically responds
-    /// to PIN and UV requests. The PIN string is converted to UTF-8 bytes and zeroed immediately after use.
-    /// </remarks>
-    public async Task<RegistrationResponse> MakeCredentialAsync(
-        RegistrationOptions options,
-        string? pin,
-        bool useUv,
-        CancellationToken cancellationToken = default)
-    {
-        var pinOwner = RentUtf8Pin(pin, out var pinByteCount);
-
-        try
-        {
-            return await DrainInteractiveStreamAsync<RegistrationResponse>(
-                MakeCredentialStreamAsync(options, cancellationToken),
-                pinOwner?.Memory[..pinByteCount],
-                useUv,
-                MissingPinBehavior.DrainFailedStatus).ConfigureAwait(false);
-        }
-        finally
-        {
-            ZeroAndDispose(pinOwner);
-        }
-    }
-
-    /// <summary>
-    /// Authenticates using an existing credential with automatic PIN/UV handling.
-    /// </summary>
-    /// <param name="options">The authentication options.</param>
-    /// <param name="pin">Optional PIN string. If null and PIN is required, throws <see cref="WebAuthnClientError"/>.</param>
-    /// <param name="useUv">Whether to use user verification when requested.</param>
-    /// <param name="cancellationToken">Cancellation token.</param>
-    /// <returns>A list of matched credentials.</returns>
-    /// <exception cref="WebAuthnClientError">Thrown on validation or operation failure.</exception>
-    /// <remarks>
-    /// This is a convenience wrapper over <see cref="GetAssertionStreamAsync"/> that automatically responds
-    /// to PIN and UV requests. The PIN string is converted to UTF-8 bytes and zeroed immediately after use.
-    /// </remarks>
-    public async Task<IReadOnlyList<MatchedCredential>> GetAssertionAsync(
-        AuthenticationOptions options,
-        string? pin,
-        bool useUv,
-        CancellationToken cancellationToken = default)
-    {
-        var pinOwner = RentUtf8Pin(pin, out var pinByteCount);
-
-        try
-        {
-            return await DrainInteractiveStreamAsync<IReadOnlyList<MatchedCredential>>(
-                GetAssertionStreamAsync(options, cancellationToken),
-                pinOwner?.Memory[..pinByteCount],
-                useUv,
-                MissingPinBehavior.DrainFailedStatus).ConfigureAwait(false);
-        }
-        finally
-        {
-            ZeroAndDispose(pinOwner);
         }
     }
 
@@ -366,65 +343,6 @@ public sealed class WebAuthnClient : IAsyncDisposable
         }
     }
 
-    private static async Task<TResult> DrainInteractiveStreamAsync<TResult>(
-        IAsyncEnumerable<WebAuthnStatus> statuses,
-        ReadOnlyMemory<byte>? pinBytes,
-        bool useUv,
-        MissingPinBehavior missingPinBehavior)
-    {
-        await foreach (var status in statuses.ConfigureAwait(false))
-        {
-            switch (status)
-            {
-                case WebAuthnStatusRequestingPin requestingPin:
-                    if (pinBytes is null)
-                    {
-                        await requestingPin.Cancel().ConfigureAwait(false);
-
-                        if (missingPinBehavior == MissingPinBehavior.ThrowAfterCancel)
-                        {
-                            throw new WebAuthnClientError(
-                                WebAuthnClientErrorCode.NotAllowed,
-                                "PIN required but not provided");
-                        }
-
-                        break;
-                    }
-
-                    await requestingPin.SubmitPin(pinBytes.Value).ConfigureAwait(false);
-                    break;
-
-                case WebAuthnStatusRequestingUv requestingUv:
-                    await requestingUv.SetUseUv(useUv).ConfigureAwait(false);
-                    break;
-
-                case WebAuthnStatusFinished<TResult> finished:
-                    return finished.Result;
-
-                case WebAuthnStatusFailed failed:
-                    throw failed.Error;
-            }
-        }
-
-        throw new WebAuthnClientError(
-            WebAuthnClientErrorCode.Unknown,
-            "Stream completed without terminal state");
-    }
-
-    private static IMemoryOwner<byte>? RentUtf8Pin(string? pin, out int pinByteCount)
-    {
-        if (pin is null)
-        {
-            pinByteCount = 0;
-            return null;
-        }
-
-        pinByteCount = Encoding.UTF8.GetByteCount(pin);
-        var pinOwner = MemoryPool<byte>.Shared.Rent(pinByteCount);
-        Encoding.UTF8.GetBytes(pin, pinOwner.Memory.Span);
-        return pinOwner;
-    }
-
     private static void ZeroAndDispose(IMemoryOwner<byte>? owner)
     {
         if (owner is null)
@@ -447,6 +365,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </remarks>
     private async Task<RegistrationResponse> MakeCredentialCoreAsync(
         RegistrationOptions options,
+        ReadOnlyMemory<byte>? callerPinBytes,
         StatusChannel<RegistrationResponse>? channel,
         CancellationToken cancellationToken)
     {
@@ -471,20 +390,20 @@ public sealed class WebAuthnClient : IAsyncDisposable
         var uvDecision = UvDecisionLogic.Decide(
             info,
             options.UserVerification,
-            pinAvailable: channel is not null, // Stream mode can request PIN interactively
+            pinAvailable: callerPinBytes is not null || _prompt is not null,
             requestedPermissions: PinUvAuthTokenPermissions.MakeCredential | PinUvAuthTokenPermissions.GetAssertion);
 
         // Acquire PIN/UV token with retry on PinAuthInvalid
         PinUvAuthTokenSession? tokenSession = null;
         IMemoryOwner<byte>? pinOwner = null;
-        ReadOnlyMemory<byte>? pinBytes = null;
+        ReadOnlyMemory<byte>? pinBytes = callerPinBytes;
+        var keepAliveProgress = CreateKeepAliveObserver(channel);
 
         try
         {
             (tokenSession, pinOwner, pinBytes) = await AcquireTokenForDecisionAsync(
                 uvDecision,
                 options.Rp.Id,
-                channel,
                 pinOwner,
                 pinBytes,
                 cancellationToken).ConfigureAwait(false);
@@ -507,7 +426,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
             MakeCredentialResponse ctapResponse;
             try
             {
-                ctapResponse = await ExecuteMakeCredentialAsync(request, cancellationToken).ConfigureAwait(false);
+                ctapResponse = await ExecuteMakeCredentialAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
             }
             catch (CtapException ex) when (ShouldRetryWithRequiredUv(ex, options.UserVerification))
             {
@@ -517,13 +436,12 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 uvDecision = UvDecisionLogic.Decide(
                     info,
                     Preferences.UserVerificationPreference.Required,
-                    pinAvailable: channel is not null,
+                    pinAvailable: callerPinBytes is not null || _prompt is not null,
                     requestedPermissions: PinUvAuthTokenPermissions.MakeCredential | PinUvAuthTokenPermissions.GetAssertion);
 
                 (tokenSession, pinOwner, pinBytes) = await AcquireTokenForDecisionAsync(
                     uvDecision,
                     options.Rp.Id,
-                    channel,
                     pinOwner,
                     pinBytes,
                     cancellationToken).ConfigureAwait(false);
@@ -539,7 +457,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 request = BuildMakeCredentialRequest(options, clientData, tokenSession, uvDecision, matchedExclude, preflightPerformed);
                 try
                 {
-                    ctapResponse = await ExecuteMakeCredentialAsync(request, cancellationToken).ConfigureAwait(false);
+                    ctapResponse = await ExecuteMakeCredentialAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
                 }
                 catch (CtapException retryEx)
                 {
@@ -591,6 +509,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// </remarks>
     private async Task<IReadOnlyList<MatchedCredential>> GetAssertionCoreAsync(
         AuthenticationOptions options,
+        ReadOnlyMemory<byte>? callerPinBytes,
         StatusChannel<IReadOnlyList<MatchedCredential>>? channel,
         CancellationToken cancellationToken)
     {
@@ -615,20 +534,20 @@ public sealed class WebAuthnClient : IAsyncDisposable
         var uvDecision = UvDecisionLogic.Decide(
             info,
             options.UserVerification,
-            pinAvailable: channel is not null, // Stream mode can request PIN interactively
+            pinAvailable: callerPinBytes is not null || _prompt is not null,
             requestedPermissions: PinUvAuthTokenPermissions.GetAssertion);
 
         // Acquire PIN/UV token with retry on PinAuthInvalid
         PinUvAuthTokenSession? tokenSession = null;
         IMemoryOwner<byte>? pinOwner = null;
-        ReadOnlyMemory<byte>? pinBytes = null;
+        ReadOnlyMemory<byte>? pinBytes = callerPinBytes;
+        var keepAliveProgress = CreateKeepAliveObserver(channel);
 
         try
         {
             (tokenSession, pinOwner, pinBytes) = await AcquireTokenForDecisionAsync(
                 uvDecision,
                 options.RpId,
-                channel,
                 pinOwner,
                 pinBytes,
                 cancellationToken).ConfigureAwait(false);
@@ -640,7 +559,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
             IReadOnlyList<(ReadOnlyMemory<byte> Id, PublicKeyCredentialUserEntity? User, GetAssertionResponse Response)> matches;
             try
             {
-                matches = await MatchCredentialsAsync(request, cancellationToken).ConfigureAwait(false);
+                matches = await MatchCredentialsAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
             }
             catch (CtapException ex) when (ShouldRetryWithRequiredUv(ex, options.UserVerification))
             {
@@ -650,13 +569,12 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 uvDecision = UvDecisionLogic.Decide(
                     info,
                     Preferences.UserVerificationPreference.Required,
-                    pinAvailable: channel is not null,
+                    pinAvailable: callerPinBytes is not null || _prompt is not null,
                     requestedPermissions: PinUvAuthTokenPermissions.GetAssertion);
 
                 (tokenSession, pinOwner, pinBytes) = await AcquireTokenForDecisionAsync(
                     uvDecision,
                     options.RpId,
-                    channel,
                     pinOwner,
                     pinBytes,
                     cancellationToken).ConfigureAwait(false);
@@ -664,7 +582,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
                 request = BuildGetAssertionRequest(options, clientData, tokenSession, uvDecision);
                 try
                 {
-                    matches = await MatchCredentialsAsync(request, cancellationToken).ConfigureAwait(false);
+                    matches = await MatchCredentialsAsync(request, keepAliveProgress, cancellationToken).ConfigureAwait(false);
                 }
                 catch (CtapException retryEx)
                 {
@@ -816,13 +734,47 @@ public sealed class WebAuthnClient : IAsyncDisposable
         ex.Status == CtapStatus.PuatRequired &&
         userVerification != Preferences.UserVerificationPreference.Required;
 
+    /// <summary>
+    /// Builds an observer that republishes authenticator-busy notifications as ceremony statuses,
+    /// so a consumer learns the moment a touch is being awaited.
+    /// </summary>
+    /// <remarks>
+    /// Returns <c>null</c> when nobody is listening, which keeps the non-streaming path free of
+    /// per-keep-alive work. Duplicate statuses are collapsed by the channel.
+    /// </remarks>
+    private static IProgress<CtapStatus>? CreateKeepAliveObserver<T>(StatusChannel<T>? channel)
+    {
+        if (channel is null)
+        {
+            return null;
+        }
+
+        return new KeepAliveObserver<T>(channel);
+    }
+
+    /// <summary>
+    /// Republishes authenticator keep-alive notifications as ceremony statuses.
+    /// </summary>
+    /// <remarks>
+    /// Reports synchronously so a status cannot arrive after the ceremony has completed, and uses
+    /// the non-blocking write so transport notifications can never stall or fail the ceremony.
+    /// </remarks>
+    private sealed class KeepAliveObserver<T>(StatusChannel<T> channel) : IProgress<CtapStatus>
+    {
+        public void Report(CtapStatus value) =>
+            channel.TryWrite(value == CtapStatus.UserActionPending
+                ? new WebAuthnStatusWaitingForUser()
+                : new WebAuthnStatusProcessing());
+    }
+
     private async Task<MakeCredentialResponse> ExecuteMakeCredentialAsync(
         BackendMakeCredentialRequest request,
+        IProgress<CtapStatus>? keepAliveProgress,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await _backend.MakeCredentialAsync(request, progress: null, cancellationToken)
+            return await _backend.MakeCredentialAsync(request, keepAliveProgress, cancellationToken)
                 .ConfigureAwait(false);
         }
         finally
@@ -833,11 +785,12 @@ public sealed class WebAuthnClient : IAsyncDisposable
 
     private async Task<IReadOnlyList<(ReadOnlyMemory<byte> Id, PublicKeyCredentialUserEntity? User, GetAssertionResponse Response)>> MatchCredentialsAsync(
         BackendGetAssertionRequest request,
+        IProgress<CtapStatus>? keepAliveProgress,
         CancellationToken cancellationToken)
     {
         try
         {
-            return await CredentialMatcher.MatchAsync(_backend, request, cancellationToken)
+            return await CredentialMatcher.MatchAsync(_backend, request, cancellationToken, keepAliveProgress)
                 .ConfigureAwait(false);
         }
         finally
@@ -862,10 +815,9 @@ public sealed class WebAuthnClient : IAsyncDisposable
     private async Task<(
         PinUvAuthTokenSession? TokenSession,
         IMemoryOwner<byte>? PinOwner,
-        ReadOnlyMemory<byte>? PinBytes)> AcquireTokenForDecisionAsync<T>(
+        ReadOnlyMemory<byte>? PinBytes)> AcquireTokenForDecisionAsync(
         UvDecision uvDecision,
         string rpId,
-        StatusChannel<T>? channel,
         IMemoryOwner<byte>? pinOwner,
         ReadOnlyMemory<byte>? pinBytes,
         CancellationToken cancellationToken)
@@ -875,25 +827,26 @@ public sealed class WebAuthnClient : IAsyncDisposable
             return (null, pinOwner, pinBytes);
         }
 
-        if (uvDecision.Method == PinUvAuthMethod.Pin && pinBytes is null && channel is not null)
+        if (uvDecision.Method == PinUvAuthMethod.Pin && pinBytes is null)
         {
-            var (pinStatus, pinResponseTask) = channel.CreatePinRequest();
-            await channel.WriteAsync(pinStatus, cancellationToken).ConfigureAwait(false);
-
-            var response = await pinResponseTask.ConfigureAwait(false);
-            if (response is null)
+            if (_prompt is null)
             {
                 throw new WebAuthnClientError(
                     WebAuthnClientErrorCode.NotAllowed,
-                    "PIN required but cancelled");
+                    "A PIN is required for this operation, but none was supplied and no credential prompt is configured.");
             }
 
-            pinOwner = MemoryPool<byte>.Shared.Rent(response.Value.Length);
-            response.Value.Span.CopyTo(pinOwner.Memory.Span);
-            pinBytes = pinOwner.Memory[..response.Value.Length];
+            var (promptedSession, acceptedSecret) = await AcquireTokenViaPromptAsync(
+                uvDecision.Permissions,
+                rpId,
+                cancellationToken).ConfigureAwait(false);
+
+            // The accepted secret is returned so a later token re-mint in the same
+            // ceremony can reuse it; the core operation zeroes and disposes it.
+            return (promptedSession, acceptedSecret, acceptedSecret.Memory);
         }
 
-        var tokenSession = await AcquirePinUvTokenWithRetryAsync(
+        var tokenSession = await AcquirePinUvTokenAsync(
             uvDecision.Method!.Value,
             uvDecision.Permissions,
             rpId,
@@ -938,7 +891,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
             // GetAssertion permission and the same token can no longer authorize a
             // subsequent MakeCredential; the device returns PinAuthInvalid.
             tokenSession.Dispose();
-            tokenSession = await AcquirePinUvTokenWithRetryAsync(
+            tokenSession = await AcquirePinUvTokenAsync(
                 uvDecision.Method!.Value,
                 PinUvAuthTokenPermissions.MakeCredential,
                 options.Rp.Id,
@@ -962,13 +915,15 @@ public sealed class WebAuthnClient : IAsyncDisposable
     }
 
     /// <summary>
-    /// Acquires a PIN/UV auth token from the backend.
+    /// Acquires a PIN/UV auth token from the backend using a secret the caller already supplied.
     /// </summary>
     /// <remarks>
-    /// On PinAuthInvalid, this method throws immediately without retrying. Retrying with identical
-    /// PIN bytes would burn YubiKey PIN attempts on wrong-PIN scenarios.
+    /// A caller-supplied secret is never retried: resubmitting identical PIN bytes would burn
+    /// authenticator attempts without any chance of a different outcome. Deciding whether to ask
+    /// the user again belongs to the caller, or to the prompt-driven path in
+    /// <see cref="AcquireTokenViaPromptAsync"/>.
     /// </remarks>
-    private async Task<PinUvAuthTokenSession> AcquirePinUvTokenWithRetryAsync(
+    private async Task<PinUvAuthTokenSession> AcquirePinUvTokenAsync(
         PinUvAuthMethod method,
         PinUvAuthTokenPermissions permissions,
         string rpId,
@@ -977,26 +932,150 @@ public sealed class WebAuthnClient : IAsyncDisposable
     {
         try
         {
-            var session = await _backend.GetPinUvTokenAsync(
+            return await _backend.GetPinUvTokenAsync(
                 method,
                 permissions,
                 rpId,
                 pinBytes,
                 progress: null,
                 cancellationToken).ConfigureAwait(false);
-
-            return session;
         }
-        catch (CtapException ex) when (ex.Status == CtapStatus.PinAuthInvalid)
+        catch (CtapException ex) when (IsPinRejection(ex.Status))
         {
-            // Throw immediately - do NOT retry with the same PIN bytes.
-            // Retrying would burn PIN attempts on the hardware.
-            throw new WebAuthnClientError(
-                WebAuthnClientErrorCode.NotAllowed,
-                "PIN authentication failed",
-                ex);
+            throw MapPinRejection(ex);
         }
     }
+
+    /// <summary>
+    /// Acquires a PIN/UV auth token by asking <see cref="_prompt"/> for the PIN, re-prompting
+    /// after a rejected attempt.
+    /// </summary>
+    /// <remarks>
+    /// Every attempt comes from a fresh prompt call; a rejected secret is zeroed immediately and
+    /// never resubmitted. The loop stops when the prompt declines, when the authenticator reports
+    /// a terminal PIN state, or when <see cref="MaxPromptAttempts"/> is reached.
+    /// </remarks>
+    /// <returns>
+    /// The token session and the accepted secret, whose ownership passes to the caller.
+    /// </returns>
+    private async Task<(PinUvAuthTokenSession TokenSession, IMemoryOwner<byte> PinOwner)> AcquireTokenViaPromptAsync(
+        PinUvAuthTokenPermissions permissions,
+        string rpId,
+        CancellationToken cancellationToken)
+    {
+        var prompt = _prompt ?? throw new InvalidOperationException("No credential prompt configured.");
+
+        var info = await _backend.GetCachedInfoAsync(cancellationToken).ConfigureAwait(false);
+        var minPinLength = info.MinPinLength ?? Ctap2MinPinLengthBytes;
+        int? retriesRemaining = null;
+
+        for (var attempt = 0; attempt < MaxPromptAttempts; attempt++)
+        {
+            var context = new CredentialPromptContext
+            {
+                Kind = CredentialKind.Pin,
+                Scope = rpId,
+                IsRetry = attempt > 0,
+                RetriesRemaining = retriesRemaining,
+                MinLengthBytes = minPinLength,
+                MaxLengthBytes = Ctap2MaxPinLengthBytes
+            };
+
+            // WaitAsync bounds the wait even if an implementation ignores the token it is handed,
+            // so a stuck prompt cannot strand the operation.
+            var secret = await prompt.RequestSecretAsync(context, cancellationToken)
+                .AsTask()
+                .WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            if (secret is null)
+            {
+                throw new WebAuthnClientError(
+                    WebAuthnClientErrorCode.NotAllowed,
+                    "PIN required but declined");
+            }
+
+            try
+            {
+                var tokenSession = await _backend.GetPinUvTokenAsync(
+                    PinUvAuthMethod.Pin,
+                    permissions,
+                    rpId,
+                    secret.Memory,
+                    progress: null,
+                    cancellationToken).ConfigureAwait(false);
+
+                return (tokenSession, secret);
+            }
+            catch (CtapException ex) when (ex.Status == CtapStatus.PinInvalid
+                                           && attempt + 1 < MaxPromptAttempts)
+            {
+                ZeroAndDispose(secret);
+                retriesRemaining = await TryGetPinRetriesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (CtapException ex) when (IsPinRejection(ex.Status))
+            {
+                ZeroAndDispose(secret);
+                throw MapPinRejection(ex);
+            }
+            catch
+            {
+                ZeroAndDispose(secret);
+                throw;
+            }
+        }
+
+        throw new WebAuthnClientError(
+            WebAuthnClientErrorCode.NotAllowed,
+            $"PIN was rejected on {MaxPromptAttempts} attempts.");
+    }
+
+    /// <summary>
+    /// Reads the authenticator's remaining PIN attempts for display in a retry prompt.
+    /// </summary>
+    /// <remarks>
+    /// Purely informational: a failure to read the counter must not replace the PIN rejection
+    /// the caller is actually dealing with, so all errors collapse to <c>null</c>.
+    /// </remarks>
+    private async Task<int?> TryGetPinRetriesAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await _backend.GetPinRetriesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (CtapException)
+        {
+            return null;
+        }
+        catch (InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    private static bool IsPinRejection(CtapStatus status) =>
+        status is CtapStatus.PinInvalid
+            or CtapStatus.PinBlocked
+            or CtapStatus.PinAuthInvalid
+            or CtapStatus.PinAuthBlocked;
+
+    /// <summary>
+    /// Maps a terminal CTAP PIN status onto the client's error vocabulary, so raw CTAP status
+    /// codes never reach high-level consumers.
+    /// </summary>
+    private static WebAuthnClientError MapPinRejection(CtapException ex) => ex.Status switch
+    {
+        CtapStatus.PinInvalid => new WebAuthnClientError(
+            WebAuthnClientErrorCode.NotAllowed, "PIN was incorrect.", ex),
+        CtapStatus.PinBlocked => new WebAuthnClientError(
+            WebAuthnClientErrorCode.NotAllowed,
+            "PIN is blocked. The authenticator must be reset before it can be used again.", ex),
+        CtapStatus.PinAuthBlocked => new WebAuthnClientError(
+            WebAuthnClientErrorCode.NotAllowed,
+            "PIN authentication is blocked until the authenticator is power-cycled.", ex),
+        _ => new WebAuthnClientError(
+            WebAuthnClientErrorCode.NotAllowed, "PIN authentication failed.", ex)
+    };
 
     private BackendMakeCredentialRequest BuildMakeCredentialRequest(
         RegistrationOptions options,

--- a/src/WebAuthn/src/Internal/ExcludeListPreflight.cs
+++ b/src/WebAuthn/src/Internal/ExcludeListPreflight.cs
@@ -122,7 +122,7 @@ internal static class ExcludeListPreflight
                         PinUvAuthProtocol = (byte)protocol.Version
                     };
 
-                    var response = await backend.GetAssertionAsync(request, progress: null, cancellationToken)
+                    var response = await backend.GetAssertionAsync(request, cancellationToken)
                         .ConfigureAwait(false);
 
                     // Match found - return the credential that matched

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/PreviewSignTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/PreviewSignTests.cs
@@ -64,8 +64,7 @@ public class PreviewSignTests
 
         var response = await client.MakeCredentialAsync(
             regOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotNull(response);
         Assert.True(response.CredentialId.Length > 0);
@@ -129,8 +128,7 @@ public class PreviewSignTests
 
         var regResponse = await regClient.MakeCredentialAsync(
             regOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotNull(regResponse.ClientExtensionResults?.PreviewSign);
 
@@ -189,8 +187,7 @@ public class PreviewSignTests
 
         var matches = await authClient.GetAssertionAsync(
             authOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotEmpty(matches);
 

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientFactoryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientFactoryTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Fido2;
 using Yubico.YubiKit.Fido2.Cose;
@@ -22,7 +23,6 @@ using Yubico.YubiKit.Tests.Shared.Infrastructure;
 using Yubico.YubiKit.WebAuthn.Client;
 using Yubico.YubiKit.WebAuthn.Client.Registration;
 using Yubico.YubiKit.WebAuthn.Preferences;
-
 using static Yubico.YubiKit.WebAuthn.IntegrationTests.WebAuthnTestHelpers;
 
 namespace Yubico.YubiKit.WebAuthn.IntegrationTests;
@@ -93,8 +93,7 @@ public class WebAuthnClientFactoryTests
 
         var response = await client.MakeCredentialAsync(
             options,
-            pin: "11234567",
-            useUv: false,
+            Encoding.UTF8.GetBytes("11234567"),
             CancellationToken.None);
 
         Assert.NotNull(response);

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
@@ -255,18 +255,9 @@ public class WebAuthnClientTests
     /// with no <c>pinUvAuthParam</c> on the wire.
     /// </para>
     /// <para>
-    /// This mirrors the canonical Rust client, whose <c>should_use_uv</c> returns false for
-    /// <c>Discouraged</c> unless user verification is actually configured AND one of: <c>alwaysUv</c>
-    /// is set, <c>makeCredUvNotRqd</c> is unset, or the request needs a permission beyond
-    /// makeCredential/getAssertion. A YubiKey 5.8.0 advertises <c>makeCredUvNotRqd: true</c>, so a
-    /// PIN being set on the key does not by itself force verification here.
-    /// </para>
-    /// <para>
     /// The flag assertions are the point of the test: user presence and user verification are
     /// independent. Touch is still required (CTAP never lets a client set <c>up</c> on
     /// makeCredential, so the authenticator default of true applies), while UV must stay clear.
-    /// An earlier revision of this test asserted <c>NotAllowed</c>; that only passed because the
-    /// client hardcoded "a PIN is available" and then failed for want of one.
     /// </para>
     /// </remarks>
     [SkippableTheory]

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
@@ -132,11 +132,6 @@ public class WebAuthnClientTests
         Assert.Contains(statuses, s => s is WebAuthnStatusProcessing);
         Assert.Contains(statuses, s => s is WebAuthnStatusFinished<RegistrationResponse>);
 
-        // The ceremony above required a touch, so the authenticator must have told us it was
-        // waiting for one. Only real hardware exercises this: it comes from CTAP HID keep-alive
-        // frames, which no fake produces.
-        Assert.Contains(statuses, s => s is WebAuthnStatusWaitingForUser);
-
         var finished = statuses.OfType<WebAuthnStatusFinished<RegistrationResponse>>().Single();
         Assert.True(finished.Result.CredentialId.Length > 0);
     }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
@@ -132,6 +132,11 @@ public class WebAuthnClientTests
         Assert.Contains(statuses, s => s is WebAuthnStatusProcessing);
         Assert.Contains(statuses, s => s is WebAuthnStatusFinished<RegistrationResponse>);
 
+        // The ceremony above required a touch, so the authenticator must have told us it was
+        // waiting for one. Only real hardware exercises this: it comes from CTAP HID keep-alive
+        // frames, which no fake produces.
+        Assert.Contains(statuses, s => s is WebAuthnStatusWaitingForUser);
+
         var finished = statuses.OfType<WebAuthnStatusFinished<RegistrationResponse>>().Single();
         Assert.True(finished.Result.CredentialId.Length > 0);
     }
@@ -244,23 +249,57 @@ public class WebAuthnClientTests
         Assert.True(authResponse.Signature.Length > 0);
     }
 
+    /// <summary>
+    /// Registration with <see cref="UserVerificationPreference.Discouraged"/> and no PIN must
+    /// succeed and produce a credential that was NOT user-verified.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The relying party asking for <c>discouraged</c> is asking for no user verification. Demanding
+    /// a PIN anyway would make a non-UV credential impossible to create, so the ceremony proceeds
+    /// with no <c>pinUvAuthParam</c> on the wire.
+    /// </para>
+    /// <para>
+    /// This mirrors the canonical Rust client, whose <c>should_use_uv</c> returns false for
+    /// <c>Discouraged</c> unless user verification is actually configured AND one of: <c>alwaysUv</c>
+    /// is set, <c>makeCredUvNotRqd</c> is unset, or the request needs a permission beyond
+    /// makeCredential/getAssertion. A YubiKey 5.8.0 advertises <c>makeCredUvNotRqd: true</c>, so a
+    /// PIN being set on the key does not by itself force verification here.
+    /// </para>
+    /// <para>
+    /// The flag assertions are the point of the test: user presence and user verification are
+    /// independent. Touch is still required (CTAP never lets a client set <c>up</c> on
+    /// makeCredential, so the authenticator default of true applies), while UV must stay clear.
+    /// An earlier revision of this test asserted <c>NotAllowed</c>; that only passed because the
+    /// client hardcoded "a PIN is available" and then failed for want of one.
+    /// </para>
+    /// </remarks>
     [SkippableTheory]
     [WithYubiKey(ConnectionType = ConnectionType.HidFido)]
     [Trait(TestCategories.Category, TestCategories.RequiresUserPresence)]
-    public async Task MakeCredential_NoPinProvided_ThrowsNotAllowed(YubiKeyTestState state)
+    public async Task MakeCredential_UvDiscouragedAndNoPinProvided_CreatesNonVerifiedCredential(
+        YubiKeyTestState state)
     {
         await using var session = await state.Device
             .CreateFidoSessionAsync();
 
+        // A PIN is deliberately set on the authenticator. Discouraged must still skip verification.
         await NormalizePinAsync(session);
 
         await using var client = CreateClient(session);
 
         var options = CreateRegistrationOptions();
 
-        var ex = await Assert.ThrowsAsync<WebAuthnClientError>(() =>
-            client.MakeCredentialAsync(options, pinBytes: null));
+        var response = await client.MakeCredentialAsync(options, pinBytes: null);
 
-        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, ex.Code);
+        Assert.NotNull(response);
+        Assert.True(response.CredentialId.Length > 0, "Credential ID should not be empty");
+
+        Assert.True(
+            response.AuthenticatorData.UserPresent,
+            "User presence must be set: makeCredential always requires touch, independent of UV.");
+        Assert.False(
+            response.AuthenticatorData.UserVerified,
+            "User verification must be clear: the relying party asked for UV=Discouraged.");
     }
 }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnClientTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Fido2;
 using Yubico.YubiKit.Fido2.Cose;
@@ -68,8 +69,7 @@ public class WebAuthnClientTests
 
         var response = await client.MakeCredentialAsync(
             options,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotNull(response);
         Assert.True(response.CredentialId.Length > 0, "Credential ID should not be empty");
@@ -97,8 +97,7 @@ public class WebAuthnClientTests
 
         var response = await client.MakeCredentialAsync(
             options,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotNull(response);
         Assert.True(response.CredentialId.Length > 0);
@@ -120,20 +119,13 @@ public class WebAuthnClientTests
         var options = CreateRegistrationOptions();
         var statuses = new List<WebAuthnStatus>();
 
-        await foreach (var status in client.MakeCredentialStreamAsync(options))
+        await foreach (var status in client.MakeCredentialStreamAsync(options, KnownTestPin))
         {
             statuses.Add(status);
 
-            switch (status)
+            if (status is WebAuthnStatusFailed failed)
             {
-                case WebAuthnStatusRequestingPin requestingPin:
-                    await requestingPin.SubmitPin(KnownTestPin);
-                    break;
-                case WebAuthnStatusRequestingUv requestingUv:
-                    await requestingUv.SetUseUv(false);
-                    break;
-                case WebAuthnStatusFailed failed:
-                    throw failed.Error;
+                throw failed.Error;
             }
         }
 
@@ -161,8 +153,7 @@ public class WebAuthnClientTests
 
         var regResponse = await regClient.MakeCredentialAsync(
             regOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotNull(regResponse);
         var credentialId = regResponse.CredentialId;
@@ -191,8 +182,7 @@ public class WebAuthnClientTests
 
         var matches = await authClient.GetAssertionAsync(
             authOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotEmpty(matches);
 
@@ -223,8 +213,7 @@ public class WebAuthnClientTests
 
         var regResponse = await regClient.MakeCredentialAsync(
             regOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         await regClient.DisposeAsync();
 
@@ -243,8 +232,7 @@ public class WebAuthnClientTests
 
         var matches = await authClient.GetAssertionAsync(
             authOptions,
-            pin: "11234567",
-            useUv: false);
+            Encoding.UTF8.GetBytes("11234567"));
 
         Assert.NotEmpty(matches);
 
@@ -271,10 +259,7 @@ public class WebAuthnClientTests
         var options = CreateRegistrationOptions();
 
         var ex = await Assert.ThrowsAsync<WebAuthnClientError>(() =>
-            client.MakeCredentialAsync(
-                options,
-                pin: (string?)null,
-                useUv: false));
+            client.MakeCredentialAsync(options, pinBytes: null));
 
         Assert.Equal(WebAuthnClientErrorCode.NotAllowed, ex.Code);
     }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnExcludeListStressTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.IntegrationTests/WebAuthnExcludeListStressTests.cs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Fido2;
 using Yubico.YubiKit.Fido2.Cose;
@@ -23,7 +24,6 @@ using Yubico.YubiKit.Tests.Shared.Infrastructure;
 using Yubico.YubiKit.WebAuthn.Client.Registration;
 using Yubico.YubiKit.WebAuthn.Preferences;
 using static Yubico.YubiKit.WebAuthn.IntegrationTests.WebAuthnTestHelpers;
-
 using CredentialManagementClass = Yubico.YubiKit.Fido2.CredentialManagement.CredentialManagement;
 
 namespace Yubico.YubiKit.WebAuthn.IntegrationTests;
@@ -162,8 +162,7 @@ public class WebAuthnExcludeListStressTests
 
                     var response = await client.MakeCredentialAsync(
                         options,
-                        pin: "11234567",
-                        useUv: false);
+                        Encoding.UTF8.GetBytes("11234567"));
 
                     createdCredentialIds.Add(response.CredentialId);
                 }
@@ -195,8 +194,7 @@ public class WebAuthnExcludeListStressTests
                 {
                     await client.MakeCredentialAsync(
                         finalOptions,
-                        pin: "11234567",
-                        useUv: false);
+                        Encoding.UTF8.GetBytes("11234567"));
                 });
 
                 Assert.True(

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
@@ -1,0 +1,244 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using NSubstitute;
+using System.Buffers;
+using System.Security.Cryptography;
+using System.Text;
+using Yubico.YubiKit.Core.Credentials;
+using Yubico.YubiKit.Core.Utilities;
+using Yubico.YubiKit.Fido2.Cose;
+using Yubico.YubiKit.Fido2.Credentials;
+using Yubico.YubiKit.Fido2.Ctap;
+using Yubico.YubiKit.Fido2.Pin;
+using Yubico.YubiKit.WebAuthn.Client;
+using Yubico.YubiKit.WebAuthn.Client.Registration;
+using Yubico.YubiKit.WebAuthn.Preferences;
+using Yubico.YubiKit.WebAuthn.UnitTests.TestSupport;
+
+namespace Yubico.YubiKit.WebAuthn.UnitTests.Client;
+
+/// <summary>
+/// Covers the SDK-owned PIN retry loop: the SDK re-prompts after a rejected PIN,
+/// never resubmits a cached secret, surfaces retries-remaining, and stops on
+/// blocked/declined/attempt-cap.
+/// </summary>
+public class CredentialPromptRetryTests
+{
+    /// <summary>Prompt that returns a scripted sequence of answers.</summary>
+    private sealed class ScriptedPrompt : ICredentialPrompt
+    {
+        private readonly Queue<byte[]?> _answers;
+
+        public ScriptedPrompt(params byte[]?[] answers) => _answers = new Queue<byte[]?>(answers);
+
+        public List<CredentialPromptContext> Contexts { get; } = [];
+
+        public ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+            CredentialPromptContext context, CancellationToken cancellationToken)
+        {
+            Contexts.Add(context);
+            var answer = _answers.Count > 0 ? _answers.Dequeue() : null;
+            return ValueTask.FromResult<IMemoryOwner<byte>?>(
+                answer is null ? null : DisposableArrayPoolBuffer.CreateFromSpan(answer));
+        }
+    }
+
+    private static readonly byte[] CorrectPin = Encoding.UTF8.GetBytes("123456");
+    private static readonly byte[] WrongPin = Encoding.UTF8.GetBytes("000000");
+
+    /// <summary>
+    /// Backend whose GetPinUvToken rejects any PIN that is not <see cref="CorrectPin"/>
+    /// with the supplied status, and reports a fixed retries-remaining count.
+    /// </summary>
+    private static IWebAuthnBackend CreateBackend(
+        CtapStatus rejectionStatus = CtapStatus.PinInvalid,
+        int? retriesRemaining = 7,
+        List<byte[]?>? submittedPins = null)
+    {
+        var backend = Substitute.For<IWebAuthnBackend>();
+        backend.GetCachedInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockAuthenticatorInfo(
+                clientPinSupported: true, uvSupported: false));
+
+        backend.GetPinRetriesAsync(Arg.Any<CancellationToken>()).Returns(retriesRemaining);
+
+        backend.GetPinUvTokenAsync(
+                Arg.Any<PinUvAuthMethod>(),
+                Arg.Any<PinUvAuthTokenPermissions>(),
+                Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>?>(),
+                Arg.Any<IProgress<CtapStatus>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var pin = callInfo.ArgAt<ReadOnlyMemory<byte>?>(3);
+                submittedPins?.Add(pin?.ToArray());
+
+                if (pin is null || !pin.Value.Span.SequenceEqual(CorrectPin))
+                {
+                    throw new CtapException(rejectionStatus);
+                }
+
+                return Task.FromResult(new PinUvAuthTokenSession(
+                    new PinUvAuthProtocolV2(), RandomNumberGenerator.GetBytes(32)));
+            });
+
+        backend.MakeCredentialAsync(
+                Arg.Any<BackendMakeCredentialRequest>(),
+                Arg.Any<IProgress<CtapStatus>?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
+
+        return backend;
+    }
+
+    private static RegistrationOptions CreateOptions() => new()
+    {
+        Challenge = RandomNumberGenerator.GetBytes(32),
+        Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
+        User = new PublicKeyCredentialUserEntity(
+            RandomNumberGenerator.GetBytes(16), "user@example.com", "User"),
+        PubKeyCredParams = [new CoseAlgorithm(-7)],
+        UserVerification = UserVerificationPreference.Required
+    };
+
+    private static WebAuthnOrigin Origin()
+    {
+        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
+            throw new InvalidOperationException("Failed to parse origin");
+        return origin;
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task WrongPinThenCorrect_RePromptsWithRetryContext_ThenSucceeds()
+    {
+        var prompt = new ScriptedPrompt(WrongPin, CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+
+        var result = await client.MakeCredentialAsync(
+            CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, prompt.Contexts.Count);
+
+        Assert.False(prompt.Contexts[0].IsRetry);
+        Assert.Equal(CredentialKind.Pin, prompt.Contexts[0].Kind);
+        Assert.Equal("example.com", prompt.Contexts[0].Scope);
+
+        Assert.True(prompt.Contexts[1].IsRetry);
+        Assert.Equal(7, prompt.Contexts[1].RetriesRemaining);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task NeverResubmitsCachedSecret_EachAttemptComesFromAFreshPrompt()
+    {
+        var submitted = new List<byte[]?>();
+        var prompt = new ScriptedPrompt(WrongPin, CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(submittedPins: submitted), Origin(), _ => false, prompt: prompt);
+
+        await client.MakeCredentialAsync(
+            CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken);
+
+        // Exactly one submission per prompt answer - no silent replay of the rejected PIN.
+        Assert.Equal(prompt.Contexts.Count, submitted.Count);
+        Assert.Equal(WrongPin, submitted[0]);
+        Assert.Equal(CorrectPin, submitted[1]);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task PromptDeclinesOnRetry_ThrowsNotAllowed()
+    {
+        var prompt = new ScriptedPrompt(WrongPin, null);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+
+        var error = await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
+
+        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, error.Code);
+        Assert.Equal(2, prompt.Contexts.Count);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task PinBlocked_StopsImmediately_WithoutRePrompting()
+    {
+        var prompt = new ScriptedPrompt(WrongPin, CorrectPin, CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(CtapStatus.PinBlocked), Origin(), _ => false, prompt: prompt);
+
+        await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
+
+        Assert.Single(prompt.Contexts);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task PinAuthInvalid_DoesNotRetry_PreservingPinAttempts()
+    {
+        var prompt = new ScriptedPrompt(WrongPin, CorrectPin, CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(CtapStatus.PinAuthInvalid), Origin(), _ => false, prompt: prompt);
+
+        await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
+
+        Assert.Single(prompt.Contexts);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task RepeatedWrongPin_StopsAtAttemptCap()
+    {
+        // A prompt that always answers wrongly must not burn every hardware attempt.
+        var prompt = new ScriptedPrompt(WrongPin, WrongPin, WrongPin, WrongPin, WrongPin, WrongPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+
+        await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
+
+        Assert.Equal(WebAuthnClient.MaxPromptAttempts, prompt.Contexts.Count);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task ExplicitPinBytes_PromptNeverInvoked()
+    {
+        var prompt = new ScriptedPrompt(CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+
+        var result = await client.MakeCredentialAsync(
+            CreateOptions(), CorrectPin, TestContext.Current.CancellationToken);
+
+        Assert.NotNull(result);
+        Assert.Empty(prompt.Contexts);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task ExplicitWrongPinBytes_DoesNotRetryViaPrompt()
+    {
+        // A caller-supplied secret is the caller's to retry; the SDK must not
+        // silently substitute a prompt for it.
+        var prompt = new ScriptedPrompt(CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+
+        await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(CreateOptions(), WrongPin, TestContext.Current.CancellationToken));
+
+        Assert.Empty(prompt.Contexts);
+    }
+}

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
@@ -36,6 +36,42 @@ namespace Yubico.YubiKit.WebAuthn.UnitTests.Client;
 /// </summary>
 public class CredentialPromptRetryTests
 {
+    private sealed class DelayedPrompt : ICredentialPrompt
+    {
+        private readonly TaskCompletionSource<IMemoryOwner<byte>?> _result =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public TaskCompletionSource Requested { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+            CredentialPromptContext context, CancellationToken cancellationToken)
+        {
+            Requested.TrySetResult();
+            return new ValueTask<IMemoryOwner<byte>?>(_result.Task);
+        }
+
+        public void Complete(IMemoryOwner<byte>? owner) => _result.TrySetResult(owner);
+
+        public void Fault(Exception error) => _result.TrySetException(error);
+    }
+
+    private sealed class TrackingMemoryOwner(params byte[] secret) : IMemoryOwner<byte>
+    {
+        public Memory<byte> Memory => secret;
+
+        public int DisposeCount { get; private set; }
+
+        public TaskCompletionSource Disposed { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public void Dispose()
+        {
+            DisposeCount++;
+            Disposed.TrySetResult();
+        }
+    }
+
     /// <summary>Prompt that returns a scripted sequence of answers.</summary>
     private sealed class ScriptedPrompt : ICredentialPrompt
     {
@@ -198,17 +234,59 @@ public class CredentialPromptRetryTests
     }
 
     [Fact(Timeout = 10000)]
-    public async Task RepeatedWrongPin_StopsAtAttemptCap()
+    public async Task RepeatedWrongPin_InvokesPromptExactlyMaxPromptAttempts()
     {
-        // A prompt that always answers wrongly must not burn every hardware attempt.
+        var submitted = new List<byte[]?>();
         var prompt = new ScriptedPrompt(WrongPin, WrongPin, WrongPin, WrongPin, WrongPin, WrongPin);
         await using var client = new WebAuthnClient(
-            CreateBackend(), Origin(), _ => false, prompt: prompt);
+            CreateBackend(submittedPins: submitted), Origin(), _ => false, prompt: prompt);
 
-        await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+        var error = await Assert.ThrowsAsync<WebAuthnClientError>(() =>
             client.MakeCredentialAsync(CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
 
+        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, error.Code);
         Assert.Equal(WebAuthnClient.MaxPromptAttempts, prompt.Contexts.Count);
+        Assert.Equal(WebAuthnClient.MaxPromptAttempts, submitted.Count);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task CancellationWhilePromptIgnoresToken_LateOwnerIsZeroedAndDisposed()
+    {
+        var prompt = new DelayedPrompt();
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+        using var cts = new CancellationTokenSource();
+
+        var operation = client.MakeCredentialAsync(CreateOptions(), pinBytes: null, cts.Token);
+        await prompt.Requested.Task.WaitAsync(TestContext.Current.CancellationToken);
+        cts.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() => operation);
+        Assert.Equal(cts.Token, exception.CancellationToken);
+
+        var owner = new TrackingMemoryOwner(1, 2, 3, 4, 5, 6);
+        prompt.Complete(owner);
+        await owner.Disposed.Task.WaitAsync(
+            TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
+
+        Assert.All(owner.Memory.ToArray(), value => Assert.Equal(0, value));
+        Assert.Equal(1, owner.DisposeCount);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task CancellationBeforePrompt_DoesNotInvokePrompt()
+    {
+        var prompt = new ScriptedPrompt(CorrectPin);
+        await using var client = new WebAuthnClient(
+            CreateBackend(), Origin(), _ => false, prompt: prompt);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var exception = await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            client.MakeCredentialAsync(CreateOptions(), pinBytes: null, cts.Token));
+
+        Assert.Equal(cts.Token, exception.CancellationToken);
+        Assert.Empty(prompt.Contexts);
     }
 
     [Fact(Timeout = 10000)]

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
@@ -177,6 +177,45 @@ public class CredentialPromptRetryTests
     }
 
     [Fact(Timeout = 10000)]
+    public async Task PromptContext_ReportsMinimumInCodePointsAndMaximumInBytes()
+    {
+        var backend = CreateBackend();
+        backend.GetCachedInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockAuthenticatorInfo(
+                clientPinSupported: true, uvSupported: false, minPinLength: 8));
+        var prompt = new ScriptedPrompt(CorrectPin);
+        await using var client = new WebAuthnClient(
+            backend, Origin(), _ => false, prompt: prompt);
+
+        await client.MakeCredentialAsync(
+            CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken);
+
+        var context = Assert.Single(prompt.Contexts);
+        Assert.Equal(8, context.MinLengthCodePoints);
+        Assert.Equal(63, context.MaxLengthBytes);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task RetryCounterFailure_DoesNotReplacePinRejection()
+    {
+        var backend = CreateBackend();
+        backend.GetPinRetriesAsync(Arg.Any<CancellationToken>())
+            .Returns(Task.FromException<int?>(new IOException("transport failed")));
+        var prompt = new ScriptedPrompt(WrongPin, WrongPin, WrongPin);
+        await using var client = new WebAuthnClient(
+            backend, Origin(), _ => false, prompt: prompt);
+
+        var error = await Assert.ThrowsAsync<WebAuthnClientError>(() =>
+            client.MakeCredentialAsync(
+                CreateOptions(), pinBytes: null, TestContext.Current.CancellationToken));
+
+        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, error.Code);
+        Assert.Equal("PIN was incorrect.", error.Message);
+        Assert.Equal(WebAuthnClient.MaxPromptAttempts, prompt.Contexts.Count);
+        Assert.Null(prompt.Contexts[1].RetriesRemaining);
+    }
+
+    [Fact(Timeout = 10000)]
     public async Task NeverResubmitsCachedSecret_EachAttemptComesFromAFreshPrompt()
     {
         var submitted = new List<byte[]?>();

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CredentialPromptRetryTests.cs
@@ -79,7 +79,6 @@ public class CredentialPromptRetryTests
                 Arg.Any<PinUvAuthTokenPermissions>(),
                 Arg.Any<string?>(),
                 Arg.Any<ReadOnlyMemory<byte>?>(),
-                Arg.Any<IProgress<CtapStatus>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(callInfo =>
             {
@@ -97,7 +96,6 @@ public class CredentialPromptRetryTests
 
         backend.MakeCredentialAsync(
                 Arg.Any<BackendMakeCredentialRequest>(),
-                Arg.Any<IProgress<CtapStatus>?>(),
                 Arg.Any<CancellationToken>())
             .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
 

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
@@ -93,11 +93,11 @@ public class WebAuthnStatusStreamTests
 
         backend.GetPinUvTokenAsync(
                 Arg.Any<PinUvAuthMethod>(), Arg.Any<PinUvAuthTokenPermissions>(), Arg.Any<string?>(),
-                Arg.Any<ReadOnlyMemory<byte>?>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<ReadOnlyMemory<byte>?>(), Arg.Any<CancellationToken>())
             .Returns(new PinUvAuthTokenSession(new PinUvAuthProtocolV2(), RandomNumberGenerator.GetBytes(32)));
 
         backend.MakeCredentialAsync(
-                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<CancellationToken>())
             .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
 
         return backend;
@@ -125,7 +125,7 @@ public class WebAuthnStatusStreamTests
     {
         var backend = CreateBackend();
         backend.GetAssertionAsync(
-                Arg.Any<BackendGetAssertionRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<BackendGetAssertionRequest>(), Arg.Any<CancellationToken>())
             .Returns<GetAssertionResponse>(_ => throw new CtapException(CtapStatus.NoCredentials));
 
         await using var client = new WebAuthnClient(backend, Origin(), _ => false);
@@ -143,36 +143,11 @@ public class WebAuthnStatusStreamTests
     }
 
     [Fact(Timeout = 10000)]
-    public async Task Stream_WhenAuthenticatorAwaitsTouch_EmitsWaitingForUser()
-    {
-        var backend = CreateBackend();
-        backend.MakeCredentialAsync(
-                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                // Mirrors a CTAP HID keep-alive reporting that a touch is awaited.
-                callInfo.ArgAt<IProgress<CtapStatus>?>(1)?.Report(CtapStatus.UserActionPending);
-                return MockFido2Responses.CreateMockMakeCredentialResponse();
-            });
-
-        await using var client = new WebAuthnClient(backend, Origin(), _ => false);
-
-        var statuses = new List<WebAuthnStatus>();
-        await foreach (var status in client.MakeCredentialStreamAsync(
-            RegOptions(), cancellationToken: TestContext.Current.CancellationToken))
-        {
-            statuses.Add(status);
-        }
-
-        Assert.Contains(statuses, s => s is WebAuthnStatusWaitingForUser);
-    }
-
-    [Fact(Timeout = 10000)]
     public async Task Stream_WhenBackendFails_EmitsFailedRatherThanThrowing()
     {
         var backend = CreateBackend();
         backend.MakeCredentialAsync(
-                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<CancellationToken>())
             .Returns<MakeCredentialResponse>(_ => throw new CtapException(CtapStatus.OperationDenied));
 
         await using var client = new WebAuthnClient(backend, Origin(), _ => false);
@@ -309,7 +284,6 @@ public class WebAuthnStatusStreamTests
         // Standard IAsyncEnumerable semantics: each enumeration re-runs the operation.
         await backend.Received(2).MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
@@ -13,13 +13,17 @@
 // limitations under the License.
 
 using NSubstitute;
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
+using Yubico.YubiKit.Core.Credentials;
+using Yubico.YubiKit.Core.Utilities;
 using Yubico.YubiKit.Fido2.Cose;
 using Yubico.YubiKit.Fido2.Credentials;
 using Yubico.YubiKit.Fido2.Ctap;
 using Yubico.YubiKit.Fido2.Pin;
 using Yubico.YubiKit.WebAuthn.Client;
+using Yubico.YubiKit.WebAuthn.Client.Authentication;
 using Yubico.YubiKit.WebAuthn.Client.Registration;
 using Yubico.YubiKit.WebAuthn.Client.Status;
 using Yubico.YubiKit.WebAuthn.Preferences;
@@ -28,406 +32,284 @@ using Yubico.YubiKit.WebAuthn.UnitTests.TestSupport;
 namespace Yubico.YubiKit.WebAuthn.UnitTests.Client.Status;
 
 /// <summary>
-/// Phase 5 tests for WebAuthn status streaming APIs.
+/// The status stream reports ceremony progress. It never gathers input: a PIN comes from the
+/// caller's bytes or the configured <see cref="ICredentialPrompt"/>, and abandoning the stream
+/// cancels the ceremony rather than stranding it.
 /// </summary>
 public class WebAuthnStatusStreamTests
 {
-    [Fact(Timeout = 5000)]
+    private sealed class FixedPrompt(byte[]? pin) : ICredentialPrompt
+    {
+        public int CallCount { get; private set; }
+
+        public ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+            CredentialPromptContext context, CancellationToken cancellationToken)
+        {
+            CallCount++;
+            return ValueTask.FromResult<IMemoryOwner<byte>?>(
+                pin is null ? null : DisposableArrayPoolBuffer.CreateFromSpan(pin));
+        }
+    }
+
+    /// <summary>Worst-case prompt: never answers and ignores the token it is handed.</summary>
+    private sealed class StuckPrompt : ICredentialPrompt
+    {
+        private readonly TaskCompletionSource<IMemoryOwner<byte>?> _never = new();
+
+        public ValueTask<IMemoryOwner<byte>?> RequestSecretAsync(
+            CredentialPromptContext context, CancellationToken cancellationToken) => new(_never.Task);
+    }
+
+    private static WebAuthnOrigin Origin()
+    {
+        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
+            throw new InvalidOperationException("Failed to parse origin");
+        return origin;
+    }
+
+    private static RegistrationOptions RegOptions(
+        UserVerificationPreference uv = UserVerificationPreference.Discouraged) => new()
+        {
+            Challenge = RandomNumberGenerator.GetBytes(32),
+            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
+            User = new PublicKeyCredentialUserEntity(
+            RandomNumberGenerator.GetBytes(16), "user@example.com", "User"),
+            PubKeyCredParams = [new CoseAlgorithm(-7)],
+            UserVerification = uv
+        };
+
+    private static AuthenticationOptions AuthOptions() => new()
+    {
+        Challenge = RandomNumberGenerator.GetBytes(32),
+        RpId = "example.com"
+    };
+
+    private static IWebAuthnBackend CreateBackend(bool pinSupported = false)
+    {
+        var backend = Substitute.For<IWebAuthnBackend>();
+        backend.GetCachedInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockAuthenticatorInfo(
+                clientPinSupported: pinSupported, uvSupported: false));
+
+        backend.GetPinUvTokenAsync(
+                Arg.Any<PinUvAuthMethod>(), Arg.Any<PinUvAuthTokenPermissions>(), Arg.Any<string?>(),
+                Arg.Any<ReadOnlyMemory<byte>?>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+            .Returns(new PinUvAuthTokenSession(new PinUvAuthProtocolV2(), RandomNumberGenerator.GetBytes(32)));
+
+        backend.MakeCredentialAsync(
+                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
+
+        return backend;
+    }
+
+    [Fact(Timeout = 10000)]
     public async Task MakeCredentialStream_HappyPath_EmitsProcessing_ThenFinished()
     {
-        // Arrange - Mock backend that returns success without needing PIN/UV
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: false,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
+        await using var client = new WebAuthnClient(CreateBackend(), Origin(), _ => false);
 
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
-
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
-        {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Discouraged
-        };
-
-        // Act - Iterate the stream and collect statuses
         var statuses = new List<WebAuthnStatus>();
-        await foreach (var status in client.MakeCredentialStreamAsync(options, TestContext.Current.CancellationToken))
+        await foreach (var status in client.MakeCredentialStreamAsync(
+            RegOptions(), cancellationToken: TestContext.Current.CancellationToken))
         {
             statuses.Add(status);
         }
 
-        // Assert - Sequence pattern: starts with Processing, ends with Finished
-        Assert.NotEmpty(statuses);
         Assert.Contains(statuses, s => s is WebAuthnStatusProcessing);
-        Assert.Contains(statuses, s => s is WebAuthnStatusFinished<RegistrationResponse>);
-
         var finished = statuses.OfType<WebAuthnStatusFinished<RegistrationResponse>>().Single();
-        Assert.NotNull(finished.Result);
         Assert.False(finished.Result.CredentialId.IsEmpty);
-        Assert.NotNull(finished.Result.PublicKey);
     }
 
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialStream_NoPin_EmitsRequestingPin_AndResumesAfterSubmit()
+    [Fact(Timeout = 10000)]
+    public async Task GetAssertionStream_NoMatchingCredentials_ReachesFinishedWithEmptyList()
     {
-        // Arrange - Mock backend whose UvDecision wants PIN
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: true,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
+        var backend = CreateBackend();
+        backend.GetAssertionAsync(
+                Arg.Any<BackendGetAssertionRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+            .Returns<GetAssertionResponse>(_ => throw new CtapException(CtapStatus.NoCredentials));
 
-        // Mock GetPinUvTokenAsync to capture the submitted PIN
-        byte[]? capturedPinBytes = null;
-        var mockTokenSession = new PinUvAuthTokenSession(
-            new PinUvAuthProtocolV2(),
-            RandomNumberGenerator.GetBytes(32));
+        await using var client = new WebAuthnClient(backend, Origin(), _ => false);
 
-        mockBackend.GetPinUvTokenAsync(
-            Arg.Any<PinUvAuthMethod>(),
-            Arg.Any<PinUvAuthTokenPermissions>(),
-            Arg.Any<string?>(),
-            Arg.Do<ReadOnlyMemory<byte>?>(pin => capturedPinBytes = pin.HasValue ? pin.Value.ToArray() : null),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(mockTokenSession);
-
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
-
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
-
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
-        {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Required
-        };
-
-        // Act - Iterate stream and respond to RequestingPin
-        bool pinRequested = false;
-        RegistrationResponse? result = null;
-
-        await foreach (var status in client.MakeCredentialStreamAsync(options, TestContext.Current.CancellationToken))
-        {
-            switch (status)
-            {
-                case WebAuthnStatusRequestingPin requestingPin:
-                    pinRequested = true;
-                    var pinBytes = Encoding.UTF8.GetBytes("123456");
-                    await requestingPin.SubmitPin(pinBytes);
-                    break;
-
-                case WebAuthnStatusFinished<RegistrationResponse> finished:
-                    result = finished.Result;
-                    break;
-            }
-        }
-
-        // Assert
-        Assert.True(pinRequested, "RequestingPin should have been emitted");
-        Assert.NotNull(result);
-        Assert.False(result.CredentialId.IsEmpty);
-
-        // Verify PIN was submitted to backend
-        Assert.NotNull(capturedPinBytes);
-        var expectedPin = Encoding.UTF8.GetBytes("123456");
-        Assert.Equal(expectedPin, capturedPinBytes);
-    }
-
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialStream_DeduplicatesConsecutiveProcessing()
-    {
-        // Focused unit test on StatusChannel itself to verify deduplication
-        // (Full integration would require wiring IProgress<CtapStatus> - Phase 6)
-
-        var channel = new StatusChannel<int>();
-
-        // Act - Write multiple identical Processing statuses, then a Finished
-        var writeTask = Task.Run(async () =>
-        {
-            await channel.WriteAsync(new WebAuthnStatusProcessing(), TestContext.Current.CancellationToken);
-            await channel.WriteAsync(new WebAuthnStatusProcessing(), TestContext.Current.CancellationToken); // Should be deduplicated
-            await channel.WriteAsync(new WebAuthnStatusProcessing(), TestContext.Current.CancellationToken); // Should be deduplicated
-            await channel.WriteAsync(new WebAuthnStatusFinished<int>(42), TestContext.Current.CancellationToken);
-            channel.Complete();
-        }, TestContext.Current.CancellationToken);
-
-        // Collect statuses from reader
         var statuses = new List<WebAuthnStatus>();
-        await foreach (var status in channel.Reader(TestContext.Current.CancellationToken))
+        await foreach (var status in client.GetAssertionStreamAsync(
+            AuthOptions(), cancellationToken: TestContext.Current.CancellationToken))
         {
             statuses.Add(status);
         }
 
-        await writeTask;
-
-        // Assert - No two adjacent Processing records
-        Assert.Equal(2, statuses.Count); // Processing, Finished (duplicates removed)
-        Assert.IsType<WebAuthnStatusProcessing>(statuses[0]);
-        Assert.IsType<WebAuthnStatusFinished<int>>(statuses[1]);
-
-        // Double-check: no consecutive duplicates
-        for (int i = 1; i < statuses.Count; i++)
-        {
-            Assert.False(
-                statuses[i].Equals(statuses[i - 1]),
-                $"Found consecutive duplicate statuses at index {i}");
-        }
+        // An empty match is a successful ceremony, not a failure.
+        var finished = statuses.OfType<WebAuthnStatusFinished<IReadOnlyList<MatchedCredential>>>().Single();
+        Assert.Empty(finished.Result);
     }
 
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialDrainConvenience_AutoRespondsWithProvidedPin()
+    [Fact(Timeout = 10000)]
+    public async Task Stream_WhenAuthenticatorAwaitsTouch_EmitsWaitingForUser()
     {
-        // Arrange - Backend wants PIN
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: true,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
-
-        byte[]? capturedPinBytes = null;
-        var mockTokenSession = new PinUvAuthTokenSession(
-            new PinUvAuthProtocolV2(),
-            RandomNumberGenerator.GetBytes(32));
-
-        mockBackend.GetPinUvTokenAsync(
-            Arg.Any<PinUvAuthMethod>(),
-            Arg.Any<PinUvAuthTokenPermissions>(),
-            Arg.Any<string?>(),
-            Arg.Do<ReadOnlyMemory<byte>?>(pin => capturedPinBytes = pin.HasValue ? pin.Value.ToArray() : null),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(mockTokenSession);
-
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
-
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
-
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
-        {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Required
-        };
-
-        // Act - Use convenience overload with string PIN
-        var result = await client.MakeCredentialAsync(options, pin: "654321", useUv: false, TestContext.Current.CancellationToken);
-
-        // Assert
-        Assert.NotNull(result);
-        Assert.False(result.CredentialId.IsEmpty);
-
-        // Verify backend.GetPinUvTokenAsync was called with UTF-8 "654321"
-        await mockBackend.Received(1).GetPinUvTokenAsync(
-            Arg.Any<PinUvAuthMethod>(),
-            Arg.Any<PinUvAuthTokenPermissions>(),
-            Arg.Any<string?>(),
-            Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>());
-
-        Assert.NotNull(capturedPinBytes);
-        var expectedPin = Encoding.UTF8.GetBytes("654321");
-        Assert.Equal(expectedPin, capturedPinBytes);
-    }
-
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialDrainConvenience_NullPinWhenRequired_ThrowsNotAllowed()
-    {
-        // Arrange - Backend wants PIN
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: true,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
-
-        // Should never reach MakeCredentialAsync
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
-
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
-
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
-        {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Required
-        };
-
-        // Act & Assert - Expect WebAuthnClientError with NotAllowed
-        var ex = await Assert.ThrowsAsync<WebAuthnClientError>(
-            async () => await client.MakeCredentialAsync(options, pin: null, useUv: false, TestContext.Current.CancellationToken));
-
-        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, ex.Code);
-
-        // Verify backend.MakeCredentialAsync was NOT invoked
-        await mockBackend.DidNotReceive().MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialDrainConvenience_NullPinBytesWhenRequired_ThrowsNotAllowed()
-    {
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: true,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
-
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
-
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
-
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
-        {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Required
-        };
-
-        var ex = await Assert.ThrowsAsync<WebAuthnClientError>(
-            async () => await client.MakeCredentialAsync(options, pinBytes: null, TestContext.Current.CancellationToken));
-
-        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, ex.Code);
-        Assert.Equal("PIN required but not provided", ex.Message);
-
-        await mockBackend.DidNotReceive().MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>());
-    }
-
-    [Fact(Timeout = 5000)]
-    public async Task MakeCredentialStream_ConsumerBreaks_ProducerCancelledQuickly()
-    {
-        // Arrange - Mock backend with cancellable long-running operation
-        var mockBackend = Substitute.For<IWebAuthnBackend>();
-        var mockInfo = MockFido2Responses.CreateMockAuthenticatorInfo(
-            clientPinSupported: false,
-            uvSupported: false);
-        mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>()).Returns(mockInfo);
-
-        // Track whether MakeCredentialAsync received a cancellation request
-        var receivedCancellation = false;
-        mockBackend.MakeCredentialAsync(
-            Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
-            Arg.Any<CancellationToken>())
-            .Returns(async callInfo =>
+        var backend = CreateBackend();
+        backend.MakeCredentialAsync(
+                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
             {
-                var ct = callInfo.ArgAt<CancellationToken>(2);
-                try
-                {
-                    // Wait indefinitely OR until cancelled
-                    await Task.Delay(Timeout.Infinite, ct);
-                    return MockFido2Responses.CreateMockMakeCredentialResponse();
-                }
-                catch (OperationCanceledException)
-                {
-                    receivedCancellation = true;
-                    throw;
-                }
+                // Mirrors a CTAP HID keep-alive reporting that a touch is awaited.
+                callInfo.ArgAt<IProgress<CtapStatus>?>(1)?.Report(CtapStatus.UserActionPending);
+                return MockFido2Responses.CreateMockMakeCredentialResponse();
             });
 
-        if (!WebAuthnOrigin.TryParse("https://example.com", out var origin))
-            throw new InvalidOperationException("Failed to parse origin");
+        await using var client = new WebAuthnClient(backend, Origin(), _ => false);
 
-        await using var client = new WebAuthnClient(mockBackend, origin, _ => false);
-
-        var options = new RegistrationOptions
+        var statuses = new List<WebAuthnStatus>();
+        await foreach (var status in client.MakeCredentialStreamAsync(
+            RegOptions(), cancellationToken: TestContext.Current.CancellationToken))
         {
-            Challenge = RandomNumberGenerator.GetBytes(32),
-            Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
-            User = new PublicKeyCredentialUserEntity(
-                RandomNumberGenerator.GetBytes(16),
-                "user@example.com",
-                "User"),
-            PubKeyCredParams = [new CoseAlgorithm(-7)],
-            UserVerification = UserVerificationPreference.Discouraged
-        };
-
-        // Act - Consumer breaks after first Processing status
-        var sawProcessing = false;
-        await foreach (var status in client.MakeCredentialStreamAsync(options, TestContext.Current.CancellationToken))
-        {
-            if (status is WebAuthnStatusProcessing)
-            {
-                sawProcessing = true;
-                break; // Consumer breaks early (iterator disposed → linked CTS cancelled)
-            }
+            statuses.Add(status);
         }
 
-        // Assert - Consumer saw Processing before breaking
-        Assert.True(sawProcessing);
+        Assert.Contains(statuses, s => s is WebAuthnStatusWaitingForUser);
+    }
 
-        // Give producer a small window to receive cancellation
-        await Task.Delay(100, TestContext.Current.CancellationToken);
+    [Fact(Timeout = 10000)]
+    public async Task Stream_WhenBackendFails_EmitsFailedRatherThanThrowing()
+    {
+        var backend = CreateBackend();
+        backend.MakeCredentialAsync(
+                Arg.Any<BackendMakeCredentialRequest>(), Arg.Any<IProgress<CtapStatus>?>(), Arg.Any<CancellationToken>())
+            .Returns<MakeCredentialResponse>(_ => throw new CtapException(CtapStatus.OperationDenied));
 
-        // Verify producer received cancellation (not stuck waiting)
-        Assert.True(receivedCancellation, "Producer should have received cancellation when consumer broke");
+        await using var client = new WebAuthnClient(backend, Origin(), _ => false);
+
+        var statuses = new List<WebAuthnStatus>();
+        await foreach (var status in client.MakeCredentialStreamAsync(
+            RegOptions(), cancellationToken: TestContext.Current.CancellationToken))
+        {
+            statuses.Add(status);
+        }
+
+        Assert.Contains(statuses, s => s is WebAuthnStatusFailed);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task Stream_WhenPinNeeded_PromptSuppliesItWithoutAnyStatusInteraction()
+    {
+        var prompt = new FixedPrompt(Encoding.UTF8.GetBytes("123456"));
+        await using var client = new WebAuthnClient(
+            CreateBackend(pinSupported: true), Origin(), _ => false, prompt: prompt);
+
+        var statuses = new List<WebAuthnStatus>();
+        await foreach (var status in client.MakeCredentialStreamAsync(
+            RegOptions(UserVerificationPreference.Required),
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            statuses.Add(status);
+        }
+
+        Assert.Equal(1, prompt.CallCount);
+        Assert.Contains(statuses, s => s is WebAuthnStatusFinished<RegistrationResponse>);
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task Stream_WhenPinNeededAndNoPromptConfigured_EmitsFailed()
+    {
+        await using var client = new WebAuthnClient(
+            CreateBackend(pinSupported: true), Origin(), _ => false);
+
+        var statuses = new List<WebAuthnStatus>();
+        await foreach (var status in client.MakeCredentialStreamAsync(
+            RegOptions(UserVerificationPreference.Required),
+            cancellationToken: TestContext.Current.CancellationToken))
+        {
+            statuses.Add(status);
+        }
+
+        var failed = statuses.OfType<WebAuthnStatusFailed>().Single();
+        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, failed.Error.Code);
+    }
+
+    /// <summary>
+    /// Regression for the deadlock that the interactive-status design allowed: a consumer that
+    /// abandons the stream while the ceremony waits on a prompt must not hang on disposal.
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public async Task Stream_ConsumerBreaksWhileWaitingOnPrompt_DisposalCompletes()
+    {
+        await using var client = new WebAuthnClient(
+            CreateBackend(pinSupported: true), Origin(), _ => false, prompt: new StuckPrompt());
+
+        var enumeration = Task.Run(async () =>
+        {
+            await foreach (var status in client.MakeCredentialStreamAsync(
+                RegOptions(UserVerificationPreference.Required), cancellationToken: CancellationToken.None))
+            {
+                if (status is WebAuthnStatusProcessing)
+                {
+                    await Task.Delay(300);
+                    break;
+                }
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var completed = await Task.WhenAny(
+            enumeration, Task.Delay(10000, TestContext.Current.CancellationToken));
+
+        Assert.True(ReferenceEquals(enumeration, completed),
+            "Abandoning the stream while a prompt is outstanding must not deadlock disposal.");
+        await enumeration;
+    }
+
+    /// <summary>
+    /// Regression for the harsher variant: a well-behaved consumer keeps enumerating and cancels
+    /// its own token. Cancellation must reach the pending prompt.
+    /// </summary>
+    [Fact(Timeout = 20000)]
+    public async Task Stream_ExternalCancellationWhileWaitingOnPrompt_Terminates()
+    {
+        await using var client = new WebAuthnClient(
+            CreateBackend(pinSupported: true), Origin(), _ => false, prompt: new StuckPrompt());
+
+        using var cts = new CancellationTokenSource();
+
+        var enumeration = Task.Run(async () =>
+        {
+            try
+            {
+                await foreach (var status in client.MakeCredentialStreamAsync(
+                    RegOptions(UserVerificationPreference.Required), cancellationToken: cts.Token))
+                {
+                    if (status is WebAuthnStatusProcessing)
+                    {
+                        cts.CancelAfter(300);
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Acceptable terminal outcome.
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var completed = await Task.WhenAny(
+            enumeration, Task.Delay(10000, TestContext.Current.CancellationToken));
+
+        Assert.True(ReferenceEquals(enumeration, completed),
+            "External cancellation must release a ceremony parked on a prompt.");
+        await enumeration;
+    }
+
+    [Fact(Timeout = 10000)]
+    public async Task Stream_ReEnumeration_StartsANewCeremony()
+    {
+        var backend = CreateBackend();
+        await using var client = new WebAuthnClient(backend, Origin(), _ => false);
+
+        var stream = client.MakeCredentialStreamAsync(
+            RegOptions(), cancellationToken: TestContext.Current.CancellationToken);
+
+        await foreach (var _ in stream) { }
+        await foreach (var _ in stream) { }
+
+        // Standard IAsyncEnumerable semantics: each enumeration re-runs the operation.
+        await backend.Received(2).MakeCredentialAsync(
+            Arg.Any<BackendMakeCredentialRequest>(),
+            Arg.Any<IProgress<CtapStatus>?>(),
+            Arg.Any<CancellationToken>());
     }
 }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/Status/WebAuthnStatusStreamTests.cs
@@ -73,7 +73,7 @@ public class WebAuthnStatusStreamTests
             Challenge = RandomNumberGenerator.GetBytes(32),
             Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
             User = new PublicKeyCredentialUserEntity(
-            RandomNumberGenerator.GetBytes(16), "user@example.com", "User"),
+                RandomNumberGenerator.GetBytes(16), "user@example.com", "User"),
             PubKeyCredParams = [new CoseAlgorithm(-7)],
             UserVerification = uv
         };
@@ -199,10 +199,7 @@ public class WebAuthnStatusStreamTests
         Assert.Equal(WebAuthnClientErrorCode.NotAllowed, failed.Error.Code);
     }
 
-    /// <summary>
-    /// Regression for the deadlock that the interactive-status design allowed: a consumer that
-    /// abandons the stream while the ceremony waits on a prompt must not hang on disposal.
-    /// </summary>
+    /// <summary>Abandoning a stream waiting on a prompt must not hang on disposal.</summary>
     [Fact(Timeout = 20000)]
     public async Task Stream_ConsumerBreaksWhileWaitingOnPrompt_DisposalCompletes()
     {
@@ -230,10 +227,7 @@ public class WebAuthnStatusStreamTests
         await enumeration;
     }
 
-    /// <summary>
-    /// Regression for the harsher variant: a well-behaved consumer keeps enumerating and cancels
-    /// its own token. Cancellation must reach the pending prompt.
-    /// </summary>
+    /// <summary>External cancellation must release a stream waiting on a prompt.</summary>
     [Fact(Timeout = 20000)]
     public async Task Stream_ExternalCancellationWhileWaitingOnPrompt_Terminates()
     {

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/UserVerification/UvDecisionLogicTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/UserVerification/UvDecisionLogicTests.cs
@@ -21,14 +21,12 @@ using Yubico.YubiKit.WebAuthn.Preferences;
 namespace Yubico.YubiKit.WebAuthn.UnitTests.Client.UserVerification;
 
 /// <summary>
-/// Truth table for "does this ceremony need a PIN/UV auth token", checked against the canonical
-/// Rust client's <c>should_use_uv</c> (<c>crates/yubikit/src/webauthn/client.rs</c>).
+/// Truth table for whether a ceremony needs a PIN/UV auth token.
 /// </summary>
 /// <remarks>
 /// The case worth protecting is <see cref="UserVerificationPreference.Discouraged"/> on a key that
-/// has a PIN set. Verification must be skipped there. An earlier implementation asked for a token
-/// whenever one was reachable, which meant that merely configuring an <c>ICredentialPrompt</c> was
-/// enough to start demanding PINs for relying parties that had explicitly asked for none.
+/// has a PIN set. Verification must be skipped when no authenticator or permission rule requires it,
+/// and <c>preferred</c> must degrade cleanly when verification is not configured.
 /// </remarks>
 public class UvDecisionLogicTests
 {
@@ -72,8 +70,7 @@ public class UvDecisionLogicTests
 
     /// <summary>
     /// A relying party that discouraged verification gets none, even though the key has a PIN and
-    /// the client could ask for it. This is the regression the prompt feature would otherwise have
-    /// introduced.
+    /// the client could ask for it.
     /// </summary>
     [Fact]
     public void Decide_DiscouragedOnModernKeyWithPinSet_DoesNotRequestToken()
@@ -228,11 +225,6 @@ public class UvDecisionLogicTests
     /// Preferred is the WebAuthn default. On a key with nothing configured it must degrade to an
     /// unverified credential rather than fail.
     /// </summary>
-    /// <remarks>
-    /// Deliberate divergence from canonical Rust, which tests whether the option is advertised
-    /// rather than enabled and would therefore fail here. See the comment in
-    /// <c>UvDecisionLogic.ShouldUseUv</c>.
-    /// </remarks>
     [Fact]
     public void Decide_PreferredOnKeyWithNoUvConfigured_DegradesToNoUv()
     {

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/UserVerification/UvDecisionLogicTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/UserVerification/UvDecisionLogicTests.cs
@@ -1,0 +1,407 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Fido2;
+using Yubico.YubiKit.Fido2.Pin;
+using Yubico.YubiKit.WebAuthn.Client;
+using Yubico.YubiKit.WebAuthn.Client.UserVerification;
+using Yubico.YubiKit.WebAuthn.Preferences;
+
+namespace Yubico.YubiKit.WebAuthn.UnitTests.Client.UserVerification;
+
+/// <summary>
+/// Truth table for "does this ceremony need a PIN/UV auth token", checked against the canonical
+/// Rust client's <c>should_use_uv</c> (<c>crates/yubikit/src/webauthn/client.rs</c>).
+/// </summary>
+/// <remarks>
+/// The case worth protecting is <see cref="UserVerificationPreference.Discouraged"/> on a key that
+/// has a PIN set. Verification must be skipped there. An earlier implementation asked for a token
+/// whenever one was reachable, which meant that merely configuring an <c>ICredentialPrompt</c> was
+/// enough to start demanding PINs for relying parties that had explicitly asked for none.
+/// </remarks>
+public class UvDecisionLogicTests
+{
+    private const PinUvAuthTokenPermissions MakeCredentialPermissions =
+        PinUvAuthTokenPermissions.MakeCredential | PinUvAuthTokenPermissions.GetAssertion;
+
+    private const PinUvAuthTokenPermissions GetAssertionPermissions =
+        PinUvAuthTokenPermissions.GetAssertion;
+
+    private const PinUvAuthTokenPermissions LargeBlobWritePermissions =
+        PinUvAuthTokenPermissions.MakeCredential
+        | PinUvAuthTokenPermissions.GetAssertion
+        | PinUvAuthTokenPermissions.LargeBlobWrite;
+
+    /// <summary>
+    /// Builds authenticator info from the four options that drive the decision. A <c>null</c>
+    /// argument means the authenticator does not advertise the option at all, which is a different
+    /// state from advertising it as <c>false</c>.
+    /// </summary>
+    private static AuthenticatorInfo InfoWithOptions(
+        bool? clientPin = null,
+        bool? uv = null,
+        bool? alwaysUv = null,
+        bool? makeCredUvNotRqd = null,
+        bool? bioEnroll = null)
+    {
+        var options = new Dictionary<string, bool>(StringComparer.Ordinal);
+
+        if (clientPin is { } clientPinValue) options["clientPin"] = clientPinValue;
+        if (uv is { } uvValue) options["uv"] = uvValue;
+        if (alwaysUv is { } alwaysUvValue) options["alwaysUv"] = alwaysUvValue;
+        if (makeCredUvNotRqd is { } makeCredValue) options["makeCredUvNotRqd"] = makeCredValue;
+        if (bioEnroll is { } bioEnrollValue) options["bioEnroll"] = bioEnrollValue;
+
+        return new AuthenticatorInfo { Options = options };
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Discouraged
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// A relying party that discouraged verification gets none, even though the key has a PIN and
+    /// the client could ask for it. This is the regression the prompt feature would otherwise have
+    /// introduced.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedOnModernKeyWithPinSet_DoesNotRequestToken()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+        Assert.False(decision.UseUv);
+        Assert.Null(decision.UvOption);
+        Assert.Null(decision.Method);
+    }
+
+    /// <summary>
+    /// A pre-CTAP-2.1 authenticator does not advertise <c>makeCredUvNotRqd</c>, and refuses an
+    /// unverified makeCredential once a PIN is set. Verification is required despite the
+    /// preference.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData(false)]
+    public void Decide_DiscouragedMakeCredentialWithoutMakeCredUvNotRqd_RequestsToken(
+        bool? makeCredUvNotRqd)
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: makeCredUvNotRqd);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+        Assert.Equal(PinUvAuthMethod.Pin, decision.Method);
+    }
+
+    /// <summary>
+    /// The same pre-CTAP-2.1 authenticator still allows an unverified getAssertion: the
+    /// makeCredential-specific rule must not leak into authentication.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedGetAssertionWithoutMakeCredUvNotRqd_DoesNotRequestToken()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            GetAssertionPermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    /// <summary>
+    /// An authenticator configured to always verify outranks the relying party's preference.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedButAlwaysUvEnabled_RequestsToken()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, alwaysUv: true, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+    }
+
+    /// <summary>
+    /// <c>alwaysUv</c> cannot force verification that the key has no way to perform.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedWithAlwaysUvButNothingConfigured_DoesNotRequestToken()
+    {
+        var info = InfoWithOptions(clientPin: false, alwaysUv: true, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    /// <summary>
+    /// Permissions beyond an ordinary ceremony (here a large-blob write) require verification
+    /// whatever the relying party asked for.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedWithPrivilegedPermission_RequestsToken()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            LargeBlobWritePermissions);
+
+        Assert.True(decision.UseToken);
+    }
+
+    /// <summary>
+    /// A privileged permission still cannot conjure verification on a key that has none configured.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedWithPrivilegedPermissionButNoUvConfigured_DoesNotRequestToken()
+    {
+        var info = InfoWithOptions(clientPin: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            LargeBlobWritePermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    /// <summary>
+    /// A key with no PIN set still advertises <c>clientPin: false</c>. Reading that as "verification
+    /// is available" is the classic misread; it must count as not configured.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedOnKeyWithNoPinSet_DoesNotRequestToken()
+    {
+        var info = InfoWithOptions(clientPin: false, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Preferred
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Preferred is the WebAuthn default. On a key with nothing configured it must degrade to an
+    /// unverified credential rather than fail.
+    /// </summary>
+    /// <remarks>
+    /// Deliberate divergence from canonical Rust, which tests whether the option is advertised
+    /// rather than enabled and would therefore fail here. See the comment in
+    /// <c>UvDecisionLogic.ShouldUseUv</c>.
+    /// </remarks>
+    [Fact]
+    public void Decide_PreferredOnKeyWithNoUvConfigured_DegradesToNoUv()
+    {
+        var info = InfoWithOptions(clientPin: false, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Preferred,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    /// <summary>
+    /// Preferred uses verification whenever the key actually has some.
+    /// </summary>
+    [Fact]
+    public void Decide_PreferredOnKeyWithPinSet_RequestsToken()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Preferred,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+        Assert.Equal(PinUvAuthMethod.Pin, decision.Method);
+
+        // Only Required pins the CTAP 'uv' option to true; Preferred leaves it unset.
+        Assert.Null(decision.UvOption);
+    }
+
+    /// <summary>
+    /// With a PIN set but no way to obtain it, Preferred proceeds unverified instead of failing.
+    /// </summary>
+    [Fact]
+    public void Decide_PreferredWithPinSetButUnobtainable_DegradesToNoUv()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Preferred,
+            pinAvailable: false,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+    }
+
+    /// <summary>
+    /// Built-in verification (biometrics) is used when no PIN can be obtained.
+    /// </summary>
+    [Fact]
+    public void Decide_PreferredWithBuiltInUvAndNoPin_UsesBuiltInUv()
+    {
+        var info = InfoWithOptions(clientPin: false, uv: true, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Preferred,
+            pinAvailable: false,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+        Assert.True(decision.UseUv);
+        Assert.Equal(PinUvAuthMethod.Uv, decision.Method);
+        Assert.True(decision.UvOption);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Required
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Required always verifies, and pins the CTAP <c>uv</c> option to true.
+    /// </summary>
+    [Fact]
+    public void Decide_RequiredWithPinSet_RequestsTokenAndSetsUvOption()
+    {
+        var info = InfoWithOptions(clientPin: true, uv: false, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Required,
+            pinAvailable: true,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+        Assert.Equal(PinUvAuthMethod.Pin, decision.Method);
+        Assert.True(decision.UvOption);
+    }
+
+    /// <summary>
+    /// Required is the one preference that fails rather than degrading, because the relying party
+    /// asked for a guarantee the authenticator cannot give.
+    /// </summary>
+    [Theory]
+    [InlineData(false, false, true)]  // PIN set but unobtainable
+    [InlineData(false, true, false)]  // no PIN configured at all
+    public void Decide_RequiredWithNoUsableMethod_ThrowsNotAllowed(
+        bool uv,
+        bool clientPin,
+        bool pinAvailable)
+    {
+        var info = InfoWithOptions(clientPin: clientPin, uv: uv, makeCredUvNotRqd: true);
+
+        var error = Assert.Throws<WebAuthnClientError>(() => UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Required,
+            pinAvailable,
+            MakeCredentialPermissions));
+
+        Assert.Equal(WebAuthnClientErrorCode.NotAllowed, error.Code);
+    }
+
+    /// <summary>
+    /// Required is satisfied by built-in verification without any PIN.
+    /// </summary>
+    [Fact]
+    public void Decide_RequiredWithBuiltInUvOnly_UsesBuiltInUv()
+    {
+        var info = InfoWithOptions(clientPin: false, uv: true, makeCredUvNotRqd: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Required,
+            pinAvailable: false,
+            MakeCredentialPermissions);
+
+        Assert.True(decision.UseToken);
+        Assert.True(decision.UseUv);
+        Assert.Equal(PinUvAuthMethod.Uv, decision.Method);
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Escalation without a usable method
+    // ---------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// When an override wants verification but no method can supply it, a non-Required ceremony
+    /// proceeds unverified rather than failing on the client's own reading of the options. If the
+    /// authenticator truly insists it answers <c>CTAP2_ERR_PUAT_REQUIRED</c>, and the client retries
+    /// with Required.
+    /// </summary>
+    [Fact]
+    public void Decide_DiscouragedEscalatedButPinUnobtainable_ProceedsWithoutUv()
+    {
+        // bioEnroll makes verification "configured", and the missing makeCredUvNotRqd forces UV,
+        // but there is no PIN to fetch and no built-in uv to fall back on.
+        var info = InfoWithOptions(clientPin: true, uv: false, bioEnroll: true);
+
+        var decision = UvDecisionLogic.Decide(
+            info,
+            UserVerificationPreference.Discouraged,
+            pinAvailable: false,
+            MakeCredentialPermissions);
+
+        Assert.False(decision.UseToken);
+        Assert.Null(decision.Method);
+    }
+
+    [Fact]
+    public void Decide_NullInfo_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => UvDecisionLogic.Decide(
+            info: null!,
+            UserVerificationPreference.Preferred,
+            pinAvailable: true,
+            MakeCredentialPermissions));
+}

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
@@ -15,6 +15,7 @@
 using NSubstitute;
 using System.Formats.Cbor;
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Fido2.Credentials;
 using Yubico.YubiKit.Fido2.Ctap;
 using Yubico.YubiKit.Fido2.Pin;
@@ -260,7 +261,7 @@ public class WebAuthnClientGetAssertionTests
             });
 
         // Act
-        var result = await _client.GetAssertionAsync(options, "123456", useUv: false, CancellationToken.None);
+        var result = await _client.GetAssertionAsync(options, Encoding.UTF8.GetBytes("123456"), CancellationToken.None);
 
         // Assert
         Assert.Single(result);
@@ -305,7 +306,7 @@ public class WebAuthnClientGetAssertionTests
             });
 
         // Act
-        var result = await _client.GetAssertionAsync(options, "123456", useUv: false, CancellationToken.None);
+        var result = await _client.GetAssertionAsync(options, Encoding.UTF8.GetBytes("123456"), CancellationToken.None);
 
         // Assert
         Assert.Empty(result);

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
@@ -64,7 +64,6 @@ public class WebAuthnClientGetAssertionTests
         BackendGetAssertionRequest? capturedRequest = null;
         _mockBackend.GetAssertionAsync(
             Arg.Do<BackendGetAssertionRequest>(r => capturedRequest = r),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(credentialId));
 
@@ -111,7 +110,6 @@ public class WebAuthnClientGetAssertionTests
 
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(credentialId, numberOfCredentials: 1));
 
@@ -141,7 +139,6 @@ public class WebAuthnClientGetAssertionTests
         // First call returns numberOfCredentials = 3
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(cred1, numberOfCredentials: 3));
 
@@ -172,7 +169,6 @@ public class WebAuthnClientGetAssertionTests
 
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(credentialId));
 
@@ -190,7 +186,6 @@ public class WebAuthnClientGetAssertionTests
         // Backend GetAssertion should have been called only once during GetAssertionAsync
         await _mockBackend.Received(1).GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -208,7 +203,6 @@ public class WebAuthnClientGetAssertionTests
 
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(credentialId, signature: signature));
 
@@ -232,7 +226,6 @@ public class WebAuthnClientGetAssertionTests
             PinUvAuthTokenPermissions.GetAssertion,
             "example.com",
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ => new PinUvAuthTokenSession(new TestPinUvAuthProtocol(), new byte[32]));
 
@@ -247,7 +240,6 @@ public class WebAuthnClientGetAssertionTests
         var callCount = 0;
         _mockBackend.GetAssertionAsync(
             Arg.Do<BackendGetAssertionRequest>(r => requests.Add(r)),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
@@ -284,7 +276,6 @@ public class WebAuthnClientGetAssertionTests
             PinUvAuthTokenPermissions.GetAssertion,
             "example.com",
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ => new PinUvAuthTokenSession(new TestPinUvAuthProtocol(), new byte[32]));
 
@@ -297,7 +288,6 @@ public class WebAuthnClientGetAssertionTests
         var callCount = 0;
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns<GetAssertionResponse>(_ =>
             {
@@ -327,7 +317,6 @@ public class WebAuthnClientGetAssertionTests
         // Backend throws "no credentials" CTAP error
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns<GetAssertionResponse>(x => throw new CtapException(CtapStatus.NoCredentials));
 
@@ -352,7 +341,6 @@ public class WebAuthnClientGetAssertionTests
 
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockGetAssertionResponse(credentialId));
 

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
@@ -16,6 +16,7 @@ using NSubstitute;
 using NSubstitute.ExceptionExtensions;
 using System.Formats.Cbor;
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Fido2.Cose;
 using Yubico.YubiKit.Fido2.Credentials;
 using Yubico.YubiKit.Fido2.Ctap;
@@ -298,7 +299,7 @@ public class WebAuthnClientMakeCredentialTests
             });
 
         // Act
-        await _client.MakeCredentialAsync(options, "123456", useUv: false, CancellationToken.None);
+        await _client.MakeCredentialAsync(options, Encoding.UTF8.GetBytes("123456"), CancellationToken.None);
 
         // Assert
         Assert.Equal(2, requests.Count);
@@ -356,7 +357,7 @@ public class WebAuthnClientMakeCredentialTests
             });
 
         // Act
-        await _client.MakeCredentialAsync(options, "123456", useUv: false, CancellationToken.None);
+        await _client.MakeCredentialAsync(options, Encoding.UTF8.GetBytes("123456"), CancellationToken.None);
 
         // Assert
         Assert.Equal(4, tokenPermissions.Count);

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
@@ -68,7 +68,6 @@ public class WebAuthnClientMakeCredentialTests
         BackendMakeCredentialRequest? capturedRequest = null;
         _mockBackend.MakeCredentialAsync(
             Arg.Do<BackendMakeCredentialRequest>(r => capturedRequest = r),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse());
 
@@ -121,7 +120,6 @@ public class WebAuthnClientMakeCredentialTests
 
         _mockBackend.MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse());
 
@@ -131,7 +129,6 @@ public class WebAuthnClientMakeCredentialTests
         // Assert - verify backend was called
         await _mockBackend.Received(1).MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -155,7 +152,6 @@ public class WebAuthnClientMakeCredentialTests
 
         _mockBackend.MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse());
 
@@ -165,7 +161,6 @@ public class WebAuthnClientMakeCredentialTests
         // Assert - verify backend was called
         await _mockBackend.Received(1).MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -185,7 +180,6 @@ public class WebAuthnClientMakeCredentialTests
         BackendMakeCredentialRequest? capturedRequest = null;
         _mockBackend.MakeCredentialAsync(
             Arg.Do<BackendMakeCredentialRequest>(r => capturedRequest = r),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse());
 
@@ -213,7 +207,6 @@ public class WebAuthnClientMakeCredentialTests
         var expectedGuid = Guid.NewGuid();
         _mockBackend.MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse(expectedGuid));
 
@@ -242,7 +235,6 @@ public class WebAuthnClientMakeCredentialTests
         BackendMakeCredentialRequest? capturedRequest = null;
         _mockBackend.MakeCredentialAsync(
             Arg.Do<BackendMakeCredentialRequest>(r => capturedRequest = r),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(CreateMockResponse());
 
@@ -254,7 +246,6 @@ public class WebAuthnClientMakeCredentialTests
         Assert.Same(options.ExcludeCredentials, capturedRequest.ExcludeList);
         await _mockBackend.DidNotReceive().GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -269,7 +260,6 @@ public class WebAuthnClientMakeCredentialTests
             Arg.Any<PinUvAuthTokenPermissions>(),
             "example.com",
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ => new PinUvAuthTokenSession(new TestPinUvAuthProtocol(), new byte[32]));
 
@@ -285,7 +275,6 @@ public class WebAuthnClientMakeCredentialTests
         var callCount = 0;
         _mockBackend.MakeCredentialAsync(
             Arg.Do<BackendMakeCredentialRequest>(r => requests.Add(r)),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
@@ -322,12 +311,10 @@ public class WebAuthnClientMakeCredentialTests
             Arg.Do<PinUvAuthTokenPermissions>(p => tokenPermissions.Add(p)),
             "example.com",
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ => new PinUvAuthTokenSession(new TestPinUvAuthProtocol(), new byte[32]));
         _mockBackend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Throws(new CtapException(CtapStatus.NoCredentials));
 
@@ -343,7 +330,6 @@ public class WebAuthnClientMakeCredentialTests
         var callCount = 0;
         _mockBackend.MakeCredentialAsync(
             Arg.Any<BackendMakeCredentialRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(_ =>
             {
@@ -371,7 +357,6 @@ public class WebAuthnClientMakeCredentialTests
         Assert.Equal(PinUvAuthTokenPermissions.MakeCredential, tokenPermissions[3]);
         await _mockBackend.Received(2).GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientPinRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientPinRetryTests.cs
@@ -70,7 +70,6 @@ public sealed class WebAuthnClientPinRetryTests
             Arg.Any<PinUvAuthTokenPermissions>(),
             Arg.Any<string?>(),
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Throws(new CtapException(CtapStatus.PinAuthInvalid))
             .AndDoes(_ => _tokenCallCount++);
@@ -107,7 +106,6 @@ public sealed class WebAuthnClientPinRetryTests
             Arg.Any<PinUvAuthTokenPermissions>(),
             Arg.Any<string?>(),
             Arg.Any<ReadOnlyMemory<byte>?>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Throws(new CtapException(CtapStatus.PinAuthInvalid))
             .AndDoes(_ => _tokenCallCount++);

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientPinRetryTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientPinRetryTests.cs
@@ -31,10 +31,6 @@ namespace Yubico.YubiKit.WebAuthn.UnitTests.Client;
 /// <summary>
 /// Tests for PIN retry behavior in WebAuthnClient.
 /// </summary>
-/// <remarks>
-/// These tests verify that PinAuthInvalid errors are handled correctly without
-/// burning YubiKey PIN attempts through unsafe retry loops.
-/// </remarks>
 public sealed class WebAuthnClientPinRetryTests
 {
     private readonly IWebAuthnBackend _mockBackend;

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Internal/ExcludeListPreflightTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Internal/ExcludeListPreflightTests.cs
@@ -59,7 +59,6 @@ public class ExcludeListPreflightTests
         // Verify backend was never called
         await backend.DidNotReceive().GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -83,7 +82,6 @@ public class ExcludeListPreflightTests
         var mockResponse = BuildMockGetAssertionResponse(credentialId);
         backend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(mockResponse);
 
@@ -121,7 +119,6 @@ public class ExcludeListPreflightTests
         // Mock backend to throw NoCredentials (no match in this chunk)
         backend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Throws(new CtapException(CtapStatus.NoCredentials));
 
@@ -160,7 +157,6 @@ public class ExcludeListPreflightTests
         var callCount = 0;
         backend.GetAssertionAsync(
             Arg.Any<BackendGetAssertionRequest>(),
-            Arg.Any<IProgress<CtapStatus>?>(),
             Arg.Any<CancellationToken>())
             .Returns(ci =>
             {

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/TestSupport/MockFido2Responses.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/TestSupport/MockFido2Responses.cs
@@ -34,7 +34,8 @@ internal static class MockFido2Responses
 
     public static AuthenticatorInfo CreateMockAuthenticatorInfo(
         bool clientPinSupported = false,
-        bool uvSupported = false)
+        bool uvSupported = false,
+        int? minPinLength = null)
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
 
@@ -42,7 +43,8 @@ internal static class MockFido2Responses
         if (clientPinSupported) optionsCount++;
         if (uvSupported) optionsCount++;
 
-        writer.WriteStartMap(optionsCount > 0 ? 4 : 3);
+        var mapSize = (optionsCount > 0 ? 4 : 3) + (minPinLength.HasValue ? 1 : 0);
+        writer.WriteStartMap(mapSize);
 
         // 0x01: versions
         writer.WriteInt32(1);
@@ -80,6 +82,13 @@ internal static class MockFido2Responses
             }
 
             writer.WriteEndMap();
+        }
+
+        // 0x0D: minimum PIN length in Unicode code points (optional)
+        if (minPinLength.HasValue)
+        {
+            writer.WriteInt32(0x0D);
+            writer.WriteInt32(minPinLength.Value);
         }
 
         writer.WriteEndMap();


### PR DESCRIPTION
Adds `ICredentialPrompt`, an asynchronous context-carrying prompt abstraction in Core, and adopts it in WebAuthn while keeping status streams observation-only.

## Credential prompting

- Returning `null` means the user declined. Cancellation and failures throw.
- A successful prompt result transfers ownership to the SDK, which zeroes and disposes it after use.
- Rejected PINs are never resubmitted; each retry requests a fresh secret and receives updated context.
- Retry-counter lookup is informational and cannot replace the original PIN rejection; caller cancellation still propagates.
- `MinLengthCodePoints` reflects the authenticator minimum, while `MaxLengthBytes` reflects the UTF-8 encoded limit.
- `ICredentialPrompt` is an SDK-to-application callback; `ISecureCredentialReader` remains an application-initiated terminal helper.
- `MaxPromptAttempts` limits SDK prompt calls per operation. Authenticator retry state remains separate.
- Late prompt results returned after cancellation are observed, zeroed, and disposed.

## WebAuthn behavior

- `WebAuthnStatus` values report progress and results but never gather input or carry response callbacks.
- No dedicated in-flight touch notification is exposed; user guidance can only be speculative.
- `UserVerificationRequirement.Discouraged` does not request verification unless an authenticator constraint or requested permission requires it.
- RP ID enforcement uses `RpIdValidator` and requires a caller-supplied Public Suffix List-backed checker.
- Extensions use internal static adapters coordinated by `ExtensionPipeline`; encoded maps and parsed outputs require explicit coverage.

## Verification

- WebAuthn unit tests: 182 passed
- Credential prompt retry and late-owner tests: 12 passed
- Existing console credential reader tests: 10 passed
- Documentation quality: 58 active files passed
- Full solution build: passed
- Package build with XML documentation: 10 packages, zero warnings
- Separate cross-vendor review of the final base-to-head change: passed with no blocking findings

Hardware user-presence ceremonies were not rerun during this documentation remediation.

Abbreviations: PIN means personal identification number; RP ID means relying party identifier; SDK means software development kit; UTF-8 means Unicode Transformation Format, 8-bit; XML means Extensible Markup Language.