### PR TITLE
refactor(openpgp): simplify VerifyPwAsync and cover its untested retry arms

### DIFF
--- a/src/OpenPgp/src/OpenPgpSession.Pin.cs
+++ b/src/OpenPgp/src/OpenPgpSession.Pin.cs
@@ -238,39 +238,8 @@ public sealed partial class OpenPgpSession
 
             if (!response.IsOK())
             {
-                // Standard wrong-PIN SW: 0x63Cx where x = remaining retries
-                var remaining = SWConstants.ExtractRetryCount(response.SW) ?? -1;
-
-                if (remaining < 0 && response.SW == SWConstants.AuthenticationMethodBlocked)
-                {
-                    // The PIN/PUK is already permanently blocked (0 retries remaining).
-                    // No status query is needed; 0x6983 unambiguously means zero.
-                    remaining = 0;
-                }
-                else if (remaining < 0 && response.SW == SWConstants.SecurityStatusNotSatisfied)
-                {
-                    // Some firmware (including 5.8.0-alpha) returns 0x6982 (Security Status
-                    // Not Satisfied) for wrong PIN instead of 0x63Cx. Per Python canonical:
-                    // query GET DATA for PW_STATUS_BYTES to get remaining attempts.
-                    try
-                    {
-                        var status = await GetPinStatusAsync(cancellationToken).ConfigureAwait(false);
-                        remaining = pw == Pw.User
-                            ? status.AttemptsUser
-                            : pw == Pw.Admin
-                                ? status.AttemptsAdmin
-                                : status.AttemptsReset;
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        throw;
-                    }
-                    catch
-                    {
-                        // If status query fails, the retry count is genuinely unknown.
-                    }
-                }
-
+                var remaining = await ResolveRemainingRetriesAsync(pw, response, cancellationToken)
+                    .ConfigureAwait(false);
                 int? retriesRemaining = remaining >= 0 ? remaining : null;
 
                 throw new OpenPgpInvalidPinException(
@@ -290,6 +259,51 @@ public sealed partial class OpenPgpSession
                 CryptographicOperations.ZeroMemory(derivedBytes);
             }
         }
