### PR TITLE
fix(piv): repair PivTool compilation after the device metadata move

### DIFF
--- a/src/Piv/examples/PivTool/Cli/Commands/CliRunner.cs
+++ b/src/Piv/examples/PivTool/Cli/Commands/CliRunner.cs
@@ -372,7 +372,7 @@ internal static class CliRunner
         if (device is null) return 1;
 
         await using var session = await device.CreatePivSessionAsync(cancellationToken: ct);
-        var result = await Certificates.GetCertificateAsync(session, slot.Value, ct);
+        var result = await PivExamples.Certificates.GetCertificateAsync(session, slot.Value, ct);
 
         if (useJson)
         {
@@ -406,7 +406,7 @@ internal static class CliRunner
         if (device is null) return 1;
 
         await using var session = await device.CreatePivSessionAsync(cancellationToken: ct);
-        var result = await Certificates.ExportCertificatePemAsync(session, slot.Value, ct);
+        var result = await PivExamples.Certificates.ExportCertificatePemAsync(session, slot.Value, ct);
 
         if (!result.Success)
         {
@@ -474,7 +474,7 @@ internal static class CliRunner
                 return 1;
             }
 
-            var result = await Certificates.ImportCertificateAsync(session, slot.Value, certData, compress, ct);
+            var result = await PivExamples.Certificates.ImportCertificateAsync(session, slot.Value, certData, compress, ct);
             if (useJson) JsonOutput.Write(result);
             else if (result.Success) Console.WriteLine("Certificate imported successfully.");
             else Console.Error.WriteLine($"Error: {result.ErrorMessage}");
@@ -520,7 +520,7 @@ internal static class CliRunner
                 return 1;
             }
 
-            var result = await Certificates.GenerateSelfSignedAsync(session, slot.Value, subject, validityDays, ct);
+            var result = await PivExamples.Certificates.GenerateSelfSignedAsync(session, slot.Value, subject, validityDays, ct);
             if (useJson) JsonOutput.Write(result);
             else if (result.Success) Console.WriteLine("Self-signed certificate generated successfully.");
             else Console.Error.WriteLine($"Error: {result.ErrorMessage}");
@@ -560,7 +560,7 @@ internal static class CliRunner
                 return 1;
             }
 
-            var result = await Certificates.GenerateCsrAsync(session, slot.Value, subject, ct);
+            var result = await PivExamples.Certificates.GenerateCsrAsync(session, slot.Value, subject, ct);
 
             if (!result.Success)
             {
@@ -607,7 +607,7 @@ internal static class CliRunner
                 return 1;
             }
 
-            var result = await Certificates.DeleteCertificateAsync(session, slot.Value, ct);
+            var result = await PivExamples.Certificates.DeleteCertificateAsync(session, slot.Value, ct);
             if (useJson) JsonOutput.Write(result);
             else if (result.Success) Console.WriteLine("Certificate deleted.");
             else Console.Error.WriteLine($"Error: {result.ErrorMessage}");

--- a/src/Piv/examples/PivTool/Cli/Commands/JsonOutput.cs
+++ b/src/Piv/examples/PivTool/Cli/Commands/JsonOutput.cs
@@ -15,7 +15,7 @@
 using System.Security.Cryptography.X509Certificates;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Yubico.YubiKit.Management;
+using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Piv.Examples.PivTool.PivExamples.Results;
 
 namespace Yubico.YubiKit.Piv.Examples.PivTool.Cli.Commands;

