### PR TITLE
fix(core): zero the private-key copies orphaned while decoding PKCS#8

### DIFF
--- a/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
+++ b/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
@@ -32,10 +32,10 @@ internal class AsnPrivateKeyDecoder
     /// ASN.1 DER-encoded private key.
     /// </summary>
     /// <param name="pkcs8EncodedKey">
-    /// The ASN.1 DER-encoded private key.
+    /// The borrowed ASN.1 DER-encoded private key. This method does not modify or clear the input.
     /// </param>
     /// <returns>
-    /// A new instance of <see cref="IPrivateKey"/>.
+    /// A new disposable private-key object that owns its decoded key material.
     /// </returns>
     /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
     /// <exception cref="InvalidOperationException">Thrown if the algorithm is not supported</exception>
@@ -83,10 +83,10 @@ internal class AsnPrivateKeyDecoder
     /// ASN.1 DER-encoded private key.
     /// </summary>
     /// <param name="pkcs8EncodedKey">
-    /// The ASN.1 DER-encoded private key.
+    /// The borrowed ASN.1 DER-encoded private key. This method does not modify or clear the input.
     /// </param>
     /// <returns>
-    /// A new instance of <see cref="Curve25519PrivateKey"/>.
+    /// A new disposable private-key object that owns its decoded key material.
     /// </returns>
     /// <exception cref="CryptographicException">Thrown if privateKey does not match expected format.</exception>
     /// <exception cref="ArgumentException">Thrown if the algorithm is not <see cref="Oids.X25519"/> or 
@@ -98,9 +98,22 @@ internal class AsnPrivateKeyDecoder
         return Curve25519PrivateKey.CreateFromValue(privateKeyHandle.Data, keyType);
     }
 
+    /// <summary>
+    /// Decodes a Curve25519 private value and its key type from a PKCS#8 private key.
+    /// </summary>
+    /// <param name="pkcs8EncodedKey">
+    /// The borrowed ASN.1 DER-encoded private key. This method does not modify or clear the input.
+    /// </param>
+    /// <returns>
+    /// A caller-owned 32-byte private-value array and the decoded key type. The caller must clear
+    /// the returned array when it is no longer needed.
+    /// </returns>
+    /// <exception cref="ArgumentException">The algorithm is not X25519 or Ed25519.</exception>
+    /// <exception cref="CryptographicException">The private-key encoding or length is invalid.</exception>
     public static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(ReadOnlyMemory<byte> pkcs8EncodedKey) =>
         GetCurve25519PrivateKeyData(pkcs8EncodedKey, privateKeyDecoded: null);
 
+    // Test observation hook. The callback must not retain or mutate the decoded private value.
     internal static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(
         ReadOnlyMemory<byte> pkcs8EncodedKey,
         Action<byte[]>? privateKeyDecoded)
@@ -149,6 +162,18 @@ internal class AsnPrivateKeyDecoder
         }
     }
 
+    /// <summary>
+    /// Decodes elliptic-curve parameters from a PKCS#8 private key.
+    /// </summary>
+    /// <param name="pkcs8EncodedKey">
+    /// The borrowed ASN.1 DER-encoded private key. This method does not modify or clear the input.
+    /// </param>
+    /// <returns>
+    /// Parameters containing caller-owned arrays. The caller must clear <see cref="ECParameters.D"/>
+    /// when the parameters are no longer needed.
+    /// </returns>
+    /// <exception cref="CryptographicException">The private-key encoding is invalid.</exception>
+    /// <exception cref="InvalidOperationException">The algorithm or curve is unsupported.</exception>
     public static ECParameters CreateECParameters(ReadOnlyMemory<byte> pkcs8EncodedKey)
     {
         var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
@@ -243,9 +268,22 @@ internal class AsnPrivateKeyDecoder
         };
     }
 
+    /// <summary>
+    /// Decodes RSA parameters from a PKCS#8 private key.
+    /// </summary>
+    /// <param name="pkcs8EncodedKey">
+    /// The borrowed ASN.1 DER-encoded private key. This method does not modify or clear the input.
+    /// </param>
+    /// <returns>
+    /// Parameters containing caller-owned arrays. The caller must clear the private parameter
+    /// arrays when they are no longer needed.
+    /// </returns>
+    /// <exception cref="CryptographicException">The private-key encoding is invalid.</exception>
+    /// <exception cref="InvalidOperationException">The algorithm is unsupported.</exception>
     public static RSAParameters CreateRSAParameters(ReadOnlyMemory<byte> pkcs8EncodedKey) =>
         CreateRSAParameters(pkcs8EncodedKey, parametersDecoded: null);
 
+    // Test observation hook. The callback must not retain or mutate the decoded private arrays.
     internal static RSAParameters CreateRSAParameters(
         ReadOnlyMemory<byte> pkcs8EncodedKey,
         Action<RSAParameters>? parametersDecoded)

--- a/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
+++ b/src/Core/src/Cryptography/AsnPrivateKeyDecoder.cs
@@ -59,13 +59,11 @@ internal class AsnPrivateKeyDecoder
                         seqAlgorithmIdentifier.ThrowIfNotEmpty();
                     }
 
-                    var rsaParameters = CreateRSAParameters(pkcs8EncodedKey);
-                    return RSAPrivateKey.CreateFromParameters(rsaParameters);
+                    return RSAPrivateKey.CreateFromPkcs8(pkcs8EncodedKey);
                 }
             case Oids.ECDSA:
                 {
-                    var ecParams = CreateECParameters(pkcs8EncodedKey);
-                    return ECPrivateKey.CreateFromParameters(ecParams);
+                    return ECPrivateKey.CreateFromPkcs8(pkcs8EncodedKey);
                 }
             case Oids.X25519:
             case Oids.Ed25519:
@@ -100,7 +98,12 @@ internal class AsnPrivateKeyDecoder
         return Curve25519PrivateKey.CreateFromValue(privateKeyHandle.Data, keyType);
     }
 