+    }
+
+    // Resolves the number of retries remaining after a failed VERIFY, handling the two
+    // status-word special cases firmware can return instead of the standard 0x63Cx form.
+    private async Task<int> ResolveRemainingRetriesAsync(
+        Pw pw,
+        ApduResponse response,
+        CancellationToken cancellationToken)
+    {
+        // Standard wrong-PIN SW: 0x63Cx where x = remaining retries
+        var remaining = SWConstants.ExtractRetryCount(response.SW) ?? -1;
+
+        if (remaining < 0 && response.SW == SWConstants.AuthenticationMethodBlocked)
+        {
+            // The PIN/PUK is already permanently blocked (0 retries remaining).
+            // No status query is needed; 0x6983 unambiguously means zero.
+            return 0;
+        }
+
+        if (remaining < 0 && response.SW == SWConstants.SecurityStatusNotSatisfied)
+        {
+            // Some firmware (including 5.8.0-alpha) returns 0x6982 (Security Status
+            // Not Satisfied) for wrong PIN instead of 0x63Cx. Per Python canonical:
+            // query GET DATA for PW_STATUS_BYTES to get remaining attempts.
+            try
+            {
+                var status = await GetPinStatusAsync(cancellationToken).ConfigureAwait(false);
+                remaining = pw switch
+                {
+                    Pw.User => status.AttemptsUser,
+                    Pw.Admin => status.AttemptsAdmin,
+                    _ => status.AttemptsReset,
+                };
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch
+            {
+                // If status query fails, the retry count is genuinely unknown.
+            }
+        }
+
+        return remaining;
     }
 
     private async Task ChangePwAsync(

--- a/src/OpenPgp/tests/Yubico.YubiKit.OpenPgp.UnitTests/OpenPgpInvalidPinExceptionTests.cs
+++ b/src/OpenPgp/tests/Yubico.YubiKit.OpenPgp.UnitTests/OpenPgpInvalidPinExceptionTests.cs
@@ -118,6 +118,52 @@ public sealed class OpenPgpInvalidPinExceptionTests
     }
 
     [Fact]
+    public async Task VerifyAdminAsync_WhenSecurityStatusNotSatisfied_FallsBackToAdminAttemptsFromPinStatusQuery()
+    {
+        // SW 6982 (Security Status Not Satisfied) for an Admin PIN verify: the fallback must
+        // resolve AttemptsAdmin, not AttemptsUser or AttemptsReset. Distinct attempt counts
+        // in PwStatusResponse make a wrong arm mapping fail loudly.
+        var connection = CreateInitializedConnection(
+            KdfNotFoundResponse(),
+            [0x69, 0x82],
+            PwStatusResponse(attemptsUser: 5, attemptsReset: 6, attemptsAdmin: 7));
+        await using var session = await OpenPgpSession.CreateAsync(
+            connection,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<OpenPgpInvalidPinException>(() => session.VerifyAdminAsync(
+            "00000000"u8.ToArray(),
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(7, exception.RetriesRemaining);
+        Assert.Equal(unchecked((short)0x6982), exception.SW);
+    }
+
+    [Fact]
+    public async Task VerifyPinAsync_ExtendedWhenSecurityStatusNotSatisfied_FallsBackToResetAttemptsFromPinStatusQuery()
+    {
+        // SW 6982 (Security Status Not Satisfied) for an extended-mode (Pw.Reset) verify: the
+        // fallback must resolve AttemptsReset, not AttemptsUser or AttemptsAdmin. The only route
+        // that reaches VerifyPwAsync with Pw.Reset is VerifyPinAsync(pinUtf8, extended: true, ...).
+        // Distinct attempt counts in PwStatusResponse make a wrong arm mapping fail loudly.
+        var connection = CreateInitializedConnection(
+            KdfNotFoundResponse(),
+            [0x69, 0x82],
+            PwStatusResponse(attemptsUser: 5, attemptsReset: 6, attemptsAdmin: 7));
+        await using var session = await OpenPgpSession.CreateAsync(
+            connection,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var exception = await Assert.ThrowsAsync<OpenPgpInvalidPinException>(() => session.VerifyPinAsync(
+            "000000"u8.ToArray(),
+            extended: true,
+            cancellationToken: TestContext.Current.CancellationToken));
+
+        Assert.Equal(6, exception.RetriesRemaining);
+        Assert.Equal(unchecked((short)0x6982), exception.SW);
+    }
+
+    [Fact]
     public async Task VerifyPinAsync_WhenStatusQueryAlsoFails_ExposesNullRetriesRemaining()
     {
         // SW 6982 followed by a failing PW_STATUS_BYTES query: the retry count is genuinely
@@ -173,8 +219,8 @@ public sealed class OpenPgpInvalidPinExceptionTests
     // so VerifyPwAsync falls back to sending raw PIN bytes through KdfNone.
     private static byte[] KdfNotFoundResponse() => [0x6A, 0x82];
 
-    private static byte[] PwStatusResponse(int attemptsUser) =>
-        [0x00, 0x7F, 0x7F, 0x7F, (byte)attemptsUser, 0x00, 0x03, 0x90, 0x00];
+    private static byte[] PwStatusResponse(int attemptsUser, int attemptsReset = 0, int attemptsAdmin = 3) =>
+        [0x00, 0x7F, 0x7F, 0x7F, (byte)attemptsUser, (byte)attemptsReset, (byte)attemptsAdmin, 0x90, 0x00];
 
     private sealed class CancelOnPwStatusLookupConnection(
         RecordingSmartCardConnection inner,


### PR DESCRIPTION
Not a CRAP change — `VerifyPwAsync` was already at the CRAP floor (14, equal to its cyclomatic complexity, because line coverage was 100%). This fixes two different problems.

## Cognitive complexity 24, against a threshold of 15

13 of those 24 points sat in one ~20-line block: the 0x6982 firmware-quirk fallback that queries `PW_STATUS_BYTES` for the remaining attempt count. 7 came from a nested ternary selecting the counter by `Pw`, and 6 from a nested `try` with two `catch` clauses at depth 2.

Extracted into `ResolveRemainingRetriesAsync`, with the ternary replaced by a `switch` expression and the status-word cases turned into guard clauses. `VerifyPwAsync` keeps the VERIFY APDU, the exception, and the `finally` that zeroes the KDF-derived bytes.

## "100% covered" was hiding a real gap

Line coverage was 100%. **Branch** coverage was 85%, and the nested ternary was at **25% — one of four.** Only the `Pw.User` arm had ever executed; the `Pw.Admin` and `Pw.Reset` arms of the fallback had never run in any test.

Two tests now drive them, with **distinct** attempt counts per arm so a wrong mapping cannot pass. `Pw.Reset` turns out to be reachable only through `VerifyPinAsync(..., extended: true)`.

## Constraints held

- `catch (OperationCanceledException) { throw; }` still precedes the bare `catch`, so a cancelled status query propagates instead of being swallowed — `SDK-HOUSE-STYLE.md:185`.
- The `finally` still zeroes `derivedBytes` unconditionally; `pinUtf8` is caller-owned and untouched.
- No command object — `SDK-HOUSE-STYLE.md:59-70`. One private method in the same partial class.
- No existing test method was modified. A private helper gained two defaulted parameters.
