### PR TITLE
fix(cli): stop returning PINs as unzeroable strings and make prompts scriptable

### DIFF
--- a/src/Cli.Commands/src/Fido/FidoCommands.cs
+++ b/src/Cli.Commands/src/Fido/FidoCommands.cs
@@ -5,7 +5,6 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Security.Cryptography;
-using System.Text;
 using Yubico.YubiKit.Cli.Commands.Infrastructure;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.Core.Devices;
@@ -215,18 +214,20 @@ public sealed class FidoAccessSetPinCommand : YkCommandBase<FidoPinSettings>
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoPinSettings settings, YkDeviceContext deviceContext)
     {
-        var newPin = settings.NewPin ?? PinPrompt.PromptForPin("New PIN");
-        byte[]? newPinBytes = null;
+        using var newPin = PinPrompt.Resolve(settings.NewPin, "New PIN");
+        if (newPin is null)
+        {
+            OutputHelpers.WriteError("New PIN is required.");
+            return ExitCode.GenericError;
+        }
 
         try
         {
-            newPinBytes = Encoding.UTF8.GetBytes(newPin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
-            await clientPin.SetPinAsync(newPinBytes);
+            await clientPin.SetPinAsync(newPin.Memory);
 
             OutputHelpers.WriteSuccess("PIN set successfully.");
             return ExitCode.Success;
@@ -235,13 +236,6 @@ public sealed class FidoAccessSetPinCommand : YkCommandBase<FidoPinSettings>
         {
             OutputHelpers.WriteError(FidoHelpers.MapCtapPinError(ex));
             return ExitCode.AuthenticationFailed;
-        }
-        finally
-        {
-            if (newPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(newPinBytes);
-            }
         }
     }
 }
@@ -254,21 +248,21 @@ public sealed class FidoAccessChangePinCommand : YkCommandBase<FidoPinSettings>
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoPinSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("Current PIN");
-        var newPin = settings.NewPin ?? PinPrompt.PromptForPin("New PIN");
-        byte[]? pinBytes = null;
-        byte[]? newPinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "Current PIN");
+        using var newPin = PinPrompt.Resolve(settings.NewPin, "New PIN");
+        if (pin is null || newPin is null)
+        {
+            OutputHelpers.WriteError("Current and new PINs are required.");
+            return ExitCode.GenericError;
+        }
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-            newPinBytes = Encoding.UTF8.GetBytes(newPin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
-            await clientPin.ChangePinAsync(pinBytes, newPinBytes);
+            await clientPin.ChangePinAsync(pin.Memory, newPin.Memory);
 
             OutputHelpers.WriteSuccess("PIN changed successfully.");
             return ExitCode.Success;
@@ -277,18 +271,6 @@ public sealed class FidoAccessChangePinCommand : YkCommandBase<FidoPinSettings>
         {
             OutputHelpers.WriteError(FidoHelpers.MapCtapPinError(ex));
             return ExitCode.AuthenticationFailed;
-        }
-        finally
-        {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
-            if (newPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(newPinBytes);
-            }
         }
     }
 }
@@ -301,19 +283,22 @@ public sealed class FidoAccessVerifyPinCommand : YkCommandBase<FidoVerifyPinSett
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoVerifyPinSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
-            pinToken = await clientPin.GetPinTokenAsync(pinBytes);
+            pinToken = await clientPin.GetPinTokenAsync(pin.Memory);
 
             OutputHelpers.WriteSuccess("PIN is correct.");
             return ExitCode.Success;
@@ -325,11 +310,6 @@ public sealed class FidoAccessVerifyPinCommand : YkCommandBase<FidoVerifyPinSett
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -346,20 +326,23 @@ public sealed class FidoConfigToggleAlwaysUvCommand : YkCommandBase<FidoConfigSe
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoConfigSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.AuthenticatorConfig);
+                pin.Memory, PinUvAuthTokenPermissions.AuthenticatorConfig);
 
             var config = new AuthenticatorConfig(session, protocol, pinToken);
             await config.ToggleAlwaysUvAsync();
@@ -374,11 +357,6 @@ public sealed class FidoConfigToggleAlwaysUvCommand : YkCommandBase<FidoConfigSe
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -395,20 +373,23 @@ public sealed class FidoConfigEnableEpAttestationCommand : YkCommandBase<FidoCon
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoConfigSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.AuthenticatorConfig);
+                pin.Memory, PinUvAuthTokenPermissions.AuthenticatorConfig);
 
             var config = new AuthenticatorConfig(session, protocol, pinToken);
             await config.EnableEnterpriseAttestationAsync();
@@ -423,11 +404,6 @@ public sealed class FidoConfigEnableEpAttestationCommand : YkCommandBase<FidoCon
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -444,20 +420,23 @@ public sealed class FidoCredentialsListCommand : YkCommandBase<FidoCredentialsLi
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoCredentialsListSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.CredentialManagement);
+                pin.Memory, PinUvAuthTokenPermissions.CredentialManagement);
 
             var credMgmt = new Fido2.CredentialManagement.CredentialManagement(
                 session, protocol, pinToken);
@@ -483,7 +462,7 @@ public sealed class FidoCredentialsListCommand : YkCommandBase<FidoCredentialsLi
                 try
                 {
                     credToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                        pinBytes, PinUvAuthTokenPermissions.CredentialManagement);
+                        pin.Memory, PinUvAuthTokenPermissions.CredentialManagement);
 
                     var innerCredMgmt = new Fido2.CredentialManagement.CredentialManagement(
                         session, protocol, credToken);
@@ -520,11 +499,6 @@ public sealed class FidoCredentialsListCommand : YkCommandBase<FidoCredentialsLi
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -561,20 +535,23 @@ public sealed class FidoCredentialsDeleteCommand : YkCommandBase<FidoCredentials
             }
         }
 
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.CredentialManagement);
+                pin.Memory, PinUvAuthTokenPermissions.CredentialManagement);
 
             var credMgmt = new Fido2.CredentialManagement.CredentialManagement(
                 session, protocol, pinToken);
@@ -592,11 +569,6 @@ public sealed class FidoCredentialsDeleteCommand : YkCommandBase<FidoCredentials
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -613,20 +585,23 @@ public sealed class FidoFingerprintsListCommand : YkCommandBase<FidoFingerprints
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoFingerprintsListSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.BioEnrollment);
+                pin.Memory, PinUvAuthTokenPermissions.BioEnrollment);
 
             var bio = new FingerprintBioEnrollment(session, protocol, pinToken);
             var templates = await bio.EnumerateEnrollmentsAsync();
@@ -654,11 +629,6 @@ public sealed class FidoFingerprintsListCommand : YkCommandBase<FidoFingerprints
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -675,20 +645,23 @@ public sealed class FidoFingerprintsAddCommand : YkCommandBase<FidoFingerprintsA
     protected override async Task<int> ExecuteCommandAsync(
         CommandContext context, FidoFingerprintsAddSettings settings, YkDeviceContext deviceContext)
     {
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.BioEnrollment);
+                pin.Memory, PinUvAuthTokenPermissions.BioEnrollment);
 
             var bio = new FingerprintBioEnrollment(session, protocol, pinToken);
 
@@ -730,11 +703,6 @@ public sealed class FidoFingerprintsAddCommand : YkCommandBase<FidoFingerprintsA
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -771,20 +739,23 @@ public sealed class FidoFingerprintsDeleteCommand : YkCommandBase<FidoFingerprin
             }
         }
 
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.BioEnrollment);
+                pin.Memory, PinUvAuthTokenPermissions.BioEnrollment);
 
             var bio = new FingerprintBioEnrollment(session, protocol, pinToken);
             await bio.RemoveEnrollmentAsync(templateId);
@@ -799,11 +770,6 @@ public sealed class FidoFingerprintsDeleteCommand : YkCommandBase<FidoFingerprin
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);
@@ -831,20 +797,23 @@ public sealed class FidoFingerprintsRenameCommand : YkCommandBase<FidoFingerprin
             return ExitCode.GenericError;
         }
 
-        var pin = settings.Pin ?? PinPrompt.PromptForPin("PIN");
-        byte[]? pinBytes = null;
+        using var pin = PinPrompt.Resolve(settings.Pin, "PIN");
+        if (pin is null)
+        {
+            OutputHelpers.WriteError("PIN is required.");
+            return ExitCode.GenericError;
+        }
+
         byte[]? pinToken = null;
 
         try
         {
-            pinBytes = Encoding.UTF8.GetBytes(pin);
-
             await using var session = await deviceContext.Device.CreateFidoSessionAsync(preferredConnection: deviceContext.PreferredConnection);
             using var protocol = new PinUvAuthProtocolV2();
             using var clientPin = new ClientPin(session, protocol);
 
             pinToken = await clientPin.GetPinUvAuthTokenUsingPinAsync(
-                pinBytes, PinUvAuthTokenPermissions.BioEnrollment);
+                pin.Memory, PinUvAuthTokenPermissions.BioEnrollment);
 
             var bio = new FingerprintBioEnrollment(session, protocol, pinToken);
             await bio.SetFriendlyNameAsync(templateId, settings.Name);
