### PR TITLE
test+refactor(core): cover and de-duplicate the Linux HID descriptor parsers (CRAP -339)

### DIFF
--- a/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
+++ b/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
@@ -1,0 +1,111 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Yubico.YubiKit.Core.Transports.Hid;
+
+/// <summary>
+/// One decoded HID report-descriptor short item.
+/// </summary>
+/// <param name="Type">The item type: <see cref="HidReportDescriptorReader.TypeMain"/>,
+/// <see cref="HidReportDescriptorReader.TypeGlobal"/>, or
+/// <see cref="HidReportDescriptorReader.TypeLocal"/> (or the reserved value 3).</param>
+/// <param name="Tag">The item tag, distinguishing items within a type (for example, Usage Page,
+/// Report Size, Input).</param>
+/// <param name="Value">The little-endian item value. Zero for a zero-size item.</param>
+internal readonly record struct HidReportItem(int Type, int Tag, uint Value);
+
+/// <summary>
+/// Platform-neutral walker over a HID report descriptor's short-item byte stream, per the HID
+/// specification's short-item encoding (prefix byte: bits 0-1 = size, bits 2-3 = type, bits 4-7
+/// = tag).
+/// </summary>
+/// <remarks>
+/// This does not implement HID long items (prefix 0xFE). A long-item prefix decodes through this
+/// short-item layout as size=2/type=3/tag=15, consuming its two length/tag bytes as an ordinary
+/// item value and desynchronizing the cursor for the remainder of the descriptor. YubiKeys do not
+/// emit long items in practice. This is a deliberate, pinned limitation inherited from the two
+/// original hand-rolled walkers this type replaces; do not add long-item handling here without a
+/// dedicated, reviewed change.
+/// </remarks>
+internal static class HidReportDescriptorReader
+{
+    /// <summary>
+    /// Main item type (bits 2-3 of the prefix byte == 0). Examples: Input, Output, Collection.
+    /// </summary>
+    internal const int TypeMain = 0;
+
+    /// <summary>
+    /// Global item type (bits 2-3 of the prefix byte == 1). Examples: Usage Page, Report Size,
+    /// Report Count.
+    /// </summary>
+    internal const int TypeGlobal = 1;
+
+    /// <summary>
+    /// Local item type (bits 2-3 of the prefix byte == 2). Examples: Usage.
+    /// </summary>
+    internal const int TypeLocal = 2;
+
+    /// <summary>
+    /// Reads the next short item from <paramref name="descriptor"/>, advancing
+    /// <paramref name="position"/> past it.
+    /// </summary>
+    /// <param name="descriptor">The raw HID report descriptor bytes.</param>
+    /// <param name="position">The read cursor. Advanced past the item just read on success;
+    /// left unspecified once this method returns <see langword="false"/>.</param>
+    /// <param name="item">The decoded item, when this method returns <see langword="true"/>.</param>
+    /// <returns><see langword="true"/> if an item was read; <see langword="false"/> once the
+    /// descriptor is exhausted or the trailing item is truncated.</returns>
+    /// <remarks>
+    /// A truncated item (fewer bytes remaining than its prefix declares) terminates the walk
+    /// rather than being clamped or skipped, matching the two hand-rolled walkers this replaces.
+    /// An item declaring a size of zero still advances the cursor by its prefix byte and yields a
+    /// <see cref="HidReportItem.Value"/> of zero.
+    /// </remarks>
+    internal static bool TryReadItem(ReadOnlySpan<byte> descriptor, ref int position, out HidReportItem item)
+    {
+        item = default;
+
+        if (position >= descriptor.Length)
+        {
+            return false;
+        }
+
+        byte prefix = descriptor[position];
+        int size = prefix & 0x03;
+        if (size == 3)
+        {
+            size = 4; // Size encoding: 0=0, 1=1, 2=2, 3=4
+        }
+
+        int type = (prefix >> 2) & 0x03;
+        int tag = (prefix >> 4) & 0x0F;
+
+        int cursor = position + 1; // Move past prefix
+
+        if (cursor + size > descriptor.Length)
+        {
+            return false;
+        }
+
+        uint value = 0;
+        for (int j = 0; j < size; j++)
+        {
+            value |= (uint)descriptor[cursor + j] << (8 * j);
+        }
+
+        item = new HidReportItem(type, tag, value);
+        position = cursor + size;
+        return true;
+    }
+}

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
@@ -323,7 +323,7 @@ internal sealed class LinuxHidDevice : IHidDevice
         }
     }
 
