### PR TITLE
docs: replace the TLV examples that reference types the SDK never had

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@
 - `ApplicationSession` centralizes firmware, initialization, authentication, and protocol ownership; prefer `IsSupported(...)` / `EnsureSupports(...)` over duplicating firmware gates.
 - Platform interop belongs under `src/Core/src/PlatformInterop/{Windows,MacOS,Linux,Desktop}` with safe handles and `SdkPlatformInfo` platform selection.
 - FIDO2 over USB primarily uses HID FIDO. SmartCard/CCID FIDO2 is supported over NFC and over USB when the FIDO2 AID is exposed; USB SmartCard FIDO2 requires firmware 5.8.0+.
-- `TlvBuilder` and `DisposableTlvList` must be disposed.
+- `Tlv` and `DisposableTlvList` must be disposed. `TlvHelper.EncodeList` does not dispose its inputs; `EncodeAndDisposeList` does.
 - Listener/native retry loops must block, back off, exit, or throttle on every failure path; add no-hardware fault-injection tests for persistent native errors.
 
 ## Hardware And Integration Tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -570,7 +570,7 @@ If you answered "no" to any of these, don't write the test.
 
 ## Git Workflow
 
-- Base branch for PRs: **`develop`** (not `main`)
+- Base branch for PRs: **`yubikit`** (the source-of-truth root; not `develop` or `main`). CI triggers on `yubikit` and `yubikit-applets` — confirm the active branch before assuming a base.
 - Only commit files YOU created or modified in the current session
 - Stage explicitly with `git add path/to/file` — NEVER `git add .` or `git add -A`
 - Use GitHub stacked PRs (`gh stack`) for multi-layer work. Put unrelated work in a **separate stack**; do not piggyback unrelated changes into an existing stack/PR.

