### PR TITLE
fix(core): preserve X25519 private values and cover private-key ASN.1

### DIFF
--- a/docs/migration/v1-to-v2-changelog.md
+++ b/docs/migration/v1-to-v2-changelog.md
@@ -84,3 +84,10 @@
 - `api-added.txt`, `api-removed.txt`, and `package-changes.txt` showed no public API or package/namespace-shape changes for this range.
 - No migration guide or map updates were needed; the existing `v1-to-v2.md` and `v1-to-v2-map.yml` guidance is unaffected.
 - Advanced `docs/migration/.state.yml` `last_analyzed_commit` to `6e8cf371214436beb36755abf0c82522d481f603`.
+
+## 2026-09-03 - Curve25519 private-value validation
+
+- Manually added for this focused correction: Core now accepts any exactly 32-byte X25519 private value, including RFC 7748 values whose stored bytes are not pre-clamped, and preserves those bytes across PKCS#8 import and export. Scalar masking remains the responsibility of the X25519 operation.
+- `Curve25519PrivateKey.CreateFromValue` now rejects incompatible key types and Curve25519 values whose length is not exactly 32 bytes with `ArgumentException`.
+- Accessing `Curve25519PrivateKey.PrivateKey` after disposal now throws `ObjectDisposedException`
+  instead of exposing the zeroed owned buffer.

--- a/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
+++ b/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
@@ -24,6 +24,9 @@ namespace Yubico.YubiKit.Core.Cryptography;
 /// </summary>
 internal class AsnPrivateKeyDecoder
 {
+    private const string Rfc5958Version1UnsupportedMessage =
+        "RFC 5958 version value 1 OneAsymmetricKey is valid but unsupported.";
+
     /// <summary>
     /// Creates an instance of <see cref="IPrivateKey"/> from a PKCS#8
     /// ASN.1 DER-encoded private key.
@@ -42,11 +45,7 @@ internal class AsnPrivateKeyDecoder
         var seqPrivateKeyInfo = reader.ReadSequence();
 
         // PKCS#8 starts with a version (integer 0)
-        var version = seqPrivateKeyInfo.ReadInteger();
-        if (version != 0)
-        {
-            throw new CryptographicException("Invalid PKCS#8 private key format: unexpected version");
-        }
+        ReadAndValidatePkcs8Version(seqPrivateKeyInfo);
 
         var seqAlgorithmIdentifier = seqPrivateKeyInfo.ReadSequence();
         var oidAlgorithm = seqAlgorithmIdentifier.ReadObjectIdentifier();
@@ -105,11 +104,7 @@ internal class AsnPrivateKeyDecoder
     {
         var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
         var seqPrivateKeyInfo = reader.ReadSequence();
-        var version = seqPrivateKeyInfo.ReadInteger();
-        if (version != 0)
-        {
-            throw new CryptographicException("Invalid PKCS#8 private key format: unexpected version");
-        }
+        ReadAndValidatePkcs8Version(seqPrivateKeyInfo);
 
         var seqAlgorithmIdentifier = seqPrivateKeyInfo.ReadSequence();
         var algorithmOid = seqAlgorithmIdentifier.ReadObjectIdentifier();
@@ -146,11 +141,7 @@ internal class AsnPrivateKeyDecoder
         var seqPrivateKeyInfo = reader.ReadSequence();
 
         // PKCS#8 starts with a version (integer 0)
-        var version = seqPrivateKeyInfo.ReadInteger();
-        if (version != 0)
-        {
-            throw new CryptographicException("Invalid PKCS#8 private key format: unexpected version");
-        }
+        ReadAndValidatePkcs8Version(seqPrivateKeyInfo);
 
         var seqAlgorithmIdentifier = seqPrivateKeyInfo.ReadSequence();
         var oidAlgorithm = seqAlgorithmIdentifier.ReadObjectIdentifier();
@@ -244,11 +235,7 @@ internal class AsnPrivateKeyDecoder
         var seqPrivateKeyInfo = reader.ReadSequence();
 
         // PKCS#8 starts with a version (integer 0)
-        var version = seqPrivateKeyInfo.ReadInteger();
-        if (version != 0)
-        {
-            throw new CryptographicException("Invalid PKCS#8 private key format: unexpected version");
-        }
+        ReadAndValidatePkcs8Version(seqPrivateKeyInfo);
 
         var seqAlgorithmIdentifier = seqPrivateKeyInfo.ReadSequence();
         var oidAlgorithm = seqAlgorithmIdentifier.ReadObjectIdentifier();
@@ -295,5 +282,16 @@ internal class AsnPrivateKeyDecoder
         };
 
         return rsaParameters.NormalizeParameters();
+    }
+
+    private static void ReadAndValidatePkcs8Version(AsnReader privateKeyInfo)
+    {
+        var version = privateKeyInfo.ReadInteger();
+        if (version != 0)
+        {
+            throw new CryptographicException(version == 1
+                ? Rfc5958Version1UnsupportedMessage
+                : "Invalid PKCS#8 private key format: unexpected version");
+        }
     }
 }

--- a/src/Core/src/Cryptography/AsnPrivateKeyEncoder.cs
+++ b/src/Core/src/Cryptography/AsnPrivateKeyEncoder.cs
@@ -203,7 +203,7 @@ internal static class AsnPrivateKeyEncoder
     {
         if (privateKey.Length != 32)
         {
-            throw new ArgumentException("Curve25519 key must be 32 bytes.");
+            throw new ArgumentException("Curve25519 key must be 32 bytes.", nameof(privateKey));
         }
 
         if (algorithmOid is null)
@@ -214,11 +214,6 @@ internal static class AsnPrivateKeyEncoder
         if (!Oids.IsCurve25519Algorithm(algorithmOid))
         {
             throw new ArgumentException("Algorithm OID is not supported.", nameof(algorithmOid));
-        }
-
-        if (algorithmOid == Oids.X25519)
-        {
-            AsnUtilities.VerifyX25519PrivateKey(privateKey);
         }
 
         // Create the PKCS#8 PrivateKeyInfo structure

--- a/src/Core/src/Cryptography/AsnUtilities.cs
+++ b/src/Core/src/Cryptography/AsnUtilities.cs
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Security.Cryptography;
-
 namespace Yubico.YubiKit.Core.Cryptography;
 
 internal static class AsnUtilities
@@ -74,21 +72,6 @@ internal static class AsnUtilities
         }
 
         return trimmedBytes;
-    }
-
-    /// <summary>
-    /// Verifies that the given X25519 private key meets the bit clamping requirements of RFC 7748.
-    /// </summary>
-    /// <param name="x25519PrivateKey">The X25519 private key to verify.</param>
-    /// <exception cref="CryptographicException">If the private key does not meet the bit clamping requirements.</exception>
-    public static void VerifyX25519PrivateKey(ReadOnlySpan<byte> x25519PrivateKey)
-    {
-        if ((x25519PrivateKey[0] & 0b111) != 0 || // Check that the 3 least significant bits are set
-            (x25519PrivateKey[31] & 0x80) != 0 || // Check most significant bit is set
-            (x25519PrivateKey[31] & 0x40) != 0x40) // Check second most significant bit not set
-        {
-            throw new CryptographicException("Invalid X25519 private key: improper bit clamping");
-        }
     }
 
     private static int GetLeadingZeroCount(ReadOnlySpan<byte> data)

--- a/src/Core/src/Cryptography/Curve25519PrivateKey.cs
+++ b/src/Core/src/Cryptography/Curve25519PrivateKey.cs
@@ -24,6 +24,9 @@ namespace Yubico.YubiKit.Core.Cryptography;
 /// This sealed class encapsulates Curve25519 private key data and supports
 /// both Ed25519 and X25519 cryptographic operations.
 /// It also provides factory methods for creating instances from private key values or DER-encoded data.