@@ -859,11 +828,6 @@ public sealed class FidoFingerprintsRenameCommand : YkCommandBase<FidoFingerprin
         }
         finally
         {
-            if (pinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(pinBytes);
-            }
-
             if (pinToken is not null)
             {
                 CryptographicOperations.ZeroMemory(pinToken);

--- a/src/Cli.Commands/src/HsmAuth/HsmAuthCommands.cs
+++ b/src/Cli.Commands/src/HsmAuth/HsmAuthCommands.cs
@@ -5,6 +5,7 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Security.Cryptography;
+using System.Text;
 using Yubico.YubiKit.Cli.Commands.Infrastructure;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.Core.Devices;
@@ -95,6 +96,24 @@ public sealed class HsmAuthCredentialsGenerateSettings : GlobalSettings
 
 public static class HsmAuthHelpers
 {
+    /// <summary>
+    /// Prompts for a YubiHSM Auth credential password.
+    /// </summary>
+    /// <returns>The password, or <see langword="null"/> if the user declined to supply one.</returns>
+    /// <remarks>
+    /// Returns a <see cref="string"/> because <c>IHsmAuthSession.PutCredentialDerivedAsync</c> and
+    /// <c>GenerateCredentialAsymmetricAsync</c> take credential passwords as <see cref="string"/>,
+    /// which cannot be zeroed. Prompting through <see cref="SecureCredential"/> at least zeroes the
+    /// input buffer; the secret is still unzeroable once it crosses the SDK boundary. Narrowing
+    /// those SDK signatures to <c>ReadOnlyMemory&lt;byte&gt;</c> is a breaking change to a shipping
+    /// package and is tracked separately.
+    /// </remarks>
+    public static string? PromptCredentialPassword()
+    {
+        using var prompted = PinPrompt.PromptForCredential("Credential password");
+        return prompted is null ? null : Encoding.UTF8.GetString(prompted.Memory.Span);
+    }
+
     public static byte[]? ResolveManagementKey(string? hex)
     {
         hex ??= "00000000000000000000000000000000";
@@ -284,8 +303,12 @@ public sealed class HsmAuthCredentialsAddCommand : YkCommandBase<HsmAuthCredenti
             return ExitCode.GenericError;
         }
 
-        var credentialPassword = settings.CredentialPassword
-                                 ?? PinPrompt.PromptForPin("Credential password");
+        var credentialPassword = settings.CredentialPassword ?? HsmAuthHelpers.PromptCredentialPassword();
+        if (credentialPassword is null)
+        {
+            OutputHelpers.WriteError("Credential password is required.");
+            return ExitCode.GenericError;
+        }
 
         try
         {
@@ -380,8 +403,12 @@ public sealed class HsmAuthCredentialsGenerateCommand : YkCommandBase<HsmAuthCre
             return ExitCode.GenericError;
         }
 
-        var credentialPassword = settings.CredentialPassword
-                                 ?? PinPrompt.PromptForPin("Credential password");
+        var credentialPassword = settings.CredentialPassword ?? HsmAuthHelpers.PromptCredentialPassword();
+        if (credentialPassword is null)
+        {
+            OutputHelpers.WriteError("Credential password is required.");
+            return ExitCode.GenericError;
+        }
 
         try
         {

--- a/src/Cli.Commands/src/Oath/OathCommands.cs
+++ b/src/Cli.Commands/src/Oath/OathCommands.cs
@@ -5,7 +5,6 @@ using Spectre.Console;
 using Spectre.Console.Cli;
 using System.ComponentModel;
 using System.Security.Cryptography;
-using System.Text;
 using Yubico.YubiKit.Cli.Commands.Infrastructure;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.Core.Devices;
@@ -232,28 +231,25 @@ public sealed class OathAccessChangePasswordCommand : YkCommandBase<OathAccessCh
             return ExitCode.Success;
         }
 
-        var newPassword = settings.NewPassword;
-        if (string.IsNullOrEmpty(newPassword))
+        using var newPassword = PinPrompt.Resolve(settings.NewPassword, "Enter new OATH password");
+
+        if (newPassword is null)
         {
-            newPassword = PinPrompt.PromptForPin("Enter new OATH password");
-            var confirm = PinPrompt.PromptForPin("Confirm new OATH password");
-            if (!string.Equals(newPassword, confirm, StringComparison.Ordinal))
-            {
-                OutputHelpers.WriteError("Passwords do not match.");
-                return ExitCode.GenericError;
-            }
+            OutputHelpers.WriteError("No new password was supplied. Use --clear to remove password protection.");
+            return ExitCode.GenericError;
         }
 
-        if (string.IsNullOrEmpty(newPassword))
+        if (string.IsNullOrEmpty(settings.NewPassword) &&
+            !PinPrompt.ConfirmMatches(newPassword, "Confirm new OATH password"))
         {
-            OutputHelpers.WriteError("New password cannot be empty. Use --clear to remove password protection.");
+            OutputHelpers.WriteError("Passwords do not match.");
             return ExitCode.GenericError;
         }
 
         byte[]? key = null;
         try
         {
-            key = session.DeriveKey(Encoding.UTF8.GetBytes(newPassword));
+            key = session.DeriveKey(newPassword.Memory);
             await session.SetKeyAsync(key);
             OutputHelpers.WriteSuccess("OATH access password set.");
             return ExitCode.Success;

--- a/src/Cli.Commands/src/Oath/OathHelpers.cs
+++ b/src/Cli.Commands/src/Oath/OathHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Yubico AB
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using System.Security.Cryptography;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.Oath;
@@ -21,7 +22,7 @@ public static class OathHelpers
     internal static async Task<bool> UnlockIfNeededAsync(
         IOathSession session,
         string? password,
-        Func<SecureCredential> promptCredentialFactory)
+        Func<IMemoryOwner<byte>?> promptCredentialFactory)
     {
         if (!session.IsLocked)
         {
@@ -29,7 +30,7 @@ public static class OathHelpers
         }
 
         var hasArgvPassword = !string.IsNullOrEmpty(password);
-        SecureCredential? passwordBytes = null;
+        IMemoryOwner<byte>? passwordBytes = null;
         byte[]? key = null;
         try
         {
@@ -41,6 +42,12 @@ public static class OathHelpers
             else
             {
                 passwordBytes = promptCredentialFactory();
+            }
+
+            if (passwordBytes is null)
+            {
+                OutputHelpers.WriteError("No OATH password was supplied.");
+                return false;
             }
 
             key = session.DeriveKey(passwordBytes.Memory);

--- a/src/Cli.Commands/src/OpenPgp/OpenPgpAccessCommands.cs
+++ b/src/Cli.Commands/src/OpenPgp/OpenPgpAccessCommands.cs
@@ -3,8 +3,6 @@
 
 using Spectre.Console.Cli;
 using System.ComponentModel;
-using System.Security.Cryptography;
-using System.Text;
 using Yubico.YubiKit.Cli.Commands.Infrastructure;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.Core.Devices;
@@ -89,27 +87,20 @@ public sealed class OpenPgpAccessSetRetriesCommand : YkCommandBase<AccessSetRetr
     {
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[]? adminPinBytes = null;
-
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-            await session.VerifyAdminAsync(adminPinBytes);
-            await session.SetPinAttemptsAsync(settings.UserRetries, settings.ResetRetries, settings.AdminRetries);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
+        }
 
-            OutputHelpers.WriteSuccess(
-                $"PIN retry counts set to User={settings.UserRetries}, " +
-                $"Reset={settings.ResetRetries}, Admin={settings.AdminRetries}.");
-            return ExitCode.Success;
-        }
-        finally
-        {
-            if (adminPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(adminPinBytes);
-            }
-        }
+        await session.VerifyAdminAsync(adminPin.Memory);
+        await session.SetPinAttemptsAsync(settings.UserRetries, settings.ResetRetries, settings.AdminRetries);
+
+        OutputHelpers.WriteSuccess(
+            $"PIN retry counts set to User={settings.UserRetries}, " +
+            $"Reset={settings.ResetRetries}, Admin={settings.AdminRetries}.");
+        return ExitCode.Success;
     }
 }
 
@@ -122,42 +113,24 @@ public sealed class OpenPgpAccessChangePinCommand : YkCommandBase<AccessChangePi
     {
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
-        var currentPin = GetPin(settings.Pin, "Enter current User PIN");
-        var newPin = GetPin(settings.NewPin, "Enter new User PIN");
-
-        if (string.IsNullOrEmpty(settings.NewPin))
+        using var currentPin = GetPin(settings.Pin, "Enter current User PIN");
+        using var newPin = GetPin(settings.NewPin, "Enter new User PIN");
+        if (currentPin is null || newPin is null)
         {
-            var confirm = PinPrompt.PromptForPin("Confirm new User PIN");
-            if (!string.Equals(newPin, confirm, StringComparison.Ordinal))
-            {
-                OutputHelpers.WriteError("New PINs do not match.");
-                return ExitCode.GenericError;
-            }
+            OutputHelpers.WriteError("Current and new User PINs are required.");
+            return ExitCode.GenericError;
         }
 
-        byte[]? currentPinBytes = null;
-        byte[]? newPinBytes = null;
-
-        try
+        if (string.IsNullOrEmpty(settings.NewPin) &&
+            !PinPrompt.ConfirmMatches(newPin, "Confirm new User PIN"))
         {
-            currentPinBytes = Encoding.UTF8.GetBytes(currentPin);
-            newPinBytes = Encoding.UTF8.GetBytes(newPin);
-            await session.ChangePinAsync(currentPinBytes, newPinBytes);
-            OutputHelpers.WriteSuccess("User PIN has been changed.");
-            return ExitCode.Success;
+            OutputHelpers.WriteError("New PINs do not match.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            if (currentPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(currentPinBytes);
-            }
 
-            if (newPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(newPinBytes);
-            }
-        }
+        await session.ChangePinAsync(currentPin.Memory, newPin.Memory);
+        OutputHelpers.WriteSuccess("User PIN has been changed.");
+        return ExitCode.Success;
     }
 }
 
@@ -170,42 +143,24 @@ public sealed class OpenPgpAccessChangeAdminPinCommand : YkCommandBase<AccessCha
     {
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
-        var currentPin = GetPin(settings.AdminPin, "Enter current Admin PIN");
-        var newPin = GetPin(settings.NewAdminPin, "Enter new Admin PIN");
-
-        if (string.IsNullOrEmpty(settings.NewAdminPin))
+        using var currentPin = GetPin(settings.AdminPin, "Enter current Admin PIN");
+        using var newPin = GetPin(settings.NewAdminPin, "Enter new Admin PIN");
+        if (currentPin is null || newPin is null)
         {
-            var confirm = PinPrompt.PromptForPin("Confirm new Admin PIN");
-            if (!string.Equals(newPin, confirm, StringComparison.Ordinal))
-            {
-                OutputHelpers.WriteError("New Admin PINs do not match.");
-                return ExitCode.GenericError;
-            }
+            OutputHelpers.WriteError("Current and new Admin PINs are required.");
+            return ExitCode.GenericError;
         }
 
-        byte[]? currentPinBytes = null;
-        byte[]? newPinBytes = null;
-
-        try
+        if (string.IsNullOrEmpty(settings.NewAdminPin) &&
+            !PinPrompt.ConfirmMatches(newPin, "Confirm new Admin PIN"))
         {
-            currentPinBytes = Encoding.UTF8.GetBytes(currentPin);
-            newPinBytes = Encoding.UTF8.GetBytes(newPin);
-            await session.ChangeAdminAsync(currentPinBytes, newPinBytes);
-            OutputHelpers.WriteSuccess("Admin PIN has been changed.");
-            return ExitCode.Success;
+            OutputHelpers.WriteError("New Admin PINs do not match.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            if (currentPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(currentPinBytes);
-            }
 
-            if (newPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(newPinBytes);
-            }
-        }
+        await session.ChangeAdminAsync(currentPin.Memory, newPin.Memory);
+        OutputHelpers.WriteSuccess("Admin PIN has been changed.");
+        return ExitCode.Success;
     }
 }
 