--- a/src/Core/CLAUDE.md
+++ b/src/Core/CLAUDE.md
@@ -135,24 +135,26 @@ var scp11Params = new Scp11KeyParameters(keyRef, sdPublicKey, ocePrivateKey, oce
 Use `TlvHelper` and `Tlv` for parsing/constructing TLV data:
 
 ```csharp
-// Parsing
-var tlvs = TlvHelper.ParseMany(data);
+// Parsing - DecodeList returns a disposable collection
+using var tlvs = TlvHelper.DecodeList(data);
 var specificTlv = tlvs.FirstOrDefault(t => t.Tag == 0x9F);
 
-// Construction
-using var builder = new TlvBuilder();
-builder.Add(0x9F, value);
-var encoded = builder.ToArray();
+// Or read a single value without materialising the list
+if (TlvHelper.TryFindValue(0x9F, data, out var found)) { /* use found */ }
 
-// Nested TLV
-using var builder = new TlvBuilder();
-using (var nested = builder.AddNested(0xE0))
-{
-    nested.Add(0x83, kidKvn);
-}
+// Construction - EncodeAndDisposeList disposes the TLVs it is given
+var encoded = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x9F, value),
+    new Tlv(0x5C, tagList));
+
+// Nested TLV - the inner encoding becomes the outer tag's value
+var inner = TlvHelper.EncodeAndDisposeList(new Tlv(0x83, kidKvn));
+var outer = TlvHelper.EncodeAndDisposeList(new Tlv(0xE0, inner));
 ```
 
-**Important:** `DisposableTlvList` and `TlvBuilder` must be disposed to avoid memory leaks.
+**Important:** `Tlv` and `DisposableTlvList` are `IDisposable` and must be disposed so their
+buffers are zeroed. `EncodeAndDisposeList` disposes the TLVs passed to it; `EncodeList` does
+not, so TLVs built inline for `EncodeList` are left unzeroed unless you dispose them yourself.
 
 ### Platform Interop Pattern
 
@@ -395,7 +397,7 @@ Behavior added by the discovery/session concurrency hardening (see `ExchangeGuar
 1. **APDU Size Limits**: YubiKey Neo uses 254-byte max; YubiKey 4+ uses extended APDUs up to 2048 bytes
 2. **Connection Ownership**: whoever CREATES a connection disposes it with `await using`. Protocols and sessions are pure users — `PcscProtocol`, `FidoHidProtocol`, `OtpHidProtocol`, and direct `Session.CreateAsync(connection)` never dispose a connection they were handed. The one exception is deliberate and internal: an `IYubiKey.Create<App>SessionAsync` convenience entry point opens a connection the caller never sees, so it calls `ApplicationSession.OwnConnection()` to hand that connection's lifetime to the session it returns. A leaked connection can retain the physical-device lease and block later opens; no finalizer releases it
 3. **SCP Key Zeroing**: Always zero SCP keys after use; `StaticKeys` implements `IDisposable`
-4. **TLV Disposal**: `TlvBuilder` and `DisposableTlvList` must be disposed
+4. **TLV Disposal**: `Tlv` and `DisposableTlvList` must be disposed
 5. **Platform-Specific Behavior**: PC/SC APIs behave differently across platforms; test on all three
 6. **Chained Response Assembly**: `INS_SEND_REMAINING` (0xC0) is used by default; some apps use custom values
 7. **Access Tiers**: Applet sessions are the golden path. Raw sessions bypass applet checks but retain session ownership and overlap guards. Raw `IConnection` calls bypass both session and exchange guards; do not interleave them, and dispose/reopen after an interrupted exchange. See [Raw Access Tiers](../../docs/architecture/raw-access-tiers.md)

--- a/src/Core/CLAUDE.md
+++ b/src/Core/CLAUDE.md
@@ -132,29 +132,17 @@ var scp11Params = new Scp11KeyParameters(keyRef, sdPublicKey, ocePrivateKey, oce
 
 ### TLV Processing
 
-Use `TlvHelper` and `Tlv` for parsing/constructing TLV data:
+The canonical usage examples for `DecodeList`, `TryFindValue`, `Tlv`, `EncodeList`, nested encoding, and
+`EncodeAndDisposeList` are in the [Core README](README.md#tlv-processing). Keep the full examples there rather
+than duplicating them in this contributor guide.
 
-```csharp
-// Parsing - DecodeList returns a disposable collection
-using var tlvs = TlvHelper.DecodeList(data);
-var specificTlv = tlvs.FirstOrDefault(t => t.Tag == 0x9F);
-
-// Or read a single value without materialising the list
-if (TlvHelper.TryFindValue(0x9F, data, out var found)) { /* use found */ }
-
-// Construction - EncodeAndDisposeList disposes the TLVs it is given
-var encoded = TlvHelper.EncodeAndDisposeList(
-    new Tlv(0x9F, value),
-    new Tlv(0x5C, tagList));
-
-// Nested TLV - the inner encoding becomes the outer tag's value
-var inner = TlvHelper.EncodeAndDisposeList(new Tlv(0x83, kidKvn));
-var outer = TlvHelper.EncodeAndDisposeList(new Tlv(0xE0, inner));
-```
-
-**Important:** `Tlv` and `DisposableTlvList` are `IDisposable` and must be disposed so their
-buffers are zeroed. `EncodeAndDisposeList` disposes the TLVs passed to it; `EncodeList` does
-not, so TLVs built inline for `EncodeList` are left unzeroed unless you dispose them yourself.
+Contributor rules:
+- Dispose every `Tlv` and `DisposableTlvList`. `EncodeAndDisposeList` disposes the `Tlv` inputs passed to that
+  call; `EncodeList` does not.
+- Neither encoding method clears caller-owned source buffers. `EncodeAndDisposeList` also does not clear its
+  returned encoding or a returned encoding used as an intermediate value in nested TLV construction.
+- Classify buffers by semantics. For sensitive nested data, clear source buffers plus returned and intermediate
+  encodings in `finally`; public or nonsecret encodings do not require special clearing.
 
 ### Platform Interop Pattern
 

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -186,25 +186,72 @@ must not be called from inside the operation being drained.
 ### TLV Processing
 
 ```csharp
+using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Utilities;
 
-// Parse TLV data - DecodeList returns a disposable collection
+// DecodeList returns a disposable collection whose Tlv buffers are cleared on dispose.
 using var tlvs = TlvHelper.DecodeList(responseData);
 var certificateTlv = tlvs.FirstOrDefault(t => t.Tag == 0x53);
 
-// Or read a single value directly
-if (TlvHelper.TryFindValue(0x53, responseData, out var certificate)) { /* use certificate */ }
+// TryFindValue returns a new buffer containing the matching value.
+if (TlvHelper.TryFindValue(0x53, responseData.Span, out var certificate))
+{
+    // Use certificate.Span. Clear certificate when its contents are sensitive.
+}
 
-// Build TLV structure - EncodeAndDisposeList disposes the TLVs it is given
-var encodedData = TlvHelper.EncodeAndDisposeList(
-    new Tlv(0x5C, new byte[] { 0x5F, 0xC1, 0x02 }),  // Tag list
-    new Tlv(0x53, certificateData));                 // Certificate
+// EncodeAndDisposeList is convenient for inline Tlv objects.
+Memory<byte> encodedData = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x5C, new byte[] { 0x5F, 0xC1, 0x02 }),
+    new Tlv(0x53, certificateData));
 