+/// Imported private key bytes are copied and preserved unchanged. In particular, X25519 masking occurs
+/// when a cryptographic operation decodes the scalar as specified by RFC 7748, not when key bytes are
+/// imported, encoded, or exported.
 /// </remarks>
 public sealed class Curve25519PrivateKey : PrivateKey
 {
@@ -33,7 +36,7 @@ public sealed class Curve25519PrivateKey : PrivateKey
     public override KeyType KeyType => KeyDefinition.KeyType;
 
     /// <summary>
-    /// Gets the key definition associated with this RSA private key.
+    /// Gets the key definition associated with this Curve25519 private key.
     /// </summary>
     /// <value>
     /// A <see cref="KeyDefinition"/> object that describes the key's properties, including its type and length.
@@ -41,19 +44,32 @@ public sealed class Curve25519PrivateKey : PrivateKey
     public KeyDefinition KeyDefinition { get; }
 
     /// <summary>
-    /// Gets the bytes representing the private scalar value.
+    /// Gets the raw private key bytes exactly as imported.
     /// </summary>
-    /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the private scalar value.</returns>
-    public ReadOnlyMemory<byte> PrivateKey => _privateKey;
+    /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the raw private key value.</returns>
+    public ReadOnlyMemory<byte> PrivateKey
+    {
+        get
+        {
+            ThrowIfDisposed();
+            return _privateKey;
+        }
+    }
 
     private Curve25519PrivateKey(
         ReadOnlyMemory<byte> privateKey,
         KeyType keyType)
     {
-        var keyDefinition = keyType.GetKeyDefinition();
-        if (keyDefinition.AlgorithmOid == Oids.X25519)
+        if (keyType is not (KeyType.X25519 or KeyType.Ed25519))
         {
-            AsnUtilities.VerifyX25519PrivateKey(privateKey.Span);
+            throw new ArgumentException("Only X25519 and Ed25519 are supported.", nameof(keyType));
+        }
+
+        var keyDefinition = keyType.GetKeyDefinition();
+
+        if (privateKey.Length != 32)
+        {
+            throw new ArgumentException("Curve25519 private keys must be exactly 32 bytes.", nameof(privateKey));
         }
 
         _privateKey = new byte[privateKey.Length];
@@ -90,6 +106,10 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// Thrown if the algorithm OID is not X25519 or Ed25519.
     /// </exception>
     /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
+    /// <remarks>
+    /// This method accepts version 0 PKCS#8 <c>PrivateKeyInfo</c>. RFC 5958 version value 1
+    /// <c>OneAsymmetricKey</c> is valid but unsupported.
+    /// </remarks>
     public static Curve25519PrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> pkcs8EncodedKey)
     {
         (var privateKey, var keyType) = AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8EncodedKey);
@@ -101,10 +121,10 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// Creates an instance of <see cref="Curve25519PrivateKey"/> from the given
     /// <paramref name="privateKey"/> and <paramref name="keyType"/>.
     /// </summary>
-    /// <param name="privateKey">The raw private key data. This is copied internally.</param>
+    /// <param name="privateKey">The 32 raw private key bytes. These are copied and preserved unchanged.</param>
     /// <param name="keyType">The type of key this is.</param>
     /// <returns>An instance of <see cref="Curve25519PrivateKey"/>.</returns>
-    /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="keyType"/> is not X25519 or Ed25519, or if <paramref name="privateKey"/> is not exactly 32 bytes.</exception>
     public static Curve25519PrivateKey CreateFromValue(ReadOnlyMemory<byte> privateKey, KeyType keyType) => new(privateKey, keyType);
 
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
@@ -1,0 +1,557 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+/// <summary>
+/// Tests for the internal <see cref="AsnPrivateKeyDecoder"/>. It is reachable from this
+/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
+/// <c>Yubico.YubiKit.Core.UnitTests</c> to every non-test project, so no production seam
+/// change is needed.
+/// </summary>
+/// <remarks>
+/// Every supported key type is anchored to an independent oracle: for EC and RSA this is the
+/// .NET BCL's own PKCS#8 implementation (<see cref="ECDsa"/> / <see cref="RSA"/>). The .NET 10
+/// BCL used by this repo has no Ed25519/X25519 oracle (no
+/// <c>System.Security.Cryptography.Ed25519</c> / <c>X25519</c> types), so Curve25519 decode
+/// tests are anchored instead to the published RFC 8410 &#167;10.3 Ed25519 vector and to an
+/// OpenSSL <c>evppkey_ecx.txt</c> PKCS#8 encoding of the RFC 7748 &#167;6.1 X25519 "Alice" test
+/// vector. A same-code round-trip is only ever used as a convenience check layered on top of
+/// one of these oracle-anchored assertions, never as the sole assertion.
+/// </remarks>
+public class AsnPrivateKeyDecoderTests
+{
+    private static ECCurve GetNamedCurve(string curveOid) => curveOid switch
+    {
+        Oids.ECP256 => ECCurve.NamedCurves.nistP256,
+        Oids.ECP384 => ECCurve.NamedCurves.nistP384,
+        Oids.ECP521 => ECCurve.NamedCurves.nistP521,
+        _ => throw new ArgumentOutOfRangeException(nameof(curveOid))
+    };
+
+    private static void AssertEcParametersMatch(ECParameters expected, ECParameters actual, string expectedCurveOid)
+    {
+        Assert.Equal(expectedCurveOid, actual.Curve.Oid.Value);
+        Assert.Equal(expected.D, actual.D);
+        Assert.Equal(expected.Q.X, actual.Q.X);
+        Assert.Equal(expected.Q.Y, actual.Q.Y);
+    }
+
+    #region CreateECParameters - Decoder vs BCL oracle (happy paths, all three curves)
+
+    [Theory]
+    [InlineData(Oids.ECP256)]
+    [InlineData(Oids.ECP384)]
+    [InlineData(Oids.ECP521)]
+    public void CreateECParameters_BclEncodedKey_MatchesBclExportedParameters(string curveOid)
+    {
+        using var bcl = ECDsa.Create(GetNamedCurve(curveOid));
+        var pkcs8 = bcl.ExportPkcs8PrivateKey();
+        var expected = bcl.ExportParameters(includePrivateParameters: true);
+
+        var actual = AsnPrivateKeyDecoder.CreateECParameters(pkcs8);
+
+        AssertEcParametersMatch(expected, actual, curveOid);
+    }
+
+    #endregion
+
+    #region CreateECParameters - malformed / branch coverage (AsnWriter-built vectors)
+
+    private static byte[] BuildEcPkcs8(
+        string algorithmOid,
+        string? curveOid,
+        int ecVersion,
+        byte[] privateKeyValue,
+        byte[]? publicKeyPointBytes = null,
+        int publicKeyUnusedBits = 0,
+        bool includeParametersField = false,
+        int pkcs8Version = 0)
+    {
+        var ecWriter = new AsnWriter(AsnEncodingRules.DER);
+        ecWriter.PushSequence();
+        ecWriter.WriteInteger(ecVersion);
+        ecWriter.WriteOctetString(privateKeyValue);
+
+        if (includeParametersField)
+        {
+            var parametersTag = new Asn1Tag(TagClass.ContextSpecific, 0, isConstructed: true);
+            ecWriter.PushSequence(parametersTag);
+            ecWriter.WriteObjectIdentifier(curveOid ?? Oids.ECP256);
+            ecWriter.PopSequence(parametersTag);
+        }
+
+        if (publicKeyPointBytes is not null)
+        {
+            var publicKeyTag = new Asn1Tag(TagClass.ContextSpecific, 1);
+            ecWriter.WriteBitString(publicKeyPointBytes, publicKeyUnusedBits, publicKeyTag);
+        }
+
+        ecWriter.PopSequence();
+        var ecPrivateKeyBytes = ecWriter.Encode();
+
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(pkcs8Version);
+
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(algorithmOid);
+        if (curveOid is not null)
+        {
+            writer.WriteObjectIdentifier(curveOid);
+        }
+        writer.PopSequence();
+
+        writer.WriteOctetString(ecPrivateKeyBytes);
+        writer.PopSequence();
+
+        return writer.Encode();
+    }
+
+    // Line 150: PKCS#8 version must be 0.
+    [Fact]
+    public void CreateECParameters_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    {
+        var pkcs8 = BuildEcPkcs8(Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32], pkcs8Version: 1);
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 157: algorithm OID must be Oids.ECDSA. The thrown message is one of the four known
+    // broken "ExceptionMessages.UnsupportedAlgorithm));" literal sites (AsnPrivateKeyDecoder.cs
+    // 159-162) -- an un-substituted resource placeholder, not real text. We assert exception
+    // type only; asserting the message would pin a defect that a real fix must not regress
+    // against.
+    [Fact]
+    public void CreateECParameters_AlgorithmOidNotEcdsa_ThrowsInvalidOperationException()
+    {
+        var pkcs8 = BuildEcPkcs8(Oids.RSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32]);
+
+        Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 166: curve OID must be P-256/P-384/P-521. Broken message site
+    // AsnPrivateKeyDecoder.cs 171-174 -- type only, see comment above.
+    [Fact]
+    public void CreateECParameters_UnsupportedCurveOid_ThrowsInvalidOperationException()
+    {
+        var pkcs8 = BuildEcPkcs8(Oids.ECDSA, "1.2.3.4.5", ecVersion: 1, privateKeyValue: new byte[32]);
+
+        Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 185: the inner RFC 5915 ECPrivateKey version must be 1.
+    [Fact]
+    public void CreateECParameters_InnerEcVersionNotOne_ThrowsCryptographicException()
+    {
+        var pkcs8 = BuildEcPkcs8(Oids.ECDSA, Oids.ECP256, ecVersion: 2, privateKeyValue: new byte[32]);
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 194: the optional-trailing-field while loop, NOT entered -- no [1] public key field
+    // present at all. This is a same-code decode used only to pin a structural branch (the
+    // loop terminates immediately because seqEcPrivateKey.HasData is false); the BCL happy-path
+    // tests above already anchor the "loop entered" side against an independent oracle.
+    [Fact]
+    public void CreateECParameters_NoPublicKeyField_LoopNotEntered_QStaysDefault()
+    {
+        var privateKeyValue = new byte[32];
+        Array.Fill(privateKeyValue, (byte)0x07);
+        var pkcs8 = BuildEcPkcs8(Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue);
+
+        var result = AsnPrivateKeyDecoder.CreateECParameters(pkcs8);
+
+        Assert.Equal(privateKeyValue, result.D);
+        Assert.Null(result.Q.X);
+        Assert.Null(result.Q.Y);
+    }
+
+    // Line 200: BIT STRING unusedBits must be 0.
+    [Fact]
+    public void CreateECParameters_PublicKeyBitStringHasUnusedBits_ThrowsCryptographicException()
+    {
+        var point = new byte[65];
+        point[0] = 0x04;
+        var pkcs8 = BuildEcPkcs8(
+            Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32],
+            publicKeyPointBytes: point, publicKeyUnusedBits: 1);
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 206 -- KNOWN DEFECT, PINNED NOT ENDORSED: a public-point prefix other than 0x04
+    // (e.g. a compressed point) silently skips the "if" and leaves Q at default (X=null,
+    // Y=null) instead of throwing. AsnPublicKeyDecoder.cs:116-119 throws
+    // CryptographicException("Unsupported EC point format") for exactly the same condition, so
+    // this decoder is inconsistent with its sibling. Fixing this is a behaviour change for a
+    // separate reviewed PR; this test only pins the current silent behaviour.
+    [Fact]
+    public void CreateECParameters_CompressedPointPrefix_SilentlyLeavesQDefault_PinnedNotEndorsed()
+    {
+        var compressedPoint = new byte[33];
+        compressedPoint[0] = 0x02; // compressed point format, not handled
+        var privateKeyValue = new byte[32];
+        Array.Fill(privateKeyValue, (byte)0x09);
+        var pkcs8 = BuildEcPkcs8(
+            Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue,
+            publicKeyPointBytes: compressedPoint);
+
+        var result = AsnPrivateKeyDecoder.CreateECParameters(pkcs8);
+
+        Assert.Equal(privateKeyValue, result.D);
+        Assert.Null(result.Q.X);
+        Assert.Null(result.Q.Y);
+    }
+
+    // Line 210 -- KNOWN DEFECT, PINNED NOT ENDORSED: a public point whose length does not match
+    // 2*coordinateSize+1 is silently ignored (Q stays default) rather than throwing. Same shape
+    // and same treatment as the compressed-point case above.
+    [Fact]
+    public void CreateECParameters_WrongLengthPublicPoint_SilentlyLeavesQDefault_PinnedNotEndorsed()
+    {
+        var wrongLengthPoint = new byte[11];
+        wrongLengthPoint[0] = 0x04;
+        var privateKeyValue = new byte[32];
+        Array.Fill(privateKeyValue, (byte)0x0A);
+        var pkcs8 = BuildEcPkcs8(
+            Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue,
+            publicKeyPointBytes: wrongLengthPoint);
+
+        var result = AsnPrivateKeyDecoder.CreateECParameters(pkcs8);
+
+        Assert.Equal(privateKeyValue, result.D);
+        Assert.Null(result.Q.X);
+        Assert.Null(result.Q.Y);
+    }
+
+    // Noted but not pinned as its own defect test per task scope: publicKeyBytes.Span[0] is
+    // indexed without a length check at line 206, so a zero-length BIT STRING throws
+    // IndexOutOfRangeException instead of a CryptographicException. Pinned here anyway since it
+    // is cheap and documents the exact failure mode.
+    [Fact]
+    public void CreateECParameters_ZeroLengthPublicKeyBitString_ThrowsIndexOutOfRangeException()
+    {
+        var pkcs8 = BuildEcPkcs8(
+            Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32],
+            publicKeyPointBytes: []);
+
+        Assert.Throws<IndexOutOfRangeException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+    }
+
+    // Line 226: an optional [0] parameters field (RFC 5915 EXPLICIT tag) is present and must be
+    // skipped via ReadEncodedValue() without disturbing decoding of the surrounding fields.
+    [Fact]
+    public void CreateECParameters_OptionalParametersFieldPresent_IsSkippedAndDecodesFine()
+    {
+        using var bcl = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var expected = bcl.ExportParameters(includePrivateParameters: true);
+        var point = new byte[65];
+        point[0] = 0x04;
+        expected.Q.X!.CopyTo(point, 1);
+        expected.Q.Y!.CopyTo(point, 33);
+
+        var pkcs8 = BuildEcPkcs8(
+            Oids.ECDSA, Oids.ECP256, ecVersion: 1, expected.D!,
+            publicKeyPointBytes: point, includeParametersField: true);
+
+        var result = AsnPrivateKeyDecoder.CreateECParameters(pkcs8);
+
+        AssertEcParametersMatch(expected, result, Oids.ECP256);
+    }
+
+    #endregion
+
+    #region CreateRSAParameters - Decoder vs BCL oracle
+
+    [Theory]
+    [InlineData(2048)]
+    [InlineData(3072)]
+    public void CreateRSAParameters_BclEncodedKey_MatchesBclExportedParameters(int keySizeBits)
+    {
+        using var rsa = RSA.Create(keySizeBits);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var expected = rsa.ExportParameters(includePrivateParameters: true);
+
+        var actual = AsnPrivateKeyDecoder.CreateRSAParameters(pkcs8);
+
+        Assert.Equal(expected.Modulus, actual.Modulus);
+        Assert.Equal(expected.Exponent, actual.Exponent);
+        Assert.Equal(expected.D, actual.D);
+        Assert.Equal(expected.P, actual.P);
+        Assert.Equal(expected.Q, actual.Q);
+        Assert.Equal(expected.DP, actual.DP);
+        Assert.Equal(expected.DQ, actual.DQ);
+        Assert.Equal(expected.InverseQ, actual.InverseQ);
+    }
+
+    private static byte[] BuildRsaPkcs8WithAlgorithmOid(string algorithmOid)
+    {
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(0);
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(algorithmOid);
+        writer.PopSequence();
+        writer.WriteOctetString([]);
+        writer.PopSequence();
+        return writer.Encode();
+    }
+
+    [Fact]
+    public void CreateRSAParameters_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    {
+        using var rsa = RSA.Create(2048);
+        var real = rsa.ExportPkcs8PrivateKey();
+        var reader = new AsnReader(real, AsnEncodingRules.DER);
+        var seq = reader.ReadSequence();
+        _ = seq.ReadInteger();
+        var algSeq = seq.ReadEncodedValue();
+        var keyOctets = seq.ReadOctetString();
+
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(1); // invalid version
+        writer.WriteEncodedValue(algSeq.Span);
+        writer.WriteOctetString(keyOctets);
+        writer.PopSequence();
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateRSAParameters(writer.Encode()));
+    }
+
+    // Broken message site AsnPrivateKeyDecoder.cs 257-260 -- type only, see comment on the EC
+    // "AlgorithmOidNotEcdsa" test above for why the message is not pinned.
+    [Fact]
+    public void CreateRSAParameters_AlgorithmOidNotRsa_ThrowsInvalidOperationException()
+    {
+        var pkcs8 = BuildRsaPkcs8WithAlgorithmOid(Oids.ECDSA);
+
+        Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreateRSAParameters(pkcs8));
+    }
+
+    #endregion
+
+    #region CreatePrivateKey - dispatches by algorithm OID
+
+    [Fact]
+    public void CreatePrivateKey_RsaPkcs8_ReturnsRsaPrivateKeyWithMatchingParameters()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var expected = rsa.ExportParameters(includePrivateParameters: true);
+
+        var key = AsnPrivateKeyDecoder.CreatePrivateKey(pkcs8);
+
+        var rsaKey = Assert.IsType<RSAPrivateKey>(key);
+        Assert.Equal(expected.Modulus, rsaKey.Parameters.Modulus);
+        Assert.Equal(expected.D, rsaKey.Parameters.D);
+    }
+
+    [Fact]
+    public void CreatePrivateKey_EcPkcs8_ReturnsEcPrivateKeyWithMatchingParameters()
+    {
+        using var bcl = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var pkcs8 = bcl.ExportPkcs8PrivateKey();
+        var expected = bcl.ExportParameters(includePrivateParameters: true);
+
+        var key = AsnPrivateKeyDecoder.CreatePrivateKey(pkcs8);
+
+        var ecKey = Assert.IsType<ECPrivateKey>(key);
+        Assert.Equal(expected.D, ecKey.Parameters.D);
+        Assert.Equal(expected.Q.X, ecKey.Parameters.Q.X);
+    }
+
+    [Fact]
+    public void CreatePrivateKey_Ed25519Pkcs8_ReturnsCurve25519PrivateKeyWithRfc8410Value()
+    {
+        var key = AsnPrivateKeyDecoder.CreatePrivateKey(Rfc8410Ed25519Pkcs8Der);
+
+        var curveKey = Assert.IsType<Curve25519PrivateKey>(key);
+        Assert.Equal(KeyType.Ed25519, curveKey.KeyType);
+        Assert.Equal(Rfc8410Ed25519RawPrivateKey, curveKey.PrivateKey.ToArray());
+    }
+
+    // Line 78-81: no case in the switch matches -- broken message site, type only.
+    [Fact]
+    public void CreatePrivateKey_UnsupportedAlgorithmOid_ThrowsInvalidOperationException()
+    {
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(0);
+        writer.PushSequence();
+        writer.WriteObjectIdentifier("2.16.840.1.101.3.4.2.1"); // SHA-256 OID, not a key algorithm
+        writer.PopSequence();
+        writer.WriteOctetString([]);
+        writer.PopSequence();
+
+        Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreatePrivateKey(writer.Encode()));
+    }
+
+    #endregion
+
+    #region Curve25519 - RFC 8410 section 10.3 Ed25519 vector (independent oracle)
+
+    // RFC 8410 section 10.3, "Examples of Ed25519 Private Key" (first example, without the
+    // public key field): https://www.rfc-editor.org/rfc/rfc8410.html#section-10.3
+    // Base64 "MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC" decodes to the
+    // PKCS#8 DER below; the RFC states the raw private key value explicitly.
+    private static readonly byte[] Rfc8410Ed25519Pkcs8Der = Convert.FromBase64String(
+        "MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC");
+
+    private static readonly byte[] Rfc8410Ed25519RawPrivateKey = Convert.FromHexString(
+        "D4EE72DBF913584AD5B6D8F1F769F8AD3AFE7C28CBF1D4FBE097A88F44755842");
+
+    // RFC 7748 section 6.1 gives Alice's X25519 private key as a raw 32-byte scalar:
+    // https://www.rfc-editor.org/rfc/rfc7748.html#section-6.1
+    // OpenSSL's evppkey_ecx.txt test vectors ("X25519 test vectors (from RFC7748 6.1)")
+    // encode that same scalar as an RFC 8410 PKCS#8 DER blob:
+    // https://github.com/openssl/openssl/blob/master/test/recipes/30-test_evp_data/evppkey_ecx.txt
+    // Verified by decoding the base64 below and confirming the trailing 32 bytes equal the raw
+    // scalar from RFC 7748.
+    private static readonly byte[] Rfc7748X25519AlicePkcs8Der = Convert.FromBase64String(
+        "MC4CAQAwBQYDK2VuBCIEIHcHbQpzGKV9PBbBclGyZkXfTC+H68CZKrF3+6UduSwq");
+
+    private static readonly byte[] Rfc7748X25519AliceRawPrivateKey = Convert.FromHexString(
+        "77076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A");
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_Rfc8410Ed25519Vector_MatchesPublishedRawKey()
+    {
+        (var privateKey, var keyType) = AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(Rfc8410Ed25519Pkcs8Der);
+
+        Assert.Equal(KeyType.Ed25519, keyType);
+        Assert.Equal(Rfc8410Ed25519RawPrivateKey, privateKey);
+    }
+
+    // GetCurve25519PrivateKeyData performs no RFC 7748 bit-clamping validation (only the Curve25519
+    // decoder's higher-level factories do, via the Curve25519PrivateKey constructor), so the
+    // unclamped RFC 7748 raw scalar decodes here without throwing.
+    [Fact]
+    public void GetCurve25519PrivateKeyData_Rfc7748X25519AliceVector_MatchesPublishedRawKey()
+    {
+        (var privateKey, var keyType) = AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(Rfc7748X25519AlicePkcs8Der);
+
+        Assert.Equal(KeyType.X25519, keyType);
+        Assert.Equal(Rfc7748X25519AliceRawPrivateKey, privateKey);
+    }
+
+    [Fact]
+    public void CreateCurve25519Key_Rfc8410Ed25519Vector_ReturnsMatchingKey()
+    {
+        // Ed25519 does not go through AsnUtilities.VerifyX25519PrivateKey's bit-clamping check,
+        // so the RFC 8410 vector can be used directly through this higher-level factory too.
+        using var key = AsnPrivateKeyDecoder.CreateCurve25519Key(Rfc8410Ed25519Pkcs8Der);
+
+        Assert.Equal(KeyType.Ed25519, key.KeyType);
+        Assert.Equal(Rfc8410Ed25519RawPrivateKey, key.PrivateKey.ToArray());
+    }
+
+    // Curve25519PrivateKey's constructor calls AsnUtilities.VerifyX25519PrivateKey for X25519
+    // keys, and the published RFC 7748 scalar above is not bit-clamped, so it cannot be used to
+    // exercise CreateCurve25519Key/CreatePrivateKey for X25519 (only the lower-level
+    // GetCurve25519PrivateKeyData, tested above, skips that check). No independently published
+    // X25519 vector with pre-clamped bytes was found, so this uses a locally constructed,
+    // properly clamped key and a same-code round trip through the encoder to build valid PKCS#8
+    // input -- documented here as round-trip-only, not oracle-anchored.
+    [Fact]
+    public void CreateCurve25519Key_ClampedX25519Value_RoundTripsThroughEncoder()
+    {
+        var clamped = new byte[32];
+        Array.Fill(clamped, (byte)0x22);
+        clamped[0] &= 0xF8;
+        clamped[31] &= 0x7F;
+        clamped[31] |= 0x40;
+
+        var pkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(clamped, KeyType.X25519);
+        using var key = AsnPrivateKeyDecoder.CreateCurve25519Key(pkcs8);
+
+        Assert.Equal(KeyType.X25519, key.KeyType);
+        Assert.Equal(clamped, key.PrivateKey.ToArray());
+    }
+
+    #endregion
+
+    #region GetCurve25519PrivateKeyData - malformed input branches
+
+    private static byte[] BuildCurve25519Pkcs8(
+        string algorithmOid,
+        byte[] innerPrivateKeyOctets,
+        int pkcs8Version = 0,
+        bool wrapInnerAsOctetString = true)
+    {
+        byte[] innerEncoded;
+        if (wrapInnerAsOctetString)
+        {
+            var innerWriter = new AsnWriter(AsnEncodingRules.DER);
+            innerWriter.WriteOctetString(innerPrivateKeyOctets);
+            innerEncoded = innerWriter.Encode();
+        }
+        else
+        {
+            innerEncoded = innerPrivateKeyOctets;
+        }
+
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(pkcs8Version);
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(algorithmOid);
+        writer.PopSequence();
+        writer.WriteOctetString(innerEncoded);
+        writer.PopSequence();
+        return writer.Encode();
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    {
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, new byte[32], pkcs8Version: 1);
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_UnsupportedAlgorithmOid_ThrowsArgumentException()
+    {
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.RSA, new byte[32]);
+
+        Assert.Throws<ArgumentException>(() => AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_InnerTagNotOctetString_ThrowsCryptographicException()
+    {
+        // Inner content is a bare INTEGER instead of the expected [UNIVERSAL 4] OCTET STRING.
+        var badInner = new AsnWriter(AsnEncodingRules.DER);
+        badInner.WriteInteger(0);
+
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, badInner.Encode(), wrapInnerAsOctetString: false);
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_InnerKeyWrongLength_ThrowsCryptographicException()
+    {
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, new byte[16]); // not 32 bytes
+
+        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+    }
+
+    #endregion
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
@@ -291,7 +291,7 @@ public class AsnPrivateKeyDecoderTests
 
         var writer = new AsnWriter(AsnEncodingRules.DER);
         writer.PushSequence();
-        writer.WriteInteger(1); // invalid version
+        writer.WriteInteger(1); // Valid RFC 5958 version value not supported by this decoder.
         writer.WriteEncodedValue(algSeq.Span);
         writer.WriteOctetString(keyOctets);
         writer.PopSequence();

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyDecoderTests.cs
@@ -18,21 +18,10 @@ using Yubico.YubiKit.Core.Cryptography;
 
 namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
 
-/// <summary>
-/// Tests for the internal <see cref="AsnPrivateKeyDecoder"/>. It is reachable from this
-/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
-/// <c>Yubico.YubiKit.Core.UnitTests</c> to every non-test project, so no production seam
-/// change is needed.
-/// </summary>
+/// <summary>Tests for <see cref="AsnPrivateKeyDecoder"/>.</summary>
 /// <remarks>
-/// Every supported key type is anchored to an independent oracle: for EC and RSA this is the
-/// .NET BCL's own PKCS#8 implementation (<see cref="ECDsa"/> / <see cref="RSA"/>). The .NET 10
-/// BCL used by this repo has no Ed25519/X25519 oracle (no
-/// <c>System.Security.Cryptography.Ed25519</c> / <c>X25519</c> types), so Curve25519 decode
-/// tests are anchored instead to the published RFC 8410 &#167;10.3 Ed25519 vector and to an
-/// OpenSSL <c>evppkey_ecx.txt</c> PKCS#8 encoding of the RFC 7748 &#167;6.1 X25519 "Alice" test
-/// vector. A same-code round-trip is only ever used as a convenience check layered on top of
-/// one of these oracle-anchored assertions, never as the sole assertion.
+/// EC and RSA vectors are checked against .NET cryptography. Curve25519 vectors come from
+/// RFC 8410 section 10.3 and the OpenSSL encoding of RFC 7748 section 6.1 Alice key material.
 /// </remarks>
 public class AsnPrivateKeyDecoderTests
 {
@@ -71,7 +60,7 @@ public class AsnPrivateKeyDecoderTests
 
     #endregion
 
-    #region CreateECParameters - malformed / branch coverage (AsnWriter-built vectors)
+    #region CreateECParameters - malformed vectors
 
     private static byte[] BuildEcPkcs8(
         string algorithmOid,
@@ -123,20 +112,16 @@ public class AsnPrivateKeyDecoderTests
         return writer.Encode();
     }
 
-    // Line 150: PKCS#8 version must be 0.
     [Fact]
-    public void CreateECParameters_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    public void CreateECParameters_Pkcs8VersionOne_ThrowsValidButUnsupportedCryptographicException()
     {
         var pkcs8 = BuildEcPkcs8(Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32], pkcs8Version: 1);
 
-        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+        var exception = Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
+
+        Assert.Contains("valid but unsupported", exception.Message, StringComparison.Ordinal);
     }
 
-    // Line 157: algorithm OID must be Oids.ECDSA. The thrown message is one of the four known
-    // broken "ExceptionMessages.UnsupportedAlgorithm));" literal sites (AsnPrivateKeyDecoder.cs
-    // 159-162) -- an un-substituted resource placeholder, not real text. We assert exception
-    // type only; asserting the message would pin a defect that a real fix must not regress
-    // against.
     [Fact]
     public void CreateECParameters_AlgorithmOidNotEcdsa_ThrowsInvalidOperationException()
     {
@@ -145,8 +130,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
     }
 
-    // Line 166: curve OID must be P-256/P-384/P-521. Broken message site
-    // AsnPrivateKeyDecoder.cs 171-174 -- type only, see comment above.
     [Fact]
     public void CreateECParameters_UnsupportedCurveOid_ThrowsInvalidOperationException()
     {
@@ -155,7 +138,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
     }
 
-    // Line 185: the inner RFC 5915 ECPrivateKey version must be 1.
     [Fact]
     public void CreateECParameters_InnerEcVersionNotOne_ThrowsCryptographicException()
     {
@@ -164,10 +146,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
     }
 
-    // Line 194: the optional-trailing-field while loop, NOT entered -- no [1] public key field
-    // present at all. This is a same-code decode used only to pin a structural branch (the
-    // loop terminates immediately because seqEcPrivateKey.HasData is false); the BCL happy-path
-    // tests above already anchor the "loop entered" side against an independent oracle.
     [Fact]
     public void CreateECParameters_NoPublicKeyField_LoopNotEntered_QStaysDefault()
     {
@@ -182,7 +160,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Null(result.Q.Y);
     }
 
-    // Line 200: BIT STRING unusedBits must be 0.
     [Fact]
     public void CreateECParameters_PublicKeyBitStringHasUnusedBits_ThrowsCryptographicException()
     {
@@ -195,17 +172,12 @@ public class AsnPrivateKeyDecoderTests
         Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
     }
 
-    // Line 206 -- KNOWN DEFECT, PINNED NOT ENDORSED: a public-point prefix other than 0x04
-    // (e.g. a compressed point) silently skips the "if" and leaves Q at default (X=null,
-    // Y=null) instead of throwing. AsnPublicKeyDecoder.cs:116-119 throws
-    // CryptographicException("Unsupported EC point format") for exactly the same condition, so
-    // this decoder is inconsistent with its sibling. Fixing this is a behaviour change for a
-    // separate reviewed PR; this test only pins the current silent behaviour.
     [Fact]
-    public void CreateECParameters_CompressedPointPrefix_SilentlyLeavesQDefault_PinnedNotEndorsed()
+    public void CreateECParameters_CompressedPointPrefix_LeavesQDefault()
     {
+        // Known limitation: unsupported point formats currently leave Q unset instead of throwing.
         var compressedPoint = new byte[33];
-        compressedPoint[0] = 0x02; // compressed point format, not handled
+        compressedPoint[0] = 0x02;
         var privateKeyValue = new byte[32];
         Array.Fill(privateKeyValue, (byte)0x09);
         var pkcs8 = BuildEcPkcs8(
@@ -219,12 +191,10 @@ public class AsnPrivateKeyDecoderTests
         Assert.Null(result.Q.Y);
     }
 
-    // Line 210 -- KNOWN DEFECT, PINNED NOT ENDORSED: a public point whose length does not match
-    // 2*coordinateSize+1 is silently ignored (Q stays default) rather than throwing. Same shape
-    // and same treatment as the compressed-point case above.
     [Fact]
-    public void CreateECParameters_WrongLengthPublicPoint_SilentlyLeavesQDefault_PinnedNotEndorsed()
+    public void CreateECParameters_WrongLengthPublicPoint_LeavesQDefault()
     {
+        // Known limitation: an invalid point length currently leaves Q unset instead of throwing.
         var wrongLengthPoint = new byte[11];
         wrongLengthPoint[0] = 0x04;
         var privateKeyValue = new byte[32];
@@ -240,13 +210,10 @@ public class AsnPrivateKeyDecoderTests
         Assert.Null(result.Q.Y);
     }
 
-    // Noted but not pinned as its own defect test per task scope: publicKeyBytes.Span[0] is
-    // indexed without a length check at line 206, so a zero-length BIT STRING throws
-    // IndexOutOfRangeException instead of a CryptographicException. Pinned here anyway since it
-    // is cheap and documents the exact failure mode.
     [Fact]
     public void CreateECParameters_ZeroLengthPublicKeyBitString_ThrowsIndexOutOfRangeException()
     {
+        // Known limitation: an empty public-key BIT STRING currently exposes an indexing exception.
         var pkcs8 = BuildEcPkcs8(
             Oids.ECDSA, Oids.ECP256, ecVersion: 1, privateKeyValue: new byte[32],
             publicKeyPointBytes: []);
@@ -254,8 +221,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Throws<IndexOutOfRangeException>(() => AsnPrivateKeyDecoder.CreateECParameters(pkcs8));
     }
 
-    // Line 226: an optional [0] parameters field (RFC 5915 EXPLICIT tag) is present and must be
-    // skipped via ReadEncodedValue() without disturbing decoding of the surrounding fields.
     [Fact]
     public void CreateECParameters_OptionalParametersFieldPresent_IsSkippedAndDecodesFine()
     {
@@ -314,7 +279,7 @@ public class AsnPrivateKeyDecoderTests
     }
 
     [Fact]
-    public void CreateRSAParameters_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    public void CreateRSAParameters_Pkcs8VersionOne_ThrowsValidButUnsupportedCryptographicException()
     {
         using var rsa = RSA.Create(2048);
         var real = rsa.ExportPkcs8PrivateKey();
@@ -331,11 +296,11 @@ public class AsnPrivateKeyDecoderTests
         writer.WriteOctetString(keyOctets);
         writer.PopSequence();
 
-        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateRSAParameters(writer.Encode()));
+        var exception = Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateRSAParameters(writer.Encode()));
+
+        Assert.Contains("valid but unsupported", exception.Message, StringComparison.Ordinal);
     }
 
