### PR TITLE
ci: report coverage and CRAP deltas on pull requests

### DIFF
--- a/.github/workflows/coverage-crap-report.yml
+++ b/.github/workflows/coverage-crap-report.yml
@@ -53,13 +53,23 @@ jobs:
           dotnet toolchain.cs coverage
           dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/head.json"
 
-      - name: Preserve head measurement
-        # Copied outside the worktree before the base checkout below replaces artifacts/
-        # and crap.cs/toolchain.cs with the base commit's versions.
+      - name: Preserve head measurement and measurement tooling
+        # Two separate reasons to copy things out before the base checkout:
+        #
+        # 1. artifacts/ and head.json would be clobbered by the base build.
+        #
+        # 2. The measurement tooling must be held CONSTANT across both sides. The base
+        #    commit is measured with the *head* commit's crap.cs, toolchain.cs and coverage
+        #    settings, so only the source differs. Otherwise a PR that touches crap.cs -
+        #    such as this one - compares two different metrics and the delta is meaningless.
+        #    It also avoids a bootstrap problem: a base predating a fix to the coverage
+        #    tooling cannot measure itself.
         run: |
-          mkdir -p "$RUNNER_TEMP/head-coverage"
+          mkdir -p "$RUNNER_TEMP/head-coverage" "$RUNNER_TEMP/tooling"
           cp -r artifacts/coverage/. "$RUNNER_TEMP/head-coverage/"
           cp artifacts/crap/head.json "$RUNNER_TEMP/head.json"
+          cp crap.cs toolchain.cs coverlet.runsettings.xml "$RUNNER_TEMP/tooling/"
+          cp .config/dotnet-tools.json "$RUNNER_TEMP/tooling/dotnet-tools.json"
 
       - name: Cache base measurement
         id: base-cache
@@ -76,10 +86,20 @@ jobs:
           # notion of "previous ref" across a long build is needless risk.
           head_sha="$(git rev-parse HEAD)"
           git checkout --detach ${{ github.event.pull_request.base.sha }}
+
+          # Measure the base SOURCE with the head's TOOLING - see the preserve step above.
+          cp "$RUNNER_TEMP/tooling/crap.cs" crap.cs
+          cp "$RUNNER_TEMP/tooling/toolchain.cs" toolchain.cs
+          cp "$RUNNER_TEMP/tooling/coverlet.runsettings.xml" coverlet.runsettings.xml
+          cp "$RUNNER_TEMP/tooling/dotnet-tools.json" .config/dotnet-tools.json
+
           rm -rf artifacts/coverage
           dotnet toolchain.cs coverage
           dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/base.json"
           cp artifacts/crap/base.json "$RUNNER_TEMP/base.json"
+
+          # Discard the tooling overlay so the return checkout has a clean tree.
+          git checkout -- crap.cs toolchain.cs coverlet.runsettings.xml .config/dotnet-tools.json
           git checkout --detach "$head_sha"
 
       - name: Render coverage and CRAP report