-// Nested TLV - the inner encoding becomes the outer tag's value
-var publicKeyBody = TlvHelper.EncodeAndDisposeList(
-    new Tlv(0x81, modulusBytes),    // RSA modulus
-    new Tlv(0x82, exponentBytes));  // RSA exponent
-var publicKeyTemplate = TlvHelper.EncodeAndDisposeList(new Tlv(0x7F49, publicKeyBody));
+// EncodeList leaves disposal to the caller.
+using var tagList = new Tlv(0x5C, new byte[] { 0x5F, 0xC1, 0x02 });
+using var certificateValue = new Tlv(0x53, certificateData);
+Memory<byte> explicitlyOwnedEncoding = TlvHelper.EncodeList([tagList, certificateValue]);
+```
+
+`Tlv` and the collection returned by `DecodeList` own buffers and must be disposed. `EncodeAndDisposeList`
+disposes only the `Tlv` inputs passed to that call; `EncodeList` does not dispose its inputs. Neither method
+clears source buffers supplied to `Tlv` constructors, returned encodings, or intermediate encodings used for
+nesting.
+
+For public, nonsecret nested data, encode the inner elements and use that encoding as the outer value:
+
+```csharp
+Memory<byte> publicKeyBody = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x81, modulusBytes),
+    new Tlv(0x82, exponentBytes));
+Memory<byte> publicKeyTemplate = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x7F49, publicKeyBody));
+```
+
+The calls dispose their `Tlv` inputs, but not `modulusBytes`, `exponentBytes`, `publicKeyBody`, or
+`publicKeyTemplate`. These values are public, so the concise example does not clear them.
+
+For sensitive nested data, clear every caller-owned source buffer and every returned or intermediate encoding
+in a `finally` block:
+
+```csharp
+using System.Security.Cryptography;
+
+Memory<byte> innerEncoding = Memory<byte>.Empty;
+Memory<byte> outerEncoding = Memory<byte>.Empty;
+
+try
+{
+    innerEncoding = TlvHelper.EncodeAndDisposeList(
+        new Tlv(0x81, privateKeyBytes));
+    outerEncoding = TlvHelper.EncodeAndDisposeList(
+        new Tlv(0x7F49, innerEncoding));
+
+    UseSensitiveEncoding(outerEncoding.Span);
+}
+finally
+{
+    CryptographicOperations.ZeroMemory(outerEncoding.Span);
+    CryptographicOperations.ZeroMemory(innerEncoding.Span);
+    CryptographicOperations.ZeroMemory(privateKeyBytes);
+}
 ```
 
 ## Architecture

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -188,23 +188,23 @@ must not be called from inside the operation being drained.
 ```csharp
 using Yubico.YubiKit.Core.Utilities;
 