@@ -218,43 +173,25 @@ public sealed class OpenPgpAccessSetResetCodeCommand : YkCommandBase<AccessSetRe
     {
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        var resetCode = GetPin(settings.ResetCode, "Enter new Reset Code");
-
-        if (string.IsNullOrEmpty(settings.ResetCode))
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        using var resetCode = GetPin(settings.ResetCode, "Enter new Reset Code");
+        if (adminPin is null || resetCode is null)
         {
-            var confirm = PinPrompt.PromptForPin("Confirm new Reset Code");
-            if (!string.Equals(resetCode, confirm, StringComparison.Ordinal))
-            {
-                OutputHelpers.WriteError("Reset Codes do not match.");
-                return ExitCode.GenericError;
-            }
+            OutputHelpers.WriteError("Admin PIN and Reset Code are required.");
+            return ExitCode.GenericError;
         }
 
-        byte[]? adminPinBytes = null;
-        byte[]? resetCodeBytes = null;
-
-        try
+        if (string.IsNullOrEmpty(settings.ResetCode) &&
+            !PinPrompt.ConfirmMatches(resetCode, "Confirm new Reset Code"))
         {
-            adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-            resetCodeBytes = Encoding.UTF8.GetBytes(resetCode);
-            await session.VerifyAdminAsync(adminPinBytes);
-            await session.SetResetCodeAsync(resetCodeBytes);
-            OutputHelpers.WriteSuccess("Reset Code has been set.");
-            return ExitCode.Success;
+            OutputHelpers.WriteError("Reset Codes do not match.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            if (adminPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(adminPinBytes);
-            }
 
-            if (resetCodeBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(resetCodeBytes);
-            }
-        }
+        await session.VerifyAdminAsync(adminPin.Memory);
+        await session.SetResetCodeAsync(resetCode.Memory);
+        OutputHelpers.WriteSuccess("Reset Code has been set.");
+        return ExitCode.Success;
     }
 }
 
@@ -267,41 +204,23 @@ public sealed class OpenPgpAccessUnblockPinCommand : YkCommandBase<AccessUnblock
     {
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
-        var resetCode = GetPin(settings.ResetCode, "Enter Reset Code");
-        var newPin = GetPin(settings.NewPin, "Enter new User PIN");
-
-        if (string.IsNullOrEmpty(settings.NewPin))
+        using var resetCode = GetPin(settings.ResetCode, "Enter Reset Code");
+        using var newPin = GetPin(settings.NewPin, "Enter new User PIN");
+        if (resetCode is null || newPin is null)
         {
-            var confirm = PinPrompt.PromptForPin("Confirm new User PIN");
-            if (!string.Equals(newPin, confirm, StringComparison.Ordinal))
-            {
-                OutputHelpers.WriteError("New PINs do not match.");
-                return ExitCode.GenericError;
-            }
+            OutputHelpers.WriteError("Reset Code and new User PIN are required.");
+            return ExitCode.GenericError;
         }
 
-        byte[]? resetCodeBytes = null;
-        byte[]? newPinBytes = null;
-
-        try
+        if (string.IsNullOrEmpty(settings.NewPin) &&
+            !PinPrompt.ConfirmMatches(newPin, "Confirm new User PIN"))
         {
-            resetCodeBytes = Encoding.UTF8.GetBytes(resetCode);
-            newPinBytes = Encoding.UTF8.GetBytes(newPin);
-            await session.ResetPinAsync(resetCodeBytes, newPinBytes, useAdmin: false);
-            OutputHelpers.WriteSuccess("User PIN has been unblocked.");
-            return ExitCode.Success;
+            OutputHelpers.WriteError("New PINs do not match.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            if (resetCodeBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(resetCodeBytes);
-            }
 
-            if (newPinBytes is not null)
-            {
-                CryptographicOperations.ZeroMemory(newPinBytes);
-            }
-        }
+        await session.ResetPinAsync(resetCode.Memory, newPin.Memory, useAdmin: false);
+        OutputHelpers.WriteSuccess("User PIN has been unblocked.");
+        return ExitCode.Success;
     }
 }

--- a/src/Cli.Commands/src/OpenPgp/OpenPgpCertificatesCommands.cs
+++ b/src/Cli.Commands/src/OpenPgp/OpenPgpCertificatesCommands.cs
@@ -135,16 +135,14 @@ public sealed class OpenPgpCertificatesImportCommand : YkCommandBase<Certificate
         OutputHelpers.WriteKeyValue("Issuer", cert.Issuer);
         OutputHelpers.WriteKeyValue("Thumbprint", cert.Thumbprint);
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[] adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            await session.VerifyAdminAsync(adminPinBytes);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(adminPinBytes);
-        }
+
+        await session.VerifyAdminAsync(adminPin.Memory);
 
         await session.PutCertificateAsync(keyRef, cert);
 
@@ -170,16 +168,14 @@ public sealed class OpenPgpCertificatesDeleteCommand : YkCommandBase<Certificate
             return ExitCode.UserCancelled;
         }
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[] adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            await session.VerifyAdminAsync(adminPinBytes);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(adminPinBytes);
-        }
+
+        await session.VerifyAdminAsync(adminPin.Memory);
 
         await session.DeleteCertificateAsync(keyRef);
 

--- a/src/Cli.Commands/src/OpenPgp/OpenPgpHelpers.cs
+++ b/src/Cli.Commands/src/OpenPgp/OpenPgpHelpers.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Yubico AB
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using Yubico.YubiKit.Cli.Shared.Output;
 using Yubico.YubiKit.OpenPgp;
 
@@ -32,15 +33,15 @@ public static class OpenPgpHelpers
             _ => keyRef.ToString()
         };
 
-    public static string GetPin(string? provided, string promptLabel)
-    {
-        if (!string.IsNullOrEmpty(provided))
-        {
-            return provided;
-        }
-
-        return PinPrompt.PromptForPin(promptLabel);
-    }
+    /// <summary>
+    /// Resolves a PIN from the command line when supplied, otherwise prompts for it.
+    /// </summary>
+    /// <returns>
+    /// Owned UTF-8 bytes that the caller must dispose to zero, or <see langword="null"/> if the
+    /// user declined to supply a PIN.
+    /// </returns>
+    public static IMemoryOwner<byte>? GetPin(string? provided, string promptLabel) =>
+        PinPrompt.Resolve(provided, promptLabel);
 
     public static bool ConfirmAction(string action, bool force)
     {

--- a/src/Cli.Commands/src/OpenPgp/OpenPgpKeysCommands.cs
+++ b/src/Cli.Commands/src/OpenPgp/OpenPgpKeysCommands.cs
@@ -115,16 +115,14 @@ public sealed class OpenPgpKeysSetTouchCommand : YkCommandBase<KeysSetTouchSetti
             return ExitCode.UserCancelled;
         }
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[] adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            await session.VerifyAdminAsync(adminPinBytes);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(adminPinBytes);
-        }
+
+        await session.VerifyAdminAsync(adminPin.Memory);
 
         await session.SetUifAsync(keyRef, uif);
 
@@ -165,16 +163,14 @@ public sealed class OpenPgpKeysImportCommand : YkCommandBase<KeysImportSettings>
             return ExitCode.GenericError;
         }
 
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[] adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            await session.VerifyAdminAsync(adminPinBytes);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(adminPinBytes);
-        }
+
+        await session.VerifyAdminAsync(adminPin.Memory);
 
         await AnsiConsole.Status()
             .StartAsync("Importing private key...", async _ =>
@@ -255,16 +251,14 @@ public sealed class OpenPgpKeysGenerateCommand : YkCommandBase<KeysGenerateSetti
         await using var session = await deviceContext.Device.CreateOpenPgpSessionAsync();
 
         var keyRef = ParseKeyRef(settings.Key);
-        var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
-        byte[] adminPinBytes = Encoding.UTF8.GetBytes(adminPin);
-        try
+        using var adminPin = GetPin(settings.AdminPin, "Enter Admin PIN");
+        if (adminPin is null)
         {
-            await session.VerifyAdminAsync(adminPinBytes);
+            OutputHelpers.WriteError("Admin PIN is required.");
+            return ExitCode.GenericError;
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(adminPinBytes);
-        }
+
+        await session.VerifyAdminAsync(adminPin.Memory);
 
         var alg = settings.Algorithm.ToUpperInvariant();
 

--- a/src/Cli.Commands/src/Piv/PivCommands.cs
+++ b/src/Cli.Commands/src/Piv/PivCommands.cs
@@ -3,6 +3,7 @@
 
 using Spectre.Console;
 using Spectre.Console.Cli;
+using System.Buffers;
 using System.ComponentModel;
 using System.Security.Cryptography;
 using Yubico.YubiKit.Cli.Commands.Infrastructure;
@@ -233,10 +234,8 @@ public static class PivHelpers
         }
     }
 
-    public static SecureCredential GetCredential(string? provided, string promptLabel) =>
-        provided is null
-            ? PinPrompt.PromptForCredential(promptLabel)
-            : SecureCredential.FromUtf8String(provided);
+    public static IMemoryOwner<byte>? GetCredential(string? provided, string promptLabel) =>
+        PinPrompt.Resolve(provided, promptLabel);
 }
 
 // ── Commands ────────────────────────────────────────────────────────────────
@@ -352,6 +351,12 @@ public sealed class PivAccessChangePinCommand : YkCommandBase<PivPinSettings>
         using var pin = PivHelpers.GetCredential(settings.Pin, "Current PIN");
         using var newPin = PivHelpers.GetCredential(settings.NewPin, "New PIN");
 