-    private static (ushort UsagePage, ushort Usage) ParseHidDescriptorBytes(ReadOnlySpan<byte> descriptor)
+    internal static (ushort UsagePage, ushort Usage) ParseHidDescriptorBytes(ReadOnlySpan<byte> descriptor)
     {
         // HID descriptor parsing - looking for Usage Page and Usage items
         // HID descriptor format: each item has a prefix byte followed by data

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidDevice.cs
@@ -17,6 +17,7 @@ using System.Runtime.Versioning;
 using Yubico.YubiKit.Core.Native;
 using Yubico.YubiKit.Core.Native.Linux.Libc;
 using Yubico.YubiKit.Core.Native.Linux.Udev;
+using Yubico.YubiKit.Core.Transports.Hid;
 using LibcNativeMethods = Yubico.YubiKit.Core.Native.Linux.Libc.NativeMethods;
 using UdevNativeMethods = Yubico.YubiKit.Core.Native.Linux.Udev.NativeMethods;
 
@@ -326,8 +327,6 @@ internal sealed class LinuxHidDevice : IHidDevice
     internal static (ushort UsagePage, ushort Usage) ParseHidDescriptorBytes(ReadOnlySpan<byte> descriptor)
     {
         // HID descriptor parsing - looking for Usage Page and Usage items
-        // HID descriptor format: each item has a prefix byte followed by data
-        // Prefix: bits 0-1 = size (0,1,2,4 bytes), bits 2-3 = type (0=main, 1=global, 2=local), bits 4-7 = tag
 
         // IMPORTANT: We need to validate the UsagePage + Usage combination
         // Don't just return the first values found - parse both, then validate
@@ -337,47 +336,24 @@ internal sealed class LinuxHidDevice : IHidDevice
         bool usagePageFound = false;
         bool usageFound = false;
 
-        int i = 0;
-        while (i < descriptor.Length)
+        int position = 0;
+        while (HidReportDescriptorReader.TryReadItem(descriptor, ref position, out HidReportItem item))
         {
-            byte prefix = descriptor[i];
-            int size = prefix & 0x03;
-            if (size == 3)
+            // Global items
+            if (item.Type == HidReportDescriptorReader.TypeGlobal)
             {
-                size = 4; // Size encoding: 0=0, 1=1, 2=2, 3=4
-            }
-
-            int type = (prefix >> 2) & 0x03;
-            int tag = (prefix >> 4) & 0x0F;
-
-            i++; // Move past prefix
-
-            if (i + size > descriptor.Length)
-            {
-                break;
-            }
-
-            uint value = 0;
-            for (int j = 0; j < size; j++)
-            {
-                value |= (uint)descriptor[i + j] << (8 * j);
-            }
-
-            // Global items (type = 1)
-            if (type == 1)
-            {
-                if (tag == 0 && !usagePageFound) // Usage Page
+                if (item.Tag == 0 && !usagePageFound) // Usage Page
                 {
-                    usagePage = (ushort)value;
+                    usagePage = (ushort)item.Value;
                     usagePageFound = true;
                 }
             }
-            // Local items (type = 2)
-            else if (type == 2)
+            // Local items
+            else if (item.Type == HidReportDescriptorReader.TypeLocal)
             {
-                if (tag == 0 && !usageFound) // Usage
+                if (item.Tag == 0 && !usageFound) // Usage
                 {
-                    usage = (ushort)value;
+                    usage = (ushort)item.Value;
                     usageFound = true;
                 }
             }
@@ -387,8 +363,6 @@ internal sealed class LinuxHidDevice : IHidDevice
             {
                 break;
             }
-
-            i += size;
         }
 
         return (usagePage, usage);

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidIOReportConnection.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidIOReportConnection.cs
@@ -17,6 +17,7 @@ using System.Runtime.Versioning;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Native;
 using Yubico.YubiKit.Core.Native.Linux.Libc;
+using Yubico.YubiKit.Core.Transports.Hid;
 using LibcNativeMethods = Yubico.YubiKit.Core.Native.Linux.Libc.NativeMethods;
 
 namespace Yubico.YubiKit.Core.Transports.Hid.Linux;
@@ -177,50 +178,27 @@ internal sealed class LinuxHidIOReportConnection : IHidConnection
         int currentReportSize = 0;
         int currentReportCount = 0;
 
-        int i = 0;
-        while (i < descriptor.Length)
+        int position = 0;
+        while (HidReportDescriptorReader.TryReadItem(descriptor, ref position, out HidReportItem item))
         {
-            byte prefix = descriptor[i];
-            int size = prefix & 0x03;
-            if (size == 3)
+            // Global items
+            if (item.Type == HidReportDescriptorReader.TypeGlobal)
             {
-                size = 4;
-            }
-
-            int type = (prefix >> 2) & 0x03;
-            int tag = (prefix >> 4) & 0x0F;
-
-            i++;
-
-            if (i + size > descriptor.Length)
-            {
-                break;
-            }
-
-            uint value = 0;
-            for (int j = 0; j < size; j++)
-            {
-                value |= (uint)descriptor[i + j] << (8 * j);
-            }
-
-            // Global items (type = 1)
-            if (type == 1)
-            {
-                switch (tag)
+                switch (item.Tag)
                 {
                     case 7: // Report Size
-                        currentReportSize = (int)value;
+                        currentReportSize = (int)item.Value;
                         break;
                     case 9: // Report Count
-                        currentReportCount = (int)value;
+                        currentReportCount = (int)item.Value;
                         break;
                 }
             }
-            // Main items (type = 0)
-            else if (type == 0)
+            // Main items
+            else if (item.Type == HidReportDescriptorReader.TypeMain)
             {
                 int reportBytes = (currentReportSize * currentReportCount + 7) / 8;
-                switch (tag)
+                switch (item.Tag)
                 {
                     case 8: // Input
                         if (reportBytes > 0)
@@ -236,8 +214,6 @@ internal sealed class LinuxHidIOReportConnection : IHidConnection
                         break;
                 }
             }
-
-            i += size;
         }
 
         return (inputSize, outputSize);

--- a/src/Core/src/Transports/Hid/Linux/LinuxHidIOReportConnection.cs
+++ b/src/Core/src/Transports/Hid/Linux/LinuxHidIOReportConnection.cs
@@ -167,7 +167,7 @@ internal sealed class LinuxHidIOReportConnection : IHidConnection
         }
     }
 