--- a/src/Piv/examples/PivTool/Cli/Menus/CertificatesMenu.cs
+++ b/src/Piv/examples/PivTool/Cli/Menus/CertificatesMenu.cs
@@ -74,7 +74,7 @@ public static class CertificatesMenu
     {
         var slot = SlotSelector.SelectSlot("Select slot:");
 
-        var result = await Certificates.GetCertificateAsync(session, slot, ct);
+        var result = await PivExamples.Certificates.GetCertificateAsync(session, slot, ct);
         if (!result.Success)
         {
             OutputHelpers.WriteError(result.ErrorMessage ?? "Failed to read certificate");
@@ -97,7 +97,7 @@ public static class CertificatesMenu
     {
         var slot = SlotSelector.SelectSlot("Select slot:");
 
-        var result = await Certificates.ExportCertificatePemAsync(session, slot, ct);
+        var result = await PivExamples.Certificates.ExportCertificatePemAsync(session, slot, ct);
 
         if (!result.Success || result.CsrPem is null)
         {
@@ -136,7 +136,7 @@ public static class CertificatesMenu
         }
 
         var certData = await File.ReadAllBytesAsync(filename, ct);
-        var result = await Certificates.ImportCertificateAsync(session, slot, certData, false, ct);
+        var result = await PivExamples.Certificates.ImportCertificateAsync(session, slot, certData, false, ct);
 
         if (result.Success)
         {
@@ -182,7 +182,7 @@ public static class CertificatesMenu
         var subject = AnsiConsole.Ask("Enter subject (e.g., CN=Test User):", "CN=Test User");
         var validDays = AnsiConsole.Ask("Enter validity in days:", 365);
 
-        var result = await Certificates.GenerateSelfSignedAsync(session, slot, subject, validDays, ct);
+        var result = await PivExamples.Certificates.GenerateSelfSignedAsync(session, slot, subject, validDays, ct);
 
         if (result.Success)
         {
@@ -204,7 +204,7 @@ public static class CertificatesMenu
         var slot = SlotSelector.SelectSlot("Select slot (must have existing key):");
         var subject = AnsiConsole.Ask("Enter subject (e.g., CN=Test User):", "CN=Test User");
 
-        var result = await Certificates.GenerateCsrAsync(session, slot, subject, ct);
+        var result = await PivExamples.Certificates.GenerateCsrAsync(session, slot, subject, ct);
 
         if (result.Success && result.CsrPem is not null)
         {
@@ -247,7 +247,7 @@ public static class CertificatesMenu
             return;
         }
 
-        var result = await Certificates.DeleteCertificateAsync(session, slot, ct);
+        var result = await PivExamples.Certificates.DeleteCertificateAsync(session, slot, ct);
 
         if (result.Success)
         {

--- a/src/Piv/examples/PivTool/PivExamples/Results/DeviceInfoResult.cs
+++ b/src/Piv/examples/PivTool/PivExamples/Results/DeviceInfoResult.cs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Yubico.YubiKit.Management;
+using Yubico.YubiKit.Core.Devices;
 
 namespace Yubico.YubiKit.Piv.Examples.PivTool.PivExamples.Results;
 


### PR DESCRIPTION
> ## Merge order: land this before #617
>
> **#617 is stacked on this branch.** It restores PivTool and OtpTool to the solution so CI actually compiles them, and it cannot merge until this one lands. Its base retargets to `yubikit` automatically once this merges.
>
> Chain: **#616 → #617**
>
> **Please merge this with a merge commit, not a squash.** #617 is based on this branch. A squash lands this work as a new commit that #617's branch does not contain, which leaves #617 showing duplicated changes and needing a rebase before it can go in. A merge commit makes #617 retarget cleanly with no further work.

**PivTool has not compiled since June.**

Commit `13486277` moved `DeviceInfo`, `DeviceCapabilities` and siblings from `Yubico.YubiKit.Management` to `Yubico.YubiKit.Core.Devices` and, as its own message says, migrated the "mandatory compile consumers". PivTool was not one — it had already fallen out of the solution five months earlier — so two of its four affected files kept importing the old namespace and nothing ever told anyone.

### The part that wasn't obvious

Repointing those two imports exposed **twelve further errors the compiler had been hiding**. Roslyn abandons method-body binding once the declaration phase has failed, and the missing `DeviceInfo` was a property *type*, so every method-body error in the project was suppressed behind it. The "3 errors" this started as was an artefact of that suppression.

Those twelve are a name collision, not more stale imports. PivTool's menus call a local static class named `Certificates` from inside namespace `Yubico.YubiKit.Piv.Examples.PivTool.Cli.Menus`. C# walks enclosing namespaces **before** consulting `using` directives, so the lookup finds the SDK's own `Yubico.YubiKit.Piv.Certificates` namespace and stops. A namespace has no accessibility, so it wins even though everything inside it is `internal`.

Call sites are now qualified through `PivExamples`, which binds unambiguously. Same target, same arguments, no behaviour change.

No analyzer suppressions were needed — the project builds with **zero warnings**, and `PivTool.csproj` is untouched.

### Scope

This only makes PivTool compile. The reason nobody noticed is fixed in the stacked PR on top of this one.

### Verification

`build --project PivTool` → 0 errors, 0 warnings. Full build clean. All 12 unit suites green (2,325 tests). `dotnet format --verify-no-changes` clean on the changed files. Cross-vendor correctness review: pass.

### Worth knowing

The Piv SDK exposes namespaces `Authentication`, `Bio`, `Certificates`, `Cryptography`, `DataObjects`, `Keys`, `Metadata`. Any PivTool example class sharing one of those names will shadow-collide the same way. Today only `Certificates` does.