-    public static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(ReadOnlyMemory<byte> pkcs8EncodedKey)
+    public static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(ReadOnlyMemory<byte> pkcs8EncodedKey) =>
+        GetCurve25519PrivateKeyData(pkcs8EncodedKey, privateKeyDecoded: null);
+
+    internal static (byte[] privateKey, KeyType keyType) GetCurve25519PrivateKeyData(
+        ReadOnlyMemory<byte> pkcs8EncodedKey,
+        Action<byte[]>? privateKeyDecoded)
     {
         var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
         var seqPrivateKeyInfo = reader.ReadSequence();
@@ -124,15 +127,26 @@ internal class AsnPrivateKeyDecoder
         }
 
         var privateKey = seqPrivateKey.ReadOctetString();
-        if (privateKey.Length != 32)
+        try
         {
-            throw new CryptographicException("Invalid Curve25519 private key: incorrect length");
+            privateKeyDecoded?.Invoke(privateKey);
+            if (privateKey.Length != 32)
+            {
+                throw new CryptographicException("Invalid Curve25519 private key: incorrect length");
+            }
+
+            seqPrivateKeyInfo.ThrowIfNotEmpty();
+
+            var keyDefinition = KeyDefinitions.GetByOid(algorithmOid);
+            return (privateKey, keyDefinition.KeyType);
         }
-
-        seqPrivateKeyInfo.ThrowIfNotEmpty();
-
-        var keyDefinition = KeyDefinitions.GetByOid(algorithmOid);
-        return (privateKey, keyDefinition.KeyType);
+        catch
+        {
+            // This method owns the array unless it returns it successfully. On any exception the
+            // array is about to become unreachable, so no caller-owned buffer is cleared here.
+            CryptographicOperations.ZeroMemory(privateKey);
+            throw;
+        }
     }
 
     public static ECParameters CreateECParameters(ReadOnlyMemory<byte> pkcs8EncodedKey)
@@ -229,7 +243,12 @@ internal class AsnPrivateKeyDecoder
         };
     }
 
-    public static RSAParameters CreateRSAParameters(ReadOnlyMemory<byte> pkcs8EncodedKey)
+    public static RSAParameters CreateRSAParameters(ReadOnlyMemory<byte> pkcs8EncodedKey) =>
+        CreateRSAParameters(pkcs8EncodedKey, parametersDecoded: null);
+
+    internal static RSAParameters CreateRSAParameters(
+        ReadOnlyMemory<byte> pkcs8EncodedKey,
+        Action<RSAParameters>? parametersDecoded)
     {
         var reader = new AsnReader(pkcs8EncodedKey, AsnEncodingRules.DER);
         var seqPrivateKeyInfo = reader.ReadSequence();
@@ -281,7 +300,22 @@ internal class AsnPrivateKeyDecoder
             InverseQ = coefficient.ToArray()
         };
 
-        return rsaParameters.NormalizeParameters();
+        try
+        {
+            parametersDecoded?.Invoke(rsaParameters);
+            return rsaParameters.NormalizeParameters();
+        }
+        finally
+        {
+            // NormalizeParameters returns a deep copy on success. On failure this decoder is
+            // unwinding. Either way, these locally allocated private arrays are not returned.
+            CryptographicOperations.ZeroMemory(rsaParameters.D);
+            CryptographicOperations.ZeroMemory(rsaParameters.P);
+            CryptographicOperations.ZeroMemory(rsaParameters.Q);
+            CryptographicOperations.ZeroMemory(rsaParameters.DP);
+            CryptographicOperations.ZeroMemory(rsaParameters.DQ);
+            CryptographicOperations.ZeroMemory(rsaParameters.InverseQ);
+        }
     }
 
     private static void ReadAndValidatePkcs8Version(AsnReader privateKeyInfo)

--- a/src/Core/src/Cryptography/Curve25519PrivateKey.cs
+++ b/src/Core/src/Cryptography/Curve25519PrivateKey.cs
@@ -46,7 +46,11 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// <summary>
     /// Gets the raw private key bytes exactly as imported.
     /// </summary>