-    private static (int InputSize, int OutputSize) ParseReportSizes(ReadOnlySpan<byte> descriptor)
+    internal static (int InputSize, int OutputSize) ParseReportSizes(ReadOnlySpan<byte> descriptor)
     {
         // Parse HID descriptor for report sizes
         // Looking for Input and Output main items with their associated Report Size and Report Count

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
@@ -1,0 +1,194 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Yubico.YubiKit.Core.Transports.Hid.Linux;
+
+namespace Yubico.YubiKit.Core.UnitTests.Transports.Hid;
+
+/// <summary>
+/// Characterization tests for the two independent, hand-rolled HID report-descriptor item
+/// walkers in <see cref="LinuxHidDevice"/> and <see cref="LinuxHidIOReportConnection"/>.
+///
+/// These tests make ZERO claim that the parsers are correct. They pin the CURRENT, observed
+/// behaviour of both parsers, byte for byte, so that a future refactor that merges the two
+/// walkers into one shared implementation can be verified as behaviour-preserving. Every
+/// vector below is run through both <see cref="LinuxHidDevice.ParseHidDescriptorBytes"/> and
+/// <see cref="LinuxHidIOReportConnection.ParseReportSizes"/>, even where the result is the
+/// uninteresting default, because "this input does not affect me" is itself part of the
+/// contract a refactor could silently break.
+/// </summary>
+public class LinuxHidDescriptorParsingTests
+{
+    // The real canonical U2F HID descriptor. (0xF1D0, 0x0001) is exactly what
+    // HidInterfaceClassifier.Classify requires to return HidInterfaceType.Fido. If this
+    // regresses, every YubiKey is dropped from Linux HID discovery. This is the single most
+    // important vector in this file.
+    public static readonly byte[] FidoU2f =
+    [
+        0x06, 0xD0, 0xF1, 0x09, 0x01, 0xA1, 0x01, 0x09, 0x20, 0x15, 0x00, 0x26, 0xFF, 0x00, 0x75, 0x08,
+        0x95, 0x40, 0x81, 0x02, 0x09, 0x21, 0x15, 0x00, 0x26, 0xFF, 0x00, 0x75, 0x08, 0x95, 0x40, 0x91, 0x02,
+        0xC0
+    ];
+
+    // (0x0001, 0x0006) is exactly what HidInterfaceClassifier.Classify requires to return
+    // HidInterfaceType.Otp.
+    public static readonly byte[] KeyboardOtp =
+    [
+        0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x75, 0x08, 0x95, 0x08, 0x81, 0x02, 0x75, 0x08, 0x95, 0x08,
+        0x91, 0x02, 0xC0
+    ];
+
+    // Zero bytes: the loop condition `i < descriptor.Length` never enters, so both parsers
+    // return their untouched defaults.
+    public static readonly byte[] Empty = [];
+
+    // Only a prefix + a truncated value: the `i + size > descriptor.Length` break path fires
+    // before any item is decoded.
+    public static readonly byte[] TruncatedValue = [0x06, 0xD0];
+
+    // A valid Usage Page item followed by a lone trailing prefix byte with no value bytes
+    // behind it: the first item parses successfully (usage page = 0x0001), then the break
+    // path fires on the second, incomplete item, leaving usage at its default.
+    public static readonly byte[] TruncatedTrailingPrefix = [0x05, 0x01, 0x09];
+
+    // Proves three things at once: size == 3 in the prefix means FOUR value bytes (not
+    // three), the value is assembled little-endian, and a 4-byte value is truncated to
+    // ushort (0x04030201 -> 0x0201, 0xDDCCBBAA -> 0xBBAA).
+    public static readonly byte[] Size3Means4Bytes = [0x07, 0x01, 0x02, 0x03, 0x04, 0x0B, 0xAA, 0xBB, 0xCC, 0xDD];
+
+    // Report Count of 0 leaves the `reportBytes > 0` guard false, so the 64-byte default is
+    // never overwritten despite an Input main item being present.
+    public static readonly byte[] ReportCountZero = [0x75, 0x08, 0x95, 0x00, 0x81, 0x02];
+
+    // An Input/Output main item appears before any Report Size/Report Count global item, so
+    // currentReportSize/currentReportCount are both still 0, `reportBytes > 0` is false, and
+    // the 64-byte defaults survive.
+    public static readonly byte[] MainBeforeGlobals = [0x81, 0x02, 0x91, 0x02];
+
+    // A non-default report size really is computed and returned (guards against a refactor
+    // that always returns the 64-byte fallback regardless of the descriptor).
+    public static readonly byte[] Input63Bytes = [0x75, 0x08, 0x95, 0x3F, 0x81, 0x02];
+
+    // (1 * 3 + 7) / 8 == 1: pins the ceiling-division bit-to-byte rounding exactly.
+    public static readonly byte[] BitRoundingSize1Count3 = [0x75, 0x01, 0x95, 0x03, 0x81, 0x02];
+
+    // One Report Size/Report Count declaration feeds BOTH the Input and the Output main item
+    // that follow it: HID global-item persistence across multiple main items.
+    public static readonly byte[] GlobalsPersistAcrossMain = [0x75, 0x08, 0x95, 0x20, 0x81, 0x02, 0x91, 0x02];
+
+    // A second Usage Page item must be ignored: first-value-wins via the `!usagePageFound`
+    // guard flag.
+    public static readonly byte[] SecondUsagePageIgnored = [0x05, 0x01, 0x05, 0x0C, 0x09, 0x06];
+
+    // Usage item appears before Usage Page in the byte stream: proves the parser is order
+    // independent (each field is captured independently, not "first item wins overall").
+    public static readonly byte[] UsageBeforeUsagePage = [0x09, 0x06, 0x05, 0x01];
+
+    // KNOWN DEFECT, PINNED DELIBERATELY. HID long items (prefix 0xFE) are not handled by
+    // either parser. 0xFE decodes via the short-item bit layout as size=2/type=3/tag=15, so
+    // its two payload bytes (0xAA, 0xBB) are consumed as an ordinary item value, the cursor
+    // then lands mid-stream at the long item's data-length/tag bytes, and the perfectly
+    // valid `05 01 09 06` keyboard descriptor that follows it is misread and lost, producing
+    // (0, 0) instead of (0x0001, 0x0006). YubiKeys do not emit long items in practice, so
+    // this is latent, not live. This test pins CURRENT behaviour for refactor safety only —
+    // it is NOT an endorsement of the defect and must not be "fixed" as part of any
+    // characterization or refactor work.
+    public static readonly byte[] LongItem0xFE = [0xFE, 0x02, 0xAA, 0xBB, 0xCC, 0x05, 0x01, 0x09, 0x06];
+
+    // Items with size 0 (bits 0-1 of prefix are both 0) still advance the cursor by exactly
+    // one byte (the prefix itself) and the loop terminates cleanly once the bytes run out.
+    public static readonly byte[] ZeroSizeItemsOnly = [0xC0, 0xC0, 0xC0];
+
+    // A two-byte Report Count (prefix 0x96 = size 2, global, tag 9) holding 0x0100 = 256.
+    // (8 * 256 + 7) / 8 == 256. Without this vector the little-endian value assembly inside
+    // ParseReportSizes is completely unobservable, because every other vector feeds it only
+    // single-byte Report Size/Report Count values, and the one multi-byte vector
+    // (Size3Means4Bytes) uses tags that ParseReportSizes ignores. Verified: a big-endian
+    // assembly would read this count as 1 and return an input size of 1 instead of 256.
+    public static readonly byte[] TwoByteReportCount = [0x75, 0x08, 0x96, 0x00, 0x01, 0x81, 0x02];
+
+    // The same guard for the other multi-byte global: a two-byte Report Size (prefix 0x76 =
+    // size 2, global, tag 7) holding 0x0010 = 16 bits, with a Report Count of 4.
+    // (16 * 4 + 7) / 8 == 8. A big-endian assembly would read the size as 0x1000 and return
+    // 2048 instead of 8.
+    public static readonly byte[] TwoByteReportSize = [0x76, 0x10, 0x00, 0x95, 0x04, 0x81, 0x02];
+
+    [Theory]
+    [MemberData(nameof(UsageVectors))]
+    public void ParseHidDescriptorBytes_PinnedVectors_ReturnsExactTuple(
+        string vectorName, byte[] descriptor, ushort expectedUsagePage, ushort expectedUsage)
+    {
+        _ = vectorName;
+
+        (ushort usagePage, ushort usage) = LinuxHidDevice.ParseHidDescriptorBytes(descriptor);
+
+        Assert.Equal(expectedUsagePage, usagePage);
+        Assert.Equal(expectedUsage, usage);
+    }
+
+    [Theory]
+    [MemberData(nameof(ReportSizeVectors))]
+    public void ParseReportSizes_PinnedVectors_ReturnsExactTuple(
+        string vectorName, byte[] descriptor, int expectedInputSize, int expectedOutputSize)
+    {
+        _ = vectorName;
+
+        (int inputSize, int outputSize) = LinuxHidIOReportConnection.ParseReportSizes(descriptor);
+
+        Assert.Equal(expectedInputSize, inputSize);
+        Assert.Equal(expectedOutputSize, outputSize);
+    }
+
+    public static TheoryData<string, byte[], ushort, ushort> UsageVectors() => new()
+    {
+        { nameof(FidoU2f), FidoU2f, 0xF1D0, 0x0001 },
+        { nameof(KeyboardOtp), KeyboardOtp, 0x0001, 0x0006 },
+        { nameof(Empty), Empty, 0x0000, 0x0000 },
+        { nameof(TruncatedValue), TruncatedValue, 0x0000, 0x0000 },
+        { nameof(TruncatedTrailingPrefix), TruncatedTrailingPrefix, 0x0001, 0x0000 },
+        { nameof(Size3Means4Bytes), Size3Means4Bytes, 0x0201, 0xBBAA },
+        { nameof(ReportCountZero), ReportCountZero, 0x0000, 0x0000 },
+        { nameof(Input63Bytes), Input63Bytes, 0x0000, 0x0000 },
+        { nameof(BitRoundingSize1Count3), BitRoundingSize1Count3, 0x0000, 0x0000 },
+        { nameof(MainBeforeGlobals), MainBeforeGlobals, 0x0000, 0x0000 },
+        { nameof(GlobalsPersistAcrossMain), GlobalsPersistAcrossMain, 0x0000, 0x0000 },
+        { nameof(SecondUsagePageIgnored), SecondUsagePageIgnored, 0x0001, 0x0006 },
+        { nameof(UsageBeforeUsagePage), UsageBeforeUsagePage, 0x0001, 0x0006 },
+        { nameof(LongItem0xFE), LongItem0xFE, 0x0000, 0x0000 },
+        { nameof(ZeroSizeItemsOnly), ZeroSizeItemsOnly, 0x0000, 0x0000 },
+        { nameof(TwoByteReportCount), TwoByteReportCount, 0x0000, 0x0000 },
+        { nameof(TwoByteReportSize), TwoByteReportSize, 0x0000, 0x0000 }
+    };
+
+    public static TheoryData<string, byte[], int, int> ReportSizeVectors() => new()
+    {
+        { nameof(FidoU2f), FidoU2f, 64, 64 },
+        { nameof(KeyboardOtp), KeyboardOtp, 8, 8 },
+        { nameof(Empty), Empty, 64, 64 },
+        { nameof(TruncatedValue), TruncatedValue, 64, 64 },
+        { nameof(TruncatedTrailingPrefix), TruncatedTrailingPrefix, 64, 64 },
+        { nameof(Size3Means4Bytes), Size3Means4Bytes, 64, 64 },
+        { nameof(ReportCountZero), ReportCountZero, 64, 64 },
+        { nameof(Input63Bytes), Input63Bytes, 63, 64 },
+        { nameof(BitRoundingSize1Count3), BitRoundingSize1Count3, 1, 64 },
+        { nameof(MainBeforeGlobals), MainBeforeGlobals, 64, 64 },
+        { nameof(GlobalsPersistAcrossMain), GlobalsPersistAcrossMain, 32, 32 },
+        { nameof(SecondUsagePageIgnored), SecondUsagePageIgnored, 64, 64 },
+        { nameof(UsageBeforeUsagePage), UsageBeforeUsagePage, 64, 64 },
+        { nameof(LongItem0xFE), LongItem0xFE, 64, 64 },
+        { nameof(ZeroSizeItemsOnly), ZeroSizeItemsOnly, 64, 64 },
+        { nameof(TwoByteReportCount), TwoByteReportCount, 256, 64 },
+        { nameof(TwoByteReportSize), TwoByteReportSize, 8, 64 }
+    };
+}


### PR DESCRIPTION
Follows the CRAP work merged in #597 / #601. Two commits: characterize, then refactor.

## The targets

`LinuxHidDevice.ParseHidDescriptorBytes` and `LinuxHidIOReportConnection.ParseReportSizes` are two hand-rolled HID report-descriptor walkers, each at 0% coverage and CRAP 182. They are not dead code — the first gates Linux HID discovery (returning `(0,0)` drops the device entirely), the second sizes the FIDO read buffer.

Unlike the flat lookup tables in #601, these have cognitive complexity 21 and 24, so coverage alone was not the right fix.

| | before | after |
|---|---:|---:|
| `ParseHidDescriptorBytes` | CRAP 182, cog 21, 0% | CRAP 10, cog 15, 100% |
| `ParseReportSizes` | CRAP 182, cog 24, 0% | CRAP 10, cog 18, 100% |
| `HidReportDescriptorReader.TryReadItem` | — | CRAP 5, cog 4, 100% |
| **total** | **364** | **25** |

## Commit 1 — characterization

17 descriptor vectors run through both parsers, 34 cases. Ground truth was produced by **executing the real parser code**, not derived by hand — the repo had no HID descriptor fixtures to reuse. `FidoU2f` and `KeyboardOtp` are the canonical descriptors, and their expected values are exactly the constants `HidInterfaceClassifier.Classify` needs to return `Fido` and `Otp`.

Production change is two keywords, `private` → `internal`.

Two vectors exist only because a mutation initially escaped. `TwoByteReportCount` and `TwoByteReportSize` were added after a big-endian mutation passed all 30 original tests: every other vector feeds `ParseReportSizes` only single-byte Report Size/Count values, where byte order is unobservable, so its value assembly was silently untested.

## Commit 2 — de-duplication

The walker — prefix decode, size-3-means-4, truncation check, little-endian assembly, cursor advance — was duplicated byte-for-byte. It now lives once in `HidReportDescriptorReader.TryReadItem`, placed in `Transports/Hid/` rather than `Transports/Hid/Linux/` because the HID short-item format is platform-neutral, beside the existing platform-neutral HID types. It carries no `[SupportedOSPlatform]`.

**The characterization test file is byte-identical between the two commits.** That is the proof of behaviour preservation, and it is mechanically checkable:

```
git diff --exit-code 0966c467 94f0c55c -- \
  src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
```

Six mutations were injected against the final design and all six were caught: size-3-means-3-bytes, big-endian assembly, clamping a truncated item instead of stopping, a cursor off-by-one, floor instead of ceiling division, and dropping the first-value-wins guard.

## Two things worth knowing

**A latent defect is pinned and documented, not fixed.** HID long items (prefix `0xFE`) are not handled: `0xFE` decodes through the short-item layout as size=2/type=3/tag=15, so its payload is consumed as an ordinary item and the remainder of the descriptor is misread and lost — a valid keyboard descriptor placed after a long item yields `(0,0)`. YubiKeys do not emit long items, so this is latent rather than live. The `LongItem0xFE` vector pins current behaviour explicitly as *not* an endorsement. It now needs fixing in one place instead of two.

**`TryReadItem` is a plain static method with a `ref` cursor, not a `ref struct` enumerator.** The enumerator was built first and worked, but **coverlet emits no coverage data at all for `ref struct` members** — verified both nested and top-level — so `MoveNext` scored 0% and CRAP 30 while demonstrably executing (mutating it failed tests). That would have permanently hidden the walker from coverage and inflated reported CRAP from 25 to 55. The `ref` cursor is equally allocation-free, keeps `ReadOnlySpan<byte>`, and stays measurable. Worth knowing before anyone reaches for a `ref struct` enumerator elsewhere in this repo.

## Verification

`toolchain.cs build` clean · `test` 12/12 · `resilience --fast` clean (required by `src/Core/CLAUDE.md` for Core transport changes) · `dotnet format --verify-no-changes` clean · `crap.cs --self-check` 51/51.