-// Parse TLV data
-var tlvs = TlvHelper.ParseMany(responseData);
+// Parse TLV data - DecodeList returns a disposable collection
+using var tlvs = TlvHelper.DecodeList(responseData);
 var certificateTlv = tlvs.FirstOrDefault(t => t.Tag == 0x53);
 
-// Build TLV structure
-using var builder = new TlvBuilder();
-builder.Add(0x5C, new byte[] { 0x5F, 0xC1, 0x02 });  // Tag list
-builder.Add(0x53, certificateData);  // Certificate
-var encodedData = builder.ToArray();
+// Or read a single value directly
+if (TlvHelper.TryFindValue(0x53, responseData, out var certificate)) { /* use certificate */ }
 
-// Nested TLV
-using var nestedBuilder = new TlvBuilder();
-using (var nested = nestedBuilder.AddNested(0x7F49))  // Public key template
-{
-    nested.Add(0x81, modulusBytes);   // RSA modulus
-    nested.Add(0x82, exponentBytes);  // RSA exponent
-}
+// Build TLV structure - EncodeAndDisposeList disposes the TLVs it is given
+var encodedData = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x5C, new byte[] { 0x5F, 0xC1, 0x02 }),  // Tag list
+    new Tlv(0x53, certificateData));                 // Certificate
+
+// Nested TLV - the inner encoding becomes the outer tag's value
+var publicKeyBody = TlvHelper.EncodeAndDisposeList(
+    new Tlv(0x81, modulusBytes),    // RSA modulus
+    new Tlv(0x82, exponentBytes));  // RSA exponent
+var publicKeyTemplate = TlvHelper.EncodeAndDisposeList(new Tlv(0x7F49, publicKeyBody));
 ```
 
 ## Architecture
@@ -277,7 +277,7 @@ Platform detection is automatic via `SdkPlatformInfo.OperatingSystem`.
 | `RawOtpHidSession` | Supported raw OTP HID logical exchange |
 | `ApduCommand` / `ApduResponse` | APDU command/response representations |
 | `ScpProtocol` | Secure Channel Protocol wrapper (SCP03, SCP11) |
-| `TlvHelper` / `TlvBuilder` | TLV parsing and construction utilities |
+| `TlvHelper` / `Tlv` | TLV parsing and construction utilities |
 | `ApplicationSession` | Base class for application-specific sessions |
 
 ## Logging


### PR DESCRIPTION
Docs-only correction of Core TLV examples and ownership guidance. This pull request is independent and can merge at any time.

## Correct APIs

- Replaces fictional `TlvBuilder` and `TlvHelper.ParseMany` examples with `Tlv`, `TlvHelper.DecodeList`, `TlvHelper.TryFindValue`, and `TlvHelper.EncodeAndDisposeList`.
- Shows nested TLV construction by encoding inner elements and passing that encoding as the outer value.
- Uses `src/Core/README.md` as the canonical usage example; `src/Core/CLAUDE.md` links to it and retains contributor rules.

## Ownership

- `DisposableTlvList` and `Tlv` inputs are disposed explicitly.
- Sensitive source, inner-encoding, and outer-encoding buffers are cleared in `finally`.
- The docs distinguish `EncodeAndDisposeList`, which disposes input TLVs, from `EncodeList`, which does not.

## Verification

- Replacement snippets were compiled against the Core project before commit.
- Documentation quality checks and separate cross-vendor remediation review passed.

Abbreviations: SDK means software development kit; TLV means tag-length-value.