-    /// <returns>A <see cref="ReadOnlyMemory{T}"/> containing the raw private key value.</returns>
+    /// <value>
+    /// A borrowed read-only view of the key-owned bytes. The view remains valid until this object
+    /// is disposed. The caller must not attempt to modify or clear the underlying memory.
+    /// </value>
+    /// <exception cref="ObjectDisposedException">This object has been disposed.</exception>
     public ReadOnlyMemory<byte> PrivateKey
     {
         get
@@ -97,10 +101,11 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// ASN.1 DER-encoded private key.
     /// </summary>
     /// <param name="pkcs8EncodedKey">
-    /// The ASN.1 DER-encoded private key.
+    /// The borrowed ASN.1 DER-encoded private key. This method copies the decoded private value and
+    /// does not modify or clear the input.
     /// </param>
     /// <returns>
-    /// A new instance of <see cref="Curve25519PrivateKey"/>.
+    /// A new disposable key that owns and clears its copied private-key material.
     /// </returns>
     /// <exception cref="ArgumentException">
     /// Thrown if the algorithm OID is not X25519 or Ed25519.
@@ -121,9 +126,12 @@ public sealed class Curve25519PrivateKey : PrivateKey
     /// Creates an instance of <see cref="Curve25519PrivateKey"/> from the given
     /// <paramref name="privateKey"/> and <paramref name="keyType"/>.
     /// </summary>
-    /// <param name="privateKey">The 32 raw private key bytes. These are copied and preserved unchanged.</param>
+    /// <param name="privateKey">
+    /// The 32 borrowed raw private-key bytes. These are copied and preserved unchanged. The caller
+    /// retains ownership and remains responsible for clearing the input.
+    /// </param>
     /// <param name="keyType">The type of key this is.</param>
-    /// <returns>An instance of <see cref="Curve25519PrivateKey"/>.</returns>
+    /// <returns>A new disposable key that owns and clears its copied private-key material.</returns>
     /// <exception cref="ArgumentException">Thrown if <paramref name="keyType"/> is not X25519 or Ed25519, or if <paramref name="privateKey"/> is not exactly 32 bytes.</exception>
     public static Curve25519PrivateKey CreateFromValue(ReadOnlyMemory<byte> privateKey, KeyType keyType) => new(privateKey, keyType);
 

--- a/src/Core/src/Cryptography/ECPrivateKey.cs
+++ b/src/Core/src/Cryptography/ECPrivateKey.cs
@@ -95,10 +95,25 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// Thrown if the private key is invalid.
         /// </exception>
         public static ECPrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
+            => CreateFromPkcs8(encodedKey, parametersDecoded: null);
+
+        internal static ECPrivateKey CreateFromPkcs8(
+            ReadOnlyMemory<byte> encodedKey,
+            Action<ECParameters>? parametersDecoded)
         {
             var parameters = AsnPrivateKeyDecoder.CreateECParameters(encodedKey);
-
-            return CreateFromParameters(parameters);
+            try
+            {
+                parametersDecoded?.Invoke(parameters);
+                return CreateFromParameters(parameters);
+            }
+            finally
+            {
+                // On success the constructor copied D; on failure this factory is unwinding.
+                // Either way, the decoder's temporary D is factory-owned. CreateFromParameters
+                // is deliberately different because its input remains caller-owned.
+                CryptographicOperations.ZeroMemory(parameters.D);
+            }
         }
 
         /// <summary>

--- a/src/Core/src/Cryptography/ECPrivateKey.cs
+++ b/src/Core/src/Cryptography/ECPrivateKey.cs
@@ -31,7 +31,9 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// </summary>
         /// <value>
         /// An <see cref="ECParameters"/> structure containing the curve parameters, key, and other
-        /// cryptographic elements needed for EC operations.
+        /// cryptographic elements needed for EC operations. The array fields are owned by this
+        /// object, must not be modified or cleared by the caller, and are cleared when the object is
+        /// disposed.
         /// </value>
         public ECParameters Parameters { get; }
 
@@ -55,16 +57,28 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// the parameters from the ECParameters object.
         /// </remarks>
         /// <param name="parameters">The EC parameters.</param>
+        /// <param name="parametersCopied">An optional internal observation hook.</param>
         /// <exception cref="ArgumentException">Thrown when parameters do not contain D value.</exception>
-        private ECPrivateKey(ECParameters parameters)
+        private ECPrivateKey(
+            ECParameters parameters,
+            Action<ECParameters>? parametersCopied = null)
         {
             if (parameters.D is null)
             {
                 throw new ArgumentException("Parameters must contain private key data (D value)", nameof(parameters));
             }
 
+            KeyDefinition = KeyDefinitions.GetByOid(parameters.Curve.Oid);
             Parameters = parameters.DeepCopy();
-            KeyDefinition = KeyDefinitions.GetByOid(Parameters.Curve.Oid);
+            try
+            {
+                parametersCopied?.Invoke(Parameters);
+            }
+            catch
+            {
+                CryptographicOperations.ZeroMemory(Parameters.D);
+                throw;
+            }
         }
 
         /// <inheritdoc/>
@@ -86,10 +100,11 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// Creates a new instance of <see cref="ECPrivateKey"/> from a DER-encoded private key.
         /// </summary>
         /// <param name="encodedKey">
-        /// The DER-encoded private key.
+        /// The borrowed DER-encoded private key. This method copies the decoded key material and
+        /// does not modify or clear the input.
         /// </param>
         /// <returns>
-        /// A new instance of <see cref="ECPrivateKey"/>.
+        /// A new disposable key that owns and clears its copied private-key material.
         /// </returns>
         /// <exception cref="CryptographicException">
         /// Thrown if the private key is invalid.
@@ -97,6 +112,7 @@ namespace Yubico.YubiKit.Core.Cryptography
         public static ECPrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
             => CreateFromPkcs8(encodedKey, parametersDecoded: null);
 
+        // Test observation hook. The callback must not retain or mutate the decoded private value.
         internal static ECPrivateKey CreateFromPkcs8(
             ReadOnlyMemory<byte> encodedKey,
             Action<ECParameters>? parametersDecoded)
@@ -119,15 +135,27 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// <summary>
         /// Creates an instance of <see cref="ECPrivateKey"/> from the given <paramref name="parameters"/>.
         /// </summary>
-        /// <param name="parameters">The parameters to create the key from.</param>
-        /// <returns>An instance of <see cref="ECPrivateKey"/>.</returns>
+        /// <param name="parameters">
+        /// The borrowed parameters to copy. The caller retains ownership of every input array and
+        /// remains responsible for clearing sensitive arrays.
+        /// </param>
+        /// <returns>A new disposable key that owns and clears its copied private-key material.</returns>
         public static ECPrivateKey CreateFromParameters(ECParameters parameters) => new(parameters);
+
+        // Test observation hook. The callback must not retain or mutate the copied private value.
+        internal static ECPrivateKey CreateFromParameters(
+            ECParameters parameters,
+            Action<ECParameters>? parametersCopied) =>
+            new(parameters, parametersCopied);
 
         /// <summary>
         /// Creates an instance of <see cref="ECPrivateKey"/> from an <see cref="ECDiffieHellman"/> instance.
         /// </summary>
-        /// <param name="ecdh">The ECDiffieHellman instance containing the private key.</param>
-        /// <returns>An instance of <see cref="ECPrivateKey"/>.</returns>
+        /// <param name="ecdh">
+        /// The borrowed <see cref="ECDiffieHellman"/> instance containing the private key. This
+        /// method does not dispose it.
+        /// </param>
+        /// <returns>A new disposable key that owns and clears its copied private-key material.</returns>
         /// <remarks>
         /// This method exports the private key parameters from the <see cref="ECDiffieHellman"/> instance
         /// and creates a new <see cref="ECPrivateKey"/> wrapper. This is useful when working with ephemeral
@@ -135,9 +163,24 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// </remarks>
         /// <exception cref="ArgumentNullException">Thrown if <paramref name="ecdh"/> is null.</exception>
         public static ECPrivateKey CreateFromEcdh(ECDiffieHellman ecdh)
+            => CreateFromEcdh(ecdh, parametersExported: null);
+
+        // Test observation hook. The callback must not retain or mutate the exported private value.
+        internal static ECPrivateKey CreateFromEcdh(
+            ECDiffieHellman ecdh,
+            Action<ECParameters>? parametersExported)
         {
             ArgumentNullException.ThrowIfNull(ecdh);
-            return CreateFromParameters(ecdh.ExportParameters(includePrivateParameters: true));
+            var parameters = ecdh.ExportParameters(includePrivateParameters: true);
+            try
+            {
+                parametersExported?.Invoke(parameters);
+                return CreateFromParameters(parameters);
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(parameters.D);
+            }
         }
 
         /// <summary>
@@ -147,15 +190,25 @@ namespace Yubico.YubiKit.Core.Cryptography
         /// <remarks>
         /// The <paramref name="privateValue"/> is taken as the raw private key data (scalar value).
         /// </remarks>
-        /// <param name="privateValue">The raw private key data.</param>
+        /// <param name="privateValue">
+        /// The borrowed raw private value to copy. The caller retains ownership and remains
+        /// responsible for clearing the input.
+        /// </param>
         /// <param name="keyType">The type of key this is.</param>
-        /// <returns>A new instance of <see cref="ECPrivateKey"/>.</returns>
+        /// <returns>A new disposable key that owns and clears its copied private-key material.</returns>
         /// <exception cref="ArgumentException">
         /// Thrown if the key type is not a valid EC key.
         /// </exception>
         public static ECPrivateKey CreateFromValue(
             ReadOnlyMemory<byte> privateValue,
             KeyType keyType)
+            => CreateFromValue(privateValue, keyType, parametersCreated: null);
+
+        // Test observation hook. The callback must not retain or mutate the temporary private values.
+        internal static ECPrivateKey CreateFromValue(
+            ReadOnlyMemory<byte> privateValue,
+            KeyType keyType,
+            Action<ECParameters>? parametersCreated)
         {
             var keyDefinition = keyType.GetKeyDefinition();
             if (keyDefinition.AlgorithmOid is not Oids.ECDSA)
@@ -173,8 +226,25 @@ namespace Yubico.YubiKit.Core.Cryptography
                 D = privateValue.ToArray(),
             };
 
-            var ecdsa = ECDsa.Create(parameters);
-            return CreateFromParameters(ecdsa.ExportParameters(true));
+            try
+            {
+                parametersCreated?.Invoke(parameters);
+                using var ecdsa = ECDsa.Create(parameters);
+                var exportedParameters = ecdsa.ExportParameters(includePrivateParameters: true);
+                try
+                {
+                    parametersCreated?.Invoke(exportedParameters);
+                    return CreateFromParameters(exportedParameters);
+                }
+                finally
+                {
+                    CryptographicOperations.ZeroMemory(exportedParameters.D);
+                }
+            }
+            finally
+            {
+                CryptographicOperations.ZeroMemory(parameters.D);
+            }
         }
 
         /// <summary>

