### PR TITLE
test: cover four flat dispatch tables (CRAP -3135)

### DIFF
--- a/src/Core/src/Native/Linux/Libc/LibcHelpers.cs
+++ b/src/Core/src/Native/Linux/Libc/LibcHelpers.cs
@@ -19,7 +19,10 @@ namespace Yubico.YubiKit.Core.Native.Linux.Libc;
 public static class LibcHelpers
 {
     public static string GetErrnoString() =>
-        Marshal.GetLastWin32Error() switch
+        GetErrnoString(Marshal.GetLastWin32Error());
+
+    internal static string GetErrnoString(int errno) =>
+        errno switch
         {
             7 => "E2BIG(7): Argument list too long",
             13 => "EACCES(13): Permission denied",

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/OidsTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/OidsTests.cs
@@ -1,0 +1,49 @@
+// Copyright 2025 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+public class OidsTests
+{
+    [Theory]
+    [InlineData(KeyType.RSA1024, Oids.RSA, null)]
+    [InlineData(KeyType.RSA2048, Oids.RSA, null)]
+    [InlineData(KeyType.RSA3072, Oids.RSA, null)]
+    [InlineData(KeyType.RSA4096, Oids.RSA, null)]
+    [InlineData(KeyType.ECP256, Oids.ECDSA, Oids.ECP256)]
+    [InlineData(KeyType.ECP384, Oids.ECDSA, Oids.ECP384)]
+    [InlineData(KeyType.ECP521, Oids.ECDSA, Oids.ECP521)]
+    [InlineData(KeyType.X25519, Oids.X25519, null)]
+    [InlineData(KeyType.Ed25519, Oids.Ed25519, null)]
+    [InlineData(KeyType.AES128, Oids.AES128Cbc, null)]
+    [InlineData(KeyType.AES192, Oids.AES192Cbc, null)]
+    [InlineData(KeyType.AES256, Oids.AES256Cbc, null)]
+    [InlineData(KeyType.TripleDES, Oids.TripleDESCbc, null)]
+    public void GetOidsByKeyType_MappedKeyType_ReturnsExpectedOidPair(
+        KeyType keyType,
+        string expectedAlgorithmOid,
+        string? expectedCurveOid)
+    {
+        (string AlgorithmOid, string? Curveoid) result = Oids.GetOidsByKeyType(keyType);
+
+        Assert.Equal(expectedAlgorithmOid, result.AlgorithmOid);
+        Assert.Equal(expectedCurveOid, result.Curveoid);
+    }
+
+    [Fact]
+    public void GetOidsByKeyType_UnsupportedKeyType_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() => Oids.GetOidsByKeyType(KeyType.None));
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Linux/LibcHelpersTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Native/Linux/LibcHelpersTests.cs
@@ -1,0 +1,69 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Native.Linux.Libc;
+
+namespace Yubico.YubiKit.Core.UnitTests.Native.Linux;
+
+public class LibcHelpersTests
+{
+    [Theory]
+    [InlineData(7, "E2BIG(7): Argument list too long")]
+    [InlineData(13, "EACCES(13): Permission denied")]
+    [InlineData(11, "EAGAIN(11): No more processes or not enough memory or maximum nesting level reached.")]
+    [InlineData(9,
+        "EBADF(9): Bad file number. Either the file descriptor is invalid or does not refer to a file, or an attempt to write to a read-only file was made.")]
+    [InlineData(16, "EBUSY(16): Device or resource is busy.")]
+    [InlineData(10, "ECHILD(10): No spawned processes.")]
+    [InlineData(36, "EDEADLK(36): Resource deadlock would occur.")]
+    [InlineData(33, "EDOM(33): The argument to a math function is not in the domain of the function.")]
+    [InlineData(17, "EEXIST(17): The file or resource already exists.")]
+    [InlineData(14, "EFAULT(14): Bad address.")]
+    [InlineData(27, "EFBIG(27): File too large.")]
+    [InlineData(42, "EILSEQ(42): Illegal sequence of bytes (for example, in an MBCS string).")]
+    [InlineData(4, "EINTR(4): Interrupted function.")]
+    [InlineData(22, "EINVAL(22): Invalid argument.")]
+    [InlineData(5, "EIO(5): I/O error.")]
+    [InlineData(21, "EISDIR(21): Object is a directory.")]
+    [InlineData(24, "EMFILE(24): Too many open files.")]
+    [InlineData(31, "EMLINK(31): Too many links.")]
+    [InlineData(38, "ENAMETOOLONG(38): Filename is too long.")]
+    [InlineData(23, "ENFILE(23): Too many files open on the system.")]
+    [InlineData(19, "ENODEV(19): No such device.")]
+    [InlineData(2, "ENOENT(2): No such file or directory.")]
+    [InlineData(8, "ENOEXEC(8): Exec format error")]
+    [InlineData(39, "ENOLCK(39): No locks available.")]
+    [InlineData(12, "ENOMEM(12): Not enough memory is available for the attempted operation.")]
+    [InlineData(28, "ENOSPC(28): No space left on the device.")]
+    [InlineData(40, "ENOSYS(40): Function not supported.")]
+    [InlineData(20, "ENOTDIR(20): Not a directory.")]
+    [InlineData(41, "ENOTDIR(41): Directory is not empty.")]
+    [InlineData(25, "ENOTTY(25): Inappropriate I/O control operation.")]
+    [InlineData(6, "ENXIO(6): No such device or address.")]
+    [InlineData(1, "EPERM(1): Operation not permitted.")]
+    [InlineData(32, "EPIPE(32): Broken pipe.")]
+    [InlineData(34, "ERANGE(34): Result too large.")]
+    [InlineData(30, "EROFS(30): Read only file system.")]
+    [InlineData(29, "ESPIPE(29): Invalid seek.")]
+    [InlineData(3, "ESRCH(3): No such process.")]
+    [InlineData(18, "EXDEV(18): An attempt was made to move a file to a different device.")]
+    [InlineData(80, "STRUNCATE(80): A string copy or concatenation resulted in a truncated string.")]
+    [InlineData(9999, "Unmapped error")]
+    public void GetErrnoString_ReturnsExpectedMappingForErrno(int errno, string expected)
+    {
+        string actual = LibcHelpers.GetErrnoString(errno);
+
+        Assert.Equal(expected, actual);
+    }
+}

--- a/src/Piv/src/Certificates/PivCertificateProtocol.cs
+++ b/src/Piv/src/Certificates/PivCertificateProtocol.cs
@@ -167,7 +167,7 @@ internal static class PivCertificateProtocol
         await PivDataObjectProtocol.PutObjectAsync(backend, isAuthenticated, objectId, null, cancellationToken).ConfigureAwait(false);
     }
 
-    private static int GetCertificateObjectId(PivSlot slot)
+    internal static int GetCertificateObjectId(PivSlot slot)
     {
         return slot switch
         {

--- a/src/Piv/tests/Yubico.YubiKit.Piv.UnitTests/Certificates/PivCertificateObjectIdTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.UnitTests/Certificates/PivCertificateObjectIdTests.cs
@@ -1,0 +1,70 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Piv.Certificates;
+
+namespace Yubico.YubiKit.Piv.UnitTests.Certificates;
+
+/// <summary>
+/// Exact-value coverage for the <c>PivSlot</c> to PIV certificate data-object-id mapping in
+/// <see cref="PivCertificateProtocol.GetCertificateObjectId(PivSlot)"/>. Each mapped slot arm
+/// asserts the specific <see cref="PivDataObject"/> constant it must resolve to, so that changing
+/// any single arm's mapping fails a test.
+/// </summary>
+public class PivCertificateObjectIdTests
+{
+    [Theory]
+    [InlineData(PivSlot.Authentication, PivDataObject.Authentication)]
+    [InlineData(PivSlot.Signature, PivDataObject.Signature)]
+    [InlineData(PivSlot.KeyManagement, PivDataObject.KeyManagement)]
+    [InlineData(PivSlot.CardAuthentication, PivDataObject.CardAuthentication)]
+    [InlineData(PivSlot.Attestation, PivDataObject.Attestation)]
+    [InlineData(PivSlot.Retired1, PivDataObject.Retired1)]
+    [InlineData(PivSlot.Retired2, PivDataObject.Retired2)]
+    [InlineData(PivSlot.Retired3, PivDataObject.Retired3)]
+    [InlineData(PivSlot.Retired4, PivDataObject.Retired4)]
+    [InlineData(PivSlot.Retired5, PivDataObject.Retired5)]
+    [InlineData(PivSlot.Retired6, PivDataObject.Retired6)]
+    [InlineData(PivSlot.Retired7, PivDataObject.Retired7)]
+    [InlineData(PivSlot.Retired8, PivDataObject.Retired8)]
+    [InlineData(PivSlot.Retired9, PivDataObject.Retired9)]
+    [InlineData(PivSlot.Retired10, PivDataObject.Retired10)]
+    [InlineData(PivSlot.Retired11, PivDataObject.Retired11)]
+    [InlineData(PivSlot.Retired12, PivDataObject.Retired12)]
+    [InlineData(PivSlot.Retired13, PivDataObject.Retired13)]
+    [InlineData(PivSlot.Retired14, PivDataObject.Retired14)]
+    [InlineData(PivSlot.Retired15, PivDataObject.Retired15)]
+    [InlineData(PivSlot.Retired16, PivDataObject.Retired16)]
+    [InlineData(PivSlot.Retired17, PivDataObject.Retired17)]
+    [InlineData(PivSlot.Retired18, PivDataObject.Retired18)]
+    [InlineData(PivSlot.Retired19, PivDataObject.Retired19)]
+    [InlineData(PivSlot.Retired20, PivDataObject.Retired20)]
+    public void GetCertificateObjectId_MappedSlot_ReturnsExpectedObjectId(PivSlot slot, int expectedObjectId)
+    {
+        int actual = PivCertificateProtocol.GetCertificateObjectId(slot);
+
+        Assert.Equal(expectedObjectId, actual);
+    }
+
+    [Fact]
+    public void GetCertificateObjectId_UnmappedSlot_ThrowsArgumentExceptionWithSlotSpecificMessage()
+    {
+        var slot = (PivSlot)0x00;
+
+        var exception = Assert.Throws<ArgumentException>(() => PivCertificateProtocol.GetCertificateObjectId(slot));
+
+        Assert.Equal("slot", exception.ParamName);
+        Assert.StartsWith("Slot 0x00 does not support certificates", exception.Message);
+    }
+}

--- a/src/WebAuthn/src/Client/WebAuthnClient.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.cs
@@ -765,7 +765,7 @@ public sealed class WebAuthnClient : IAsyncDisposable
     /// CredentialExcluded and previewSign-specific statuses are handled by their own catch arms
     /// upstream and never reach this mapper.
     /// </summary>
-    private static WebAuthnClientError MapCtapStatusToWebAuthnError(CtapException ex) =>
+    internal static WebAuthnClientError MapCtapStatusToWebAuthnError(CtapException ex) =>
         ex.Status switch
         {
             CtapStatus.PinAuthInvalid or CtapStatus.PinInvalid or CtapStatus.PinAuthBlocked

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CtapStatusMappingTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/CtapStatusMappingTests.cs
@@ -1,0 +1,75 @@
+// Copyright Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Fido2.Ctap;
+using Yubico.YubiKit.WebAuthn.Client;
+
+namespace Yubico.YubiKit.WebAuthn.UnitTests.Client;
+
+public class CtapStatusMappingTests
+{
+    [Theory]
+    // NotAllowed group
+    [InlineData(CtapStatus.PinAuthInvalid, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinInvalid, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinAuthBlocked, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinBlocked, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinPolicyViolation, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PuatRequired, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.PinTokenExpired, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.NotAllowed, WebAuthnClientErrorCode.NotAllowed)]
+    [InlineData(CtapStatus.OperationDenied, WebAuthnClientErrorCode.NotAllowed)]
+    // Constraint group
+    [InlineData(CtapStatus.KeyStoreFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.LargeBlobStorageFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.FpDatabaseFull, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.LimitExceeded, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.RequestTooLarge, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.UserActionTimeout, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.ActionTimeout, WebAuthnClientErrorCode.Constraint)]
+    [InlineData(CtapStatus.Timeout, WebAuthnClientErrorCode.Constraint)]
+    // NotSupported group
+    [InlineData(CtapStatus.UnsupportedAlgorithm, WebAuthnClientErrorCode.NotSupported)]
+    [InlineData(CtapStatus.UnsupportedOption, WebAuthnClientErrorCode.NotSupported)]
+    [InlineData(CtapStatus.InvalidOption, WebAuthnClientErrorCode.NotSupported)]
+    // Security group
+    [InlineData(CtapStatus.PinNotSet, WebAuthnClientErrorCode.Security)]
+    [InlineData(CtapStatus.UpRequired, WebAuthnClientErrorCode.Security)]
+    // InvalidState group
+    [InlineData(CtapStatus.NoCredentials, WebAuthnClientErrorCode.InvalidState)]
+    [InlineData(CtapStatus.InvalidCredential, WebAuthnClientErrorCode.InvalidState)]
+    // Default group (not a member of any arm above)
+    [InlineData(CtapStatus.Other, WebAuthnClientErrorCode.Unknown)]
+    public void MapCtapStatusToWebAuthnError_MapsStatusToExpectedCode(
+        CtapStatus status,
+        WebAuthnClientErrorCode expectedCode)
+    {
+        var ctapException = new CtapException(status, "ctap failure message");
+
+        var result = WebAuthnClient.MapCtapStatusToWebAuthnError(ctapException);
+
+        Assert.Equal(expectedCode, result.Code);
+    }
+
+    [Fact]
+    public void MapCtapStatusToWebAuthnError_PropagatesMessageAndInnerException()
+    {
+        var ctapException = new CtapException(CtapStatus.PinInvalid, "specific ctap message");
+
+        var result = WebAuthnClient.MapCtapStatusToWebAuthnError(ctapException);
+
+        Assert.Equal("specific ctap message", result.Message);
+        Assert.Same(ctapException, result.InnerException);
+    }
+}


### PR DESCRIPTION
Stacks on #597. Four independent test-only changes, written in parallel by four Sonnet 5 agents in isolated worktrees, then verified.

## What and why

These four methods sat near the top of the CRAP ranking purely because they were untested. All four have **cognitive complexity 1** — flat `switch` dispatch tables that are large but trivially readable. Their shape is correct, so the fix is coverage, not refactoring.

| method | CRAP before | after | coverage | arms |
|---|---:|---:|---:|---:|
| `LibcHelpers.GetErrnoString` | 1640 | 42 | 100% | 39 + default |
| `PivCertificateProtocol.GetCertificateObjectId` | 702 | 26 | 100% | 25 + default |
| `WebAuthnClient.MapCtapStatusToWebAuthnError` | 650 | 25 | 100% | 24 statuses |
| `Oids.GetOidsByKeyType` | 210 | 14 | 100% | 13 + default |

**3,135 CRAP removed**, 101% of the predicted 3,093.

## Production changes are three keywords and one seam

- `GetCertificateObjectId`: `private` → `internal`
- `MapCtapStatusToWebAuthnError`: `private` → `internal`
- `Oids.GetOidsByKeyType`: **no change** (already public)
- `LibcHelpers.GetErrnoString`: extracted an `internal GetErrnoString(int errno)` overload holding the switch verbatim; the public parameterless method keeps its exact behaviour and delegates. It previously read ambient process state via `Marshal.GetLastWin32Error()`, so the mapping could not be driven from a test.

No `.csproj` changes — `Directory.Build.targets` already grants `InternalsVisibleTo` to `$(AssemblyName).UnitTests` for every non-test project.

## Verification

Coverage percentage was explicitly *not* the acceptance bar. The bar was: **if one arm's mapping changes, a test must fail.**

- **Mutation-tested.** Pointing `KeyType.X25519` at the Ed25519 OID failed exactly the X25519 case. Pointing `PivSlot.Retired7` at `Retired8`'s object id failed exactly the Retired7 case. Both reverted.
- **Cross-vendor review.** `gpt-5.6-sol` reviewed all four diffs against the mutation question specifically — `{"status":"pass","findings":[]}`.
- `dotnet toolchain.cs build` clean · `test` 12/12 · `dotnet format` clean.

## Two things worth flagging

**A pre-existing bug is now pinned.** `LibcHelpers` maps errno 41 to `"ENOTDIR(41): Directory is not empty."` — errno 41 is `ENOTEMPTY`; the label is wrong. The test pins current behaviour rather than silently changing it. Worth a separate fix.

**`CRAP >= 8` barely moved (427 → 428) despite 3,135 CRAP removed.** That is expected, not a failure: a fully covered method's CRAP equals its cyclomatic complexity, so a 40-arm table floors at 40 and stays above any sane threshold. **Total CRAP load is the meaningful progress metric here, not the count above a threshold** — something to keep in mind before wiring a count-based CI gate.