-    // Broken message site AsnPrivateKeyDecoder.cs 257-260 -- type only, see comment on the EC
-    // "AlgorithmOidNotEcdsa" test above for why the message is not pinned.
     [Fact]
     public void CreateRSAParameters_AlgorithmOidNotRsa_ThrowsInvalidOperationException()
     {
@@ -386,7 +351,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Equal(Rfc8410Ed25519RawPrivateKey, curveKey.PrivateKey.ToArray());
     }
 
-    // Line 78-81: no case in the switch matches -- broken message site, type only.
     [Fact]
     public void CreatePrivateKey_UnsupportedAlgorithmOid_ThrowsInvalidOperationException()
     {
@@ -400,6 +364,16 @@ public class AsnPrivateKeyDecoderTests
         writer.PopSequence();
 
         Assert.Throws<InvalidOperationException>(() => AsnPrivateKeyDecoder.CreatePrivateKey(writer.Encode()));
+    }
+
+    [Fact]
+    public void CreatePrivateKey_Pkcs8VersionOne_ThrowsValidButUnsupportedCryptographicException()
+    {
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, new byte[32], pkcs8Version: 1);
+
+        var exception = Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreatePrivateKey(pkcs8));
+
+        Assert.Contains("valid but unsupported", exception.Message, StringComparison.Ordinal);
     }
 
     #endregion