+        if (pin is null || newPin is null)
+        {
+            OutputHelpers.WriteError("Current and new PINs are required.");
+            return ExitCode.GenericError;
+        }
+
         try
         {
             await using var session = await deviceContext.Device.CreatePivSessionAsync();
@@ -378,6 +383,12 @@ public sealed class PivAccessChangePukCommand : YkCommandBase<PivPukSettings>
         using var puk = PivHelpers.GetCredential(settings.Puk, "Current PUK");
         using var newPuk = PivHelpers.GetCredential(settings.NewPuk, "New PUK");
 
+        if (puk is null || newPuk is null)
+        {
+            OutputHelpers.WriteError("Current and new PUKs are required.");
+            return ExitCode.GenericError;
+        }
+
         try
         {
             await using var session = await deviceContext.Device.CreatePivSessionAsync();
@@ -403,6 +414,12 @@ public sealed class PivAccessUnblockPinCommand : YkCommandBase<PivUnblockPinSett
     {
         using var puk = PivHelpers.GetCredential(settings.Puk, "PUK");
         using var newPin = PivHelpers.GetCredential(settings.NewPin, "New PIN");
+
+        if (puk is null || newPin is null)
+        {
+            OutputHelpers.WriteError("PUK and new PIN are required.");
+            return ExitCode.GenericError;
+        }
 
         try
         {

--- a/src/Cli.Commands/tests/Yubico.YubiKit.Cli.Commands.UnitTests/Oath/OathHelpersTests.cs
+++ b/src/Cli.Commands/tests/Yubico.YubiKit.Cli.Commands.UnitTests/Oath/OathHelpersTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Yubico AB
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using System.Text;
 using Yubico.YubiKit.Cli.Commands.Oath;
 using Yubico.YubiKit.Cli.Shared.Output;
@@ -58,7 +59,7 @@ public sealed class OathHelpersTests
     {
         var session = new FakeOathSession();
         using var console = new ConsoleCapture();
-        using var prompted = SecureCredential.FromUtf8String("prompt-password");
+        var prompted = new TrackingCredential("prompt-password");
 
         var result = await OathHelpers.UnlockIfNeededAsync(
             session,
@@ -69,7 +70,7 @@ public sealed class OathHelpersTests
         Assert.DoesNotContain(OathHelpers.ArgvPasswordWarning, console.ErrorOutput);
         Assert.Empty(console.Output);
         Assert.Equal(Encoding.UTF8.GetBytes("prompt-password"), session.DerivedPasswordBytes);
-        Assert.All(GetOwnedBuffer(prompted), b => Assert.Equal(0, b));
+        Assert.True(prompted.WasDisposed);
     }
 
     [Fact]
@@ -77,7 +78,7 @@ public sealed class OathHelpersTests
     {
         var session = new FakeOathSession();
         using var console = new ConsoleCapture();
-        using var prompted = SecureCredential.FromUtf8String("prompt-password");
+        var prompted = new TrackingCredential("prompt-password");
 
         var result = await OathHelpers.UnlockIfNeededAsync(
             session,
@@ -88,16 +89,9 @@ public sealed class OathHelpersTests
         Assert.DoesNotContain(OathHelpers.ArgvPasswordWarning, console.ErrorOutput);
         Assert.Empty(console.Output);
         Assert.Equal(Encoding.UTF8.GetBytes("prompt-password"), session.DerivedPasswordBytes);
-        Assert.All(GetOwnedBuffer(prompted), b => Assert.Equal(0, b));
+        Assert.True(prompted.WasDisposed);
     }
 
-    private static byte[] GetOwnedBuffer(SecureCredential credential)
-    {
-        var field = typeof(SecureCredential).GetField("_buffer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
-            ?? throw new InvalidOperationException("SecureCredential buffer field not found.");
-
-        return (byte[])field.GetValue(credential)!;
-    }
 
     private sealed class FakeOathSession : IOathSession
     {
@@ -183,6 +177,38 @@ public sealed class OathHelpersTests
 
         public void Dispose() { }
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    [Fact]
+    public async Task UnlockIfNeededAsync_WhenUserDeclinesPrompt_FailsWithoutValidating()
+    {
+        var session = new FakeOathSession();
+        using var console = new ConsoleCapture();
+
+        var result = await OathHelpers.UnlockIfNeededAsync(
+            session,
+            password: null,
+            promptCredentialFactory: () => null);
+
+        Assert.False(result);
+        Assert.Empty(session.ValidatedKeys);
+        Assert.DoesNotContain(OathHelpers.ArgvPasswordWarning, console.ErrorOutput);
+    }
+
+    /// <summary>
+    /// Records disposal so tests can assert the consumer released the credential it was handed.
+    /// Zeroing itself is <see cref="SecureCredential"/>'s contract and is tested in
+    /// Cli.Shared.UnitTests, not here.
+    /// </summary>
+    private sealed class TrackingCredential(string value) : IMemoryOwner<byte>
+    {
+        private readonly byte[] _bytes = Encoding.UTF8.GetBytes(value);
+
+        public bool WasDisposed { get; private set; }
+
+        public Memory<byte> Memory => _bytes;
+
+        public void Dispose() => WasDisposed = true;
     }
 
     private sealed class ConsoleCapture : IDisposable

--- a/src/Cli.Shared/src/Output/PinPrompt.cs
+++ b/src/Cli.Shared/src/Output/PinPrompt.cs
@@ -21,10 +21,10 @@ namespace Yubico.YubiKit.Cli.Shared.Output;
 /// Provides PIN/password prompts with masked input for CLI tools.
 /// </summary>
 /// <remarks>
-/// Every member returns <see cref="IMemoryOwner{T}"/> whose <see cref="IMemoryOwner{T}.Memory"/>
-/// is sized exactly to the secret and is zeroed on disposal, so results must always be consumed
-/// with <c>using</c>. A <see langword="null"/> result means the user <b>declined</b> to supply a
-/// credential and never signals an error, matching the SDK's <c>ICredentialPrompt</c> contract.
+/// Credential-producing members return an <see cref="IMemoryOwner{T}"/> whose
+/// <see cref="IMemoryOwner{T}.Memory"/> is sized exactly to the secret and zeroed on disposal, so
+/// results must always be consumed with <c>using</c>. A <see langword="null"/> result means the
+/// user declined to supply a credential and never signals an input error.
 /// </remarks>
 public static class PinPrompt
 {
@@ -34,13 +34,23 @@ public static class PinPrompt
     /// <param name="provided">The value passed on the command line, if any.</param>
     /// <param name="label">Label shown when prompting.</param>
     /// <returns>
-    /// Owned UTF-8 bytes, or <see langword="null"/> if no value was supplied on the command line
-    /// and the user declined the prompt.
+    /// Owned bytes, or <see langword="null"/> if no value was supplied on the command line and the
+    /// user declined the prompt.
     /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// No command-line value was supplied and the prompted credential contains invalid Unicode
+    /// text, or its UTF-8 encoding exceeds the prompt limit.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// No command-line value was supplied and <paramref name="label"/> is <see langword="null"/>,
+    /// empty, or consists only of white-space characters.
+    /// </exception>
     /// <remarks>
-    /// This is the single seam CLI commands should use. Passing a secret on the command line is
-    /// inherently insecure — it is visible to other processes and cannot be zeroed — so the
-    /// prompt is the intended path and the command-line value is a testing/demo convenience.
+    /// Command-line and interactive values are encoded as UTF-8 text. When standard input is
+    /// redirected, bytes are read as supplied after removing line endings. Resolve is the command
+    /// seam between already-supplied values and prompting. Command-line strings can be visible to
+    /// other processes and cannot be cleared from managed memory; prefer prompting for production
+    /// credential entry.
     /// </remarks>
     public static IMemoryOwner<byte>? Resolve(string? provided, string label) =>
         string.IsNullOrEmpty(provided)
@@ -48,12 +58,23 @@ public static class PinPrompt
             : SecureCredential.FromUtf8String(provided);
 
     /// <summary>
-    /// Prompts the user for a credential interactively, returning owned UTF-8 bytes that are
-    /// zeroed on disposal.
+    /// Prompts the user for a credential, returning owned bytes that are zeroed on disposal.
     /// </summary>
     /// <returns>
-    /// The credential, or <see langword="null"/> if the user declined to supply one.
+    /// The credential, or <see langword="null"/> if the user pressed Escape, pressed Enter with an
+    /// empty entry, or supplied an empty redirected line or end-of-input.
     /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The entered credential contains invalid Unicode text, or its UTF-8 encoding exceeds the
+    /// prompt limit.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="label"/> is <see langword="null"/>, empty, or consists only of white-space characters.
+    /// </exception>
+    /// <remarks>
+    /// Interactive text is encoded as UTF-8. Redirected standard input is treated as raw bytes
+    /// after line endings are removed.
+    /// </remarks>
     public static IMemoryOwner<byte>? PromptForCredential(string label = "PIN") =>
         SecureCredential.Prompt(label);
 
@@ -66,19 +87,17 @@ public static class PinPrompt
     /// A declined confirmation counts as a mismatch.
     /// </returns>
     /// <remarks>
-    /// Comparison is constant-time. Callers must not hand-roll this check: the natural
-    /// spellings (<c>string.Equals</c>, <c>SequenceEqual</c>) are content-dependent in timing
-    /// and are forbidden on secrets by the repository's security rules.
+    /// The confirmation entry is resolved through the prompt seam, and
+    /// <see cref="CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>
+    /// avoids content-dependent secret comparisons. Callers should use this method rather than
+    /// comparing credential bytes with <c>SequenceEqual</c>.
     /// </remarks>
     public static bool ConfirmMatches(IMemoryOwner<byte> credential, string confirmLabel) =>
         ConfirmMatches(credential, () => PromptForCredential(confirmLabel));
 
     /// <inheritdoc cref="ConfirmMatches(IMemoryOwner{byte}, string)"/>
     /// <param name="credential">The credential to confirm.</param>
-    /// <param name="promptForConfirmation">
-    /// Supplies the second entry. Exists so the constant-time comparison can be tested without a
-    /// console.
-    /// </param>
+    /// <param name="promptForConfirmation">Supplies the second entry.</param>
     internal static bool ConfirmMatches(
         IMemoryOwner<byte> credential,
         Func<IMemoryOwner<byte>?> promptForConfirmation)

--- a/src/Cli.Shared/src/Output/PinPrompt.cs
+++ b/src/Cli.Shared/src/Output/PinPrompt.cs
@@ -12,26 +12,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Spectre.Console;
+using System.Buffers;
+using System.Security.Cryptography;
 
 namespace Yubico.YubiKit.Cli.Shared.Output;
 
 /// <summary>
 /// Provides PIN/password prompts with masked input for CLI tools.
 /// </summary>
+/// <remarks>
+/// Every member returns <see cref="IMemoryOwner{T}"/> whose <see cref="IMemoryOwner{T}.Memory"/>
+/// is sized exactly to the secret and is zeroed on disposal, so results must always be consumed
+/// with <c>using</c>. A <see langword="null"/> result means the user <b>declined</b> to supply a
+/// credential and never signals an error, matching the SDK's <c>ICredentialPrompt</c> contract.
+/// </remarks>
 public static class PinPrompt
 {
     /// <summary>
-    /// Prompts the user for a PIN interactively with masked input.
-    /// Used when --pin is not provided on the command line.
+    /// Resolves a credential supplied on the command line, prompting for it when absent.
     /// </summary>
-    public static string PromptForPin(string label = "PIN") =>
-        AnsiConsole.Prompt(
-            new TextPrompt<string>($"{label}:")
-                .Secret());
+    /// <param name="provided">The value passed on the command line, if any.</param>
+    /// <param name="label">Label shown when prompting.</param>
+    /// <returns>
+    /// Owned UTF-8 bytes, or <see langword="null"/> if no value was supplied on the command line
+    /// and the user declined the prompt.
+    /// </returns>
+    /// <remarks>
+    /// This is the single seam CLI commands should use. Passing a secret on the command line is
+    /// inherently insecure — it is visible to other processes and cannot be zeroed — so the
+    /// prompt is the intended path and the command-line value is a testing/demo convenience.
+    /// </remarks>
+    public static IMemoryOwner<byte>? Resolve(string? provided, string label) =>
+        string.IsNullOrEmpty(provided)
+            ? PromptForCredential(label)
+            : SecureCredential.FromUtf8String(provided);
 
     /// <summary>
-    /// Prompts the user for a PIN interactively and returns owned UTF-8 bytes.
+    /// Prompts the user for a credential interactively, returning owned UTF-8 bytes that are
+    /// zeroed on disposal.
     /// </summary>
-    public static SecureCredential PromptForCredential(string label = "PIN") => SecureCredential.Prompt(label);
+    /// <returns>
+    /// The credential, or <see langword="null"/> if the user declined to supply one.
+    /// </returns>
+    public static IMemoryOwner<byte>? PromptForCredential(string label = "PIN") =>
+        SecureCredential.Prompt(label);
+
+    /// <summary>
+    /// Prompts a second time and reports whether the re-entered value matches
+    /// <paramref name="credential"/>, the conventional check when establishing a new secret.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true"/> only if the user supplied a second value and it matches.
+    /// A declined confirmation counts as a mismatch.
+    /// </returns>
+    /// <remarks>
+    /// Comparison is constant-time. Callers must not hand-roll this check: the natural
+    /// spellings (<c>string.Equals</c>, <c>SequenceEqual</c>) are content-dependent in timing
+    /// and are forbidden on secrets by the repository's security rules.
+    /// </remarks>
+    public static bool ConfirmMatches(IMemoryOwner<byte> credential, string confirmLabel) =>
+        ConfirmMatches(credential, () => PromptForCredential(confirmLabel));
+
+    /// <inheritdoc cref="ConfirmMatches(IMemoryOwner{byte}, string)"/>
+    /// <param name="credential">The credential to confirm.</param>
+    /// <param name="promptForConfirmation">
+    /// Supplies the second entry. Exists so the constant-time comparison can be tested without a
+    /// console.
+    /// </param>
+    internal static bool ConfirmMatches(
+        IMemoryOwner<byte> credential,
+        Func<IMemoryOwner<byte>?> promptForConfirmation)
+    {
+        ArgumentNullException.ThrowIfNull(credential);
+        ArgumentNullException.ThrowIfNull(promptForConfirmation);
+
+        using var confirmation = promptForConfirmation();
+        return confirmation is not null
+               && CryptographicOperations.FixedTimeEquals(
+                   credential.Memory.Span, confirmation.Memory.Span);
+    }
 }

--- a/src/Cli.Shared/src/Output/SecureCredential.cs
+++ b/src/Cli.Shared/src/Output/SecureCredential.cs
@@ -21,7 +21,6 @@ public sealed class SecureCredential : IMemoryOwner<byte>
 {
     /// <summary>Sentinel returned by the read helpers when the user abandoned the prompt.</summary>
     private const int Declined = -1;
-
     private readonly byte[] _buffer;
     private readonly int _length;
     private bool _disposed;
@@ -48,6 +47,17 @@ public sealed class SecureCredential : IMemoryOwner<byte>
         }
     }
 
+    /// <summary>
+    /// Encodes a non-empty string as UTF-8 and owns the resulting bytes until disposal.
+    /// </summary>
+    /// <param name="value">The non-empty credential text to encode.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="value"/> is <see langword="null"/> or empty.
+    /// </exception>
+    /// <remarks>
+    /// Disposal clears the encoded bytes, but the source string cannot be cleared from managed
+    /// memory. Prefer an interactive prompt when the credential was not already supplied as text.
+    /// </remarks>
     public static SecureCredential FromUtf8String(string value)
     {
         if (string.IsNullOrEmpty(value))
@@ -60,13 +70,24 @@ public sealed class SecureCredential : IMemoryOwner<byte>
     }
 
     /// <summary>
-    /// Prompts for a credential, masking interactive input and reading a single line when
-    /// standard input is redirected.
+    /// Prompts for a credential, encoding interactive text as UTF-8 or reading raw bytes from
+    /// redirected standard input after removing line endings.
     /// </summary>
     /// <returns>
     /// The credential, or <see langword="null"/> if the user declined to supply one — either by
-    /// pressing Escape, or by supplying an empty line or end-of-input on redirected input.
+    /// pressing Escape, pressing Enter with an empty entry, or supplying an empty line or
+    /// end-of-input on redirected input.
     /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// The entered credential contains invalid Unicode text, or its UTF-8 encoding exceeds
+    /// <paramref name="maxByteLength"/> bytes.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="label"/> is <see langword="null"/>, empty, or consists only of white-space characters.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="maxByteLength"/> is less than one.
+    /// </exception>
     /// <remarks>
     /// <see langword="null"/> means exactly one thing: no credential was supplied. It never
     /// signals an input error. This mirrors the <c>ICredentialPrompt</c> contract so console
@@ -113,7 +134,9 @@ public sealed class SecureCredential : IMemoryOwner<byte>
 
     internal byte[] DangerousGetBufferForTesting() => _buffer;
 
-    internal static SecureCredential? FromConsoleKeysForTesting(IReadOnlyList<ConsoleKeyInfo> keys, int maxByteLength = 128)
+    internal static SecureCredential? FromConsoleKeysForTesting(
+        IReadOnlyList<ConsoleKeyInfo> keys,
+        int maxByteLength = 128)
     {
         var index = 0;
         var buffer = new byte[maxByteLength];
@@ -130,6 +153,18 @@ public sealed class SecureCredential : IMemoryOwner<byte>
         }
 
         return new SecureCredential(buffer, length);
+    }
+
+    internal static int ReadMaskedConsoleInputForTesting(
+        IReadOnlyList<ConsoleKeyInfo> keys,
+        byte[] buffer)
+    {
+        var index = 0;
+        return ReadMaskedConsoleInput(
+            label: string.Empty,
+            buffer,
+            () => keys[index++],
+            writePrompt: false);
     }
 
     /// <summary>
@@ -151,65 +186,115 @@ public sealed class SecureCredential : IMemoryOwner<byte>
         }
 
         var length = 0;
-        var characterCount = 0;
-        Span<int> byteCounts = stackalloc int[buffer.Length];
-        Span<char> chars = stackalloc char[1];
+        var pendingHighSurrogate = '\0';
 
-        while (true)
+        try
         {
-            var key = readKey();
-            if (key.Key is ConsoleKey.Enter)
+            while (true)
             {
-                if (writePrompt)
+                var key = readKey();
+                if (key.Key is ConsoleKey.Enter)
                 {
-                    Console.Error.WriteLine();
+                    if (pendingHighSurrogate is not '\0')
+                    {
+                        pendingHighSurrogate = '\0';
+                        throw new InvalidOperationException("Credential contains malformed UTF-16 input.");
+                    }
+
+                    if (writePrompt)
+                    {
+                        Console.Error.WriteLine();
+                    }
+
+                    return length;
                 }
 
-                return length;
-            }
-
-            if (key.Key is ConsoleKey.Escape)
-            {
-                buffer[..length].Clear();
-                if (writePrompt)
+                if (key.Key is ConsoleKey.Escape)
                 {
-                    Console.Error.WriteLine();
+                    pendingHighSurrogate = '\0';
+                    CryptographicOperations.ZeroMemory(buffer);
+                    if (writePrompt)
+                    {
+                        Console.Error.WriteLine();
+                    }
+
+                    return Declined;
                 }
 
-                return Declined;
-            }
-
-            if (key.Key is ConsoleKey.Backspace)
-            {
-                if (characterCount > 0)
+                if (key.Key is ConsoleKey.Backspace)
                 {
-                    var previousByteCount = byteCounts[--characterCount];
-                    buffer.Slice(length - previousByteCount, previousByteCount).Clear();
-                    length -= previousByteCount;
+                    if (pendingHighSurrogate is not '\0')
+                    {
+                        pendingHighSurrogate = '\0';
+                    }
+                    else if (length > 0)
+                    {
+                        var scalarStart = length - 1;
+                        while (scalarStart > 0 && IsUtf8ContinuationByte(buffer[scalarStart]))
+                        {
+                            scalarStart--;
+                        }
+
+                        CryptographicOperations.ZeroMemory(buffer[scalarStart..length]);
+                        length = scalarStart;
+                    }
+
+                    continue;
                 }
 
-                continue;
-            }
+                if (char.IsControl(key.KeyChar))
+                {
+                    // A control key interrupts a partially entered surrogate pair.
+                    pendingHighSurrogate = '\0';
+                    continue;
+                }
 
-            if (char.IsControl(key.KeyChar))
-            {
-                continue;
-            }
+                Rune scalar;
+                if (pendingHighSurrogate is not '\0')
+                {
+                    if (!Rune.TryCreate(pendingHighSurrogate, key.KeyChar, out scalar))
+                    {
+                        pendingHighSurrogate = '\0';
+                        throw new InvalidOperationException("Credential contains malformed UTF-16 input.");
+                    }
 
-            chars[0] = key.KeyChar;
-            var byteCount = Encoding.UTF8.GetByteCount(chars);
-            if (length + byteCount > buffer.Length)
-            {
-                throw new InvalidOperationException("Credential value is too long.");
-            }
+                    pendingHighSurrogate = '\0';
+                }
+                else if (char.IsHighSurrogate(key.KeyChar))
+                {
+                    pendingHighSurrogate = key.KeyChar;
+                    continue;
+                }
+                else if (char.IsLowSurrogate(key.KeyChar))
+                {
+                    pendingHighSurrogate = '\0';
+                    throw new InvalidOperationException("Credential contains malformed UTF-16 input.");
+                }
+                else
+                {
+                    scalar = new Rune(key.KeyChar);
+                }
 
-            length += Encoding.UTF8.GetBytes(chars, buffer[length..]);
-            byteCounts[characterCount++] = byteCount;
+                var byteCount = scalar.Utf8SequenceLength;
+                if (length + byteCount > buffer.Length)
+                {
+                    throw new InvalidOperationException("Credential value is too long.");
+                }
+
+                length += scalar.EncodeToUtf8(buffer[length..]);
+            }
+        }
+        catch
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+            throw;
         }
     }
 
+    private static bool IsUtf8ContinuationByte(byte value) => (value & 0b1100_0000) == 0b1000_0000;
+
     /// <summary>
-    /// Reads one line of redirected input.
+    /// Reads raw bytes through the end of one line of redirected input.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/src/Cli.Shared/src/Output/SecureCredential.cs
+++ b/src/Cli.Shared/src/Output/SecureCredential.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Yubico AB
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using System.Security.Cryptography;
 using System.Text;
 
@@ -9,8 +10,18 @@ namespace Yubico.YubiKit.Cli.Shared.Output;
 /// <summary>
 /// Owns credential bytes for the shortest practical CLI lifetime and zeros them on disposal.
 /// </summary>
-public sealed class SecureCredential : IDisposable
+/// <remarks>
+/// Implements <see cref="IMemoryOwner{T}"/> so prompted credentials flow directly into SDK
+/// surfaces that take ownership of a secret buffer, including
+/// <c>ICredentialPrompt.RequestSecretAsync</c>. <see cref="Memory"/> is always sized
+/// <b>exactly</b> to the secret: the SDK transmits the whole of it, so a longer buffer would
+/// send trailing padding as part of the credential.
+/// </remarks>
+public sealed class SecureCredential : IMemoryOwner<byte>
 {
+    /// <summary>Sentinel returned by the read helpers when the user abandoned the prompt.</summary>
+    private const int Declined = -1;
+
     private readonly byte[] _buffer;
     private readonly int _length;
     private bool _disposed;
@@ -21,7 +32,14 @@ public sealed class SecureCredential : IDisposable
         _length = length;
     }
 
-    public ReadOnlyMemory<byte> Memory
+    /// <summary>
+    /// Gets the credential bytes, sized exactly to the secret.
+    /// </summary>
+    /// <remarks>
+    /// Mirrors <c>DisposableArrayPoolBuffer.Memory</c> in Core, which is the shape SDK surfaces
+    /// taking ownership of a secret expect. Callers must not mutate the contents.
+    /// </remarks>
+    public Memory<byte> Memory
     {
         get
         {
@@ -41,27 +59,36 @@ public sealed class SecureCredential : IDisposable
         return new SecureCredential(bytes, bytes.Length);
     }
 
-    public static SecureCredential Prompt(string label, int maxByteLength = 128)
+    /// <summary>
+    /// Prompts for a credential, masking interactive input and reading a single line when
+    /// standard input is redirected.
+    /// </summary>
+    /// <returns>
+    /// The credential, or <see langword="null"/> if the user declined to supply one — either by
+    /// pressing Escape, or by supplying an empty line or end-of-input on redirected input.
+    /// </returns>
+    /// <remarks>
+    /// <see langword="null"/> means exactly one thing: no credential was supplied. It never
+    /// signals an input error. This mirrors the <c>ICredentialPrompt</c> contract so console
+    /// prompts and SDK prompts agree on what a declined credential looks like.
+    /// </remarks>
+    public static SecureCredential? Prompt(string label, int maxByteLength = 128)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(label);
-
-        if (maxByteLength <= 0)
-        {
-            throw new ArgumentOutOfRangeException(nameof(maxByteLength));
-        }
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxByteLength);
 
         var buffer = new byte[maxByteLength];
-        var length = 0;
 
         try
         {
-            length = Console.IsInputRedirected
-                ? ReadRedirectedInput(buffer)
+            var length = Console.IsInputRedirected
+                ? ReadRedirectedInput(buffer, Console.OpenStandardInput())
                 : ReadMaskedConsoleInput(label, buffer, () => Console.ReadKey(intercept: true));
 
-            if (length == 0)
+            if (length <= 0)
             {
-                throw new ArgumentException("Credential value cannot be empty.", nameof(label));
+                CryptographicOperations.ZeroMemory(buffer);
+                return null;
             }
 
             return new SecureCredential(buffer, length);
@@ -86,7 +113,7 @@ public sealed class SecureCredential : IDisposable
 
     internal byte[] DangerousGetBufferForTesting() => _buffer;
 
-    internal static SecureCredential FromConsoleKeysForTesting(IReadOnlyList<ConsoleKeyInfo> keys, int maxByteLength = 128)
+    internal static SecureCredential? FromConsoleKeysForTesting(IReadOnlyList<ConsoleKeyInfo> keys, int maxByteLength = 128)
     {
         var index = 0;
         var buffer = new byte[maxByteLength];
@@ -96,9 +123,22 @@ public sealed class SecureCredential : IDisposable
             () => keys[index++],
             writePrompt: false);
 
+        if (length <= 0)
+        {
+            CryptographicOperations.ZeroMemory(buffer);
+            return null;
+        }
+
         return new SecureCredential(buffer, length);
     }
 
+    /// <summary>
+    /// Reads a masked line of console input.
+    /// </summary>
+    /// <returns>
+    /// The number of bytes written to <paramref name="buffer"/>, or <see cref="Declined"/> if
+    /// the user pressed Escape to abandon the prompt.
+    /// </returns>
     private static int ReadMaskedConsoleInput(
         string label,
         Span<byte> buffer,
@@ -126,6 +166,17 @@ public sealed class SecureCredential : IDisposable
                 }
 
                 return length;
+            }
+
+            if (key.Key is ConsoleKey.Escape)
+            {
+                buffer[..length].Clear();
+                if (writePrompt)
+                {
+                    Console.Error.WriteLine();
+                }
+
+                return Declined;
             }
 
             if (key.Key is ConsoleKey.Backspace)
@@ -157,17 +208,38 @@ public sealed class SecureCredential : IDisposable
         }
     }
 