--- a/src/Core/src/Cryptography/IPrivateKey.cs
+++ b/src/Core/src/Cryptography/IPrivateKey.cs
@@ -28,12 +28,14 @@ public interface IPrivateKey : IKeyBase
     /// Exports the current key in the PKCS#8 PrivateKeyInfo format.
     /// </summary>
     /// <returns>
-    /// A byte array containing the PKCS#8 PrivateKeyInfo representation of this key.
+    /// A new caller-owned byte array containing the PKCS#8 PrivateKeyInfo representation of this
+    /// key. The caller must clear the array when it is no longer needed.
     /// </returns>
     public byte[] ExportPkcs8PrivateKey();
 
     /// <summary>
     /// Clears the buffers containing private key data.
     /// </summary>
+    /// <remarks>Callers should not use the key after clearing it.</remarks>
     public void Clear();
 }

--- a/src/Core/src/Cryptography/RSAParametersExtensions.cs
+++ b/src/Core/src/Cryptography/RSAParametersExtensions.cs
@@ -49,29 +49,55 @@ public static class RSAParametersExtensions
     /// </summary>
     /// <param name="parameters">The RSA parameters to normalize</param>
     /// <returns>A new (copied) RSAParameters with normalized values</returns>
-    internal static RSAParameters NormalizeParameters(this RSAParameters parameters)
+    internal static RSAParameters NormalizeParameters(this RSAParameters parameters) =>
+        NormalizeParameters(parameters, parametersCopied: null);
+
+    // Test observation hook. The callback must not retain or mutate the copied arrays.
+    internal static RSAParameters NormalizeParameters(
+        this RSAParameters parameters,
+        Action<RSAParameters>? parametersCopied)
     {
         var normalized = parameters.DeepCopy();
-        if (normalized.D is null || normalized.P is null || normalized.Q is null ||
-            normalized.DP is null || normalized.DQ is null || normalized.InverseQ is null ||
-            normalized.Modulus is null)
+        try
         {
-            return normalized; // Can't normalize if missing required components
+            parametersCopied?.Invoke(normalized);
+            if (normalized.D is null || normalized.P is null || normalized.Q is null ||
+                normalized.DP is null || normalized.DQ is null || normalized.InverseQ is null ||
+                normalized.Modulus is null)
+            {
+                return normalized; // Can't normalize if missing required components
+            }
+
+            // For private key, we need D to be same length as Modulus,
+            // and P, Q, DP, DQ, InverseQ to be half the length of Modulus (rounded up)
+            var modulusLength = normalized.Modulus.Length;
+            var halfLength = (modulusLength + 1) / 2; // Round up
+
+            normalized.D = PadToLengthAndClear(normalized.D, modulusLength);
+            normalized.P = PadToLengthAndClear(normalized.P, halfLength);
+            normalized.Q = PadToLengthAndClear(normalized.Q, halfLength);
+            normalized.DP = PadToLengthAndClear(normalized.DP, halfLength);
+            normalized.DQ = PadToLengthAndClear(normalized.DQ, halfLength);
+            normalized.InverseQ = PadToLengthAndClear(normalized.InverseQ, halfLength);
+
+            return normalized;
+        }
+        catch
+        {
+            ClearPrivateParameters(normalized);
+            throw;
+        }
+    }
+
+    private static byte[] PadToLengthAndClear(byte[] data, int targetLength)
+    {
+        var padded = PadToLength(data, targetLength);
+        if (!ReferenceEquals(data, padded))
+        {
+            CryptographicOperations.ZeroMemory(data);
         }
 
-        // For private key, we need D to be same length as Modulus,
-        // and P, Q, DP, DQ, InverseQ to be half the length of Modulus (rounded up)
-        var modulusLength = normalized.Modulus.Length;
-        var halfLength = (modulusLength + 1) / 2; // Round up
-
-        normalized.D = PadToLength(normalized.D, modulusLength);
-        normalized.P = PadToLength(normalized.P, halfLength);
-        normalized.Q = PadToLength(normalized.Q, halfLength);
-        normalized.DP = PadToLength(normalized.DP, halfLength);
-        normalized.DQ = PadToLength(normalized.DQ, halfLength);
-        normalized.InverseQ = PadToLength(normalized.InverseQ, halfLength);
-
-        return normalized;
+        return padded;
     }
 
     /// <summary>