@@ -438,9 +412,6 @@ public class AsnPrivateKeyDecoderTests
         Assert.Equal(Rfc8410Ed25519RawPrivateKey, privateKey);
     }
 
-    // GetCurve25519PrivateKeyData performs no RFC 7748 bit-clamping validation (only the Curve25519
-    // decoder's higher-level factories do, via the Curve25519PrivateKey constructor), so the
-    // unclamped RFC 7748 raw scalar decodes here without throwing.
     [Fact]
     public void GetCurve25519PrivateKeyData_Rfc7748X25519AliceVector_MatchesPublishedRawKey()
     {
@@ -453,35 +424,40 @@ public class AsnPrivateKeyDecoderTests
     [Fact]
     public void CreateCurve25519Key_Rfc8410Ed25519Vector_ReturnsMatchingKey()
     {
-        // Ed25519 does not go through AsnUtilities.VerifyX25519PrivateKey's bit-clamping check,
-        // so the RFC 8410 vector can be used directly through this higher-level factory too.
         using var key = AsnPrivateKeyDecoder.CreateCurve25519Key(Rfc8410Ed25519Pkcs8Der);
 
         Assert.Equal(KeyType.Ed25519, key.KeyType);
         Assert.Equal(Rfc8410Ed25519RawPrivateKey, key.PrivateKey.ToArray());
     }
 
-    // Curve25519PrivateKey's constructor calls AsnUtilities.VerifyX25519PrivateKey for X25519
-    // keys, and the published RFC 7748 scalar above is not bit-clamped, so it cannot be used to
-    // exercise CreateCurve25519Key/CreatePrivateKey for X25519 (only the lower-level
-    // GetCurve25519PrivateKeyData, tested above, skips that check). No independently published
-    // X25519 vector with pre-clamped bytes was found, so this uses a locally constructed,
-    // properly clamped key and a same-code round trip through the encoder to build valid PKCS#8
-    // input -- documented here as round-trip-only, not oracle-anchored.
     [Fact]
-    public void CreateCurve25519Key_ClampedX25519Value_RoundTripsThroughEncoder()
+    public void CreateCurve25519Key_Rfc7748X25519AliceVector_ReturnsMatchingKey()
     {
-        var clamped = new byte[32];
-        Array.Fill(clamped, (byte)0x22);
-        clamped[0] &= 0xF8;
-        clamped[31] &= 0x7F;
-        clamped[31] |= 0x40;
-
-        var pkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(clamped, KeyType.X25519);
-        using var key = AsnPrivateKeyDecoder.CreateCurve25519Key(pkcs8);
+        using var key = AsnPrivateKeyDecoder.CreateCurve25519Key(Rfc7748X25519AlicePkcs8Der);
 
         Assert.Equal(KeyType.X25519, key.KeyType);
-        Assert.Equal(clamped, key.PrivateKey.ToArray());
+        Assert.Equal(Rfc7748X25519AliceRawPrivateKey, key.PrivateKey.ToArray());
+    }
+
+    [Fact]
+    public void CreateCurve25519Key_Pkcs8VersionOne_ThrowsValidButUnsupportedCryptographicException()
+    {
+        var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, new byte[32], pkcs8Version: 1);
+
+        var exception = Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.CreateCurve25519Key(pkcs8));
+
+        Assert.Contains("valid but unsupported", exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreatePrivateKey_Rfc7748X25519AliceVector_ReturnsMatchingKey()
+    {
+        var key = AsnPrivateKeyDecoder.CreatePrivateKey(Rfc7748X25519AlicePkcs8Der);
+        using var disposableKey = Assert.IsAssignableFrom<IDisposable>(key);
+
+        var curveKey = Assert.IsType<Curve25519PrivateKey>(key);
+        Assert.Equal(KeyType.X25519, curveKey.KeyType);
+        Assert.Equal(Rfc7748X25519AliceRawPrivateKey, curveKey.PrivateKey.ToArray());
     }
 
     #endregion
@@ -518,11 +494,13 @@ public class AsnPrivateKeyDecoderTests
     }
 
     [Fact]