-    private static int ReadRedirectedInput(Span<byte> buffer)
+    /// <summary>
+    /// Reads one line of redirected input.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Terminates on line feed or end-of-input only. Treating a carriage return as a terminator
+    /// would leave the line feed of a CRLF pair unread, and the <b>next</b> prompt in the same
+    /// process would then see an empty line and report the credential as declined — breaking
+    /// every flow that reads two secrets, such as confirmation and change-PIN.
+    /// </para>
+    /// <para>
+    /// Carriage returns are discarded rather than buffered, so a credential of exactly
+    /// <c>buffer.Length</c> bytes followed by CRLF is accepted instead of being rejected as
+    /// over-long. A carriage return is a line-terminator artifact and is never treated as
+    /// credential content.
+    /// </para>
+    /// </remarks>
+    internal static int ReadRedirectedInput(Span<byte> buffer, Stream input)
     {
-        var input = Console.OpenStandardInput();
         var length = 0;
 
         while (true)
         {
             var value = input.ReadByte();
-            if (value < 0 || value is '\n' or '\r')
+            if (value < 0 || value is '\n')
             {
                 return length;
+            }
+
+            if (value is '\r')
+            {
+                continue;
             }
 
             if (length == buffer.Length)

--- a/src/Cli.Shared/src/Output/SecureCredential.cs
+++ b/src/Cli.Shared/src/Output/SecureCredential.cs
@@ -21,14 +21,17 @@ public sealed class SecureCredential : IMemoryOwner<byte>
 {
     /// <summary>Sentinel returned by the read helpers when the user abandoned the prompt.</summary>
     private const int Declined = -1;
-    private readonly byte[] _buffer;
+    private byte[]? _buffer;
     private readonly int _length;
-    private bool _disposed;
+    private readonly ArrayPool<byte>? _pool;
 
-    private SecureCredential(byte[] buffer, int length)
+    private delegate int CredentialReader(Span<byte> buffer);
+
+    private SecureCredential(byte[] buffer, int length, ArrayPool<byte>? pool = null)
     {
         _buffer = buffer;
         _length = length;
+        _pool = pool;
     }
 
     /// <summary>
@@ -42,8 +45,9 @@ public sealed class SecureCredential : IMemoryOwner<byte>
     {
         get
         {
-            ObjectDisposedException.ThrowIf(_disposed, this);
-            return _buffer.AsMemory(0, _length);
+            var buffer = _buffer;
+            ObjectDisposedException.ThrowIf(buffer is null, this);
+            return buffer.AsMemory(0, _length);
         }
     }
 
@@ -98,61 +102,49 @@ public sealed class SecureCredential : IMemoryOwner<byte>
         ArgumentException.ThrowIfNullOrWhiteSpace(label);
         ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxByteLength);
 
-        var buffer = new byte[maxByteLength];
-
-        try
-        {
-            var length = Console.IsInputRedirected
+        return ReadWithPooledBuffer(
+            maxByteLength,
+            ArrayPool<byte>.Shared,
+            buffer => Console.IsInputRedirected
                 ? ReadRedirectedInput(buffer, Console.OpenStandardInput())
-                : ReadMaskedConsoleInput(label, buffer, () => Console.ReadKey(intercept: true));
-
-            if (length <= 0)
-            {
-                CryptographicOperations.ZeroMemory(buffer);
-                return null;
-            }
-
-            return new SecureCredential(buffer, length);
-        }
-        catch
-        {
-            CryptographicOperations.ZeroMemory(buffer);
-            throw;
-        }
+                : ReadMaskedConsoleInput(
+                    label,
+                    buffer,
+                    () => Console.ReadKey(intercept: true)));
     }
 
     public void Dispose()
     {
-        if (_disposed)
+        var buffer = Interlocked.Exchange(ref _buffer, null);
+        if (buffer is null)
         {
             return;
         }
 
-        CryptographicOperations.ZeroMemory(_buffer);
-        _disposed = true;
+        CryptographicOperations.ZeroMemory(buffer);
+        _pool?.Return(buffer);
     }
 
-    internal byte[] DangerousGetBufferForTesting() => _buffer;
+    internal byte[] DangerousGetBufferForTesting() =>
+        _buffer ?? throw new ObjectDisposedException(nameof(SecureCredential));
 
     internal static SecureCredential? FromConsoleKeysForTesting(
         IReadOnlyList<ConsoleKeyInfo> keys,
-        int maxByteLength = 128)
+        int maxByteLength = 128,
+        ArrayPool<byte>? pool = null)
     {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(maxByteLength);
+
         var index = 0;
-        var buffer = new byte[maxByteLength];
-        var length = ReadMaskedConsoleInput(
-            label: string.Empty,
-            buffer,
-            () => keys[index++],
-            writePrompt: false);
-
-        if (length <= 0)
-        {
-            CryptographicOperations.ZeroMemory(buffer);
-            return null;
-        }
-
-        return new SecureCredential(buffer, length);
+        pool ??= ArrayPool<byte>.Shared;
+        return ReadWithPooledBuffer(
+            maxByteLength,
+            pool,
+            buffer => ReadMaskedConsoleInput(
+                label: string.Empty,
+                buffer,
+                () => keys[index++],
+                writePrompt: false));
     }
 
     internal static int ReadMaskedConsoleInputForTesting(
@@ -292,6 +284,41 @@ public sealed class SecureCredential : IMemoryOwner<byte>
     }
 
     private static bool IsUtf8ContinuationByte(byte value) => (value & 0b1100_0000) == 0b1000_0000;
