### PR TITLE
refactor(core): dispose the TLVs built for the SCP11 host authenticate command

### DIFF
--- a/src/Core/src/Protocols/SmartCard/Scp/ScpState.Scp11.cs
+++ b/src/Core/src/Protocols/SmartCard/Scp/ScpState.Scp11.cs
@@ -88,17 +88,15 @@ internal partial class ScpState
         // GPC v2.3 Amendment F (SCP11) v1.4 §7.6.2.3
         // Construct the host authentication command
         // These contain the parameters for the host authentication command that the YubiKey will respond to.
-        var oceAuthenticateData = TlvHelper.EncodeList(
-        [
-            new Tlv(0xA6, TlvHelper.EncodeList(
-            [
+        // EncodeAndDisposeList rather than EncodeList: these Tlvs are constructed inline and
+        // unreachable afterwards, and EncodeList does not dispose what it is given.
+        var oceAuthenticateData = TlvHelper.EncodeAndDisposeList(
+            new Tlv(0xA6, TlvHelper.EncodeAndDisposeList(
                 new Tlv(0x90, [0x11, scpTypeParam]),
                 new Tlv(0x95, keyUsage),
                 new Tlv(0x80, keyType),
-                new Tlv(0x81, keyLen)
-            ])),
-            new Tlv(0x5F49, epkOce)
-        ]);
+                new Tlv(0x81, keyLen))),
+            new Tlv(0x5F49, epkOce));
 
         try
         {


### PR DESCRIPTION
> ## Merge order: independent
>
> Nothing is stacked on this, and it is not stacked on anything. It can merge at any time.

The six `Tlv` instances assembled for the SCP11 host authentication command (`ScpState.Scp11.cs:91`) are constructed inline and handed to `TlvHelper.EncodeList`, which **does not dispose what it is given**. `Tlv` is `IDisposable` precisely so its backing array can be zeroed, so those six arrays are left intact on the heap until collected.

`EncodeAndDisposeList` exists for exactly this shape. Swapped in for both the inner and outer call.

### This is hygiene, not a secret leak

Worth stating plainly so nobody reads it as more than it is — **everything in these TLVs is public**:

| Tag | Contents | Sensitivity |
|---|---|---|
| `0x90` | protocol version + SCP type param | public parameter |
| `0x95` | key usage | public parameter |
| `0x80` | key type | public parameter |
| `0x81` | key length | public parameter |
| `0x5F49` | `epkOce` — ephemeral **public** key, `ExportParameters().ToUncompressedPoint()` | public by definition |

The command is transmitted with `useScp: false` (`:111`), so all of it goes over the wire **in the clear by design**, per GPC v2.3 Amendment F §7.6.2.3.

The surrounding code already handles what is actually sensitive:
- the ephemeral private scalar is zeroed as soon as the key pair is built (`:78-79`)
- the encoded command buffer is zeroed in the `finally` once the handshake has consumed it (`:141`)

The undisposed intermediates were the one gap, and they hold nothing secret.

### Why fix it anyway

This is the canonical SCP11 implementation and the natural thing to copy when adding a command elsewhere. `AGENTS.md` and `src/Core/CLAUDE.md` both state that `Tlv` must be disposed. Code that contradicts the documented rule in the most-read place teaches the wrong habit.

### No behavioural change

`EncodeAndDisposeList` produces the same encoding and only disposes the inputs afterwards. The returned buffer is a separate array, so the later reuse of `oceAuthenticateData` for key derivation (`:132`) is unaffected.

### Verification

Full build clean. All 12 suites green, including 144 SCP tests. `dotnet format --verify-no-changes` clean.