-    public void GetCurve25519PrivateKeyData_Pkcs8VersionNotZero_ThrowsCryptographicException()
+    public void GetCurve25519PrivateKeyData_Rfc5958VersionValueOne_IsValidButUnsupported()
     {
         var pkcs8 = BuildCurve25519Pkcs8(Oids.Ed25519, new byte[32], pkcs8Version: 1);
 
-        Assert.Throws<CryptographicException>(() => AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+        var exception = Assert.Throws<CryptographicException>(() =>
+            AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(pkcs8));
+        Assert.Contains("valid but unsupported", exception.Message, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -536,7 +514,7 @@ public class AsnPrivateKeyDecoderTests
     [Fact]
     public void GetCurve25519PrivateKeyData_InnerTagNotOctetString_ThrowsCryptographicException()
     {
-        // Inner content is a bare INTEGER instead of the expected [UNIVERSAL 4] OCTET STRING.
+        // The inner value is an INTEGER with one zero content octet, not an OCTET STRING.
         var badInner = new AsnWriter(AsnEncodingRules.DER);
         badInner.WriteInteger(0);
 

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyEncoderTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyEncoderTests.cs
@@ -1,0 +1,300 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+/// <summary>
+/// Tests for the internal <see cref="AsnPrivateKeyEncoder"/>. It is reachable from this
+/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
+/// <c>Yubico.YubiKit.Core.UnitTests</c> to every non-test project, so no production seam
+/// change is needed.
+/// </summary>
+/// <remarks>
+/// Direction 2 of the BCL-anchored contract: our code encodes, and the BCL's own
+/// <see cref="RSA.ImportPkcs8PrivateKey"/> / <see cref="ECDsa.ImportPkcs8PrivateKey"/> decodes
+/// and must accept the bytes. The private helpers <c>EncodeECKey</c> and
+/// <c>EncodeCurve25519Key</c> are exercised only through the public overloads listed in the
+/// task scope; their accessibility is not widened.
+/// </remarks>
+public class AsnPrivateKeyEncoderTests
+{
+    private static ECCurve GetNamedCurve(string curveOid) => curveOid switch
+    {
+        Oids.ECP256 => ECCurve.NamedCurves.nistP256,
+        Oids.ECP384 => ECCurve.NamedCurves.nistP384,
+        Oids.ECP521 => ECCurve.NamedCurves.nistP521,
+        _ => throw new ArgumentOutOfRangeException(nameof(curveOid))
+    };
+
+    private static KeyType GetKeyType(string curveOid) => curveOid switch
+    {
+        Oids.ECP256 => KeyType.ECP256,
+        Oids.ECP384 => KeyType.ECP384,
+        Oids.ECP521 => KeyType.ECP521,
+        _ => throw new ArgumentOutOfRangeException(nameof(curveOid))
+    };
+
+    #region EncodeToPkcs8(RSAParameters) - Encoder vs BCL oracle
+
+    [Theory]
+    [InlineData(2048)]
+    [InlineData(3072)]
+    public void EncodeToPkcs8_RsaParameters_BclAcceptsAndMatchesOriginal(int keySizeBits)
+    {
+        using var rsa = RSA.Create(keySizeBits);
+        var expected = rsa.ExportParameters(includePrivateParameters: true);
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(expected);
+
+        using var check = RSA.Create();
+        check.ImportPkcs8PrivateKey(ourPkcs8, out _);
+        var actual = check.ExportParameters(includePrivateParameters: true);
+
+        Assert.Equal(expected.Modulus, actual.Modulus);
+        Assert.Equal(expected.Exponent, actual.Exponent);
+        Assert.Equal(expected.D, actual.D);
+        Assert.Equal(expected.P, actual.P);
+        Assert.Equal(expected.Q, actual.Q);
+        Assert.Equal(expected.DP, actual.DP);
+        Assert.Equal(expected.DQ, actual.DQ);
+        Assert.Equal(expected.InverseQ, actual.InverseQ);
+    }
+
+    [Fact]
+    public void EncodeToPkcs8_RsaParameters_MissingPrivateParts_ThrowsArgumentException()
+    {
+        using var rsa = RSA.Create(2048);
+        var publicParameters = rsa.ExportParameters(includePrivateParameters: false);
+        var publicOnly = new RSAParameters
+        {
+            Modulus = publicParameters.Modulus,
+            Exponent = publicParameters.Exponent
+        };
+
+        Assert.Throws<ArgumentException>(() => AsnPrivateKeyEncoder.EncodeToPkcs8(publicOnly));
+    }
+
+    #endregion
+
+    #region EncodeToPkcs8(ECParameters) - Encoder vs BCL oracle
+
+    // NEWLY DISCOVERED DEFECT (not one of the three pre-identified in the task description) --
+    // PINNED, NOT ENDORSED, NOT FIXED (production changes are out of scope for this task).
+    //
+    // RFC 5915's `publicKey [1] BIT STRING OPTIONAL` field uses EXPLICIT tagging by default
+    // (the RFC's ASN.1 module does not declare IMPLICIT TAGS): the correct wire form is a
+    // constructed context-tag-1 container (0xA1) wrapping a complete, ordinary universal BIT
+    // STRING TLV (0x03 ...). This is exactly what the .NET BCL itself emits from
+    // ECDsa.ExportPkcs8PrivateKey() and what any RFC 5915-compliant consumer (OpenSSL, other
+    // PKCS#8 libraries, etc.) expects.
+    //
+    // AsnPrivateKeyEncoder.EncodeECKey instead writes this field with IMPLICIT tagging -- a
+    // single Asn1Tag(TagClass.ContextSpecific, 1) with the default isConstructed:false passed
+    // straight to WriteBitString -- producing a primitive 0x81 tag with no nested BIT STRING
+    // TLV. The BCL's own ECDsa.ImportPkcs8PrivateKey rejects that byte layout outright with
+    // CryptographicException("ASN1 corrupted data."). Confirmed directly: hand-building both
+    // the EXPLICIT (accepted) and IMPLICIT (rejected) forms in isolation reproduces this
+    // exactly, isolating the defect to the tagging style, independent of any other field.
+    //
+    // Because AsnPrivateKeyDecoder.CreateECParameters reads the private-key SEQUENCE under
+    // AsnEncodingRules.BER, and BER's constructed-primitive-chunking rules for a
+    // single-nested-TLV constructed BIT STRING happen to yield the same effective content as
+    // an EXPLICIT wrapper, our own decoder can read BCL-produced (EXPLICIT) keys correctly
+    // (see CreateECParameters_BclEncodedKey_MatchesBclExportedParameters) even though our own
+    // encoder cannot produce them. This is a one-directional defect: any EC private key
+    // exported by this SDK with its public point populated (the common case -- see
+    // ECPrivateKey.CreateFromParameters/CreateFromEcdh, which are typically fed a full
+    // ECParameters with Q already populated) is NOT importable by a standards-compliant
+    // RFC 5915 consumer, including the .NET BCL's own ECDsa. Only when the public point is
+    // omitted (see the "WithoutPublicPoint" test below) does the encoder's output happen to
+    // still be importable.
+    [Theory]
+    [InlineData(Oids.ECP256)]
+    [InlineData(Oids.ECP384)]
+    [InlineData(Oids.ECP521)]
+    public void EncodeToPkcs8_EcParametersWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed(
+        string curveOid)
+    {
+        using var bcl = ECDsa.Create(GetNamedCurve(curveOid));
+        var expected = bcl.ExportParameters(includePrivateParameters: true);
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(expected);
+
+        using var check = ECDsa.Create();
+        Assert.Throws<CryptographicException>(() => check.ImportPkcs8PrivateKey(ourPkcs8, out _));
+    }
+
+    // EncodeECKey's `publicPoint.HasValue` false branch: when ECParameters.Q is not populated,
+    // the [1] public key field is omitted entirely from the RFC 5915 structure. The BCL still
+    // accepts the resulting PKCS#8 (it derives the public point from D and the named curve).
+    [Fact]
+    public void EncodeToPkcs8_EcParametersWithoutPublicPoint_BclStillAcceptsAndMatchesD()
+    {
+        using var bcl = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var full = bcl.ExportParameters(includePrivateParameters: true);
+        var withoutQ = new ECParameters
+        {
+            Curve = full.Curve,
+            D = full.D
+        };
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(withoutQ);
+
+        using var check = ECDsa.Create();
+        check.ImportPkcs8PrivateKey(ourPkcs8, out _);
+        var actual = check.ExportParameters(includePrivateParameters: true);
+
+        Assert.Equal(full.D, actual.D);
+    }
+
+    [Fact]
+    public void EncodeToPkcs8_EcParametersDIsNull_ThrowsArgumentException()
+    {
+        var parameters = new ECParameters { Curve = ECCurve.NamedCurves.nistP256 };
+
+        Assert.Throws<ArgumentException>(() => AsnPrivateKeyEncoder.EncodeToPkcs8(parameters));
+    }
+
+    [Fact]
+    public void EncodeToPkcs8_EcParametersCurveOidValueIsNull_ThrowsArgumentException()
+    {
+        // A curve whose Oid has a FriendlyName but no Value -- constructible only via
+        // ECCurve.CreateFromOid with a custom Oid, since the named-curve factories always
+        // populate Value.
+        var curve = ECCurve.CreateFromOid(new Oid(null, "not-a-real-curve"));
+        var parameters = new ECParameters { Curve = curve, D = new byte[32] };
+
+        Assert.Throws<ArgumentException>(() => AsnPrivateKeyEncoder.EncodeToPkcs8(parameters));
+    }
+
+    #endregion
+
+    #region EncodeToPkcs8(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>?, KeyType) - EC via raw values
+
+    // Same newly discovered EXPLICIT-vs-IMPLICIT [1] publicKey tagging defect pinned above,
+    // reached this time through the raw-memory overload (which funnels into the same private
+    // EncodeECKey helper). See the detailed comment on
+    // EncodeToPkcs8_EcParametersWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed.
+    [Theory]
+    [InlineData(Oids.ECP256)]
+    [InlineData(Oids.ECP384)]
+    [InlineData(Oids.ECP521)]
+    public void EncodeToPkcs8_RawEcKeyWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed(
+        string curveOid)
+    {
+        using var bcl = ECDsa.Create(GetNamedCurve(curveOid));
+        var expected = bcl.ExportParameters(includePrivateParameters: true);
+        var point = new byte[1 + expected.Q.X!.Length + expected.Q.Y!.Length];
+        point[0] = 0x04;
+        expected.Q.X.CopyTo(point, 1);
+        expected.Q.Y.CopyTo(point, 1 + expected.Q.X.Length);
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(expected.D!, point, GetKeyType(curveOid));
+
+        using var check = ECDsa.Create();
+        Assert.Throws<CryptographicException>(() => check.ImportPkcs8PrivateKey(ourPkcs8, out _));
+    }
+
+    [Fact]
+    public void EncodeToPkcs8_UnsupportedKeyType_ThrowsNotSupportedException() =>
+        Assert.Throws<NotSupportedException>(() =>
+            AsnPrivateKeyEncoder.EncodeToPkcs8(new byte[32], null, KeyType.RSA2048));
+
+    #endregion
+
+    #region EncodeToPkcs8(ReadOnlyMemory<byte>, KeyType) / Curve25519 - Ed25519 vs published oracle
+
+    // Same RFC 8410 section 10.3 vector used in AsnPrivateKeyDecoderTests, restated here so this
+    // file's oracle-anchoring is self-contained.
+    // https://www.rfc-editor.org/rfc/rfc8410.html#section-10.3
+    private static readonly byte[] Rfc8410Ed25519RawPrivateKey = Convert.FromHexString(
+        "D4EE72DBF913584AD5B6D8F1F769F8AD3AFE7C28CBF1D4FBE097A88F44755842");
+
+    private static readonly byte[] Rfc8410Ed25519Pkcs8Der = Convert.FromBase64String(
+        "MC4CAQAwBQYDK2VwBCIEINTuctv5E1hK1bbY8fdp+K06/nwoy/HU++CXqI9EdVhC");
+
+    [Fact]
+    public void EncodeToPkcs8_Ed25519RawKey_TwoArgOverload_ExactlyMatchesRfc8410PublishedDer()
+    {
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(Rfc8410Ed25519RawPrivateKey, KeyType.Ed25519);
+
+        Assert.Equal(Rfc8410Ed25519Pkcs8Der, ourPkcs8);
+    }
+
+    // The three-arg overload's publicPoint parameter is ignored entirely for Curve25519 key
+    // types (EncodeCurve25519Key never reads it), so passing an arbitrary non-null value here
+    // must not change the output at all.
+    [Fact]
+    public void EncodeToPkcs8_Ed25519RawKey_ThreeArgOverload_IgnoresPublicPointAndMatchesRfc8410()
+    {
+        var arbitraryPublicPoint = new byte[] { 0xAA, 0xBB, 0xCC };
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(
+            Rfc8410Ed25519RawPrivateKey, arbitraryPublicPoint, KeyType.Ed25519);
+
+        Assert.Equal(Rfc8410Ed25519Pkcs8Der, ourPkcs8);
+    }
+
+    [Fact]
+    public void EncodeToPkcs8_Curve25519Key_WrongLength_ThrowsArgumentException() =>
+        Assert.Throws<ArgumentException>(() =>
+            AsnPrivateKeyEncoder.EncodeToPkcs8(new byte[10], KeyType.Ed25519));
+
+    // No X25519 oracle exists in the .NET BCL used by this repo (no Ed25519/X25519 types), and
+    // no independently published vector combining a pre-clamped raw X25519 key with its PKCS#8
+    // DER was found (the RFC 7748 test vectors used elsewhere in this suite are NOT
+    // bit-clamped, and AsnUtilities.VerifyX25519PrivateKey -- invoked here via
+    // EncodeCurve25519Key -- rejects unclamped keys). This test therefore verifies the produced
+    // DER's ASN.1 *structure* independently, using System.Formats.Asn1.AsnReader (the BCL's own
+    // ASN.1 parser) directly rather than our production AsnPrivateKeyDecoder, and only then adds
+    // a same-code round trip through our decoder as a convenience check. The round trip alone
+    // would not be sufficient per this task's bar; the AsnReader-based structural check is the
+    // best available independent anchor for X25519 in the absence of a BCL crypto oracle.
+    [Fact]
+    public void EncodeToPkcs8_ClampedX25519Key_ProducesRfc8410CompliantDerStructure()
+    {
+        var clamped = new byte[32];
+        Array.Fill(clamped, (byte)0x33);
+        clamped[0] &= 0xF8;
+        clamped[31] &= 0x7F;
+        clamped[31] |= 0x40;
+
+        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(clamped, KeyType.X25519);
+
+        var reader = new AsnReader(ourPkcs8, AsnEncodingRules.DER);
+        var seq = reader.ReadSequence();
+        Assert.Equal(0, seq.ReadInteger());
+        var algorithmSeq = seq.ReadSequence();
+        Assert.Equal(Oids.X25519, algorithmSeq.ReadObjectIdentifier());
+        algorithmSeq.ThrowIfNotEmpty();
+        var outerOctetString = seq.ReadOctetString();
+        seq.ThrowIfNotEmpty();
+
+        var innerReader = new AsnReader(outerOctetString, AsnEncodingRules.DER);
+        var innerOctetString = innerReader.ReadOctetString();
+        innerReader.ThrowIfNotEmpty();
+        Assert.Equal(clamped, innerOctetString);
+
+        // Convenience round trip through our own decoder (not itself an independent oracle).
+        (var decoded, var keyType) = AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(ourPkcs8);
+        Assert.Equal(KeyType.X25519, keyType);
+        Assert.Equal(clamped, decoded);
+    }
+
+    #endregion
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyEncoderTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnPrivateKeyEncoderTests.cs
@@ -12,24 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Formats.Asn1;
 using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Cryptography;
 
 namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
 
-/// <summary>
-/// Tests for the internal <see cref="AsnPrivateKeyEncoder"/>. It is reachable from this
-/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
-/// <c>Yubico.YubiKit.Core.UnitTests</c> to every non-test project, so no production seam
-/// change is needed.
-/// </summary>
+/// <summary>Tests for <see cref="AsnPrivateKeyEncoder"/>.</summary>
 /// <remarks>
-/// Direction 2 of the BCL-anchored contract: our code encodes, and the BCL's own
-/// <see cref="RSA.ImportPkcs8PrivateKey"/> / <see cref="ECDsa.ImportPkcs8PrivateKey"/> decodes
-/// and must accept the bytes. The private helpers <c>EncodeECKey</c> and
-/// <c>EncodeCurve25519Key</c> are exercised only through the public overloads listed in the
-/// task scope; their accessibility is not widened.
+/// RSA and EC output is checked against .NET cryptography. Curve25519 output is checked against
+/// RFC 8410 and the OpenSSL encoding of the RFC 7748 section 6.1 Alice key material.
 /// </remarks>
 public class AsnPrivateKeyEncoderTests
 {
@@ -93,43 +84,15 @@ public class AsnPrivateKeyEncoderTests
 
     #region EncodeToPkcs8(ECParameters) - Encoder vs BCL oracle
 
-    // NEWLY DISCOVERED DEFECT (not one of the three pre-identified in the task description) --
-    // PINNED, NOT ENDORSED, NOT FIXED (production changes are out of scope for this task).
-    //
-    // RFC 5915's `publicKey [1] BIT STRING OPTIONAL` field uses EXPLICIT tagging by default
-    // (the RFC's ASN.1 module does not declare IMPLICIT TAGS): the correct wire form is a
-    // constructed context-tag-1 container (0xA1) wrapping a complete, ordinary universal BIT
-    // STRING TLV (0x03 ...). This is exactly what the .NET BCL itself emits from
-    // ECDsa.ExportPkcs8PrivateKey() and what any RFC 5915-compliant consumer (OpenSSL, other
-    // PKCS#8 libraries, etc.) expects.
-    //
-    // AsnPrivateKeyEncoder.EncodeECKey instead writes this field with IMPLICIT tagging -- a
-    // single Asn1Tag(TagClass.ContextSpecific, 1) with the default isConstructed:false passed
-    // straight to WriteBitString -- producing a primitive 0x81 tag with no nested BIT STRING
-    // TLV. The BCL's own ECDsa.ImportPkcs8PrivateKey rejects that byte layout outright with
-    // CryptographicException("ASN1 corrupted data."). Confirmed directly: hand-building both
-    // the EXPLICIT (accepted) and IMPLICIT (rejected) forms in isolation reproduces this
-    // exactly, isolating the defect to the tagging style, independent of any other field.
-    //
-    // Because AsnPrivateKeyDecoder.CreateECParameters reads the private-key SEQUENCE under
-    // AsnEncodingRules.BER, and BER's constructed-primitive-chunking rules for a
-    // single-nested-TLV constructed BIT STRING happen to yield the same effective content as
-    // an EXPLICIT wrapper, our own decoder can read BCL-produced (EXPLICIT) keys correctly
-    // (see CreateECParameters_BclEncodedKey_MatchesBclExportedParameters) even though our own
-    // encoder cannot produce them. This is a one-directional defect: any EC private key
-    // exported by this SDK with its public point populated (the common case -- see
-    // ECPrivateKey.CreateFromParameters/CreateFromEcdh, which are typically fed a full
-    // ECParameters with Q already populated) is NOT importable by a standards-compliant
-    // RFC 5915 consumer, including the .NET BCL's own ECDsa. Only when the public point is
-    // omitted (see the "WithoutPublicPoint" test below) does the encoder's output happen to
-    // still be importable.
     [Theory]
     [InlineData(Oids.ECP256)]
     [InlineData(Oids.ECP384)]
     [InlineData(Oids.ECP521)]
-    public void EncodeToPkcs8_EcParametersWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed(
+    public void EncodeToPkcs8_EcParametersWithPublicPoint_BclImportThrowsCryptographicException(
         string curveOid)
     {
+        // Known limitation: the optional public-key field uses implicit tagging, so a
+        // standards-compliant importer rejects the encoded key.
         using var bcl = ECDsa.Create(GetNamedCurve(curveOid));
         var expected = bcl.ExportParameters(includePrivateParameters: true);
 
@@ -139,9 +102,6 @@ public class AsnPrivateKeyEncoderTests
         Assert.Throws<CryptographicException>(() => check.ImportPkcs8PrivateKey(ourPkcs8, out _));
     }
 
-    // EncodeECKey's `publicPoint.HasValue` false branch: when ECParameters.Q is not populated,
-    // the [1] public key field is omitted entirely from the RFC 5915 structure. The BCL still
-    // accepts the resulting PKCS#8 (it derives the public point from D and the named curve).
     [Fact]
     public void EncodeToPkcs8_EcParametersWithoutPublicPoint_BclStillAcceptsAndMatchesD()
     {
@@ -173,9 +133,6 @@ public class AsnPrivateKeyEncoderTests
     [Fact]
     public void EncodeToPkcs8_EcParametersCurveOidValueIsNull_ThrowsArgumentException()
     {
-        // A curve whose Oid has a FriendlyName but no Value -- constructible only via
-        // ECCurve.CreateFromOid with a custom Oid, since the named-curve factories always
-        // populate Value.
         var curve = ECCurve.CreateFromOid(new Oid(null, "not-a-real-curve"));
         var parameters = new ECParameters { Curve = curve, D = new byte[32] };
 
@@ -186,17 +143,15 @@ public class AsnPrivateKeyEncoderTests
 
     #region EncodeToPkcs8(ReadOnlyMemory<byte>, ReadOnlyMemory<byte>?, KeyType) - EC via raw values
 
-    // Same newly discovered EXPLICIT-vs-IMPLICIT [1] publicKey tagging defect pinned above,
-    // reached this time through the raw-memory overload (which funnels into the same private
-    // EncodeECKey helper). See the detailed comment on
-    // EncodeToPkcs8_EcParametersWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed.
     [Theory]
     [InlineData(Oids.ECP256)]
     [InlineData(Oids.ECP384)]
     [InlineData(Oids.ECP521)]
-    public void EncodeToPkcs8_RawEcKeyWithPublicPoint_BclRejectsImplicitlyTaggedPublicKeyField_PinnedNotEndorsed(
+    public void EncodeToPkcs8_RawEcKeyWithPublicPoint_BclImportThrowsCryptographicException(
         string curveOid)
     {
+        // Known limitation: the optional public-key field uses implicit tagging, so a
+        // standards-compliant importer rejects the encoded key.
         using var bcl = ECDsa.Create(GetNamedCurve(curveOid));
         var expected = bcl.ExportParameters(includePrivateParameters: true);
         var point = new byte[1 + expected.Q.X!.Length + expected.Q.Y!.Length];
@@ -219,8 +174,7 @@ public class AsnPrivateKeyEncoderTests
 
     #region EncodeToPkcs8(ReadOnlyMemory<byte>, KeyType) / Curve25519 - Ed25519 vs published oracle
 
-    // Same RFC 8410 section 10.3 vector used in AsnPrivateKeyDecoderTests, restated here so this
-    // file's oracle-anchoring is self-contained.
+    // RFC 8410 section 10.3, first Ed25519 private-key example.
     // https://www.rfc-editor.org/rfc/rfc8410.html#section-10.3
     private static readonly byte[] Rfc8410Ed25519RawPrivateKey = Convert.FromHexString(
         "D4EE72DBF913584AD5B6D8F1F769F8AD3AFE7C28CBF1D4FBE097A88F44755842");
@@ -236,9 +190,6 @@ public class AsnPrivateKeyEncoderTests
         Assert.Equal(Rfc8410Ed25519Pkcs8Der, ourPkcs8);
     }
 
-    // The three-arg overload's publicPoint parameter is ignored entirely for Curve25519 key
-    // types (EncodeCurve25519Key never reads it), so passing an arbitrary non-null value here
-    // must not change the output at all.
     [Fact]
     public void EncodeToPkcs8_Ed25519RawKey_ThreeArgOverload_IgnoresPublicPointAndMatchesRfc8410()
     {
@@ -251,49 +202,29 @@ public class AsnPrivateKeyEncoderTests
     }
 
     [Fact]
-    public void EncodeToPkcs8_Curve25519Key_WrongLength_ThrowsArgumentException() =>
-        Assert.Throws<ArgumentException>(() =>
+    public void EncodeToPkcs8_Curve25519Key_WrongLength_ThrowsArgumentExceptionWithPrivateKeyParamName()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
             AsnPrivateKeyEncoder.EncodeToPkcs8(new byte[10], KeyType.Ed25519));
 
-    // No X25519 oracle exists in the .NET BCL used by this repo (no Ed25519/X25519 types), and
-    // no independently published vector combining a pre-clamped raw X25519 key with its PKCS#8
-    // DER was found (the RFC 7748 test vectors used elsewhere in this suite are NOT
-    // bit-clamped, and AsnUtilities.VerifyX25519PrivateKey -- invoked here via
-    // EncodeCurve25519Key -- rejects unclamped keys). This test therefore verifies the produced
-    // DER's ASN.1 *structure* independently, using System.Formats.Asn1.AsnReader (the BCL's own
-    // ASN.1 parser) directly rather than our production AsnPrivateKeyDecoder, and only then adds
-    // a same-code round trip through our decoder as a convenience check. The round trip alone
-    // would not be sufficient per this task's bar; the AsnReader-based structural check is the
-    // best available independent anchor for X25519 in the absence of a BCL crypto oracle.
+        Assert.Equal("privateKey", exception.ParamName);
+    }
+
+    // RFC 7748 section 6.1 Alice key, encoded by OpenSSL's evppkey_ecx.txt vector.
+    private static readonly byte[] Rfc7748X25519AliceRawPrivateKey = Convert.FromHexString(
+        "77076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A");
+
+    private static readonly byte[] Rfc7748X25519AlicePkcs8Der = Convert.FromBase64String(
+        "MC4CAQAwBQYDK2VuBCIEIHcHbQpzGKV9PBbBclGyZkXfTC+H68CZKrF3+6UduSwq");
+
     [Fact]
-    public void EncodeToPkcs8_ClampedX25519Key_ProducesRfc8410CompliantDerStructure()
+    public void EncodeToPkcs8_Rfc7748X25519AliceKey_MatchesOpenSslPkcs8Vector()
     {
-        var clamped = new byte[32];
-        Array.Fill(clamped, (byte)0x33);
-        clamped[0] &= 0xF8;
-        clamped[31] &= 0x7F;
-        clamped[31] |= 0x40;
+        var encoded = AsnPrivateKeyEncoder.EncodeToPkcs8(
+            Rfc7748X25519AliceRawPrivateKey,
+            KeyType.X25519);
 
-        var ourPkcs8 = AsnPrivateKeyEncoder.EncodeToPkcs8(clamped, KeyType.X25519);
-
-        var reader = new AsnReader(ourPkcs8, AsnEncodingRules.DER);
-        var seq = reader.ReadSequence();
-        Assert.Equal(0, seq.ReadInteger());
-        var algorithmSeq = seq.ReadSequence();
-        Assert.Equal(Oids.X25519, algorithmSeq.ReadObjectIdentifier());
-        algorithmSeq.ThrowIfNotEmpty();
-        var outerOctetString = seq.ReadOctetString();
-        seq.ThrowIfNotEmpty();
-
-        var innerReader = new AsnReader(outerOctetString, AsnEncodingRules.DER);
-        var innerOctetString = innerReader.ReadOctetString();
-        innerReader.ThrowIfNotEmpty();
-        Assert.Equal(clamped, innerOctetString);
-
-        // Convenience round trip through our own decoder (not itself an independent oracle).
-        (var decoded, var keyType) = AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(ourPkcs8);
-        Assert.Equal(KeyType.X25519, keyType);
-        Assert.Equal(clamped, decoded);
+        Assert.Equal(Rfc7748X25519AlicePkcs8Der, encoded);
     }
 
     #endregion

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnUtilitiesTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnUtilitiesTests.cs
@@ -12,31 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Cryptography;
 
 namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
 
-/// <summary>
-/// Tests for <see cref="AsnUtilities"/>. This is an internal type; it is reachable from this
-/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
-/// <c>Yubico.YubiKit.Core.UnitTests</c>.
-/// </summary>
+/// <summary>Tests for <see cref="AsnUtilities"/>.</summary>
 /// <remarks>
-/// <para>
-/// <c>GetLeadingZeroCount</c> is <see langword="private"/> and is not directly reachable even with
-/// <c>InternalsVisibleTo</c>. It is exercised indirectly through both public overloads of
-/// <see cref="AsnUtilities.TrimLeadingZeroes"/>.
-/// </para>
-/// <para>
-/// ASN.1 INTEGER sign rule reminder: a value needs a leading <c>0x00</c> byte only when the
-/// high bit (0x80) of its first significant byte is set (which would otherwise make a DER
-/// INTEGER negative in two's-complement). <see cref="AsnUtilities.EnsurePositive"/> and
-/// <see cref="AsnUtilities.TrimLeadingZeroes(System.Span{byte})"/> are inverses only when the
-/// input already has at most one leading zero byte -- see
-/// <see cref="EnsurePositive_DoesNotStripExtraLeadingZeroes_UnlikeGetIntegerBytes"/> for the
-/// pinned divergence.
-/// </para>
+/// A positive ASN.1 INTEGER needs a leading <c>0x00</c> content octet only when the high bit of
+/// its first significant content octet is set; otherwise the signed value would be negative.
 /// </remarks>
 public class AsnUtilitiesTests
 {
@@ -72,9 +55,6 @@ public class AsnUtilitiesTests
         Assert.Equal<byte>([0x7F], result.ToArray());
     }
 
-    // Pinned: an all-zero input does NOT trim to an empty span. GetLeadingZeroCount's
-    // "reached the end" branch returns (data.Length - 1), i.e. the position of the LAST
-    // zero byte, so a single 0x00 byte survives.
     [Fact]
     public void TrimLeadingZeroes_ReadOnlySpan_AllZeroes_LeavesSingleZeroByte()
     {
@@ -96,10 +76,6 @@ public class AsnUtilitiesTests
     #endregion
 
     #region TrimLeadingZeroes(Span<byte>)
-
-    // Separate overload, same underlying private GetLeadingZeroCount helper. Exercised with
-    // its own explicit test data (not just delegating to the ReadOnlySpan cases above) so this
-    // overload is independently covered.
 
     [Fact]
     public void TrimLeadingZeroes_Span_NoLeadingZeroes_ReturnsUnchanged()
@@ -198,11 +174,6 @@ public class AsnUtilitiesTests
         Assert.Equal<byte>([0x00, 0x80, 0x01], result);
     }
 
-    // Pinned divergence from GetIntegerBytes: EnsurePositive only inspects value[0]. It does
-    // NOT strip pre-existing leading zero bytes, so an already-zero-padded-but-non-minimal
-    // input is returned unchanged (still non-minimal), whereas GetIntegerBytes trims first and
-    // would collapse this down to a single 0x7F byte. They are inverses only when the input
-    // has at most one leading zero already.
     [Fact]
     public void EnsurePositive_DoesNotStripExtraLeadingZeroes_UnlikeGetIntegerBytes()
     {
@@ -250,66 +221,11 @@ public class AsnUtilitiesTests
     [Fact]
     public void GetIntegerBytes_LeadingZeroesThenHighBitSet_TrimsThenPrependsOneZero()
     {
-        // Two leading zeroes, trims to {0x80}, high bit is set on the trimmed value, so exactly
-        // one zero is re-added (minimal DER INTEGER encoding), not the original two.
         byte[] value = [0x00, 0x00, 0x80];
 
         var result = AsnUtilities.GetIntegerBytes(value.AsSpan());
 
         Assert.Equal<byte>([0x00, 0x80], result.ToArray());
-    }
-
-    #endregion
-
-    #region VerifyX25519PrivateKey
-
-    // A validly clamped X25519 private key per RFC 7748 clamping: bits 0-2 of byte[0] clear,
-    // bit 7 of byte[31] clear, bit 6 of byte[31] set.
-    private static byte[] MakeClampedKey()
-    {
-        var key = new byte[32];
-        Array.Fill(key, (byte)0x11);
-        key[0] &= 0xF8; // clear low 3 bits
-        key[31] &= 0x7F; // clear high bit
-        key[31] |= 0x40; // set second-highest bit
-        return key;
-    }
-
-    [Fact]
-    public void VerifyX25519PrivateKey_ProperlyClampedKey_DoesNotThrow()
-    {
-        var key = MakeClampedKey();
-
-        var exception = Record.Exception(() => AsnUtilities.VerifyX25519PrivateKey(key));
-
-        Assert.Null(exception);
-    }
-
-    [Fact]
-    public void VerifyX25519PrivateKey_LowThreeBitsOfFirstByteSet_ThrowsCryptographicException()
-    {
-        var key = MakeClampedKey();
-        key[0] |= 0x01;
-
-        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
-    }
-
-    [Fact]
-    public void VerifyX25519PrivateKey_HighBitOfLastByteSet_ThrowsCryptographicException()
-    {
-        var key = MakeClampedKey();
-        key[31] |= 0x80;
-
-        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
-    }
-
-    [Fact]
-    public void VerifyX25519PrivateKey_SecondHighestBitOfLastByteClear_ThrowsCryptographicException()
-    {
-        var key = MakeClampedKey();
-        key[31] &= 0xBF; // clear bit 0x40, which must be set
-
-        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
     }
 
     #endregion

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnUtilitiesTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/AsnUtilitiesTests.cs
@@ -1,0 +1,316 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Cryptography;
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+/// <summary>
+/// Tests for <see cref="AsnUtilities"/>. This is an internal type; it is reachable from this
+/// assembly because <c>Directory.Build.targets</c> grants <c>InternalsVisibleTo</c> for
+/// <c>Yubico.YubiKit.Core.UnitTests</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>GetLeadingZeroCount</c> is <see langword="private"/> and is not directly reachable even with
+/// <c>InternalsVisibleTo</c>. It is exercised indirectly through both public overloads of
+/// <see cref="AsnUtilities.TrimLeadingZeroes"/>.
+/// </para>
+/// <para>
+/// ASN.1 INTEGER sign rule reminder: a value needs a leading <c>0x00</c> byte only when the
+/// high bit (0x80) of its first significant byte is set (which would otherwise make a DER
+/// INTEGER negative in two's-complement). <see cref="AsnUtilities.EnsurePositive"/> and
+/// <see cref="AsnUtilities.TrimLeadingZeroes(System.Span{byte})"/> are inverses only when the
+/// input already has at most one leading zero byte -- see
+/// <see cref="EnsurePositive_DoesNotStripExtraLeadingZeroes_UnlikeGetIntegerBytes"/> for the
+/// pinned divergence.
+/// </para>
+/// </remarks>
+public class AsnUtilitiesTests
+{
+    #region TrimLeadingZeroes(ReadOnlySpan<byte>)
+
+    [Fact]
+    public void TrimLeadingZeroes_ReadOnlySpan_NoLeadingZeroes_ReturnsUnchanged()
+    {
+        byte[] data = [0x01, 0x02, 0x03];
+
+        var result = AsnUtilities.TrimLeadingZeroes((ReadOnlySpan<byte>)data);
+
+        Assert.Equal(data, result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_ReadOnlySpan_OneLeadingZero_IsRemoved()
+    {
+        byte[] data = [0x00, 0x80, 0x01];
+
+        var result = AsnUtilities.TrimLeadingZeroes((ReadOnlySpan<byte>)data);
+
+        Assert.Equal<byte>([0x80, 0x01], result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_ReadOnlySpan_MultipleLeadingZeroes_AreAllRemoved()
+    {
+        byte[] data = [0x00, 0x00, 0x00, 0x7F];
+
+        var result = AsnUtilities.TrimLeadingZeroes((ReadOnlySpan<byte>)data);
+
+        Assert.Equal<byte>([0x7F], result.ToArray());
+    }
+
+    // Pinned: an all-zero input does NOT trim to an empty span. GetLeadingZeroCount's
+    // "reached the end" branch returns (data.Length - 1), i.e. the position of the LAST
+    // zero byte, so a single 0x00 byte survives.
+    [Fact]
+    public void TrimLeadingZeroes_ReadOnlySpan_AllZeroes_LeavesSingleZeroByte()
+    {
+        byte[] data = [0x00, 0x00, 0x00];
+
+        var result = AsnUtilities.TrimLeadingZeroes((ReadOnlySpan<byte>)data);
+
+        Assert.Equal<byte>([0x00], result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_ReadOnlySpan_EmptyInput_ReturnsEmpty()
+    {
+        var result = AsnUtilities.TrimLeadingZeroes(ReadOnlySpan<byte>.Empty);
+
+        Assert.Equal(0, result.Length);
+    }
+
+    #endregion
+
+    #region TrimLeadingZeroes(Span<byte>)
+
+    // Separate overload, same underlying private GetLeadingZeroCount helper. Exercised with
+    // its own explicit test data (not just delegating to the ReadOnlySpan cases above) so this
+    // overload is independently covered.
+
+    [Fact]
+    public void TrimLeadingZeroes_Span_NoLeadingZeroes_ReturnsUnchanged()
+    {
+        byte[] data = [0x05, 0x06];
+
+        var result = AsnUtilities.TrimLeadingZeroes(data.AsSpan());
+
+        Assert.Equal<byte>([0x05, 0x06], result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_Span_LeadingZeroes_AreRemoved()
+    {
+        byte[] data = [0x00, 0x00, 0x01, 0x02];
+
+        var result = AsnUtilities.TrimLeadingZeroes(data.AsSpan());
+
+        Assert.Equal<byte>([0x01, 0x02], result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_Span_AllZeroes_LeavesSingleZeroByte()
+    {
+        byte[] data = [0x00, 0x00];
+
+        var result = AsnUtilities.TrimLeadingZeroes(data.AsSpan());
+
+        Assert.Equal<byte>([0x00], result.ToArray());
+    }
+
+    [Fact]
+    public void TrimLeadingZeroes_Span_EmptyInput_ReturnsEmpty()
+    {
+        var result = AsnUtilities.TrimLeadingZeroes(Span<byte>.Empty);
+
+        Assert.Equal(0, result.Length);
+    }
+
+    #endregion
+
+    #region GetCoordinateSizeFromCurve
+
+    [Theory]
+    [InlineData(Oids.ECP256, 32)]
+    [InlineData(Oids.ECP384, 48)]
+    [InlineData(Oids.ECP521, 66)]
+    public void GetCoordinateSizeFromCurve_SupportedCurve_ReturnsExpectedSize(string curveOid, int expectedSize)
+    {
+        var size = AsnUtilities.GetCoordinateSizeFromCurve(curveOid);
+
+        Assert.Equal(expectedSize, size);
+    }
+
+    [Fact]
+    public void GetCoordinateSizeFromCurve_UnsupportedOid_ThrowsNotSupportedException() =>
+        Assert.Throws<NotSupportedException>(() => AsnUtilities.GetCoordinateSizeFromCurve("1.2.3.4.5.6.7"));
+
+    #endregion
+
+    #region EnsurePositive
+
+    [Fact]
+    public void EnsurePositive_NullInput_ReturnsEmptyArray()
+    {
+        var result = AsnUtilities.EnsurePositive(null);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void EnsurePositive_EmptyInput_ReturnsEmptyArray()
+    {
+        var result = AsnUtilities.EnsurePositive([]);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void EnsurePositive_HighBitNotSet_ReturnsUnchanged()
+    {
+        byte[] value = [0x7F, 0x01];
+
+        var result = AsnUtilities.EnsurePositive(value);
+
+        Assert.Equal<byte>([0x7F, 0x01], result);
+    }
+
+    [Fact]
+    public void EnsurePositive_HighBitSet_PrependsLeadingZero()
+    {
+        byte[] value = [0x80, 0x01];
+
+        var result = AsnUtilities.EnsurePositive(value);
+
+        Assert.Equal<byte>([0x00, 0x80, 0x01], result);
+    }
+
+    // Pinned divergence from GetIntegerBytes: EnsurePositive only inspects value[0]. It does
+    // NOT strip pre-existing leading zero bytes, so an already-zero-padded-but-non-minimal
+    // input is returned unchanged (still non-minimal), whereas GetIntegerBytes trims first and
+    // would collapse this down to a single 0x7F byte. They are inverses only when the input
+    // has at most one leading zero already.
+    [Fact]
+    public void EnsurePositive_DoesNotStripExtraLeadingZeroes_UnlikeGetIntegerBytes()
+    {
+        byte[] value = [0x00, 0x00, 0x7F];
+
+        var ensurePositiveResult = AsnUtilities.EnsurePositive(value);
+        var getIntegerBytesResult = AsnUtilities.GetIntegerBytes(value.AsSpan()).ToArray();
+
+        Assert.Equal<byte>([0x00, 0x00, 0x7F], ensurePositiveResult);
+        Assert.Equal<byte>([0x7F], getIntegerBytesResult);
+    }
+
+    #endregion
+
+    #region GetIntegerBytes
+
+    [Fact]
+    public void GetIntegerBytes_EmptyInput_ReturnsSingleZeroByte()
+    {
+        var result = AsnUtilities.GetIntegerBytes(Span<byte>.Empty);
+
+        Assert.Equal<byte>([0x00], result.ToArray());
+    }
+
+    [Fact]
+    public void GetIntegerBytes_NoLeadingZeroesHighBitClear_ReturnsUnchanged()
+    {
+        byte[] value = [0x7F, 0x01];
+
+        var result = AsnUtilities.GetIntegerBytes(value.AsSpan());
+
+        Assert.Equal<byte>([0x7F, 0x01], result.ToArray());
+    }
+
+    [Fact]
+    public void GetIntegerBytes_HighBitSetAfterTrim_PrependsLeadingZero()
+    {
+        byte[] value = [0x80, 0x01];
+
+        var result = AsnUtilities.GetIntegerBytes(value.AsSpan());
+
+        Assert.Equal<byte>([0x00, 0x80, 0x01], result.ToArray());
+    }
+
+    [Fact]
+    public void GetIntegerBytes_LeadingZeroesThenHighBitSet_TrimsThenPrependsOneZero()
+    {
+        // Two leading zeroes, trims to {0x80}, high bit is set on the trimmed value, so exactly
+        // one zero is re-added (minimal DER INTEGER encoding), not the original two.
+        byte[] value = [0x00, 0x00, 0x80];
+
+        var result = AsnUtilities.GetIntegerBytes(value.AsSpan());
+
+        Assert.Equal<byte>([0x00, 0x80], result.ToArray());
+    }
+
+    #endregion
+
+    #region VerifyX25519PrivateKey
+
+    // A validly clamped X25519 private key per RFC 7748 clamping: bits 0-2 of byte[0] clear,
+    // bit 7 of byte[31] clear, bit 6 of byte[31] set.
+    private static byte[] MakeClampedKey()
+    {
+        var key = new byte[32];
+        Array.Fill(key, (byte)0x11);
+        key[0] &= 0xF8; // clear low 3 bits
+        key[31] &= 0x7F; // clear high bit
+        key[31] |= 0x40; // set second-highest bit
+        return key;
+    }
+
+    [Fact]
+    public void VerifyX25519PrivateKey_ProperlyClampedKey_DoesNotThrow()
+    {
+        var key = MakeClampedKey();
+
+        var exception = Record.Exception(() => AsnUtilities.VerifyX25519PrivateKey(key));
+
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public void VerifyX25519PrivateKey_LowThreeBitsOfFirstByteSet_ThrowsCryptographicException()
+    {
+        var key = MakeClampedKey();
+        key[0] |= 0x01;
+
+        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
+    }
+
+    [Fact]
+    public void VerifyX25519PrivateKey_HighBitOfLastByteSet_ThrowsCryptographicException()
+    {
+        var key = MakeClampedKey();
+        key[31] |= 0x80;
+
+        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
+    }
+
+    [Fact]
+    public void VerifyX25519PrivateKey_SecondHighestBitOfLastByteClear_ThrowsCryptographicException()
+    {
+        var key = MakeClampedKey();
+        key[31] &= 0xBF; // clear bit 0x40, which must be set
+
+        Assert.Throws<CryptographicException>(() => AsnUtilities.VerifyX25519PrivateKey(key));
+    }
+
+    #endregion
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/Curve25519PrivateKeyTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/Curve25519PrivateKeyTests.cs
@@ -1,0 +1,109 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Security.Cryptography;
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+public class Curve25519PrivateKeyTests
+{
+    // RFC 7748 section 6.1, Alice's X25519 private key, encoded as PKCS#8 by
+    // the OpenSSL evppkey_ecx.txt test vector.
+    private const string Rfc7748AlicePrivateKeyHex =
+        "77076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A";
+
+    private const string Rfc7748AlicePkcs8Base64 =
+        "MC4CAQAwBQYDK2VuBCIEIHcHbQpzGKV9PBbBclGyZkXfTC+H68CZKrF3+6UduSwq";
+
+    [Fact]
+    public void CreateFromValue_Rfc7748AliceKey_PreservesRawBytes()
+    {
+        var rawPrivateKey = Convert.FromHexString(Rfc7748AlicePrivateKeyHex);
+
+        using var key = Curve25519PrivateKey.CreateFromValue(rawPrivateKey, KeyType.X25519);
+
+        Assert.Equal(rawPrivateKey, key.PrivateKey.ToArray());
+    }
+
+    [Fact]
+    public void CreateFromPkcs8_Rfc7748AliceKey_PreservesRawBytes()
+    {
+        var pkcs8 = Convert.FromBase64String(Rfc7748AlicePkcs8Base64);
+
+        using var key = Curve25519PrivateKey.CreateFromPkcs8(pkcs8);
+
+        Assert.Equal(KeyType.X25519, key.KeyType);
+        Assert.Equal(Convert.FromHexString(Rfc7748AlicePrivateKeyHex), key.PrivateKey.ToArray());
+    }
+
+    [Fact]
+    public void ExportPkcs8PrivateKey_Rfc7748AliceKey_PreservesExactEncoding()
+    {
+        var rawPrivateKey = Convert.FromHexString(Rfc7748AlicePrivateKeyHex);
+        using var key = Curve25519PrivateKey.CreateFromValue(rawPrivateKey, KeyType.X25519);
+
+        var encoded = key.ExportPkcs8PrivateKey();
+
+        Assert.Equal(Convert.FromBase64String(Rfc7748AlicePkcs8Base64), encoded);
+    }
+
+    [Theory]
+    [InlineData(KeyType.X25519, 31)]
+    [InlineData(KeyType.X25519, 33)]
+    [InlineData(KeyType.Ed25519, 31)]
+    [InlineData(KeyType.Ed25519, 33)]
+    public void CreateFromValue_WrongLength_ThrowsArgumentExceptionWithPrivateKeyParamName(KeyType keyType, int length)
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            Curve25519PrivateKey.CreateFromValue(new byte[length], keyType));
+
+        Assert.Equal("privateKey", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateFromValue_IncompatibleKeyType_ThrowsArgumentException()
+    {
+        var exception = Assert.Throws<ArgumentException>(() =>
+            Curve25519PrivateKey.CreateFromValue(new byte[32], KeyType.ECP256));
+
+        Assert.Equal("keyType", exception.ParamName);
+    }
+
+    [Fact]
+    public void CreateFromValue_CopiesCallerOwnedBytes()
+    {
+        var rawPrivateKey = Convert.FromHexString(Rfc7748AlicePrivateKeyHex);
+        var expected = rawPrivateKey.ToArray();
+        using var key = Curve25519PrivateKey.CreateFromValue(rawPrivateKey, KeyType.X25519);
+
+        CryptographicOperations.ZeroMemory(rawPrivateKey);
+
+        Assert.Equal(expected, key.PrivateKey.ToArray());
+    }
+
+    [Fact]
+    public void Dispose_ZeroesOwnedBytesAndPreventsExport()
+    {
+        var rawPrivateKey = Convert.FromHexString(Rfc7748AlicePrivateKeyHex);
+        var key = Curve25519PrivateKey.CreateFromValue(rawPrivateKey, KeyType.X25519);
+        var ownedBytes = key.PrivateKey;
+
+        key.Dispose();
+
+        Assert.All(ownedBytes.ToArray(), value => Assert.Equal(0, value));
+        Assert.Throws<ObjectDisposedException>(() => _ = key.PrivateKey);
+        Assert.Throws<ObjectDisposedException>(() => key.ExportPkcs8PrivateKey());
+    }
+}

--- a/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivImportTests.cs
+++ b/src/Piv/tests/Yubico.YubiKit.Piv.IntegrationTests/PivImportTests.cs
@@ -128,26 +128,33 @@ public class PivImportTests
         await session.ResetAsync();
         await session.AuthenticateAsync(GetDefaultManagementKey(state.FirmwareVersion));
 
-        // Generate Ed25519 private key (32 random bytes)
         var ed25519Bytes = new byte[32];
         RandomNumberGenerator.Fill(ed25519Bytes);
-        var privateKey = Curve25519PrivateKey.CreateFromValue(ed25519Bytes, Core.Cryptography.KeyType.Ed25519);
+        try
+        {
+            using var privateKey = Curve25519PrivateKey.CreateFromValue(
+                ed25519Bytes,
+                Core.Cryptography.KeyType.Ed25519);
 
-        var detectedAlgorithm = await session.ImportKeyAsync(
-            PivSlot.Authentication,
-            privateKey);
+            var detectedAlgorithm = await session.ImportKeyAsync(
+                PivSlot.Authentication,
+                privateKey);
 
-        Assert.Equal(PivAlgorithm.Ed25519, detectedAlgorithm);
+            Assert.Equal(PivAlgorithm.Ed25519, detectedAlgorithm);
 
-        // Sign with YubiKey
-        await session.VerifyPinAsync(DefaultPin);
-        var dataToSign = SHA256.HashData("Ed25519 import test"u8);
-        var signature = await session.SignOrDecryptAsync(
-            PivSlot.Authentication,
-            PivAlgorithm.Ed25519,
-            dataToSign);
+            await session.VerifyPinAsync(DefaultPin);
+            var dataToSign = SHA256.HashData("Ed25519 import test"u8);
+            var signature = await session.SignOrDecryptAsync(
+                PivSlot.Authentication,
+                PivAlgorithm.Ed25519,
+                dataToSign);
 
-        Assert.False(signature.IsEmpty);
+            Assert.False(signature.IsEmpty);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(ed25519Bytes);
+        }
     }
 
     [SkippableTheory]
@@ -158,23 +165,28 @@ public class PivImportTests
         await session.ResetAsync();
         await session.AuthenticateAsync(GetDefaultManagementKey(state.FirmwareVersion));
 
-        // Generate X25519 private key with proper RFC 7748 bit clamping
-        var x25519Bytes = new byte[32];
-        RandomNumberGenerator.Fill(x25519Bytes);
-        x25519Bytes[0] &= 248;   // Clear bits 0, 1, 2
-        x25519Bytes[31] &= 127;  // Clear bit 255 (most significant)
-        x25519Bytes[31] |= 64;   // Set bit 254
-        var privateKey = Curve25519PrivateKey.CreateFromValue(x25519Bytes, Core.Cryptography.KeyType.X25519);
+        var x25519Bytes = Convert.FromHexString(
+            "77076D0A7318A57D3C16C17251B26645DF4C2F87EBC0992AB177FBA51DB92C2A");
+        try
+        {
+            using var privateKey = Curve25519PrivateKey.CreateFromValue(
+                x25519Bytes,
+                Core.Cryptography.KeyType.X25519);
 
-        var detectedAlgorithm = await session.ImportKeyAsync(
-            PivSlot.KeyManagement,
-            privateKey);
+            var detectedAlgorithm = await session.ImportKeyAsync(
+                PivSlot.KeyManagement,
+                privateKey);
 
-        Assert.Equal(PivAlgorithm.X25519, detectedAlgorithm);
+            Assert.Equal(PivAlgorithm.X25519, detectedAlgorithm);
 
-        // Verify slot metadata
-        var metadata = await session.GetSlotMetadataAsync(PivSlot.KeyManagement);
-        Assert.NotNull(metadata);
-        Assert.Equal(PivAlgorithm.X25519, metadata.Value.Algorithm);
+            // Verify slot metadata
+            var metadata = await session.GetSlotMetadataAsync(PivSlot.KeyManagement);
+            Assert.NotNull(metadata);
+            Assert.Equal(PivAlgorithm.X25519, metadata.Value.Algorithm);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(x25519Bytes);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Accepts any exactly 32-byte X25519 private value and preserves its bytes through Public-Key Cryptography Standards number 8 import and export.
- Removes pre-clamping validation from stored X25519 key material; scalar masking remains the responsibility of the operation that consumes the key.
- Rejects unsupported key types and invalid X25519 or Ed25519 lengths.
- Centralizes private-key container version validation and prevents access to owned private bytes after disposal.
- Replaces self-referential tests with Base Class Library or published Request for Comments vectors, including X25519 and Ed25519 coverage.

## Why

The previous X25519 verifier rejected valid Request for Comments 7748 private values unless their stored bytes were already clamped. Public-Key Cryptography Standards number 8 containers preserve private values; they must not silently rewrite those bytes during construction, import, or export.

## Verification

- Core cryptography tests: 109 passed.
- Focused Personal Identity Verification import tests: 3 passed.
- Full repository build passed locally.
- The Curve25519 and Ed25519 slice passed separate cross-vendor implementation review, architecture-fit review, and scoped code audit.

## Stack

Pull request #607 remains stacked on this branch and owns private-key decoder zeroing and ownership documentation.