### PR TITLE
fix(core): skip HID long items instead of misparsing the rest of the descriptor

### DIFF
--- a/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
+++ b/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
@@ -31,14 +31,8 @@ internal readonly record struct HidReportItem(int Type, int Tag, uint Value);
 /// = tag).
 /// </summary>
 /// <remarks>
-/// HID long items (prefix 0xFE) are recognized and skipped entirely: <see cref="TryReadItem"/>
-/// consumes the long item's <c>bDataSize</c>/<c>bLongItemTag</c> header and its data bytes, then
-/// continues to the next item so a long item is never surfaced to callers. Neither consumer of
-/// this reader has any use for long-item data, and HID 1.11 defines no standard long-item tags,
-/// so skipping is correct. A truncated long item (fewer than 3 header bytes, or fewer than
-/// <c>bDataSize</c> data bytes remaining) terminates the walk by returning
-/// <see langword="false"/>, matching short-item truncation semantics. A descriptor consisting
-/// solely of long items terminates cleanly once the bytes are exhausted.
+/// HID long items (prefix 0xFE) have no standard tags in HID 1.11. Complete long items are skipped
+/// without being surfaced. A truncated long-item header or payload ends iteration.
 /// </remarks>
 internal static class HidReportDescriptorReader
 {
@@ -69,14 +63,15 @@ internal static class HidReportDescriptorReader
     /// <paramref name="position"/> past it.
     /// </summary>
     /// <param name="descriptor">The raw HID report descriptor bytes.</param>
-    /// <param name="position">The read cursor. Advanced past the item just read on success;
-    /// left unspecified once this method returns <see langword="false"/>.</param>
+    /// <param name="position">The read cursor. On success, it is advanced past any skipped long
+    /// items and the decoded short item. Its value is unspecified when this method returns
+    /// <see langword="false"/>.</param>
     /// <param name="item">The decoded item, when this method returns <see langword="true"/>.</param>
     /// <returns><see langword="true"/> if an item was read; <see langword="false"/> once the
     /// descriptor is exhausted or the trailing item is truncated.</returns>
     /// <remarks>
-    /// A truncated item (fewer bytes remaining than its prefix declares) terminates the walk
-    /// rather than being clamped or skipped, matching the two hand-rolled walkers this replaces.
+    /// A truncated short item (fewer bytes remaining than its prefix declares) terminates the
+    /// walk rather than being clamped or skipped.
     /// An item declaring a size of zero still advances the cursor by its prefix byte and yields a
     /// <see cref="HidReportItem.Value"/> of zero.
     /// </remarks>
@@ -95,9 +90,6 @@ internal static class HidReportDescriptorReader
 
             if (prefix == LongItemPrefix)
             {
-                // Long item: 0xFE, bDataSize, bLongItemTag, <bDataSize bytes of data>. Neither
-                // consumer of this reader uses long-item data, so skip the whole item (header +
-                // data) and continue to the next item.
                 if (position + 3 > descriptor.Length)
                 {
                     return false;

--- a/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
+++ b/src/Core/src/Transports/Hid/HidReportDescriptorReader.cs
@@ -31,12 +31,14 @@ internal readonly record struct HidReportItem(int Type, int Tag, uint Value);
 /// = tag).
 /// </summary>
 /// <remarks>
-/// This does not implement HID long items (prefix 0xFE). A long-item prefix decodes through this
-/// short-item layout as size=2/type=3/tag=15, consuming its two length/tag bytes as an ordinary
-/// item value and desynchronizing the cursor for the remainder of the descriptor. YubiKeys do not
-/// emit long items in practice. This is a deliberate, pinned limitation inherited from the two
-/// original hand-rolled walkers this type replaces; do not add long-item handling here without a
-/// dedicated, reviewed change.
+/// HID long items (prefix 0xFE) are recognized and skipped entirely: <see cref="TryReadItem"/>
+/// consumes the long item's <c>bDataSize</c>/<c>bLongItemTag</c> header and its data bytes, then
+/// continues to the next item so a long item is never surfaced to callers. Neither consumer of
+/// this reader has any use for long-item data, and HID 1.11 defines no standard long-item tags,
+/// so skipping is correct. A truncated long item (fewer than 3 header bytes, or fewer than
+/// <c>bDataSize</c> data bytes remaining) terminates the walk by returning
+/// <see langword="false"/>, matching short-item truncation semantics. A descriptor consisting
+/// solely of long items terminates cleanly once the bytes are exhausted.
 /// </remarks>
 internal static class HidReportDescriptorReader
 {
@@ -55,6 +57,12 @@ internal static class HidReportDescriptorReader
     /// Local item type (bits 2-3 of the prefix byte == 2). Examples: Usage.
     /// </summary>
     internal const int TypeLocal = 2;
+
+    /// <summary>
+    /// The reserved prefix byte identifying a HID long item: <c>0xFE</c>, followed by
+    /// <c>bDataSize</c>, <c>bLongItemTag</c>, and <c>bDataSize</c> bytes of data.
+    /// </summary>
+    private const byte LongItemPrefix = 0xFE;
 
     /// <summary>
     /// Reads the next short item from <paramref name="descriptor"/>, advancing
@@ -76,36 +84,62 @@ internal static class HidReportDescriptorReader
     {
         item = default;
 
-        if (position >= descriptor.Length)
+        while (true)
         {
-            return false;
+            if (position >= descriptor.Length)
+            {
+                return false;
+            }
+
+            byte prefix = descriptor[position];
+
+            if (prefix == LongItemPrefix)
+            {
+                // Long item: 0xFE, bDataSize, bLongItemTag, <bDataSize bytes of data>. Neither
+                // consumer of this reader uses long-item data, so skip the whole item (header +
+                // data) and continue to the next item.
+                if (position + 3 > descriptor.Length)
+                {
+                    return false;
+                }
+
+                byte dataSize = descriptor[position + 1];
+                int longItemLength = 3 + dataSize;
+
+                if (position + longItemLength > descriptor.Length)
+                {
+                    return false;
+                }
+
+                position += longItemLength;
+                continue;
+            }
+
+            int size = prefix & 0x03;
+            if (size == 3)
+            {
+                size = 4; // Size encoding: 0=0, 1=1, 2=2, 3=4
+            }
+
+            int type = (prefix >> 2) & 0x03;
+            int tag = (prefix >> 4) & 0x0F;
+
+            int cursor = position + 1; // Move past prefix
+
+            if (cursor + size > descriptor.Length)
+            {
+                return false;
+            }
+
+            uint value = 0;
+            for (int j = 0; j < size; j++)
+            {
+                value |= (uint)descriptor[cursor + j] << (8 * j);
+            }
+
+            item = new HidReportItem(type, tag, value);
+            position = cursor + size;
+            return true;
         }
-
-        byte prefix = descriptor[position];
-        int size = prefix & 0x03;
-        if (size == 3)
-        {
-            size = 4; // Size encoding: 0=0, 1=1, 2=2, 3=4
-        }
-
-        int type = (prefix >> 2) & 0x03;
-        int tag = (prefix >> 4) & 0x0F;
-
-        int cursor = position + 1; // Move past prefix
-
-        if (cursor + size > descriptor.Length)
-        {
-            return false;
-        }
-
-        uint value = 0;
-        for (int j = 0; j < size; j++)
-        {
-            value |= (uint)descriptor[cursor + j] << (8 * j);
-        }
-
-        item = new HidReportItem(type, tag, value);
-        position = cursor + size;
-        return true;
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
@@ -95,16 +95,52 @@ public class LinuxHidDescriptorParsingTests
     // independent (each field is captured independently, not "first item wins overall").
     public static readonly byte[] UsageBeforeUsagePage = [0x09, 0x06, 0x05, 0x01];
 
-    // KNOWN DEFECT, PINNED DELIBERATELY. HID long items (prefix 0xFE) are not handled by
-    // either parser. 0xFE decodes via the short-item bit layout as size=2/type=3/tag=15, so
-    // its two payload bytes (0xAA, 0xBB) are consumed as an ordinary item value, the cursor
-    // then lands mid-stream at the long item's data-length/tag bytes, and the perfectly
-    // valid `05 01 09 06` keyboard descriptor that follows it is misread and lost, producing
-    // (0, 0) instead of (0x0001, 0x0006). YubiKeys do not emit long items in practice, so
-    // this is latent, not live. This test pins CURRENT behaviour for refactor safety only —
-    // it is NOT an endorsement of the defect and must not be "fixed" as part of any
-    // characterization or refactor work.
+    // HID long item (prefix 0xFE): bDataSize = 0x02, bLongItemTag = 0xAA, 2 data bytes
+    // (0xBB, 0xCC), for a total of 3 + 2 = 5 bytes (position 0 -> 5). TryReadItem skips the
+    // whole long item and resumes at position 5, where the perfectly valid `05 01 09 06`
+    // keyboard Usage Page + Usage pair is decoded normally, giving (0x0001, 0x0006). Neither
+    // Report Size, Report Count, Input, nor Output items are present, so the report-size
+    // parser's (64, 64) defaults are unaffected.
     public static readonly byte[] LongItem0xFE = [0xFE, 0x02, 0xAA, 0xBB, 0xCC, 0x05, 0x01, 0x09, 0x06];
+
+    // Long item with bDataSize == 0: prefix 0xFE, dataSize 0, tag 0xAA — exactly 3 bytes total
+    // (position 0 -> 3), the minimum legal long item. Followed by the same valid Usage Page +
+    // Usage pair, decoded normally: usage page = 0x0001, usage = 0x0006. No Report Size/Report
+    // Count/Input/Output items are present, so report sizes stay at the (64, 64) defaults.
+    public static readonly byte[] LongItemZeroDataSize = [0xFE, 0x00, 0xAA, 0x05, 0x01, 0x09, 0x06];
+
+    // Long item with a 4-byte payload: prefix 0xFE, dataSize 4, tag 0xAA, four data bytes
+    // (0xBB..0xEE), total 3 + 4 = 7 bytes (position 0 -> 7). Confirms the skip length is
+    // 3 + bDataSize, not a fixed size, before the same valid Usage Page + Usage pair is
+    // decoded: usage page = 0x0001, usage = 0x0006. Report sizes stay at (64, 64).
+    public static readonly byte[] LongItemFourByteDataSize =
+        [0xFE, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x05, 0x01, 0x09, 0x06];
+
+    // A valid Usage Page item (usage page = 0x0001) is read first (position 0 -> 2). Then a
+    // long-item header declares bDataSize = 5 (position 2 -> 5 reads FE 05 AA), but only 2
+    // data bytes remain (BB CC) instead of 5, so the bounds check at position 5
+    // (5 + 5 = 10 > length 7) fails and TryReadItem returns false. The walk stops there: the
+    // Usage Page already read survives (usage page = 0x0001), but Usage is never reached, so
+    // usage stays at its default 0x0000. No Report Size/Report Count/Input/Output items are
+    // present, so report sizes stay at (64, 64).
+    public static readonly byte[] TruncatedLongItemPayload = [0x05, 0x01, 0xFE, 0x05, 0xAA, 0xBB, 0xCC];
+
+    // Only the long-item prefix byte itself, nothing else: the header bounds check
+    // (0 + 3 > length 1) fails immediately, so TryReadItem returns false on the very first
+    // call. No items are ever produced; both parsers return their untouched defaults.
+    public static readonly byte[] LongItemPrefixOnly = [0xFE];
+
+    // The long-item prefix plus its bDataSize byte, but the bLongItemTag byte is missing: the
+    // header bounds check (0 + 3 > length 2) fails for the same reason. No items are ever
+    // produced; both parsers return their untouched defaults.
+    public static readonly byte[] LongItemHeaderTruncated = [0xFE, 0x02];
+
+    // A descriptor consisting solely of two back-to-back long items (bDataSize 1, then
+    // bDataSize 0), with no short items anywhere. Both are skipped in full
+    // (position 0 -> 4, then 4 -> 7); position then equals the descriptor length (7), so
+    // TryReadItem returns false and the walk terminates cleanly. Both parsers return their
+    // untouched defaults.
+    public static readonly byte[] AllLongItems = [0xFE, 0x01, 0xAA, 0xBB, 0xFE, 0x00, 0xCC];
 
     // Items with size 0 (bits 0-1 of prefix are both 0) still advance the cursor by exactly
     // one byte (the prefix itself) and the loop terminates cleanly once the bytes run out.
@@ -165,10 +201,16 @@ public class LinuxHidDescriptorParsingTests
         { nameof(GlobalsPersistAcrossMain), GlobalsPersistAcrossMain, 0x0000, 0x0000 },
         { nameof(SecondUsagePageIgnored), SecondUsagePageIgnored, 0x0001, 0x0006 },
         { nameof(UsageBeforeUsagePage), UsageBeforeUsagePage, 0x0001, 0x0006 },
-        { nameof(LongItem0xFE), LongItem0xFE, 0x0000, 0x0000 },
+        { nameof(LongItem0xFE), LongItem0xFE, 0x0001, 0x0006 },
         { nameof(ZeroSizeItemsOnly), ZeroSizeItemsOnly, 0x0000, 0x0000 },
         { nameof(TwoByteReportCount), TwoByteReportCount, 0x0000, 0x0000 },
-        { nameof(TwoByteReportSize), TwoByteReportSize, 0x0000, 0x0000 }
+        { nameof(TwoByteReportSize), TwoByteReportSize, 0x0000, 0x0000 },
+        { nameof(LongItemZeroDataSize), LongItemZeroDataSize, 0x0001, 0x0006 },
+        { nameof(LongItemFourByteDataSize), LongItemFourByteDataSize, 0x0001, 0x0006 },
+        { nameof(TruncatedLongItemPayload), TruncatedLongItemPayload, 0x0001, 0x0000 },
+        { nameof(LongItemPrefixOnly), LongItemPrefixOnly, 0x0000, 0x0000 },
+        { nameof(LongItemHeaderTruncated), LongItemHeaderTruncated, 0x0000, 0x0000 },
+        { nameof(AllLongItems), AllLongItems, 0x0000, 0x0000 }
     };
 
     public static TheoryData<string, byte[], int, int> ReportSizeVectors() => new()
@@ -189,6 +231,12 @@ public class LinuxHidDescriptorParsingTests
         { nameof(LongItem0xFE), LongItem0xFE, 64, 64 },
         { nameof(ZeroSizeItemsOnly), ZeroSizeItemsOnly, 64, 64 },
         { nameof(TwoByteReportCount), TwoByteReportCount, 256, 64 },
-        { nameof(TwoByteReportSize), TwoByteReportSize, 8, 64 }
+        { nameof(TwoByteReportSize), TwoByteReportSize, 8, 64 },
+        { nameof(LongItemZeroDataSize), LongItemZeroDataSize, 64, 64 },
+        { nameof(LongItemFourByteDataSize), LongItemFourByteDataSize, 64, 64 },
+        { nameof(TruncatedLongItemPayload), TruncatedLongItemPayload, 64, 64 },
+        { nameof(LongItemPrefixOnly), LongItemPrefixOnly, 64, 64 },
+        { nameof(LongItemHeaderTruncated), LongItemHeaderTruncated, 64, 64 },
+        { nameof(AllLongItems), AllLongItems, 64, 64 }
     };
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/Hid/LinuxHidDescriptorParsingTests.cs
@@ -17,23 +17,12 @@ using Yubico.YubiKit.Core.Transports.Hid.Linux;
 namespace Yubico.YubiKit.Core.UnitTests.Transports.Hid;
 
 /// <summary>
-/// Characterization tests for the two independent, hand-rolled HID report-descriptor item
-/// walkers in <see cref="LinuxHidDevice"/> and <see cref="LinuxHidIOReportConnection"/>.
-///
-/// These tests make ZERO claim that the parsers are correct. They pin the CURRENT, observed
-/// behaviour of both parsers, byte for byte, so that a future refactor that merges the two
-/// walkers into one shared implementation can be verified as behaviour-preserving. Every
-/// vector below is run through both <see cref="LinuxHidDevice.ParseHidDescriptorBytes"/> and
-/// <see cref="LinuxHidIOReportConnection.ParseReportSizes"/>, even where the result is the
-/// uninteresting default, because "this input does not affect me" is itself part of the
-/// contract a refactor could silently break.
+/// Characterizes Linux HID report-descriptor parsing, including malformed descriptors. Some
+/// expectations preserve parser choices rather than define general HID protocol requirements.
 /// </summary>
 public class LinuxHidDescriptorParsingTests
 {
-    // The real canonical U2F HID descriptor. (0xF1D0, 0x0001) is exactly what
-    // HidInterfaceClassifier.Classify requires to return HidInterfaceType.Fido. If this
-    // regresses, every YubiKey is dropped from Linux HID discovery. This is the single most
-    // important vector in this file.
+    // Losing the canonical U2F usage pair prevents Linux HID discovery from classifying the device.
     public static readonly byte[] FidoU2f =
     [
         0x06, 0xD0, 0xF1, 0x09, 0x01, 0xA1, 0x01, 0x09, 0x20, 0x15, 0x00, 0x26, 0xFF, 0x00, 0x75, 0x08,
@@ -41,123 +30,68 @@ public class LinuxHidDescriptorParsingTests
         0xC0
     ];
 
-    // (0x0001, 0x0006) is exactly what HidInterfaceClassifier.Classify requires to return
-    // HidInterfaceType.Otp.
+    // The keyboard usage pair is required for OTP classification.
     public static readonly byte[] KeyboardOtp =
     [
         0x05, 0x01, 0x09, 0x06, 0xA1, 0x01, 0x75, 0x08, 0x95, 0x08, 0x81, 0x02, 0x75, 0x08, 0x95, 0x08,
         0x91, 0x02, 0xC0
     ];
 
-    // Zero bytes: the loop condition `i < descriptor.Length` never enters, so both parsers
-    // return their untouched defaults.
     public static readonly byte[] Empty = [];
 
-    // Only a prefix + a truncated value: the `i + size > descriptor.Length` break path fires
-    // before any item is decoded.
+    // A truncated short item is not partially decoded.
     public static readonly byte[] TruncatedValue = [0x06, 0xD0];
 
-    // A valid Usage Page item followed by a lone trailing prefix byte with no value bytes
-    // behind it: the first item parses successfully (usage page = 0x0001), then the break
-    // path fires on the second, incomplete item, leaving usage at its default.
+    // Values decoded before a truncated trailing item are preserved.
     public static readonly byte[] TruncatedTrailingPrefix = [0x05, 0x01, 0x09];
 
-    // Proves three things at once: size == 3 in the prefix means FOUR value bytes (not
-    // three), the value is assembled little-endian, and a 4-byte value is truncated to
-    // ushort (0x04030201 -> 0x0201, 0xDDCCBBAA -> 0xBBAA).
+    // HID size code 3 means four little-endian bytes; usage results are narrowed to ushort.
     public static readonly byte[] Size3Means4Bytes = [0x07, 0x01, 0x02, 0x03, 0x04, 0x0B, 0xAA, 0xBB, 0xCC, 0xDD];
 
-    // Report Count of 0 leaves the `reportBytes > 0` guard false, so the 64-byte default is
-    // never overwritten despite an Input main item being present.
+    // A zero report count does not replace the default report size.
     public static readonly byte[] ReportCountZero = [0x75, 0x08, 0x95, 0x00, 0x81, 0x02];
 
-    // An Input/Output main item appears before any Report Size/Report Count global item, so
-    // currentReportSize/currentReportCount are both still 0, `reportBytes > 0` is false, and
-    // the 64-byte defaults survive.
+    // Main items need prior report-size and report-count globals to determine their byte size.
     public static readonly byte[] MainBeforeGlobals = [0x81, 0x02, 0x91, 0x02];
 
-    // A non-default report size really is computed and returned (guards against a refactor
-    // that always returns the 64-byte fallback regardless of the descriptor).
+    // A descriptor can replace the default with a non-default byte-aligned report size.
     public static readonly byte[] Input63Bytes = [0x75, 0x08, 0x95, 0x3F, 0x81, 0x02];
 
-    // (1 * 3 + 7) / 8 == 1: pins the ceiling-division bit-to-byte rounding exactly.
+    // Non-byte-aligned reports round up to a whole byte.
     public static readonly byte[] BitRoundingSize1Count3 = [0x75, 0x01, 0x95, 0x03, 0x81, 0x02];
 
-    // One Report Size/Report Count declaration feeds BOTH the Input and the Output main item
-    // that follow it: HID global-item persistence across multiple main items.
+    // HID global items persist across subsequent main items.
     public static readonly byte[] GlobalsPersistAcrossMain = [0x75, 0x08, 0x95, 0x20, 0x81, 0x02, 0x91, 0x02];
 
-    // A second Usage Page item must be ignored: first-value-wins via the `!usagePageFound`
-    // guard flag.
+    // Classification uses the first Usage Page item.
     public static readonly byte[] SecondUsagePageIgnored = [0x05, 0x01, 0x05, 0x0C, 0x09, 0x06];
 
-    // Usage item appears before Usage Page in the byte stream: proves the parser is order
-    // independent (each field is captured independently, not "first item wins overall").
+    // Usage and Usage Page are captured independently of their order.
     public static readonly byte[] UsageBeforeUsagePage = [0x09, 0x06, 0x05, 0x01];
 
-    // HID long item (prefix 0xFE): bDataSize = 0x02, bLongItemTag = 0xAA, 2 data bytes
-    // (0xBB, 0xCC), for a total of 3 + 2 = 5 bytes (position 0 -> 5). TryReadItem skips the
-    // whole long item and resumes at position 5, where the perfectly valid `05 01 09 06`
-    // keyboard Usage Page + Usage pair is decoded normally, giving (0x0001, 0x0006). Neither
-    // Report Size, Report Count, Input, nor Output items are present, so the report-size
-    // parser's (64, 64) defaults are unaffected.
     public static readonly byte[] LongItem0xFE = [0xFE, 0x02, 0xAA, 0xBB, 0xCC, 0x05, 0x01, 0x09, 0x06];
 
-    // Long item with bDataSize == 0: prefix 0xFE, dataSize 0, tag 0xAA — exactly 3 bytes total
-    // (position 0 -> 3), the minimum legal long item. Followed by the same valid Usage Page +
-    // Usage pair, decoded normally: usage page = 0x0001, usage = 0x0006. No Report Size/Report
-    // Count/Input/Output items are present, so report sizes stay at the (64, 64) defaults.
     public static readonly byte[] LongItemZeroDataSize = [0xFE, 0x00, 0xAA, 0x05, 0x01, 0x09, 0x06];
 
-    // Long item with a 4-byte payload: prefix 0xFE, dataSize 4, tag 0xAA, four data bytes
-    // (0xBB..0xEE), total 3 + 4 = 7 bytes (position 0 -> 7). Confirms the skip length is
-    // 3 + bDataSize, not a fixed size, before the same valid Usage Page + Usage pair is
-    // decoded: usage page = 0x0001, usage = 0x0006. Report sizes stay at (64, 64).
     public static readonly byte[] LongItemFourByteDataSize =
         [0xFE, 0x04, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0x05, 0x01, 0x09, 0x06];
 
-    // A valid Usage Page item (usage page = 0x0001) is read first (position 0 -> 2). Then a
-    // long-item header declares bDataSize = 5 (position 2 -> 5 reads FE 05 AA), but only 2
-    // data bytes remain (BB CC) instead of 5, so the bounds check at position 5
-    // (5 + 5 = 10 > length 7) fails and TryReadItem returns false. The walk stops there: the
-    // Usage Page already read survives (usage page = 0x0001), but Usage is never reached, so
-    // usage stays at its default 0x0000. No Report Size/Report Count/Input/Output items are
-    // present, so report sizes stay at (64, 64).
+    // A truncated long-item payload stops parsing after preserving preceding values.
     public static readonly byte[] TruncatedLongItemPayload = [0x05, 0x01, 0xFE, 0x05, 0xAA, 0xBB, 0xCC];
 
-    // Only the long-item prefix byte itself, nothing else: the header bounds check
-    // (0 + 3 > length 1) fails immediately, so TryReadItem returns false on the very first
-    // call. No items are ever produced; both parsers return their untouched defaults.
     public static readonly byte[] LongItemPrefixOnly = [0xFE];
 
-    // The long-item prefix plus its bDataSize byte, but the bLongItemTag byte is missing: the
-    // header bounds check (0 + 3 > length 2) fails for the same reason. No items are ever
-    // produced; both parsers return their untouched defaults.
     public static readonly byte[] LongItemHeaderTruncated = [0xFE, 0x02];
 
-    // A descriptor consisting solely of two back-to-back long items (bDataSize 1, then
-    // bDataSize 0), with no short items anywhere. Both are skipped in full
-    // (position 0 -> 4, then 4 -> 7); position then equals the descriptor length (7), so
-    // TryReadItem returns false and the walk terminates cleanly. Both parsers return their
-    // untouched defaults.
+    // A descriptor containing only complete long items terminates without producing a short item.
     public static readonly byte[] AllLongItems = [0xFE, 0x01, 0xAA, 0xBB, 0xFE, 0x00, 0xCC];
 
-    // Items with size 0 (bits 0-1 of prefix are both 0) still advance the cursor by exactly
-    // one byte (the prefix itself) and the loop terminates cleanly once the bytes run out.
+    // Zero-size short items still make progress through the descriptor.
     public static readonly byte[] ZeroSizeItemsOnly = [0xC0, 0xC0, 0xC0];
 
-    // A two-byte Report Count (prefix 0x96 = size 2, global, tag 9) holding 0x0100 = 256.
-    // (8 * 256 + 7) / 8 == 256. Without this vector the little-endian value assembly inside
-    // ParseReportSizes is completely unobservable, because every other vector feeds it only
-    // single-byte Report Size/Report Count values, and the one multi-byte vector
-    // (Size3Means4Bytes) uses tags that ParseReportSizes ignores. Verified: a big-endian
-    // assembly would read this count as 1 and return an input size of 1 instead of 256.
+    // These two globals make multi-byte little-endian assembly observable in report-size parsing.
     public static readonly byte[] TwoByteReportCount = [0x75, 0x08, 0x96, 0x00, 0x01, 0x81, 0x02];
 
-    // The same guard for the other multi-byte global: a two-byte Report Size (prefix 0x76 =
-    // size 2, global, tag 7) holding 0x0010 = 16 bits, with a Report Count of 4.
-    // (16 * 4 + 7) / 8 == 8. A big-endian assembly would read the size as 0x1000 and return
-    // 2048 instead of 8.
     public static readonly byte[] TwoByteReportSize = [0x76, 0x10, 0x00, 0x95, 0x04, 0x81, 0x02];
 
     [Theory]


### PR DESCRIPTION
Fixes Linux HID report-descriptor parsing when a long item appears before relevant short items.

## The defect

HID long items use `0xFE`, a payload length, a long-item tag, and then the declared payload. The parser previously decoded `0xFE` as a short item, consumed the length and tag as value bytes, and left the cursor inside the payload. A valid keyboard descriptor after that point could be lost and the interface omitted from Linux HID discovery.

## The correction

- Complete long items are skipped as one header-plus-payload unit and parsing continues.
- A truncated long-item header or payload terminates the walk safely without reading past the descriptor.
- Short-item behavior remains unchanged.

## Verification

- The former known-defect vector now returns the descriptor values after the long item.
- Coverage includes zero-length and multi-byte payloads, truncated headers and payloads, and descriptors containing only complete long items.
- Existing short-item vectors retain their expected values.
- Fast resilience checks and a separate cross-vendor remediation review passed.

Abbreviations: HID means Human Interface Device.