@@ -97,6 +123,16 @@ public static class RSAParametersExtensions
         System.Buffer.BlockCopy(data, 0, result, padding, data.Length);
 
         return result;
+    }
+
+    private static void ClearPrivateParameters(RSAParameters parameters)
+    {
+        CryptographicOperations.ZeroMemory(parameters.D);
+        CryptographicOperations.ZeroMemory(parameters.P);
+        CryptographicOperations.ZeroMemory(parameters.Q);
+        CryptographicOperations.ZeroMemory(parameters.DP);
+        CryptographicOperations.ZeroMemory(parameters.DQ);
+        CryptographicOperations.ZeroMemory(parameters.InverseQ);
     }
 
 }

--- a/src/Core/src/Cryptography/RSAPrivateKey.cs
+++ b/src/Core/src/Cryptography/RSAPrivateKey.cs
@@ -31,7 +31,8 @@ public sealed class RSAPrivateKey : PrivateKey
     /// Gets the RSA cryptographic parameters required for the private key operations.
     /// </summary>
     /// <value>
-    /// A structure containing RSA parameters, including Modulus, Exponent, D, P, Q, DP, DQ, and InverseQ values.
+    /// A structure containing the RSA parameters. The array fields are owned by this object, must
+    /// not be modified or cleared by the caller, and are cleared when the object is disposed.
     /// </value>
     /// <remarks>
     /// This property provides access to the fundamental mathematical components needed for RSA private key operations.
@@ -50,12 +51,14 @@ public sealed class RSAPrivateKey : PrivateKey
     /// <inheritdoc />
     public override KeyType KeyType => KeyDefinition.KeyType;
 
-    private RSAPrivateKey(RSAParameters parameters)
+    private RSAPrivateKey(
+        RSAParameters parameters,
+        Action<RSAParameters>? parametersCopied = null)
     {
         var keyLengthBits = parameters.DP?.Length * 8 * 2 ?? 0;
 
-        Parameters = parameters.NormalizeParameters();
         KeyDefinition = KeyDefinitions.GetByRSALength(keyLengthBits);
+        Parameters = parameters.NormalizeParameters(parametersCopied);
     }
 
     /// <summary>
@@ -88,10 +91,11 @@ public sealed class RSAPrivateKey : PrivateKey
     /// PKCS#8 private key.
     /// </summary>
     /// <param name="encodedKey">
-    /// The DER-encoded PKCS#8 private key.
+    /// The borrowed DER-encoded PKCS#8 private key. This method copies the decoded key material and
+    /// does not modify or clear the input.
     /// </param>
     /// <returns>
-    /// A new instance of <see cref="RSAPrivateKey"/>.
+    /// A new disposable key that owns and clears its copied private-key material.
     /// </returns>
     /// <exception cref="CryptographicException">
     /// Thrown if the private key is invalid.
@@ -102,6 +106,7 @@ public sealed class RSAPrivateKey : PrivateKey
     public static RSAPrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
         => CreateFromPkcs8(encodedKey, parametersDecoded: null);
 
+    // Test observation hook. The callback must not retain or mutate the decoded private arrays.
     internal static RSAPrivateKey CreateFromPkcs8(
         ReadOnlyMemory<byte> encodedKey,
         Action<RSAParameters>? parametersDecoded)
@@ -131,10 +136,17 @@ public sealed class RSAPrivateKey : PrivateKey
     /// <paramref name="parameters"/>.
     /// </summary>
     /// <param name="parameters">
-    /// The RSA parameters containing the private key data.
+    /// The borrowed RSA parameters to copy. The caller retains ownership of every input array and
+    /// remains responsible for clearing sensitive arrays.
     /// </param>
     /// <returns>
-    /// A new instance of <see cref="RSAPrivateKey"/>.
+    /// A new disposable key that owns and clears its copied private-key material.
     /// </returns>
     public static RSAPrivateKey CreateFromParameters(RSAParameters parameters) => new(parameters);
+
+    // Test observation hook. The callback must not retain or mutate the copied arrays.
+    internal static RSAPrivateKey CreateFromParameters(
+        RSAParameters parameters,
+        Action<RSAParameters>? parametersCopied) =>
+        new(parameters, parametersCopied);
 }

--- a/src/Core/src/Cryptography/RSAPrivateKey.cs
+++ b/src/Core/src/Cryptography/RSAPrivateKey.cs
@@ -100,9 +100,30 @@ public sealed class RSAPrivateKey : PrivateKey
     /// When the RSA key length is not supported.
     /// </exception>
     public static RSAPrivateKey CreateFromPkcs8(ReadOnlyMemory<byte> encodedKey)
