### PR TITLE
security(core): stop abandoning an unzeroed copy of every encoded TLV

### DIFF
--- a/src/Core/src/Utilities/TlvHelper.cs
+++ b/src/Core/src/Utilities/TlvHelper.cs
@@ -74,13 +74,17 @@ public static class TlvHelper
     /// </summary>
     /// <param name="tlvData">List of Tlvs to encode</param>
     /// <returns>
-    ///     BER-TLV encoded list, or an empty buffer if <paramref name="tlvData" /> contains no elements.
+    ///     A caller-owned buffer containing the BER-TLV encoded list, or an empty buffer if
+    ///     <paramref name="tlvData" /> contains no elements. The caller must securely clear the returned
+    ///     buffer when it contains sensitive data.
     /// </returns>
-    /// <exception cref="ArgumentNullException"><paramref name="tlvData" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="tlvData" /> is <see langword="null" />, or contains a <see langword="null" /> element.
+    /// </exception>
     /// <remarks>
-    ///     A disposed <see cref="Tlv" /> still reports its original <see cref="Tlv.TotalLength" /> while
-    ///     exposing zeroed bytes, so passing one encodes a correctly sized run of <c>0x00</c> rather than
-    ///     throwing. Encode before disposing, or use <see cref="EncodeAndDisposeList" />.
+    ///     This method does not dispose the input <see cref="Tlv" /> objects. The caller remains responsible
+    ///     for disposing them. Source buffers used to construct the TLVs also remain caller-owned and are not
+    ///     cleared by this method.
     /// </remarks>
     public static Memory<byte> EncodeList(Tlv[] tlvData)
     {
@@ -88,16 +92,15 @@ public static class TlvHelper
 
         var tlvSpan = tlvData.AsSpan();
 
-        // Exact, not an estimate: Tlv.TotalLength is the length of the buffer Tlv.AsSpan() exposes,
-        // so the sum is the precise output size and no growth step is possible. The header
-        // arithmetic behind it is pinned by TlvHelperTests.Tlv_TotalLength_IsHeaderPlusValue.
+        // TotalLength is the exact encoded span length. Direct assembly avoids abandoning a second
+        // complete copy of potentially sensitive encoded data on the managed heap.
         var totalLength = 0;
         foreach (var tlv in tlvSpan)
+        {
+            ArgumentNullException.ThrowIfNull(tlv, nameof(tlvData));
             totalLength += tlv.TotalLength;
+        }
 
-        // Assemble directly into the array that is returned. Staging through a separate writer
-        // would leave a second, complete copy of every encoded value - including PINs, keys and
-        // other secret material - on the heap, abandoned to the GC without being zeroed.
         var encoded = new byte[totalLength];
         var position = 0;
         foreach (var tlv in tlvSpan)
@@ -114,8 +117,23 @@ public static class TlvHelper
     ///     Encodes a collection of TLV objects into a single byte sequence, then disposes each TLV.
     ///     Use this when the TLV objects are created inline and not needed after encoding.
     /// </summary>
+    /// <param name="tlvData">TLVs to encode and dispose. Each TLV is disposed even if encoding fails.</param>
+    /// <returns>
+    ///     A caller-owned buffer containing the BER-TLV encoded list, or an empty buffer if
+    ///     <paramref name="tlvData" /> contains no elements. The caller must securely clear the returned
+    ///     buffer when it contains sensitive data.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    ///     <paramref name="tlvData" /> is <see langword="null" />, or contains a <see langword="null" /> element.
+    /// </exception>
+    /// <remarks>
+    ///     Source buffers used to construct the TLVs remain caller-owned and are not cleared by this method.
+    ///     Disposing the input TLVs does not clear the returned buffer.
+    /// </remarks>
     public static Memory<byte> EncodeAndDisposeList(params Tlv[] tlvData)
     {
+        ArgumentNullException.ThrowIfNull(tlvData);
+
         try
         {
             return EncodeList(tlvData);
@@ -124,25 +142,24 @@ public static class TlvHelper
         {
             foreach (var tlv in tlvData)
             {
-                tlv.Dispose();
+                tlv?.Dispose();
             }
         }
     }
-
-    // /// <summary>
-    // ///     Encodes an array of Tlvs into a sequence of BER-TLV encoded data.
-    // /// </summary>
-    // /// <param name="tlvs">Array of Tlvs to encode</param>
-    // /// <returns>BER-TLV encoded array</returns>
-    // public static Memory<byte> EncodeMany(params Tlv[] tlvs) => EncodeList(tlvs);
 
     /// <summary>
     ///     Decode a single TLV encoded object, returning only the value.
     /// </summary>
     /// <param name="expectedTag">The expected tag value of the given TLV data</param>
     /// <param name="tlvData">The TLV data</param>
-    /// <returns>The value of the TLV</returns>
+    /// <returns>
+    ///     A caller-owned buffer containing the TLV value. The caller must securely clear the returned
+    ///     buffer when it contains sensitive data.
+    /// </returns>
     /// <exception cref="InvalidOperationException">If the TLV tag differs from expectedTag</exception>
+    /// <remarks>
+    ///     The returned buffer is a copy and remains valid after the internal <see cref="Tlv" /> is disposed.
+    /// </remarks>
     public static Memory<byte> GetValue(int expectedTag, ReadOnlySpan<byte> tlvData)
     {
         using var tlv = Tlv.Create(tlvData);
@@ -158,6 +175,10 @@ public static class TlvHelper
     /// <param name="tlvData">Sequence of TLV encoded data</param>
     /// <param name="value">The value of the first TLV with the matching tag, or default if not found</param>
     /// <returns>True if the tag was found, false otherwise</returns>
+    /// <remarks>
+    ///     When this method returns <see langword="true" />, <paramref name="value" /> is a caller-owned buffer.
+    ///     The caller must securely clear it when it contains sensitive data.
+    /// </remarks>
     public static bool TryFindValue(int tag, ReadOnlySpan<byte> tlvData, out Memory<byte> value)
     {
         var buffer = tlvData;
@@ -175,6 +196,18 @@ public static class TlvHelper
         return false;
     }
 
+    /// <summary>
+    ///     Encodes a mapping of tag-value pairs into BER-TLV data ordered by ascending tag.
+    /// </summary>
+    /// <param name="tlvData">Dictionary of TLV tag-value pairs.</param>
+    /// <returns>
+    ///     A caller-owned buffer containing the BER-TLV encoded dictionary, or an empty buffer if
+    ///     <paramref name="tlvData" /> contains no elements. The caller must securely clear the returned
+    ///     buffer when it contains sensitive data.
+    /// </returns>
+    /// <remarks>
+    ///     Source buffers used as dictionary values remain caller-owned and are not cleared by this method.
+    /// </remarks>
     public static Memory<byte> EncodeDictionary(IReadOnlyDictionary<int, byte[]?> tlvData)
     {
         if (tlvData.Count == 0) return Memory<byte>.Empty;

--- a/src/Core/src/Utilities/TlvHelper.cs
+++ b/src/Core/src/Utilities/TlvHelper.cs
@@ -73,25 +73,41 @@ public static class TlvHelper
     ///     Encodes a list of Tlvs into a sequence of BER-TLV encoded data.
     /// </summary>
     /// <param name="tlvData">List of Tlvs to encode</param>
-    /// <returns>BER-TLV encoded list</returns>
+    /// <returns>
+    ///     BER-TLV encoded list, or an empty buffer if <paramref name="tlvData" /> contains no elements.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="tlvData" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    ///     A disposed <see cref="Tlv" /> still reports its original <see cref="Tlv.TotalLength" /> while
+    ///     exposing zeroed bytes, so passing one encodes a correctly sized run of <c>0x00</c> rather than
+    ///     throwing. Encode before disposing, or use <see cref="EncodeAndDisposeList" />.
+    /// </remarks>
     public static Memory<byte> EncodeList(Tlv[] tlvData)
     {
-        // Calculate total size to avoid resizing
-        var estimatedSize = 0;
+        ArgumentNullException.ThrowIfNull(tlvData);
+
         var tlvSpan = tlvData.AsSpan();
+
+        // Exact, not an estimate: Tlv.TotalLength is the length of the buffer Tlv.AsSpan() exposes,
+        // so the sum is the precise output size and no growth step is possible. The header
+        // arithmetic behind it is pinned by TlvHelperTests.Tlv_TotalLength_IsHeaderPlusValue.
+        var totalLength = 0;
         foreach (var tlv in tlvSpan)
-            estimatedSize += tlv.TotalLength;
+            totalLength += tlv.TotalLength;
 
-        var writer = new ArrayBufferWriter<byte>(estimatedSize);
-
+        // Assemble directly into the array that is returned. Staging through a separate writer
+        // would leave a second, complete copy of every encoded value - including PINs, keys and
+        // other secret material - on the heap, abandoned to the GC without being zeroed.
+        var encoded = new byte[totalLength];
+        var position = 0;
         foreach (var tlv in tlvSpan)
         {
-            var tlvBytes = tlv.AsMemory().Span;
-            tlvBytes.CopyTo(writer.GetSpan(tlvBytes.Length));
-            writer.Advance(tlvBytes.Length);
+            var tlvBytes = tlv.AsSpan();
+            tlvBytes.CopyTo(encoded.AsSpan(position));
+            position += tlvBytes.Length;
         }
 
-        return writer.WrittenMemory.ToArray();
+        return encoded;
     }
 
     /// <summary>

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/TlvHelperTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/TlvHelperTests.cs
@@ -145,12 +145,8 @@ public class TlvHelperTests
     }
 
     /// <summary>
-    ///     Pins the header arithmetic that makes <see cref="Tlv.TotalLength" /> trustworthy as the
-    ///     sole size input to <see cref="TlvHelper.EncodeList" />. The expected size is spelled out
-    ///     here rather than read back off the Tlv, so this fails if either the length-field encoding
-    ///     in <see cref="Tlv" /> or the meaning of TotalLength changes.
-    ///     An undersized TotalLength would make EncodeList throw; an oversized one would silently
-    ///     zero-pad its output.
+    ///     Verifies the invariant that total output length is exact because <see cref="Tlv.TotalLength" />
+    ///     equals the encoded span length.
     /// </summary>
     [Theory]
     [InlineData(0x5A, 0x00, 2)]   // 1 tag + 1 short-form length
@@ -164,6 +160,7 @@ public class TlvHelperTests
     {
         using var tlv = new Tlv(tag, new byte[valueLength]);
 
+        // These literal sizes stay independent of the production TotalLength implementation.
         Assert.Equal(headerLength + valueLength, tlv.TotalLength);
     }
 
@@ -196,5 +193,31 @@ public class TlvHelperTests
         var encoded = TlvHelper.EncodeList([]);
 
         Assert.True(encoded.IsEmpty);
+    }
+
+    [Fact]
+    public void EncodeAndDisposeList_WithNullArray_ThrowsArgumentNullException()
+    {
+        var exception = Assert.Throws<ArgumentNullException>(() => TlvHelper.EncodeAndDisposeList(null!));
+
+        Assert.Equal("tlvData", exception.ParamName);
+    }
+
+    [Fact]
+    public void EncodeAndDisposeList_WithNullElement_DisposesAllNonNullTlvs()
+    {
+        using var first = new Tlv(0x5A, [0xAA]);
+        using var sensitiveLater = new Tlv(0x5B, [0x10, 0x20, 0x30]);
+        var tlvs = new Tlv[] { first, null!, sensitiveLater };
+
+        var exception = Assert.Throws<ArgumentNullException>(() => TlvHelper.EncodeAndDisposeList(tlvs));
+
+        Assert.Equal("tlvData", exception.ParamName);
+        Assert.Equal(0, first.Length);
+        Assert.Equal(0, first.Tag);
+        Assert.Equal(0, sensitiveLater.Length);
+        Assert.Equal(0, sensitiveLater.Tag);
+        Assert.All(first.AsSpan().ToArray(), static b => Assert.Equal(0, b));
+        Assert.All(sensitiveLater.AsSpan().ToArray(), static b => Assert.Equal(0, b));
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/TlvHelperTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Utilities/TlvHelperTests.cs
@@ -143,4 +143,58 @@ public class TlvHelperTests
         Assert.Equal(1, tlv.Length);
         Assert.Equal(0xAA, tlv.Value.Span[0]);
     }
+
+    /// <summary>
+    ///     Pins the header arithmetic that makes <see cref="Tlv.TotalLength" /> trustworthy as the
+    ///     sole size input to <see cref="TlvHelper.EncodeList" />. The expected size is spelled out
+    ///     here rather than read back off the Tlv, so this fails if either the length-field encoding
+    ///     in <see cref="Tlv" /> or the meaning of TotalLength changes.
+    ///     An undersized TotalLength would make EncodeList throw; an oversized one would silently
+    ///     zero-pad its output.
+    /// </summary>
+    [Theory]
+    [InlineData(0x5A, 0x00, 2)]   // 1 tag + 1 short-form length
+    [InlineData(0x5A, 0x7F, 2)]   // largest short-form length
+    [InlineData(0x5A, 0x80, 3)]   // 1 tag + 0x81 0x80
+    [InlineData(0x5A, 0xFF, 3)]
+    [InlineData(0x5A, 0x100, 4)]  // 1 tag + 0x82 0x01 0x00
+    [InlineData(0x9F33, 0x7F, 3)] // 2-byte tag + 1 short-form length
+    [InlineData(0x9F33, 0x100, 5)]
+    public void Tlv_TotalLength_IsHeaderPlusValue(int tag, int valueLength, int headerLength)
+    {
+        using var tlv = new Tlv(tag, new byte[valueLength]);
+
+        Assert.Equal(headerLength + valueLength, tlv.TotalLength);
+    }
+
+    [Fact]
+    public void EncodeList_EmitsExpectedBytes()
+    {
+        using var first = new Tlv(0x5A, new byte[] { 0xAA });
+        using var second = new Tlv(0x9F33, new byte[] { 0xFF });
+
+        var encoded = TlvHelper.EncodeList([first, second]);
+
+        Assert.Equal(
+            new byte[] { 0x5A, 0x01, 0xAA, 0x9F, 0x33, 0x01, 0xFF },
+            encoded.ToArray());
+    }
+
+    [Fact]
+    public void EncodeList_WithSingleElement_EmitsThatElementOnly()
+    {
+        using var only = new Tlv(0x5A, new byte[] { 0xAA, 0xBB });
+
+        var encoded = TlvHelper.EncodeList([only]);
+
+        Assert.Equal(new byte[] { 0x5A, 0x02, 0xAA, 0xBB }, encoded.ToArray());
+    }
+
+    [Fact]
+    public void EncodeList_WithNoElements_ReturnsEmpty()
+    {
+        var encoded = TlvHelper.EncodeList([]);
+
+        Assert.True(encoded.IsEmpty);
+    }
 }


### PR DESCRIPTION
> ## Merge order: independent
>
> Nothing is stacked on this, and it is not stacked on anything. It can merge at any time, in any order relative to the other open PRs in this batch.

`TlvHelper.EncodeList` assembled its output in an `ArrayBufferWriter<byte>`, then returned `writer.WrittenMemory.ToArray()`. The copy handed to the caller is fine — **the writer's own array is the problem.** It holds the complete BER-TLV encoding of every value passed in, nothing zeroes it, and it is dropped for the GC to reclaim whenever it gets around to it. The bytes stay readable on the heap, can be duplicated by a compacting collection, and can surface in a crash dump.

### Why it matters

This is the shared encoder for **21 production call sites**:

| Module | Sites | Payload |
|---|---|---|
| `HsmAuthSession` | 11 | credential passwords, key material |
| `SecurityDomainSession` | 3 | cert store, key identifiers |
| `ScpState.Scp11` | 2 | SCP11 key-agreement data |
| `OpenPgp/Kdf` | 1 | KDF material |
| PIV data objects | 4 | card metadata |

Every module that encodes a secret into a TLV left a copy of it behind.

### The fix is subtraction, not zeroing

`Tlv.TotalLength` is the length of the very array `Tlv.AsSpan()` exposes, so the sum over the input is not an estimate that might need to grow — it is the **exact** output size. That makes the staging buffer unnecessary. TLVs are now written straight into the array that is returned.

There is no second copy to leak, so this costs **one allocation and one full copy less** than before, rather than adding zeroing work.

Adding zeroing would also have been awkward: `ArrayBufferWriter` exposes no way to clear the array it is about to abandon short of `MemoryMarshal.AsMemory(writer.WrittenMemory)`, which is what `PivDataObjectProtocol.cs:158` resorts to. Not creating the buffer avoids needing that.

### Two input contracts changed, both now documented

**Empty array** previously threw, because `ArrayBufferWriter` rejects a zero `initialCapacity`:

```
System.ArgumentException : Value does not fall within the expected range. (Parameter 'initialCapacity')
   at System.Buffers.ArrayBufferWriter`1..ctor(Int32 initialCapacity)
```

It now returns an empty buffer, matching `EncodeDictionary`. I read all 21 call sites: none can pass an empty array, so this is unreachable in-tree.

**Null array** previously threw the *same* exception by the same accident, since `AsSpan()` maps `null` to an empty span. Removing the writer would have silently turned that into an empty APDU data field, so `EncodeList` now has an explicit `ArgumentNullException.ThrowIfNull`. Losing that failure mode was the one real regression risk in this change.

### Tests

Because `TotalLength` is now the sole size input, a theory pins the **header arithmetic** behind it — expected sizes are written as literals rather than read back off the `Tlv`, so it fails if either the length-field encoding or the meaning of `TotalLength` changes. Verified to fail (7/7 cases) against an off-by-one mutant of `Tlv.Encode`.

Encoded output is asserted against **literal bytes** for the single- and multi-element cases. A boundary theory covers offset arithmetic and absence of trailing slack at the short-form/long-form transitions (`0x7F`, `0x80`, `0x100`).

The empty-input test fails on the current code and passes after.

### Honest scoping note

The absence of a leak here is **structural** — there is no longer a second buffer — so it is verified by inspection, not by a runtime assertion. I did not add a test pretending to prove a negative about GC-reachable memory.

Deliberately **not** fixed here:

- **`ChainedResponseReceiver.cs:44`** — nothing to fix. `ApduResponse` copies (`ApduResponse.cs:34`) and the writer is already cleared at `:57`.
- **`SecurityDomainSession`** has five writers, not two. The two carrying real secrets — `:484` (SCP03 static ENC/MAC/DEK) and `:691` (SCP11 private key) — already `Clear()` in a `finally`. `:360` and `:752` do not clear, but carry CA identifiers and serial numbers, which are public on the wire.
- **A narrower related issue this PR does not solve:** `ArrayBufferWriter.Clear()` only zeroes the *current* array. A default-constructed writer allocates 256 bytes on first write and doubles from there, abandoning each previous array unzeroed — `Clear()` provably cannot reach those. This does **not** affect the SecurityDomain key paths: `:484` (SCP03, ~67-115 bytes) and `:691` (SCP11, ~55 bytes for the P-256-only private path) never exceed 256, so they never grow and `Clear()` fully covers them. It does affect `:423`, which concatenates raw DER certificates, and `ChainedResponseReceiver.cs:44`, which by definition accumulates more than one APDU's worth of response data. Certificates are public; chained response plaintext is command-dependent. Worth filing separately, but it is not a key-material leak.

### Verification

Full build clean. All 12 suites green (2,341 tests). `dotnet format --verify-no-changes` clean.