+
+    private static SecureCredential? ReadWithPooledBuffer(
+        int maxByteLength,
+        ArrayPool<byte> pool,
+        CredentialReader readCredential)
+    {
+        var buffer = pool.Rent(maxByteLength);
+        var ownershipTransferred = false;
+
+        try
+        {
+            var length = readCredential(buffer.AsSpan(0, maxByteLength));
+            if (length <= 0)
+            {
+                return null;
+            }
+
+            var credential = new SecureCredential(buffer, length, pool);
+            ownershipTransferred = true;
+            return credential;
+        }
+        finally
+        {
+            if (!ownershipTransferred)
+            {
+                ClearAndReturn(buffer, pool);
+            }
+        }
+    }
+
+    private static void ClearAndReturn(byte[] buffer, ArrayPool<byte> pool)
+    {
+        CryptographicOperations.ZeroMemory(buffer);
+        pool.Return(buffer);
+    }
 
     /// <summary>
     /// Reads raw bytes through the end of one line of redirected input.

--- a/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/PinPromptTests.cs
+++ b/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/PinPromptTests.cs
@@ -1,0 +1,71 @@
+// Copyright 2026 Yubico AB
+// Licensed under the Apache License, Version 2.0.
+
+using System.Buffers;
+using System.Text;
+using Yubico.YubiKit.Cli.Shared.Output;
+
+namespace Yubico.YubiKit.Cli.Shared.UnitTests.Output;
+
+public sealed class PinPromptTests
+{
+    [Fact]
+    public void Resolve_WithCommandLineValue_DoesNotPrompt()
+    {
+        using var resolved = PinPrompt.Resolve("123456", "PIN");
+
+        Assert.NotNull(resolved);
+        Assert.Equal(Encoding.UTF8.GetBytes("123456"), resolved.Memory.ToArray());
+    }
+
+    [Fact]
+    public void ConfirmMatches_ReturnsTrueForIdenticalEntry()
+    {
+        using var first = SecureCredential.FromUtf8String("correct horse");
+
+        Assert.True(PinPrompt.ConfirmMatches(
+            first,
+            () => SecureCredential.FromUtf8String("correct horse")));
+    }
+
+    [Fact]
+    public void ConfirmMatches_ReturnsFalseForDifferentEntry()
+    {
+        using var first = SecureCredential.FromUtf8String("correct horse");
+
+        Assert.False(PinPrompt.ConfirmMatches(
+            first,
+            () => SecureCredential.FromUtf8String("battery staple")));
+    }
+
+    [Fact]
+    public void ConfirmMatches_ReturnsFalseForPrefixOfTheSecret()
+    {
+        // Guards against a length-insensitive comparison treating a prefix as a match.
+        using var first = SecureCredential.FromUtf8String("123456");
+
+        Assert.False(PinPrompt.ConfirmMatches(
+            first,
+            () => SecureCredential.FromUtf8String("1234")));
+    }
+
+    [Fact]
+    public void ConfirmMatches_TreatsDeclinedConfirmationAsMismatch()
+    {
+        using var first = SecureCredential.FromUtf8String("123456");
+
+        Assert.False(PinPrompt.ConfirmMatches(first, () => null));
+    }
+
+    [Fact]
+    public void ConfirmMatches_DisposesTheConfirmationEntry()
+    {
+        using var first = SecureCredential.FromUtf8String("123456");
+        var confirmation = SecureCredential.FromUtf8String("123456");
+        var buffer = confirmation.DangerousGetBufferForTesting();
+
+        Assert.True(PinPrompt.ConfirmMatches(first, () => confirmation));
+
+        Assert.All(buffer, b => Assert.Equal(0, b));
+    }
+}

