### PR TITLE
fix(toolchain): fail when a test filter matches nothing

### DIFF
--- a/.claude/skills/domain-test/SKILL.md
+++ b/.claude/skills/domain-test/SKILL.md
@@ -96,6 +96,23 @@ The `--filter` option supports various patterns:
 | `Category!=RequiresHardware` | Exclude tests needing physical YubiKey |
 | `Category!=Slow` | Exclude slow tests (>5 seconds) |
 
+### Reading the result — two traps
+
+**Judge a run by the per-project `total:` line, never the closing summary.** That last line —
+`Passed: 1 | Failed: 0 | Skipped: 1 | Total: 2` — counts **projects**, not tests. Grepping for
+`Passed:` will report success for a run that executed nothing:
+
+```bash
+dotnet toolchain.cs -- test --project Core --filter "FullyQualifiedName~MyThing" \
+  | grep -E "total:|failed:"
+```
+
+**`Method~` is not a VSTest property.** Unit projects run xUnit v3 / Microsoft Testing Platform;
+integration projects run xUnit v2 under VSTest, which only knows `FullyQualifiedName`,
+`DisplayName` and traits. The toolchain normalises `Method~`/`Name~` to `FullyQualifiedName~` for
+those projects so both runners accept one syntax, and a filter matching zero tests now fails the
+target rather than reporting green. Prefer `FullyQualifiedName~` when you want to be exact.
+
 ### Test Category Traits
 
 Tests are categorized using `TestCategories` constants from `Yubico.YubiKit.Tests.Shared.Infrastructure`:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,10 +9,12 @@
 - Use .NET 10 SDK. The repo defaults to `net10.0`, C# 14, nullable enabled, central package management, and warnings-as-errors for non-test projects.
 - Do not run `dotnet build` directly. Use `dotnet toolchain.cs build` or `dotnet toolchain.cs -- build --project Piv`.
 - Do not run `dotnet test` directly. Unit tests mix xUnit v3/Microsoft Testing Platform and xUnit v2; `dotnet toolchain.cs test` detects and invokes the right runner.
-- Focus tests with both module and filter when possible: `dotnet toolchain.cs -- test --project Fido2 --filter "Method~Sign"`.
+- Focus tests with both module and filter when possible: `dotnet toolchain.cs -- test --project Fido2 --filter "Method~Sign"`. The toolchain normalises `Method~`/`Name~` to `FullyQualifiedName~` for the xUnit v2 integration projects, which have no `Method` property; use `FullyQualifiedName~` directly if you want to be explicit.
+- A filter matching zero tests fails the target (`No tests matched the specified filter`). Do not judge a run by the closing `Passed: N | ... | Total: N` line — that counts **projects**, not tests. Read the per-project `total:` figure.
 - When touching Core runtime loops, polling paths, recovery logic, or listener lifecycle cleanup, also run `dotnet toolchain.cs -- resilience --fast`.
 - `--integration` requires `--project`: `dotnet toolchain.cs -- test --integration --project Piv --smoke`.
-- `--smoke` skips `Slow` and `RequiresUserPresence`; agents should not run touch/insert/remove tests unless a human explicitly coordinates hardware.
+- `--smoke` skips `Slow` and `RequiresUserPresence`; agents should not run touch/insert/remove tests unless a human explicitly coordinates hardware. It can thin coverage sharply — on WebAuthn it leaves a single SmartCard test — so check `total:` before calling a smoke pass validation.
+- Never run a whole `Category=RequiresUserPresence` lane as one blocking command: it blocks for minutes, and aborting mid-ceremony leaves the authenticator holding a user-presence request that wedges the key until it is re-plugged. One narrowly filtered test per invocation, with the human ready.
 - Use `dotnet toolchain.cs -- --help` when arguments act strangely; every script long option, including `--project`, requires the preceding `--` separator.
 - CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.2`.
 - Scope `dotnet format` to your staged files via `--include`, never the whole solution — see `CLAUDE.md` Pre-Commit Checklist for the exact command.

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -212,6 +212,8 @@ dotnet test Yubico.YubiKit.Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Yubico.Yub
   ```
 - Filter syntax: `FullyQualifiedName~Substring`, `Method~Name`, `Category!=Slow`
 - The toolchain auto-translates VSTest filter expressions to xUnit v3 native options (`--filter-method`, `--filter-trait`, etc.)
+- It also normalises `Method~` / `Name~` to `FullyQualifiedName~` for the xUnit v2 (VSTest) projects, which have no `Method` property. Without that, `Method~Sign` matches **zero** tests on every integration project while working fine on the unit projects. `FullyQualifiedName~` is the precise form if you want to be explicit
+- **A filter matching no tests is an error, not a pass.** The toolchain preflights both runners and fails with `No tests matched the specified filter`. Left unguarded, VSTest prints `No test matches the given testcase filter` and still exits `0`, which previously surfaced as `✓ All tests passed` from a run that never happened
 
 ### For AI Agents / Automation
 