+        => CreateFromPkcs8(encodedKey, parametersDecoded: null);
+
+    internal static RSAPrivateKey CreateFromPkcs8(
+        ReadOnlyMemory<byte> encodedKey,
+        Action<RSAParameters>? parametersDecoded)
     {
         var parameters = AsnPrivateKeyDecoder.CreateRSAParameters(encodedKey);
-        return new RSAPrivateKey(parameters);
+        try
+        {
+            parametersDecoded?.Invoke(parameters);
+            return new RSAPrivateKey(parameters);
+        }
+        finally
+        {
+            // On success the constructor copied these values; on failure this factory is
+            // unwinding. Either way, the decoder's temporary private arrays are factory-owned.
+            // CreateFromParameters is deliberately different because its input remains caller-owned.
+            CryptographicOperations.ZeroMemory(parameters.D);
+            CryptographicOperations.ZeroMemory(parameters.P);
+            CryptographicOperations.ZeroMemory(parameters.Q);
+            CryptographicOperations.ZeroMemory(parameters.DP);
+            CryptographicOperations.ZeroMemory(parameters.DQ);
+            CryptographicOperations.ZeroMemory(parameters.InverseQ);
+        }
     }
 
     /// <summary>

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/PrivateKeyDecodingZeroingTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/PrivateKeyDecodingZeroingTests.cs
@@ -1,0 +1,226 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Formats.Asn1;
+using System.Security.Cryptography;
+using Yubico.YubiKit.Core.Cryptography;
+
+namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
+
+public class PrivateKeyDecodingZeroingTests
+{
+    [Fact]
+    public void CreateRSAParameters_ZeroesPrivateArraysSupersededByNormalization()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var expected = rsa.ExportParameters(includePrivateParameters: true);
+        RSAParameters actual = default;
+        byte[][]? decoderArrays = null;
+
+        try
+        {
+            actual = AsnPrivateKeyDecoder.CreateRSAParameters(
+                pkcs8,
+                parameters => decoderArrays = GetPrivateArrays(parameters));
+
+            AssertAllZero(Assert.IsType<byte[][]>(decoderArrays));
+            Assert.Equal(expected.D, actual.D);
+            Assert.Equal(expected.P, actual.P);
+            Assert.Equal(expected.Q, actual.Q);
+            Assert.Equal(expected.DP, actual.DP);
+            Assert.Equal(expected.DQ, actual.DQ);
+            Assert.Equal(expected.InverseQ, actual.InverseQ);
+            AssertContainsNonZero(Assert.IsType<byte[]>(actual.D));
+        }
+        finally
+        {
+            ZeroPrivateArrays(expected);
+            ZeroPrivateArrays(actual);
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
+    public void RSAPrivateKey_CreateFromPkcs8_ZeroesDecoderArraysAndPreservesCopiedKey()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        var expected = rsa.ExportParameters(includePrivateParameters: true);
+        byte[][]? decoderArrays = null;
+
+        try
+        {
+            using var key = RSAPrivateKey.CreateFromPkcs8(
+                pkcs8,
+                parameters => decoderArrays = GetPrivateArrays(parameters));
+
+            var orphanedArrays = Assert.IsType<byte[][]>(decoderArrays);
+            AssertAllZero(orphanedArrays);
+
+            var survivingD = Assert.IsType<byte[]>(key.Parameters.D);
+            Assert.NotSame(orphanedArrays[0], survivingD);
+            Assert.Equal(expected.D, survivingD);
+            Assert.Equal(expected.P, key.Parameters.P);
+            Assert.Equal(expected.Q, key.Parameters.Q);
+            Assert.Equal(expected.DP, key.Parameters.DP);
+            Assert.Equal(expected.DQ, key.Parameters.DQ);
+            Assert.Equal(expected.InverseQ, key.Parameters.InverseQ);
+            AssertContainsNonZero(survivingD);
+        }
+        finally
+        {
+            ZeroPrivateArrays(expected);
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
+    public void ECPrivateKey_CreateFromPkcs8_ZeroesDecoderDAndPreservesCopiedKey()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var pkcs8 = ecdsa.ExportPkcs8PrivateKey();
+        var expected = ecdsa.ExportParameters(includePrivateParameters: true);
+        byte[]? decoderD = null;
+
+        try
+        {
+            using var key = ECPrivateKey.CreateFromPkcs8(
+                pkcs8,
+                parameters => decoderD = parameters.D);
+
+            var orphanedD = Assert.IsType<byte[]>(decoderD);
+            AssertAllZero([orphanedD]);
+
+            var survivingD = Assert.IsType<byte[]>(key.Parameters.D);
+            Assert.NotSame(orphanedD, survivingD);
+            Assert.Equal(expected.D, survivingD);
+            Assert.Equal(expected.Q.X, key.Parameters.Q.X);
+            Assert.Equal(expected.Q.Y, key.Parameters.Q.Y);
+            AssertContainsNonZero(survivingD);
+        }
+        finally
+        {
+            if (expected.D is not null)
+            {
+                CryptographicOperations.ZeroMemory(expected.D);
+            }
+
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_TrailingDataThrowsAndZeroesDecodedScalar()
+    {
+        var privateKey = new byte[32];
+        Array.Fill(privateKey, (byte)0x5A);
+        var pkcs8 = BuildCurve25519Pkcs8WithTrailingData(privateKey);
+        byte[]? decodedPrivateKey = null;
+
+        try
+        {
+            Assert.Throws<AsnContentException>(() =>
+                AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(
+                    pkcs8,
+                    decoded => decodedPrivateKey = decoded));
+
+            AssertAllZero([Assert.IsType<byte[]>(decodedPrivateKey)]);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(privateKey);
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    private static byte[][] GetPrivateArrays(RSAParameters parameters) =>
+    [
+        Assert.IsType<byte[]>(parameters.D),
+        Assert.IsType<byte[]>(parameters.P),
+        Assert.IsType<byte[]>(parameters.Q),
+        Assert.IsType<byte[]>(parameters.DP),
+        Assert.IsType<byte[]>(parameters.DQ),
+        Assert.IsType<byte[]>(parameters.InverseQ)
+    ];
+
+    private static void AssertAllZero(IEnumerable<byte[]> arrays)
+    {
+        foreach (var array in arrays)
+        {
+            Assert.All(array, value => Assert.Equal(0, value));
+        }
+    }
+
+    private static void AssertContainsNonZero(byte[] array) =>
+        Assert.Contains(array, value => value != 0);
+
+    private static void ZeroPrivateArrays(RSAParameters parameters)
+    {
+        foreach (var array in GetExistingPrivateArrays(parameters))
+        {
+            CryptographicOperations.ZeroMemory(array);
+        }
+    }
+
+    private static IEnumerable<byte[]> GetExistingPrivateArrays(RSAParameters parameters)
+    {
+        if (parameters.D is not null)
+        {
+            yield return parameters.D;
+        }
+
+        if (parameters.P is not null)
+        {
+            yield return parameters.P;
+        }
+
+        if (parameters.Q is not null)
+        {
+            yield return parameters.Q;
+        }
+
+        if (parameters.DP is not null)
+        {
+            yield return parameters.DP;
+        }
+
+        if (parameters.DQ is not null)
+        {
+            yield return parameters.DQ;
+        }
+
+        if (parameters.InverseQ is not null)
+        {
+            yield return parameters.InverseQ;
+        }
+    }
+
+    private static byte[] BuildCurve25519Pkcs8WithTrailingData(byte[] privateKey)
+    {
+        var innerWriter = new AsnWriter(AsnEncodingRules.DER);
+        innerWriter.WriteOctetString(privateKey);
+
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(0);
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(Oids.Ed25519);
+        writer.PopSequence();
+        writer.WriteOctetString(innerWriter.Encode());
+        writer.WriteNull();
+        writer.PopSequence();
+        return writer.Encode();
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/PrivateKeyDecodingZeroingTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Cryptography/PrivateKeyDecodingZeroingTests.cs
@@ -21,6 +21,87 @@ namespace Yubico.YubiKit.Core.UnitTests.Cryptography;
 public class PrivateKeyDecodingZeroingTests
 {
     [Fact]
+    public void NormalizeParameters_PaddingRequired_ZeroesSupersededCopies()
+    {
+        var original = new RSAParameters
+        {
+            Modulus = [0x01, 0x02, 0x03, 0x04],
+            Exponent = [0x01, 0x00, 0x01],
+            D = [0x11, 0x12, 0x13],
+            P = [0x21],
+            Q = [0x31],
+            DP = [0x41],
+            DQ = [0x51],
+            InverseQ = [0x61]
+        };
+        RSAParameters normalized = default;
+        byte[][]? supersededArrays = null;
+
+        try
+        {
+            normalized = original.NormalizeParameters(
+                copied => supersededArrays = GetPrivateArrays(copied));
+
+            AssertAllZero(Assert.IsType<byte[][]>(supersededArrays));
+            Assert.Equal(4, normalized.D!.Length);
+            Assert.Equal(2, normalized.P!.Length);
+            AssertContainsNonZero(normalized.D);
+            AssertContainsNonZero(normalized.P);
+        }
+        finally
+        {
+            ZeroPrivateArrays(original);
+            ZeroPrivateArrays(normalized);
+        }
+    }
+
+    [Fact]
+    public void RSAPrivateKey_CreateFromParameters_UnsupportedLength_DoesNotAllocateOwnedCopy()
+    {
+        var parameters = CreateRsaParameters(modulusLength: 192);
+        RSAParameters? copiedParameters = null;
+
+        try
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                RSAPrivateKey.CreateFromParameters(
+                    parameters,
+                    copied => copiedParameters = copied));
+
+            Assert.Null(copiedParameters);
+        }
+        finally
+        {
+            ZeroPrivateArrays(parameters);
+        }
+    }
+
+    [Fact]
+    public void ECPrivateKey_CreateFromParameters_UnsupportedCurve_DoesNotAllocateOwnedCopy()
+    {
+        var parameters = new ECParameters
+        {
+            Curve = ECCurve.CreateFromValue("1.2.3.4"),
+            D = [0x11]
+        };
+        ECParameters? copiedParameters = null;
+
+        try
+        {
+            Assert.Throws<NotSupportedException>(() =>
+                ECPrivateKey.CreateFromParameters(
+                    parameters,
+                    copied => copiedParameters = copied));
+
+            Assert.Null(copiedParameters);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(parameters.D);
+        }
+    }
+
+    [Fact]
     public void CreateRSAParameters_ZeroesPrivateArraysSupersededByNormalization()
     {
         using var rsa = RSA.Create(2048);
@@ -87,6 +168,32 @@ public class PrivateKeyDecodingZeroingTests
     }
 
     [Fact]
+    public void RSAPrivateKey_CreateFromPkcs8_ObserverThrows_ZeroesDecoderArrays()
+    {
+        using var rsa = RSA.Create(2048);
+        var pkcs8 = rsa.ExportPkcs8PrivateKey();
+        byte[][]? decoderArrays = null;
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                RSAPrivateKey.CreateFromPkcs8(
+                    pkcs8,
+                    parameters =>
+                    {
+                        decoderArrays = GetPrivateArrays(parameters);
+                        throw new InvalidOperationException("observe failure");
+                    }));
+
+            AssertAllZero(Assert.IsType<byte[][]>(decoderArrays));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
     public void ECPrivateKey_CreateFromPkcs8_ZeroesDecoderDAndPreservesCopiedKey()
     {
         using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
@@ -122,6 +229,71 @@ public class PrivateKeyDecodingZeroingTests
     }
 
     [Fact]
+    public void ECPrivateKey_CreateFromPkcs8_ObserverThrows_ZeroesDecoderD()
+    {
+        using var ecdsa = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var pkcs8 = ecdsa.ExportPkcs8PrivateKey();
+        byte[]? decoderD = null;
+
+        try
+        {
+            Assert.Throws<InvalidOperationException>(() =>
+                ECPrivateKey.CreateFromPkcs8(
+                    pkcs8,
+                    parameters =>
+                    {
+                        decoderD = parameters.D;
+                        throw new InvalidOperationException("observe failure");
+                    }));
+
+            AssertAllZero([Assert.IsType<byte[]>(decoderD)]);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
+    public void ECPrivateKey_CreateFromEcdh_ZeroesExportedPrivateValue()
+    {
+        using var ecdh = ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256);
+        byte[]? exportedD = null;
+
+        using var key = ECPrivateKey.CreateFromEcdh(
+            ecdh,
+            parameters => exportedD = parameters.D);
+
+        AssertAllZero([Assert.IsType<byte[]>(exportedD)]);
+        AssertContainsNonZero(Assert.IsType<byte[]>(key.Parameters.D));
+    }
+
+    [Fact]
+    public void ECPrivateKey_CreateFromValue_ZeroesAllTemporaryPrivateValues()
+    {
+        using var source = ECDsa.Create(ECCurve.NamedCurves.nistP256);
+        var sourceParameters = source.ExportParameters(includePrivateParameters: true);
+        var privateValue = Assert.IsType<byte[]>(sourceParameters.D);
+        var temporaryValues = new List<byte[]>();
+
+        try
+        {
+            using var key = ECPrivateKey.CreateFromValue(
+                privateValue,
+                KeyType.ECP256,
+                parameters => temporaryValues.Add(Assert.IsType<byte[]>(parameters.D)));
+
+            Assert.Equal(2, temporaryValues.Count);
+            AssertAllZero(temporaryValues);
+            AssertContainsNonZero(Assert.IsType<byte[]>(key.Parameters.D));
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(privateValue);
+        }
+    }
+
+    [Fact]
     public void GetCurve25519PrivateKeyData_TrailingDataThrowsAndZeroesDecodedScalar()
     {
         var privateKey = new byte[32];
@@ -132,6 +304,30 @@ public class PrivateKeyDecodingZeroingTests
         try
         {
             Assert.Throws<AsnContentException>(() =>
+                AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(
+                    pkcs8,
+                    decoded => decodedPrivateKey = decoded));
+
+            AssertAllZero([Assert.IsType<byte[]>(decodedPrivateKey)]);
+        }
+        finally
+        {
+            CryptographicOperations.ZeroMemory(privateKey);
+            CryptographicOperations.ZeroMemory(pkcs8);
+        }
+    }
+
+    [Fact]
+    public void GetCurve25519PrivateKeyData_WrongLengthThrowsAndZeroesDecodedScalar()
+    {
+        var privateKey = new byte[31];
+        Array.Fill(privateKey, (byte)0x5A);
+        var pkcs8 = BuildCurve25519Pkcs8(privateKey);
+        byte[]? decodedPrivateKey = null;
+
+        try
+        {
+            Assert.Throws<CryptographicException>(() =>
                 AsnPrivateKeyDecoder.GetCurve25519PrivateKeyData(
                     pkcs8,
                     decoded => decodedPrivateKey = decoded));
@@ -172,6 +368,22 @@ public class PrivateKeyDecodingZeroingTests
         {
             CryptographicOperations.ZeroMemory(array);
         }
+    }
+
+    private static RSAParameters CreateRsaParameters(int modulusLength)
+    {
+        var halfLength = modulusLength / 2;
+        return new RSAParameters
+        {
+            Modulus = Enumerable.Repeat((byte)0x11, modulusLength).ToArray(),
+            Exponent = [0x01, 0x00, 0x01],
+            D = Enumerable.Repeat((byte)0x21, modulusLength).ToArray(),
+            P = Enumerable.Repeat((byte)0x31, halfLength).ToArray(),
+            Q = Enumerable.Repeat((byte)0x41, halfLength).ToArray(),
+            DP = Enumerable.Repeat((byte)0x51, halfLength).ToArray(),
+            DQ = Enumerable.Repeat((byte)0x61, halfLength).ToArray(),
+            InverseQ = Enumerable.Repeat((byte)0x71, halfLength).ToArray()
+        };
     }
 
     private static IEnumerable<byte[]> GetExistingPrivateArrays(RSAParameters parameters)
@@ -220,6 +432,22 @@ public class PrivateKeyDecodingZeroingTests
         writer.PopSequence();
         writer.WriteOctetString(innerWriter.Encode());
         writer.WriteNull();
+        writer.PopSequence();
+        return writer.Encode();
+    }
+
+    private static byte[] BuildCurve25519Pkcs8(byte[] privateKey)
+    {
+        var innerWriter = new AsnWriter(AsnEncodingRules.DER);
+        innerWriter.WriteOctetString(privateKey);
+
+        var writer = new AsnWriter(AsnEncodingRules.DER);
+        writer.PushSequence();
+        writer.WriteInteger(0);
+        writer.PushSequence();
+        writer.WriteObjectIdentifier(Oids.Ed25519);
+        writer.PopSequence();
+        writer.WriteOctetString(innerWriter.Encode());
         writer.PopSequence();
         return writer.Encode();
     }


### PR DESCRIPTION
## Summary

- Clears decoder-owned RSA, elliptic-curve, X25519, and Ed25519 private-key temporaries on success and failure.
- Clears superseded RSA normalization buffers when leading-zero padding creates replacement arrays.
- Validates RSA key length and elliptic-curve identifiers before allocating key-owned copies.
- Clears exported elliptic-curve private values in `CreateFromEcdh` and all temporaries in `CreateFromValue`.
- Documents borrowed inputs, caller-owned raw returns, key-owned views, disposal, and clearing responsibilities across the private-key surface.

## Ownership

PKCS#8 and parameter inputs remain caller-owned and are never modified or cleared. Raw decoder returns and PKCS#8 export arrays are caller-owned and must be cleared by the caller. Disposable private-key objects own their copied private material and clear it on disposal.

Internal observe-only hooks make otherwise unreachable arrays testable without changing public API. Their callbacks must not retain or mutate the observed buffers.

## Verification

- Private-key zeroing tests: 12 passed.
- Core cryptography tests: 121 passed.
- Core library, unit-test, and integration-test projects: built with zero warnings and zero errors.
- Explicit-include formatting: clean.
- Separate cross-vendor DevTeam security review: passed after identifying and closing additional RSA and elliptic-curve factory leaks.

## Stack

- Base: #604
- Descendants: #610 and #611