--- a/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
+++ b/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
@@ -9,6 +9,37 @@ namespace Yubico.YubiKit.Cli.Shared.UnitTests.Output;
 
 public sealed class SecureCredentialTests
 {
+    private sealed class TrackingArrayPool(int bufferLength) : ArrayPool<byte>
+    {
+        private readonly byte[] _buffer = new byte[bufferLength];
+
+        public int RequestedLength { get; private set; }
+
+        public int ReturnCount { get; private set; }
+
+        public bool ReturnedCleared { get; private set; }
+
+        public override byte[] Rent(int minimumLength)
+        {
+            if (minimumLength > _buffer.Length)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(minimumLength),
+                    minimumLength,
+                    "Test pool buffer is too small.");
+            }
+
+            RequestedLength = minimumLength;
+            return _buffer;
+        }
+
+        public override void Return(byte[] array, bool clearArray = false)
+        {
+            ReturnCount++;
+            ReturnedCleared = array.AsSpan().IndexOfAnyExcept((byte)0) < 0;
+        }
+    }
+
     [Fact]
     public void FromUtf8String_ExposesUtf8Bytes()
     {
@@ -333,7 +364,74 @@ public sealed class SecureCredentialTests
 
         Assert.NotNull(credential);
         Assert.Equal(1, credential.Memory.Length);
-        Assert.Equal(128, credential.DangerousGetBufferForTesting().Length);
+        Assert.True(credential.DangerousGetBufferForTesting().Length >= 128);
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_DisposeReturnsClearedBufferToPool()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+        var pool = new TrackingArrayPool(bufferLength: 256);
+
+        var credential = SecureCredential.FromConsoleKeysForTesting(
+            keys,
+            maxByteLength: 128,
+            pool);
+
+        Assert.NotNull(credential);
+        Assert.Equal(128, pool.RequestedLength);
+        Assert.Equal(0, pool.ReturnCount);
+
+        credential.Dispose();
+
+        Assert.Equal(1, pool.ReturnCount);
+        Assert.True(pool.ReturnedCleared);
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_DeclineReturnsClearedBufferToPool()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('9', ConsoleKey.D9, shift: false, alt: false, control: false),
+            new('\u001b', ConsoleKey.Escape, shift: false, alt: false, control: false)
+        ];
+        var pool = new TrackingArrayPool(bufferLength: 16);
+
+        var credential = SecureCredential.FromConsoleKeysForTesting(
+            keys,
+            maxByteLength: 4,
+            pool);
+
+        Assert.Null(credential);
+        Assert.Equal(1, pool.ReturnCount);
+        Assert.True(pool.ReturnedCleared);
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_InputCannotUsePoolSlack()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('2', ConsoleKey.D2, shift: false, alt: false, control: false),
+            new('3', ConsoleKey.D3, shift: false, alt: false, control: false),
+            new('4', ConsoleKey.D4, shift: false, alt: false, control: false),
+            new('5', ConsoleKey.D5, shift: false, alt: false, control: false)
+        ];
+        var pool = new TrackingArrayPool(bufferLength: 16);
+
+        Assert.Throws<InvalidOperationException>(() =>
+            SecureCredential.FromConsoleKeysForTesting(
+                keys,
+                maxByteLength: 4,
+                pool));
+        Assert.Equal(1, pool.ReturnCount);
+        Assert.True(pool.ReturnedCleared);
     }
 
     [Fact]

--- a/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
+++ b/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
@@ -1,6 +1,7 @@
 // Copyright 2026 Yubico AB
 // Licensed under the Apache License, Version 2.0.
 
+using System.Buffers;
 using System.Text;
 using Yubico.YubiKit.Cli.Shared.Output;
 
@@ -56,6 +57,154 @@ public sealed class SecureCredentialTests
 
         using var credential = SecureCredential.FromConsoleKeysForTesting(keys);
 
+        Assert.NotNull(credential);
         Assert.Equal(Encoding.UTF8.GetBytes("1"), credential.Memory.ToArray());
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_EscapeDeclines()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('2', ConsoleKey.D2, shift: false, alt: false, control: false),
+            new('\u001b', ConsoleKey.Escape, shift: false, alt: false, control: false)
+        ];
+
+        Assert.Null(SecureCredential.FromConsoleKeysForTesting(keys));
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_EnterOnEmptyInputDeclines()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        Assert.Null(SecureCredential.FromConsoleKeysForTesting(keys));
+    }
+
+    [Theory]
+    [InlineData("123456\n", "123456")]
+    [InlineData("123456\r\n", "123456")]
+    [InlineData("123456", "123456")]
+    [InlineData("123456\r", "123456")]
+    public void ReadRedirectedInput_StripsLineTerminators(string input, string expected)
+    {
+        Span<byte> buffer = new byte[128];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+
+        var length = SecureCredential.ReadRedirectedInput(buffer, stream);
+
+        Assert.Equal(expected, Encoding.UTF8.GetString(buffer[..length]));
+    }
+
+    [Fact]
+    public void ReadRedirectedInput_CrLf_SecondReadSeesTheSecondLine()
+    {
+        // A carriage return must not terminate the read on its own: doing so leaves the line feed
+        // unread, and the next prompt in the same process reports a declined credential. That
+        // breaks every two-secret flow (confirmation, change-PIN) on CRLF input.
+        Span<byte> first = new byte[128];
+        Span<byte> second = new byte[128];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("alpha\r\nbeta\r\n"));
+
+        var firstLength = SecureCredential.ReadRedirectedInput(first, stream);
+        var secondLength = SecureCredential.ReadRedirectedInput(second, stream);
+
+        Assert.Equal("alpha", Encoding.UTF8.GetString(first[..firstLength]));
+        Assert.Equal("beta", Encoding.UTF8.GetString(second[..secondLength]));
+    }
+
+    [Fact]
+    public void ReadRedirectedInput_EmptyLineIsDeclined()
+    {
+        Span<byte> buffer = new byte[128];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("\r\n"));
+
+        Assert.Equal(0, SecureCredential.ReadRedirectedInput(buffer, stream));
+    }
+
+    [Theory]
+    [InlineData("123456\n")]
+    [InlineData("123456\r\n")]
+    [InlineData("123456")]
+    public void ReadRedirectedInput_AcceptsCredentialOfExactlyMaxLength(string input)
+    {
+        // The CRLF carriage return must not be counted against the buffer, or a credential of
+        // exactly the maximum length is wrongly rejected as over-long on Windows-style input.
+        Span<byte> buffer = new byte[6];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes(input));
+
+        var length = SecureCredential.ReadRedirectedInput(buffer, stream);
+
+        Assert.Equal("123456", Encoding.UTF8.GetString(buffer[..length]));
+    }
+
+    [Fact]
+    public void ReadRedirectedInput_ThrowsWhenCredentialExceedsMaxLength()
+    {
+        Span<byte> buffer = new byte[6];
+        using var stream = new MemoryStream(Encoding.UTF8.GetBytes("1234567\r\n"));
+
+        try
+        {
+            SecureCredential.ReadRedirectedInput(buffer, stream);
+            Assert.Fail("Expected an over-long credential to be rejected.");
+        }
+        catch (InvalidOperationException)
+        {
+        }
+    }
+
+    [Fact]
+    public void MemoryIsSizedExactlyToTheSecret()
+    {
+        // The SDK transmits the whole of Memory, so a buffer longer than the secret would send
+        // trailing padding as part of the credential.
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        using var credential = SecureCredential.FromConsoleKeysForTesting(keys, maxByteLength: 128);
+
+        Assert.NotNull(credential);
+        Assert.Equal(1, credential.Memory.Length);
+        Assert.Equal(128, credential.DangerousGetBufferForTesting().Length);
+    }
+
+    [Fact]
+    public void ExposesItselfAsIMemoryOwnerSizedToTheSecret()
+    {
+        using var credential = SecureCredential.FromUtf8String("123456");
+
+        IMemoryOwner<byte> owner = credential;
+
+        Assert.Equal(Encoding.UTF8.GetBytes("123456"), owner.Memory.ToArray());
+    }
+
+    [Fact]
+    public void IMemoryOwnerMemory_ThrowsAfterDispose()
+    {
+        IMemoryOwner<byte> owner = SecureCredential.FromUtf8String("123456");
+
+        owner.Dispose();
+
+        Assert.Throws<ObjectDisposedException>((Action)(() => _ = owner.Memory));
+    }
+
+    [Fact]
+    public void DeclinedInteractiveInputLeavesNoSecretBehind()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('9', ConsoleKey.D9, shift: false, alt: false, control: false),
+            new('\u001b', ConsoleKey.Escape, shift: false, alt: false, control: false)
+        ];
+
+        Assert.Null(SecureCredential.FromConsoleKeysForTesting(keys));
     }
 }