@@ -221,3 +223,19 @@ When writing scripts or automation that runs tests:
 2. **Never assume** `dotnet test` will work for all projects
 3. **Use `--project`** to filter to specific projects: `dotnet toolchain.cs -- test --project Fido2`
 4. **Combine `--project` with `--filter`** for targeted test runs: `dotnet toolchain.cs -- test --project Fido2 --filter "Method~Sign"`
+5. **Read the per-project `total:` line, not the final summary line.** The closing
+   `Passed: 1 | Failed: 0 | Skipped: 1 | Total: 2` counts **projects**, not tests. Grepping for
+   `Passed:` therefore reads green off a run that executed nothing. Assert on the per-project
+   `total:` / `Total tests:` figure instead:
+
+   ```bash
+   dotnet toolchain.cs -- test --project Core --filter "FullyQualifiedName~FidoHidProtocol" \
+     | grep -E "total:|failed:"
+   ```
+
+   A zero-match filter now fails the target outright, but the project-vs-test counting still
+   catches people out when a filter matches fewer tests than intended.
+6. **Add `--smoke` to any unattended hardware run.** It skips `Slow` and `RequiresUserPresence`,
+   so a missing human cannot leave a ceremony parked and wedge the key. Be aware it can thin
+   coverage sharply — on WebAuthn it reduces the integration lane to a single SmartCard test, so
+   check the `total:` figure before treating a smoke pass as meaningful validation.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -41,6 +41,34 @@ dotnet toolchain.cs -- test --filter "Method~Sign"
 dotnet toolchain.cs -- test --project Piv --filter "Method~Sign"
 ```
 
+### Reading filter results
+
+Two things routinely mislead people here, both worth knowing before you trust a green run.
+
+**`Method~` is not a VSTest property.** The unit projects run xUnit v3 / Microsoft Testing
+Platform; the integration projects run xUnit v2 under VSTest, where only `FullyQualifiedName`,
+`DisplayName` and traits exist. The toolchain normalises `Method~` and `Name~` to
+`FullyQualifiedName~` for those projects so one syntax works on both runners. `FullyQualifiedName~`
+is the precise form if you would rather be explicit.
+
+**A zero-match filter fails the target.** VSTest prints `No test matches the given testcase filter`
+and still exits `0`, so an unguarded run reports `✓ All tests passed` having executed nothing. The
+toolchain preflights both runners and fails with `No tests matched the specified filter` instead.
+
+**The closing summary counts projects, not tests.** This line:
+
+```
+Passed: 1 | Failed: 0 | Skipped: 1 | Total: 2
+```
+
+means two *projects*. Grepping for `Passed:` will read green off a run of zero tests. Assert on the
+per-project figure instead:
+
+```bash
+dotnet toolchain.cs -- test --project Core --filter "FullyQualifiedName~FidoHidProtocol" \
+  | grep -E "total:|failed:"
+```
+
 ## Integration Test Strategy
 
 Integration tests require a physical YubiKey and can be slow (especially RSA keygen). Follow this tiered approach:

--- a/toolchain.cs
+++ b/toolchain.cs
@@ -679,10 +679,24 @@ List<(string Project, bool Passed, string? Error, bool Skipped)> RunTestProjects
             }
             else
             {
-                // xUnit v2 uses --filter directly
+                // xUnit v2 runs under VSTest, which takes --filter directly.
                 command = $"test {projectPath} -c {configuration} --logger \"console;verbosity=normal\"";
                 if (!string.IsNullOrEmpty(testFilter))
-                    command += $" --filter \"{testFilter}\"";
+                {
+                    var vsTestFilter = TranslateToVsTestFilter(testFilter);
+
+                    // Same preflight the MTP path gets. Without it a filter matching nothing makes
+                    // VSTest print "No test matches..." and still exit 0, which this method would
+                    // report as "All tests passed" — a green result from a run that never happened.
+                    if (!VsTestFilterHasMatches(projectPath, vsTestFilter))
+                    {
+                        results.Add((projectName, true, "No matching tests", true));
+                        PrintColored($"○ {projectName} - No matching tests", ConsoleColor.Yellow);
+                        continue;
+                    }
+
+                    command += $" --filter \"{vsTestFilter}\"";
+                }
             }
 
             Run("dotnet", command);
@@ -911,6 +925,39 @@ static (string Args, bool HasPositiveFilters, string[] PositiveArgs) TranslateTo
     }
 
     return (string.Join(" ", mtpArgs), hasPositiveFilters, [..positiveArgs]);
+}
+
+// Normalises a --filter expression for VSTest (xUnit v2, the integration projects).
+//
+// VSTest only understands FullyQualifiedName, DisplayName and trait properties. `Method` is an
+// MSTest/NUnit property, so `Method~Sign` silently matches nothing here even though the MTP path
+// translates it happily — the exact asymmetry that made documented commands no-op on the hardware
+// lanes. Map it onto the closest portable equivalent so one documented syntax works everywhere.
+//
+// FullyQualifiedName covers namespace.class.method, so the rewrite is slightly wider than a
+// method-only match: `Method~Sign` will also match a class named SignatureTests. That fails safe
+// (more tests, never fewer), and VsTestFilterHasMatches still catches a filter that matches none.
+static string TranslateToVsTestFilter(string vstestFilter) =>
+    Regex.Replace(vstestFilter, @"\b(Method|Name)\s*~", "FullyQualifiedName~");
+
+// True when the filter selects at least one test in the project.
+//
+// Discovery-only, so it never runs a ceremony or touches hardware.
+bool VsTestFilterHasMatches(string projectPath, string vsTestFilter)
+{
+    var (exitCode, output) = RunDotnetAndCapture(
+    [
+        "test", projectPath, "-c", configuration, "--list-tests", "--filter", vsTestFilter
+    ]);
+
+    // VSTest 18.x reports zero discovery matches with this text and still exits 0.
+    if (output.Contains("No test matches the given testcase filter", StringComparison.OrdinalIgnoreCase))
+        return false;
+
+    if (exitCode != 0)
+        throw new InvalidOperationException($"Failed to list tests for {projectPath}: {output}");
+
+    return true;
 }
 
 bool MtpFilterHasMatches(string projectPath, string[] positiveMtpFilterArgs)


### PR DESCRIPTION
## The problem

A `--filter` that selected no tests reported success.

VSTest prints `No test matches the given testcase filter` and then exits `0`, so `RunTestProjects` recorded the project as passed and printed `✓ All tests passed` for a run that executed nothing. Anything grepping the output for `Passed:` read green off a complete no-op.

That isn't hypothetical — it has already been reported once as hardware validation that never ran.

```console
$ dotnet toolchain.cs -- test --integration --project WebAuthn --filter "Method~ThisDoesNotExistAnywhere"