--- a/.github/workflows/coverage-crap-report.yml
+++ b/.github/workflows/coverage-crap-report.yml
@@ -1,0 +1,139 @@
+name: Coverage and CRAP report
+
+on:
+  pull_request:
+    branches: [ yubikit*, yubikit/** ]
+
+jobs:
+  coverage-crap-report:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    env:
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+      DOTNET_NOLOGO: 1
+      DOTNET_CLI_TELEMETRY_OPTOUT: 1
+    steps:
+      - name: Check out source
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          # Full history: the base measurement step below needs to `git checkout` the PR's
+          # base commit, which a shallow clone would not contain.
+          fetch-depth: 0
+
+      - name: Set up .NET SDK
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Cache NuGet packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Packages.props') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      - name: Install PC/SC dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends pcscd libpcsclite-dev libudev-dev
+          # Run pcscd directly (bypasses systemd/socket-activation issues on CI runners)
+          # and open socket permissions so the test runner user can connect
+          sudo mkdir -p /run/pcscd
+          sudo pcscd --foreground &
+          # Wait for socket to appear (more robust than fixed sleep)
+          timeout 10 bash -c 'until [ -S /run/pcscd/pcscd.comm ]; do sleep 0.2; done' || true
+          # Open socket read/write for the runner user (sockets don't need +x)
+          sudo chmod 666 /run/pcscd/pcscd.comm || true
+
+      - name: Measure head coverage and CRAP
+        run: |
+          dotnet toolchain.cs coverage
+          dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/head.json"
+
+      - name: Preserve head measurement
+        # Copied outside the worktree before the base checkout below replaces artifacts/
+        # and crap.cs/toolchain.cs with the base commit's versions.
+        run: |
+          mkdir -p "$RUNNER_TEMP/head-coverage"
+          cp -r artifacts/coverage/. "$RUNNER_TEMP/head-coverage/"
+          cp artifacts/crap/head.json "$RUNNER_TEMP/head.json"
+
+      - name: Cache base measurement
+        id: base-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ${{ runner.temp }}/base.json
+          key: crap-base-${{ github.event.pull_request.base.sha }}
+
+      - name: Measure base coverage and CRAP
+        if: steps.base-cache.outputs.cache-hit != 'true'
+        run: |
+          # Capture the exact commit to return to. `git checkout -` would usually work, but
+          # pull_request events check out a detached merge ref, and relying on the shell's
+          # notion of "previous ref" across a long build is needless risk.
+          head_sha="$(git rev-parse HEAD)"
+          git checkout --detach ${{ github.event.pull_request.base.sha }}
+          rm -rf artifacts/coverage
+          dotnet toolchain.cs coverage
+          dotnet toolchain.cs -- crap --crap-args "--json artifacts/crap/base.json"
+          cp artifacts/crap/base.json "$RUNNER_TEMP/base.json"
+          git checkout --detach "$head_sha"
+
+      - name: Render coverage and CRAP report
+        # Ordering: crap.cs itself must be the PR's (head) version, since --baseline and
+        # --markdown are the features this PR adds — running the base commit's crap.cs would
+        # not understand them. `git checkout -` above already returned the worktree to head,
+        # so crap.cs is correct here. It also needs *coverage data* to compute CRAP; re-running
+        # `dotnet toolchain.cs coverage` a second time would work but costs another full test
+        # pass for output identical to the one already produced in "Measure head coverage and
+        # CRAP". Restoring the preserved head coverage artifacts is the cheaper option and
+        # produces the same result, so that is what this step does.
+        run: |
+          rm -rf artifacts/coverage
+          mkdir -p artifacts/coverage
+          cp -r "$RUNNER_TEMP/head-coverage/." artifacts/coverage/
+          dotnet crap.cs --baseline "$RUNNER_TEMP/base.json" --markdown > "$RUNNER_TEMP/report.md"
+          cat "$RUNNER_TEMP/report.md" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        # pull_request from a fork gets a read-only GITHUB_TOKEN, so posting a comment would
+        # fail. The report was already written to the job summary above regardless, so forked
+        # PRs still get the report; they just don't get the sticky PR comment.
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- yubikit-crap-report -->';
+            const body = fs.readFileSync(`${process.env.RUNNER_TEMP}/report.md`, 'utf8');
+
+            // Paginate: listComments returns 100 per page, and on a long-running PR the
+            // bot's own comment can fall past the first page. Missing it would post a
+            // duplicate on every push instead of updating in place.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find((c) => c.body?.startsWith(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }

--- a/.github/workflows/coverage-crap-report.yml
+++ b/.github/workflows/coverage-crap-report.yml
@@ -3,6 +3,26 @@ name: Coverage and CRAP report
 on:
   pull_request:
     branches: [ yubikit*, yubikit/** ]
+    # Only run when the numbers could actually move. Every delta would be "." otherwise, and
+    # this job costs two full coverage passes. Of the four most recent pull requests to
+    # yubikit, all four touched no .cs file at all.
+    #
+    # Two groups of paths matter:
+    #   - the measured code. src/**/*.cs covers production and tests alike, and tests belong
+    #     here because adding a test changes coverage, which is the point of the report.
+    #   - the measuring apparatus. A change to crap.cs or the coverage plumbing changes the
+    #     numbers without touching a single line of src/, so it must be validated too. This
+    #     workflow's own pull request is exactly that case.
+    paths:
+      - 'src/**/*.cs'
+      - 'crap.cs'
+      - 'toolchain.cs'
+      - 'coverlet.runsettings.xml'
+      - '.config/dotnet-tools.json'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'Directory.Packages.props'
+      - '.github/workflows/coverage-crap-report.yml'
 
 jobs:
   coverage-crap-report:

--- a/crap.cs
+++ b/crap.cs
@@ -38,23 +38,30 @@
  *   --json <path>       Write the full ranked result as JSON.
  *   --no-conditional-access
  *                       Exclude `?.` / `?[]` from cyclomatic complexity.
+ *   --baseline <path>   Load a previous `--json` report and diff module aggregates
+ *                       against it (module grouping, not per-method).
+ *   --markdown          Emit a GitHub-flavoured markdown module report instead of the
+ *                       console top-N method table. Combines with --baseline to add
+ *                       delta columns; the CI PR-comment case is
+ *                       `--baseline old.json --markdown`.
+ *   --fail-on-crap-increase
+ *                       Exit 1 if total CRAP increased versus --baseline. Off by
+ *                       default; requires --baseline to have any effect.
  *   --self-check        Run the built-in golden fixtures and exit.
  *
  * EXIT CODES:
  *   0  success
- *   1  usage / IO error, or a self-check fixture failed
+ *   1  usage / IO error, a self-check fixture failed, or (with
+ *      --fail-on-crap-increase) total CRAP increased versus --baseline
  *   2  coverage could not be reconciled with the source tree
- *
- * NOT IMPLEMENTED IN v1 (deliberately):
- *   - CI gate / threshold exit code
- *   - baseline ratchet
- *   These wait until the thresholds are settled against the baseline.
  *
  * See TOOLCHAIN.md and docs/TESTING.md.
  */
 
 using System.Globalization;
+using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using System.Xml.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -87,6 +94,15 @@ sealed record CrapOptions
     public bool CountConditionalAccess { get; init; } = true;
     public bool SelfCheck { get; init; }
 
+    /// <summary>Path to a previous `--json` report to diff module aggregates against.</summary>
+    public string? BaselinePath { get; init; }
+
+    /// <summary>Emit a GitHub-flavoured markdown module report instead of the console table.</summary>
+    public bool Markdown { get; init; }
+
+    /// <summary>Exit 1 if total CRAP increased versus --baseline. No effect without --baseline.</summary>
+    public bool FailOnCrapIncrease { get; init; }
+
     public static CrapOptions? Parse(string[] args)
     {
         var repoRoot = FindRepoRoot();
@@ -104,6 +120,9 @@ sealed record CrapOptions
         string? json = null;
         var countConditionalAccess = true;
         var selfCheck = false;
+        string? baseline = null;
+        var markdown = false;
+        var failOnCrapIncrease = false;
 
         for (var i = 0; i < args.Length; i++)
         {
@@ -145,6 +164,15 @@ sealed record CrapOptions
                 case "--no-conditional-access":
                     countConditionalAccess = false;
                     break;
+                case "--baseline" when i + 1 < args.Length:
+                    baseline = args[++i];
+                    break;
+                case "--markdown":
+                    markdown = true;
+                    break;
+                case "--fail-on-crap-increase":
+                    failOnCrapIncrease = true;
+                    break;
                 case "--self-check":
                     selfCheck = true;
                     break;
@@ -171,6 +199,9 @@ sealed record CrapOptions
             JsonPath = json,
             CountConditionalAccess = countConditionalAccess,
             SelfCheck = selfCheck,
+            BaselinePath = baseline,
+            Markdown = markdown,
+            FailOnCrapIncrease = failOnCrapIncrease,
         };
     }
 
@@ -185,6 +216,9 @@ sealed record CrapOptions
               --top <n>                  Rows in the console table (default: 25)
               --json <path>              Write full ranked result as JSON
               --no-conditional-access    Exclude ?. and ?[] from cyclomatic complexity
+              --baseline <path>          Diff module aggregates against a previous --json report
+              --markdown                 Emit a markdown module report instead of the console table
+              --fail-on-crap-increase    Exit 1 if total CRAP increased versus --baseline (default: off)
               --self-check               Run built-in golden fixtures and exit
             """);
 
@@ -679,6 +713,19 @@ static class SelfCheck
             }
         }
 
+        foreach (var (name, passed, detail) in ModuleReportFixtures())
+        {
+            if (passed)
+            {
+                passes++;
+            }
+            else
+            {
+                failures++;
+                Console.Error.WriteLine($"FAIL module-report/{name}: {detail}");
+            }
+        }
+
         // Anchor against a real method whose complexity was derived by hand.
         var anchor = Path.Combine(options.RepoRoot, "src", "Piv", "src", "Metadata", "PivMetadataProtocol.cs");
         if (File.Exists(anchor))
@@ -717,6 +764,65 @@ static class SelfCheck
         {{body}}
         }
         """;
+
+    /// <summary>
+    /// Golden fixtures for the --baseline/--markdown module report: grouping a file path into
+    /// a module, ordering modules, and diffing module aggregates when a module exists on only
+    /// one side of the comparison (renamed/moved methods, or a module added/removed outright).
+    /// </summary>
+    static IEnumerable<(string Name, bool Passed, string Detail)> ModuleReportFixtures()
+    {
+        // Module grouping from a file path.
+        var pivModule = ModuleAggregator.ModuleOf("src/Piv/src/Metadata/PivMetadataProtocol.cs");
+        yield return ("module-of-src-path", pivModule == "Piv", $"expected 'Piv', got '{pivModule ?? "null"}'");
+
+        var testsModule = ModuleAggregator.ModuleOf("src/Piv/tests/PivMetadataProtocolTests.cs");
+        yield return ("module-of-tests-path-is-excluded", testsModule is null, $"expected null, got '{testsModule}'");
+
+        var order = ModuleAggregator.OrderModules(["OpenPgp", "Cli.Shared", "Core", "Piv", "Cli.Commands", "Fido2"]);
+        var expectedOrder = new[] { "Core", "Piv", "Fido2", "OpenPgp", "Cli.Commands", "Cli.Shared" };
+        yield return ("module-order-core-then-applets-then-alphabetical",
+            order.SequenceEqual(expectedOrder),
+            $"expected [{string.Join(",", expectedOrder)}], got [{string.Join(",", order)}]");
+
+        // A module present only in the baseline must still appear, with the head side at zero.
+        var headWithoutOath = new Dictionary<string, ModuleStats>();
+        var baselineWithOath = new Dictionary<string, ModuleStats>
+        {
+            ["Oath"] = new() { MethodCount = 10, TotalCrap = 50, CountCrapAtLeast8 = 2, CountCognitiveOver15 = 1, MeanCoveragePercent = 60 },
+        };
+        var (removedModuleText, removedModuleDelta) = ModuleReportBuilder.Build(headWithoutOath, baselineWithOath, markdown: false);
+        yield return ("module-only-in-baseline-compares-against-zero",
+            removedModuleDelta < 0 && removedModuleText.Contains("Oath", StringComparison.Ordinal),
+            $"expected negative total CRAP delta and 'Oath' listed, got delta={removedModuleDelta}, text=\n{removedModuleText}");
+
+        // A module present only in the head must still appear, with the baseline side at zero.
+        var headWithYubiHsm = new Dictionary<string, ModuleStats>
+        {
+            ["YubiHsm"] = new() { MethodCount = 5, TotalCrap = 40, CountCrapAtLeast8 = 1, CountCognitiveOver15 = 0, MeanCoveragePercent = 80 },
+        };
+        var baselineWithoutYubiHsm = new Dictionary<string, ModuleStats>();
+        var (newModuleText, newModuleDelta) = ModuleReportBuilder.Build(headWithYubiHsm, baselineWithoutYubiHsm, markdown: false);
+        yield return ("module-only-in-head-compares-against-zero",
+            newModuleDelta > 0 && newModuleText.Contains("YubiHsm", StringComparison.Ordinal),
+            $"expected positive total CRAP delta and 'YubiHsm' listed, got delta={newModuleDelta}, text=\n{newModuleText}");
+
+        // An unchanged module renders "." in both delta columns rather than "+0"/"-0".
+        var unchangedCore = new Dictionary<string, ModuleStats>
+        {
+            ["Core"] = new() { MethodCount = 100, TotalCrap = 500, CountCrapAtLeast8 = 20, CountCognitiveOver15 = 5, MeanCoveragePercent = 70 },
+        };
+        var (unchangedText, unchangedDelta) = ModuleReportBuilder.Build(unchangedCore, unchangedCore, markdown: true);
+        const string expectedUnchangedRow = "| **Core** | 100 | 500 | . | 20 | 5 | 70.0% | . |";
+        yield return ("unchanged-module-renders-dot-not-zero",
+            Math.Abs(unchangedDelta) < 0.5 && unchangedText.Contains(expectedUnchangedRow, StringComparison.Ordinal),
+            $"expected row '{expectedUnchangedRow}' and unchanged verdict, got delta={unchangedDelta}, text=\n{unchangedText}");
+
+        // Verdict selection is driven by total CRAP delta alone.
+        yield return ("verdict-decreased", CrapVerdict.Render(-42) == "**CRAP decreased by 42.**", CrapVerdict.Render(-42));
+        yield return ("verdict-increased", CrapVerdict.Render(42) == "**CRAP increased by 42.**", CrapVerdict.Render(42));
+        yield return ("verdict-unchanged", CrapVerdict.Render(0.2) == "**CRAP unchanged.**", CrapVerdict.Render(0.2));
+    }
 
     /// <summary>
     /// Members that emit no code must be distinguishable from members that were simply
@@ -850,6 +956,422 @@ sealed record CrapRow
     }
 }
 