--- a/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
+++ b/src/Cli.Shared/tests/Yubico.YubiKit.Cli.Shared.UnitTests/Output/SecureCredentialTests.cs
@@ -62,6 +62,166 @@ public sealed class SecureCredentialTests
     }
 
     [Fact]
+    public void ReadMaskedConsoleInputForTesting_BackspaceZeroesRetractedMultiByteScalar()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('é', ConsoleKey.E, shift: false, alt: false, control: false),
+            new('\0', ConsoleKey.Backspace, shift: false, alt: false, control: false),
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+        var buffer = new byte[8];
+
+        var length = SecureCredential.ReadMaskedConsoleInputForTesting(keys, buffer);
+
+        Assert.Equal(1, length);
+        Assert.Equal((byte)'1', buffer[0]);
+        Assert.All(buffer[1..], value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_BackspaceToEmptyThenEnterDeclines()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\0', ConsoleKey.Backspace, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        Assert.Null(SecureCredential.FromConsoleKeysForTesting(keys));
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_ValidSurrogatePairEncodesUnicodeScalar()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\uDE00', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        using var credential = SecureCredential.FromConsoleKeysForTesting(keys);
+
+        Assert.NotNull(credential);
+        Assert.Equal(Encoding.UTF8.GetBytes("\U0001F600"), credential.Memory.ToArray());
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_BackspaceAfterSurrogatePairRemovesWholeScalar()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\uDE00', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\0', ConsoleKey.Backspace, shift: false, alt: false, control: false),
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        using var credential = SecureCredential.FromConsoleKeysForTesting(keys);
+
+        Assert.NotNull(credential);
+        Assert.Equal(Encoding.UTF8.GetBytes("1"), credential.Memory.ToArray());
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_BackspaceRemovesPendingHighSurrogate()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\0', ConsoleKey.Backspace, shift: false, alt: false, control: false),
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+
+        using var credential = SecureCredential.FromConsoleKeysForTesting(keys);
+
+        Assert.NotNull(credential);
+        Assert.Equal(Encoding.UTF8.GetBytes("1"), credential.Memory.ToArray());
+    }
+
+    [Theory]
+    [InlineData('\uD83D')]
+    [InlineData('\uDE00')]
+    public void ReadMaskedConsoleInputForTesting_UnmatchedSurrogateIsRejectedAndCleared(char surrogate)
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('9', ConsoleKey.D9, shift: false, alt: false, control: false),
+            new(surrogate, ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\r', ConsoleKey.Enter, shift: false, alt: false, control: false)
+        ];
+        var buffer = new byte[16];
+
+        Assert.Throws<InvalidOperationException>(
+            () => SecureCredential.ReadMaskedConsoleInputForTesting(keys, buffer));
+        Assert.All(buffer, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void ReadMaskedConsoleInputForTesting_HighSurrogateBeforeNonLowSurrogateIsRejectedAndCleared()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('9', ConsoleKey.D9, shift: false, alt: false, control: false),
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false)
+        ];
+        var buffer = new byte[16];
+
+        Assert.Throws<InvalidOperationException>(
+            () => SecureCredential.ReadMaskedConsoleInputForTesting(keys, buffer));
+        Assert.All(buffer, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void FromConsoleKeysForTesting_ControlKeyInterruptsPendingSurrogate()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\0', ConsoleKey.Home, shift: false, alt: false, control: false),
+            new('\uDE00', ConsoleKey.NoName, shift: false, alt: false, control: false)
+        ];
+
+        Assert.Throws<InvalidOperationException>(() => SecureCredential.FromConsoleKeysForTesting(keys));
+    }
+
+    [Fact]
+    public void ReadMaskedConsoleInputForTesting_MultiByteScalarThatWouldExceedMaxLengthIsRejectedAndCleared()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('a', ConsoleKey.A, shift: false, alt: false, control: false),
+            new('é', ConsoleKey.E, shift: false, alt: false, control: false)
+        ];
+        var buffer = new byte[2];
+
+        Assert.Throws<InvalidOperationException>(
+            () => SecureCredential.ReadMaskedConsoleInputForTesting(keys, buffer));
+        Assert.All(buffer, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
+    public void ReadMaskedConsoleInputForTesting_EscapeClearsPendingHighSurrogateAndBufferedBytes()
+    {
+        ConsoleKeyInfo[] keys =
+        [
+            new('1', ConsoleKey.D1, shift: false, alt: false, control: false),
+            new('\uD83D', ConsoleKey.NoName, shift: false, alt: false, control: false),
+            new('\u001b', ConsoleKey.Escape, shift: false, alt: false, control: false)
+        ];
+        var buffer = new byte[16];
+
+        Assert.Equal(-1, SecureCredential.ReadMaskedConsoleInputForTesting(keys, buffer));
+        Assert.All(buffer, value => Assert.Equal(0, value));
+    }
+
+    [Fact]
     public void FromConsoleKeysForTesting_EscapeDeclines()
     {
         ConsoleKeyInfo[] keys =

--- a/src/Fido2/examples/FidoTool/Cli/Output/OutputHelpers.cs
+++ b/src/Fido2/examples/FidoTool/Cli/Output/OutputHelpers.cs
@@ -15,7 +15,6 @@
 using Spectre.Console;
 using SharedConfirm = Yubico.YubiKit.Cli.Shared.Output.ConfirmationPrompts;
 using SharedOutput = Yubico.YubiKit.Cli.Shared.Output.OutputHelpers;
-using SharedPin = Yubico.YubiKit.Cli.Shared.Output.PinPrompt;
 
 namespace Yubico.YubiKit.Fido2.Examples.FidoTool.Cli.Output;
 
@@ -78,7 +77,4 @@ public static class OutputHelpers
     /// <inheritdoc cref="SharedConfirm.ConfirmDestructive"/>
     public static bool ConfirmDestructive(string action, string confirmationWord = "RESET") =>
         SharedConfirm.ConfirmDestructive(action, confirmationWord);
-
-    /// <inheritdoc cref="SharedPin.PromptForPin"/>
-    public static string PromptForPin(string label = "PIN") => SharedPin.PromptForPin(label);
 }

--- a/src/OpenPgp/examples/OpenPgpTool/Cli/Output/OutputHelpers.cs
+++ b/src/OpenPgp/examples/OpenPgpTool/Cli/Output/OutputHelpers.cs
@@ -4,7 +4,6 @@
 using Spectre.Console;
 using SharedConfirm = Yubico.YubiKit.Cli.Shared.Output.ConfirmationPrompts;
 using SharedOutput = Yubico.YubiKit.Cli.Shared.Output.OutputHelpers;
-using SharedPin = Yubico.YubiKit.Cli.Shared.Output.PinPrompt;
 
 namespace Yubico.YubiKit.OpenPgp.Examples.OpenPgpTool.Cli.Output;
 
@@ -63,9 +62,4 @@ public static class OutputHelpers
     /// <inheritdoc cref="SharedConfirm.ConfirmDestructive"/>
     public static bool ConfirmDestructive(string action, string confirmationWord = "RESET") =>
         SharedConfirm.ConfirmDestructive(action, confirmationWord);
-
-    /// <summary>
-    /// Prompts for a PIN with masked input.
-    /// </summary>
-    public static string PromptPin(string label) => SharedPin.PromptForPin(label);
 }


### PR DESCRIPTION
Replaces command-line secret strings with an owning byte buffer that can be cleared and makes prompts usable with redirected input. #615 remains stacked on this branch.

## Credential ownership

- `SecureCredential` implements `IMemoryOwner<byte>` and exposes `Memory` sliced exactly to the secret length.
- Interactive and redirected prompt buffers are rented from `ArrayPool<byte>`, bounded to the requested maximum, zeroed before every return, and returned exactly once on decline, failure, or disposal.
- Atomic disposal prevents concurrent double-return and access after disposal.
- Unicode scalar input, including surrogate pairs and backspace, is encoded correctly as UTF-8; malformed pairs fail and clear buffered bytes.
- `PinPrompt.ConfirmMatches` uses fixed-time comparison, and `PinPrompt.Resolve` centralizes command-line-or-prompt selection.
- `null` means no credential was supplied and never represents an input error.

`SecureCredential` mentions `ICredentialPrompt` as a prose integration example, but this branch has no compile dependency on #598 and can merge independently.

## Scripted input

Redirected reads terminate on line feed or end-of-input and discard carriage returns. This preserves consecutive prompts with CRLF input and accepts a credential exactly at the configured limit without consuming pool slack.

## Verification

- Cli.Shared unit tests: 43 passed
- Full build and all unit suites passed during implementation
- Scoped formatting passed
- Separate cross-vendor review of the final pooled-buffer implementation passed with no blocking findings

The stacked #615 removes the final YubiHSM string-password boundary.

Abbreviations: CLI means command-line interface; CRLF means carriage return and line feed; PIN means personal identification number; SDK means software development kit; UTF-8 means Unicode Transformation Format, 8-bit.