No test matches the given testcase filter `Method~ThisDoesNotExistAnywhere` in ...
✓ Yubico.YubiKit.WebAuthn.IntegrationTests - All tests passed
Passed: 1 | Failed: 0 | Skipped: 1 | Total: 2
$ echo $?
0
```

## Two causes

**1. The guard existed but had a hole.** The xUnit v3 / Microsoft Testing Platform path already preflighted its inclusion filter and reported `○ No matching tests`, and an aggregate guard already failed the target when nothing matched anywhere. Only the xUnit v2 / VSTest path — which is every integration project — skipped it. `VsTestFilterHasMatches` closes that with a discovery-only `--list-tests` probe, so the existing guard now fires for both runners. Nothing new was invented here; the design was already right.

**2. `Method~` matches nothing under VSTest.** It only knows `FullyQualifiedName`, `DisplayName` and traits — `Method` is an MSTest/NUnit property. So the widely documented `Method~Sign` matched zero tests on every integration project while working fine on the unit projects, because the MTP translator accepts it. `TranslateToVsTestFilter` normalises `Method~` and `Name~` to `FullyQualifiedName~` so one documented syntax works on both runners.

`FullyQualifiedName` covers `namespace.class.method`, so that rewrite is marginally wider than a method-only match — `Method~Sign` will also match a class called `SignatureTests`. It fails safe (more tests, never fewer), and the zero-match guard covers the case that actually bites.

## Before / after

| Command (integration project) | Before | After |
|---|---|---|
| `--filter "Method~NoSuchThing"` | `✓ All tests passed`, exit 0 | `FAILED! No tests matched the specified filter` |
| `--filter "Method~CreateWebAuthnClientAsync"` | 0 tests, silently | 2 tests run |
| `--filter "FullyQualifiedName~..."` | 2 tests run | 2 tests run (unchanged) |

## Docs

Moved the operational knowledge into the places people actually read, rather than leaving it in a plan file:

- `AGENTS.md` — normalisation, zero-match failure, the counting trap, `--smoke` thinning coverage, and not running a whole user-presence lane as one blocking command
- `TOOLCHAIN.md` — filter-syntax section, plus two items under *For AI Agents / Automation*
- `docs/TESTING.md` — new "Reading filter results" section (both test `CLAUDE.md` files point here as required reading)
- `.claude/skills/domain-test/SKILL.md` — "Reading the result — two traps"

Two traps survive the code fix and are documented rather than fixed, since both are judgement calls:

- the closing `Passed: N | ... | Total: N` line counts **projects**, not tests, so automation should assert on the per-project `total:` figure
- `--smoke` can thin a lane to near-nothing — on WebAuthn it leaves a single SmartCard test — so a smoke pass isn't validation without checking that count

Existing `Method~Sign` examples were left as-is; they work correctly now, so rewriting them would just be churn.

## Testing

- `dotnet toolchain.cs docs-qa` — 56 files
- `dotnet toolchain.cs test` — 12/12 projects
- `dotnet toolchain.cs -- resilience --fast` — 70/70
- MTP filtered path unchanged — 34/34
- zero-match and real-match cases verified by hand on both runners

One cost worth flagging for review: the preflight adds roughly 8s to *filtered* integration runs, since it's an extra build plus discovery pass. Unfiltered runs are unaffected — it only runs when `--filter` is present. Happy to make it conditional on `--integration` if reviewers would rather not pay that.