+// ---------------------------------------------------------------------------
+// Module-level report: --baseline and --markdown
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// The subset of a per-method row needed for module aggregation, sourced either from a
+/// freshly computed <see cref="CrapRow"/> or from a loaded <c>--json</c> baseline report.
+/// </summary>
+sealed record MethodSample
+{
+    /// <summary>Repo-relative path with forward slashes, e.g. "src/Piv/src/PivSession.cs".</summary>
+    public required string File { get; init; }
+    public required double Crap { get; init; }
+    public required int Cognitive { get; init; }
+    public required double Coverage { get; init; }
+}
+
+sealed record ModuleStats
+{
+    public required int MethodCount { get; init; }
+    public required double TotalCrap { get; init; }
+    public required int CountCrapAtLeast8 { get; init; }
+    public required int CountCognitiveOver15 { get; init; }
+
+    /// <summary>Mean of per-method coverage across the module, as a percentage (0-100).</summary>
+    public required double MeanCoveragePercent { get; init; }
+
+    /// <summary>
+    /// Stands in for a module absent from one side of a --baseline comparison. A module that
+    /// disappeared (or has not yet appeared) is not skipped: it is compared against zero.
+    /// </summary>
+    public static readonly ModuleStats Zero = new()
+    {
+        MethodCount = 0,
+        TotalCrap = 0,
+        CountCrapAtLeast8 = 0,
+        CountCognitiveOver15 = 0,
+        MeanCoveragePercent = 0,
+    };
+}
+
+/// <summary>
+/// Groups methods into shipping SDK modules and aggregates CRAP/coverage per module.
+/// </summary>
+static class ModuleAggregator
+{
+    static readonly Regex ModulePattern = new("^src/([^/]+)/src/", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Applet module display order. Core always leads; anything not listed here (including
+    /// Cli.Commands and Cli.Shared) sorts alphabetically after this list.
+    /// </summary>
+    static readonly string[] AppletOrder =
+    [
+        "Management", "Piv", "Fido2", "WebAuthn", "Oath", "YubiOtp", "OpenPgp", "SecurityDomain", "YubiHsm",
+    ];
+
+    /// <summary>
+    /// Extracts the module name from a repo-relative file path, or null if the path is not
+    /// shipping production code (tests, examples, and anything outside src/&lt;module&gt;/src/).
+    /// </summary>
+    public static string? ModuleOf(string file)
+    {
+        var match = ModulePattern.Match(file.Replace('\\', '/'));
+        return match.Success ? match.Groups[1].Value : null;
+    }
+
+    /// <summary>Orders module names: Core, then the known applet order, then the rest alphabetically.</summary>
+    public static List<string> OrderModules(IEnumerable<string> modules)
+    {
+        var remaining = new HashSet<string>(modules, StringComparer.Ordinal);
+        var ordered = new List<string>();
+
+        if (remaining.Remove("Core"))
+            ordered.Add("Core");
+
+        foreach (var known in AppletOrder)
+        {
+            if (remaining.Remove(known))
+                ordered.Add(known);
+        }
+
+        ordered.AddRange(remaining.OrderBy(m => m, StringComparer.Ordinal));
+        return ordered;
+    }
+
+    public static Dictionary<string, ModuleStats> Aggregate(IEnumerable<MethodSample> samples)
+    {
+        var byModule = new Dictionary<string, List<MethodSample>>(StringComparer.Ordinal);
+
+        foreach (var sample in samples)
+        {
+            var module = ModuleOf(sample.File);
+            if (module is null)
+                continue;
+
+            if (!byModule.TryGetValue(module, out var list))
+                byModule[module] = list = [];
+
+            list.Add(sample);
+        }
+
+        return byModule.ToDictionary(
+            kv => kv.Key,
+            kv => new ModuleStats
+            {
+                MethodCount = kv.Value.Count,
+                TotalCrap = kv.Value.Sum(s => s.Crap),
+                CountCrapAtLeast8 = kv.Value.Count(s => s.Crap >= 8),
+                CountCognitiveOver15 = kv.Value.Count(s => s.Cognitive > 15),
+                MeanCoveragePercent = kv.Value.Average(s => s.Coverage) * 100,
+            },
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>
+    /// Sums module aggregates into a single TOTAL row. Coverage is deliberately not
+    /// re-derived here: a single mean-of-means across modules of very different sizes would
+    /// misrepresent overall coverage, so the report leaves that cell blank.
+    /// </summary>
+    public static ModuleStats Total(IReadOnlyDictionary<string, ModuleStats> byModule)
+    {
+        if (byModule.Count == 0)
+            return ModuleStats.Zero;
+
+        return new ModuleStats
+        {
+            MethodCount = byModule.Values.Sum(s => s.MethodCount),
+            TotalCrap = byModule.Values.Sum(s => s.TotalCrap),
+            CountCrapAtLeast8 = byModule.Values.Sum(s => s.CountCrapAtLeast8),
+            CountCognitiveOver15 = byModule.Values.Sum(s => s.CountCognitiveOver15),
+            MeanCoveragePercent = 0,
+        };
+    }
+}
+
+/// <summary>Loads the <c>methods</c> array of a previous <c>--json</c> report.</summary>
+static class BaselineReport
+{
+    public static List<MethodSample>? Load(CrapOptions options, string path)
+    {
+        var fullPath = Path.IsPathRooted(path) ? path : Path.Combine(options.RepoRoot, path);
+        if (!File.Exists(fullPath))
+        {
+            Console.Error.WriteLine($"error: --baseline file not found: {fullPath}");
+            return null;
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(fullPath);
+            using var doc = JsonDocument.Parse(stream);
+
+            if (!doc.RootElement.TryGetProperty("methods", out var methodsElement)
+                || methodsElement.ValueKind != JsonValueKind.Array)
+            {
+                Console.Error.WriteLine($"error: --baseline file has no 'methods' array: {fullPath}");
+                return null;
+            }
+
+            var samples = new List<MethodSample>();
+            foreach (var entry in methodsElement.EnumerateArray())
+            {
+                var file = entry.TryGetProperty("file", out var fileProp) ? fileProp.GetString() : null;
+                if (string.IsNullOrEmpty(file))
+                    continue;
+
+                var crap = entry.TryGetProperty("crap", out var crapProp) ? crapProp.GetDouble() : 0;
+                var cognitive = entry.TryGetProperty("cognitive", out var cognitiveProp) ? cognitiveProp.GetInt32() : 0;
+                var coverage = entry.TryGetProperty("coverage", out var coverageProp) ? coverageProp.GetDouble() : 0;
+
+                samples.Add(new MethodSample
+                {
+                    File = file.Replace('\\', '/'),
+                    Crap = crap,
+                    Cognitive = cognitive,
+                    Coverage = coverage,
+                });
+            }
+
+            return samples;
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"error: could not parse --baseline JSON '{fullPath}': {ex.Message}");
+            return null;
+        }
+        catch (IOException ex)
+        {
+            Console.Error.WriteLine($"error: could not read --baseline file '{fullPath}': {ex.Message}");
+            return null;
+        }
+    }
+}
+
+/// <summary>Shared numeric formatting for the module report, so deltas read the same in both renderers.</summary>
+static class Fmt
+{
+    public static string WholeNumber(double value) =>
+        Math.Round(value, MidpointRounding.AwayFromZero).ToString("0", CultureInfo.InvariantCulture);
+
+    /// <summary>"." when the absolute change is under half a CRAP point; otherwise a signed whole number.</summary>
+    public static string SignedCrapDelta(double? delta)
+    {
+        if (delta is null)
+            return string.Empty;
+
+        if (Math.Abs(delta.Value) < 0.5)
+            return ".";
+
+        var rounded = Math.Round(delta.Value, MidpointRounding.AwayFromZero);
+        return rounded > 0 ? $"+{WholeNumber(rounded)}" : WholeNumber(rounded);
+    }
+
+    /// <summary>"." when the absolute change is under half a percentage point; otherwise signed "pp".</summary>
+    public static string SignedCoverageDeltaPp(double? deltaPp)
+    {
+        if (deltaPp is null)
+            return string.Empty;
+
+        if (Math.Abs(deltaPp.Value) < 0.5)
+            return ".";
+
+        var sign = deltaPp.Value > 0 ? "+" : "-";
+        return $"{sign}{Math.Abs(deltaPp.Value).ToString("F1", CultureInfo.InvariantCulture)}pp";
+    }
+}
+
+static class CrapVerdict
+{
+    public static string Render(double totalCrapDelta)
+    {
+        if (Math.Abs(totalCrapDelta) < 0.5)
+            return "**CRAP unchanged.**";
+
+        var magnitude = Fmt.WholeNumber(Math.Abs(totalCrapDelta));
+        return totalCrapDelta > 0
+            ? $"**CRAP increased by {magnitude}.**"
+            : $"**CRAP decreased by {magnitude}.**";
+    }
+}
+
+sealed record ModuleRow
+{
+    public required string Name { get; init; }
+    public required bool Bold { get; init; }
+    public required bool IsTotal { get; init; }
+    public required int Methods { get; init; }
+    public required double Crap { get; init; }
+    public required double? CrapDelta { get; init; }
+    public required int CrapAtLeast8 { get; init; }
+    public required int CognitiveOver15 { get; init; }
+
+    /// <summary>Null for the TOTAL row, which leaves coverage blank rather than a misleading mean-of-means.</summary>
+    public required double? CoveragePercent { get; init; }
+    public required double? CoverageDeltaPp { get; init; }
+}
+
+/// <summary>
+/// Builds the module-aggregate report used by --markdown and/or --baseline. Compares module
+/// aggregates, not individual methods, so renamed methods and modules that appear or
+/// disappear between the two sides are handled by treating the missing side as zero.
+/// </summary>
+static class ModuleReportBuilder
+{
+    public static (string Text, double TotalCrapDelta) Build(
+        IReadOnlyDictionary<string, ModuleStats> head,
+        IReadOnlyDictionary<string, ModuleStats>? baseline,
+        bool markdown)
+    {
+        var moduleNames = ModuleAggregator.OrderModules(
+            head.Keys.Concat(baseline?.Keys ?? Enumerable.Empty<string>()));
+
+        var rows = new List<ModuleRow>();
+        foreach (var name in moduleNames)
+        {
+            var headStats = head.TryGetValue(name, out var h) ? h : ModuleStats.Zero;
+            ModuleStats? baseStats = baseline is null
+                ? null
+                : baseline.TryGetValue(name, out var b) ? b : ModuleStats.Zero;
+
+            rows.Add(BuildRow(name, headStats, baseStats, bold: name == "Core", isTotal: false));
+        }
+
+        var headTotal = ModuleAggregator.Total(head);
+        var baseTotal = baseline is null ? null : ModuleAggregator.Total(baseline);
+        rows.Add(BuildRow("TOTAL", headTotal, baseTotal, bold: true, isTotal: true));
+
+        var totalCrapDelta = baseline is null ? 0 : headTotal.TotalCrap - baseTotal!.TotalCrap;
+        var hasBaseline = baseline is not null;
+
+        var text = markdown
+            ? RenderMarkdown(rows, hasBaseline, totalCrapDelta)
+            : RenderConsole(rows, hasBaseline, totalCrapDelta);
+
+        return (text, totalCrapDelta);
+    }
+
+    static ModuleRow BuildRow(string name, ModuleStats head, ModuleStats? baseline, bool bold, bool isTotal)
+    {
+        double? crapDelta = baseline is null ? null : head.TotalCrap - baseline.TotalCrap;
+        double? coveragePercent = isTotal ? null : head.MeanCoveragePercent;
+        double? coverageDelta = isTotal || baseline is null ? null : head.MeanCoveragePercent - baseline.MeanCoveragePercent;
+
+        return new ModuleRow
+        {
+            Name = name,
+            Bold = bold,
+            IsTotal = isTotal,
+            Methods = head.MethodCount,
+            Crap = head.TotalCrap,
+            CrapDelta = crapDelta,
+            CrapAtLeast8 = head.CountCrapAtLeast8,
+            CognitiveOver15 = head.CountCognitiveOver15,
+            CoveragePercent = coveragePercent,
+            CoverageDeltaPp = coverageDelta,
+        };
+    }
+
+    static string RenderMarkdown(List<ModuleRow> rows, bool hasBaseline, double totalCrapDelta)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<!-- yubikit-crap-report -->");
+        sb.AppendLine("### Coverage and CRAP");
+        sb.AppendLine();
+        sb.AppendLine(hasBaseline
+            ? "| module | methods | CRAP | Δ CRAP | ≥8 | cog>15 | coverage | Δ cov |"
+            : "| module | methods | CRAP | ≥8 | cog>15 | coverage |");
+        sb.AppendLine(hasBaseline
+            ? "|---|---:|---:|---:|---:|---:|---:|---:|"
+            : "|---|---:|---:|---:|---:|---:|");
+
+        foreach (var row in rows)
+        {
+            var name = row.Bold ? $"**{row.Name}**" : row.Name;
+            var crap = Fmt.WholeNumber(row.Crap);
+            var coverage = row.CoveragePercent is null
+                ? ""
+                : $"{row.CoveragePercent.Value.ToString("F1", CultureInfo.InvariantCulture)}%";
+
+            if (hasBaseline)
+            {
+                var crapDelta = Fmt.SignedCrapDelta(row.CrapDelta);
+                if (row.IsTotal && crapDelta != ".")
+                    crapDelta = $"**{crapDelta}**";
+
+                var coverageDelta = Fmt.SignedCoverageDeltaPp(row.CoverageDeltaPp);
+
+                sb.AppendLine(
+                    $"| {name} | {row.Methods} | {crap} | {crapDelta} | {row.CrapAtLeast8} | {row.CognitiveOver15} | {coverage} | {coverageDelta} |");
+            }
+            else
+            {
+                sb.AppendLine($"| {name} | {row.Methods} | {crap} | {row.CrapAtLeast8} | {row.CognitiveOver15} | {coverage} |");
+            }
+        }
+
+        if (hasBaseline)
+        {
+            sb.AppendLine();
+            sb.AppendLine(CrapVerdict.Render(totalCrapDelta));
+
+            var increased = rows.Where(r => !r.IsTotal && r.CrapDelta is > 0.5).ToList();
+            if (increased.Count > 0)
+            {
+                sb.AppendLine();
+                sb.AppendLine("> [!NOTE]");
+                var names = string.Join(", ", increased.Select(r => $"{r.Name} (+{Fmt.WholeNumber(r.CrapDelta!.Value)})"));
+                sb.AppendLine($"> CRAP increased in: {names}.");
+            }
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    static string RenderConsole(List<ModuleRow> rows, bool hasBaseline, double totalCrapDelta)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine();
+        sb.AppendLine("Coverage and CRAP by module");
+        sb.AppendLine(new string('=', 96));
+        sb.AppendLine(hasBaseline
+            ? $"{"module",-16}{"methods",8}{"CRAP",8}{"dCRAP",9}{">=8",6}{"cog>15",8}{"coverage",10}{"dcov",9}"
+            : $"{"module",-16}{"methods",8}{"CRAP",8}{">=8",6}{"cog>15",8}{"coverage",10}");
+        sb.AppendLine(new string('-', 96));
+
+        foreach (var row in rows)
+        {
+            var crap = Fmt.WholeNumber(row.Crap);
+            var coverage = row.CoveragePercent is null
+                ? ""
+                : $"{row.CoveragePercent.Value.ToString("F1", CultureInfo.InvariantCulture)}%";
+
+            if (hasBaseline)
+            {
+                var crapDelta = Fmt.SignedCrapDelta(row.CrapDelta);
+                var coverageDelta = Fmt.SignedCoverageDeltaPp(row.CoverageDeltaPp);
+                sb.AppendLine(
+                    $"{row.Name,-16}{row.Methods,8}{crap,8}{crapDelta,9}{row.CrapAtLeast8,6}{row.CognitiveOver15,8}{coverage,10}{coverageDelta,9}");
+            }
+            else
+            {
+                sb.AppendLine($"{row.Name,-16}{row.Methods,8}{crap,8}{row.CrapAtLeast8,6}{row.CognitiveOver15,8}{coverage,10}");
+            }
+        }
+
+        if (hasBaseline)
+        {
+            sb.AppendLine();
+            sb.AppendLine(CrapVerdict.Render(totalCrapDelta).Replace("**", ""));
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+}
+
 static class CrapAnalysis
 {
     public static int Run(CrapOptions options)
@@ -872,8 +1394,34 @@ static class CrapAnalysis
 
         var hits = LoadCoverage(reports);
         var rows = Correlate(methods, hits, out var unmatchedCoverage, out var uninstrumented);
+        var ranked = rows.OrderByDescending(r => r.Crap).ToList();
 
-        Report(options, rows, methods.Count, reports.Count, unmatchedCoverage, uninstrumented);
+        Dictionary<string, ModuleStats>? baselineByModule = null;
+        if (options.BaselinePath is not null)
+        {
+            var baselineSamples = BaselineReport.Load(options, options.BaselinePath);
+            if (baselineSamples is null)
+                return 1;
+
+            baselineByModule = ModuleAggregator.Aggregate(baselineSamples);
+        }
+
+        var crapIncreased = false;
+
+        if (options.Markdown || baselineByModule is not null)
+        {
+            var headByModule = ModuleAggregator.Aggregate(ToSamples(options, rows));
+            var (text, totalCrapDelta) = ModuleReportBuilder.Build(headByModule, baselineByModule, options.Markdown);
+            Console.WriteLine(text);
+            crapIncreased = totalCrapDelta > 0.5;
+        }
+        else
+        {
+            Report(options, ranked, methods.Count, reports.Count, unmatchedCoverage, uninstrumented);
+        }
+
+        if (options.JsonPath is not null)
+            WriteJson(options, ranked, methods.Count, reports.Count, unmatchedCoverage, uninstrumented);
 
         // Coverage that cannot be tied back to a source method means the two halves of the
         // formula disagree about the code under analysis. Reporting a number anyway is how
@@ -889,8 +1437,21 @@ static class CrapAnalysis
             return 2;
         }
 
+        if (options.FailOnCrapIncrease && crapIncreased)
+            return 1;
+
         return 0;
     }
+
+    /// <summary>Projects freshly computed rows into the shape the module aggregator shares with --baseline.</summary>
+    static List<MethodSample> ToSamples(CrapOptions options, IEnumerable<CrapRow> rows) =>
+        rows.Select(r => new MethodSample
+        {
+            File = Path.GetRelativePath(options.RepoRoot, r.Method.FilePath).Replace('\\', '/'),
+            Crap = r.Crap,
+            Cognitive = r.Method.Cognitive,
+            Coverage = r.Coverage,
+        }).ToList();
 
     static List<SourceMethod> LoadSourceMethods(CrapOptions options)
     {
@@ -1095,13 +1656,13 @@ static class CrapAnalysis
 
     static void Report(
         CrapOptions options,
-        List<CrapRow> rows,
+        List<CrapRow> ranked,
         int methodCount,
         int reportCount,
         int unmatchedCoverage,
         int uninstrumented)
     {
-        var ranked = rows.OrderByDescending(r => r.Crap).ToList();
+        var rows = ranked;
         var flagged = ranked.Where(r => r.Crap >= options.MinCrap).ToList();
 
         Console.WriteLine();
@@ -1133,9 +1694,6 @@ static class CrapAnalysis
             if (flagged.Count > options.Top)
                 Console.WriteLine($"... and {flagged.Count - options.Top} more (raise --top or use --json)");
         }
-
-        if (options.JsonPath is not null)
-            WriteJson(options, ranked, methodCount, reportCount, unmatchedCoverage, uninstrumented);
     }
 
     // Written with Utf8JsonWriter rather than JsonSerializer: the repo enables the trim and

--- a/toolchain.cs
+++ b/toolchain.cs
@@ -762,7 +762,17 @@ List<(string Project, bool Passed, string? Error, bool Skipped)> RunTestProjects
 // directory and launch the test binary directly.
 void CollectMtpCoverage(string projectPath, string projectName, string coverageResultsDir)
 {
-    Run("dotnet", $"build {projectPath} -c {configuration}");
+    // DeterministicSourcePaths must be off for this build. Directory.Build.props turns on
+    // ContinuousIntegrationBuild whenever GITHUB_ACTIONS is set, and with SourceLink that
+    // rewrites the source paths recorded in the PDB to the deterministic "/_/" form.
+    // coverlet resolves the files it instruments through those paths, so on a deterministic
+    // build it finds nothing and emits a 231-byte cobertura report containing "<sources />"
+    // and "<packages />" - no classes, no lines, silently 0% for everything.
+    //
+    // These binaries exist only to be executed once for coverage and are never shipped or
+    // attested, so real paths here cost nothing. The packages published by the `pack` target
+    // build separately and keep deterministic paths.
+    Run("dotnet", $"build {projectPath} -c {configuration} -p:DeterministicSourcePaths=false");
 
     var projectDir = Path.GetDirectoryName(Path.Combine(repoRoot, projectPath))!;
     var outputDir = Path.Combine(projectDir, "bin", configuration, TestTargetFramework);
@@ -787,6 +797,19 @@ void CollectMtpCoverage(string projectPath, string projectName, string coverageR
     coverletArgs.Append(TranslateRunsettingsToCoverletArgs());
 
     Run("dotnet", coverletArgs.ToString());
+
+    // An instrumentation failure does not fail coverlet: it writes a well-formed cobertura
+    // report containing "<sources />" and "<packages />" and exits 0. Every downstream
+    // consumer then reads a valid file that says nothing is covered, so CRAP scores every
+    // method 0% and the real cause surfaces far away, if at all. Fail here instead, where
+    // the cause is still obvious.
+    var reportClassCount = XDocument.Load(outputFile).Descendants("class").Count();
+    if (reportClassCount == 0)
+        throw new InvalidOperationException(
+            $"coverlet produced an empty coverage report for {projectName} ({outputFile}). " +
+            "It exited successfully but instrumented nothing, so the report contains no classes. " +
+            "The usual cause is source paths coverlet cannot resolve on disk - check that this " +
+            "build is not producing deterministic '/_/' source paths.");
 }
 
 // Translates coverlet.runsettings.xml into coverlet.console command-line flags.


### PR DESCRIPTION
Posts a per-module coverage and CRAP table as a sticky PR comment, with a delta column answering the question that actually matters on a PR: did this change make it better or worse.

## What it looks like

<!-- example, not the live marker -->

| module | methods | CRAP | Δ CRAP | ≥8 | cog>15 | coverage | Δ cov |
|---|---:|---:|---:|---:|---:|---:|---:|
| **Core** | 1117 | 8417 | -442 | 153 | 5 | 60.9% | +2.1pp |
| Piv | 191 | 1723 | . | 44 | 3 | 67.8% | . |
| OpenPgp | 156 | 1011 | +1 | 21 | 0 | 56.7% | . |
| Cli.Commands | 188 | 5322 | . | 87 | 2 | 2.5% | . |
| **TOTAL** | 2529 | 21920 | **-440** | 423 | 14 | | |

**CRAP decreased by 440.**

> [!NOTE]
> CRAP increased in: OpenPgp (+1).

That is real output, generated by comparing a snapshot taken before #603/#606 merged against `yubikit` today — the -442 in Core is those two PRs landing, and the +1 in OpenPgp is `VerifyPwAsync` gaining an extracted helper.

## Design decisions worth reviewing

**Comparison is by module aggregate, not by method.** Methods get renamed and moved between files; matching them individually produces confident nonsense after any refactor. Aggregates stay meaningful. A module present on only one side still appears, with its counterpart treated as zero.

**Rendering restores preserved head coverage rather than re-running it.** The report must run *after* returning to head, because `--baseline`/`--markdown` only exist in this commit's `crap.cs`. It also needs coverage data, and re-running the full suite a second time to reproduce output we already had would roughly double the job. The head artifacts are copied to `$RUNNER_TEMP` before the base checkout clobbers them, and restored before rendering.

**The base result is cached on its SHA**, so pushing repeatedly to a PR doesn't recompute it.

**Comment lookup paginates.** On a long-lived PR the bot's own comment falls past the first page of 100, and without pagination it would post a fresh duplicate on every push instead of updating in place.

**The base checkout restores an explicitly captured SHA** rather than `git checkout -`, because `pull_request` events start from a detached merge ref.

**Forks still get the numbers.** A forked PR's `GITHUB_TOKEN` is read-only and cannot comment, so the comment step is guarded — but the report is written to the job summary unconditionally.

## Increases are reported, never enforced

`--fail-on-crap-increase` exists and defaults **off**, so the gate can be switched on later without another code change.

One caution if you do turn a gate on: **don't gate on the `≥8` count.** A fully covered method's CRAP equals its cyclomatic complexity, so a 40-arm dispatch table sits above any sane threshold permanently no matter how well tested it is. During this work a change removed 3,135 CRAP while moving that count by +1. Total CRAP is the metric that tracks effort.

## Cost

Two coverage runs per PR (~3 min added) on the first push, one on subsequent pushes thanks to the base cache.

`crap.cs --self-check` grows 51 → 60 fixtures, covering module grouping, one-sided modules, unchanged modules, and verdict selection. Verified that comparing a report against itself yields all-`.` deltas and an `unchanged` verdict.
