### PR TITLE
test(core): consolidate test doubles and wait helpers onto shared infrastructure

### DIFF
--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeDeviceMergerTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeDeviceMergerTests.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -172,15 +172,5 @@ public class CompositeDeviceMergerTests
         var composite = merged.OfType<CompositeYubiKey>().Single(c => c.DeviceId == "ykphysical:103");
         Assert.NotNull(composite.DeviceInfo);
         Assert.Equal(103, composite.DeviceInfo!.Value.SerialNumber);
-    }
-
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException("FakeYubiKey does not support connections.");
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeDeviceMergerVectorTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/CompositeDeviceMergerVectorTests.cs
@@ -14,6 +14,7 @@
 
 using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -802,21 +803,10 @@ public class CompositeDeviceMergerVectorTests
         int? serial = null,
         bool isUsb = true,
         string? topologyKey = null) =>
-        new(new StubYubiKey(deviceId, connection), connection, isUsb, pid, serial, DeviceInfo: null, topologyKey);
+        new(new FakeYubiKey(deviceId, connection), connection, isUsb, pid, serial, DeviceInfo: null, topologyKey);
 
     private static string Describe(IReadOnlyList<IYubiKey> result) =>
         string.Join("; ", result.Select(d => d is CompositeYubiKey c
             ? $"{c.DeviceId}=[{string.Join("|", c.MemberDeviceIds)}]"
             : $"{d.DeviceId}({d.AvailableConnections})"));
-
-    private sealed class StubYubiKey(string deviceId, ConnectionType connection) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-
-        public ConnectionType AvailableConnections { get; } = connection;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection =>
-            throw new InvalidOperationException("Merger vectors never open connections.");
-    }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceEventBroadcasterTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceEventBroadcasterTests.cs
@@ -27,7 +27,7 @@ namespace Yubico.YubiKit.Core.UnitTests.Devices;
 public class DeviceEventBroadcasterTests
 {
     private static DeviceEvent Event(string deviceId = "device-1") =>
-        new(DeviceAction.Added, new StubYubiKey(deviceId));
+        new(DeviceAction.Added, new FakeYubiKey(deviceId));
 
     // ---------- Multicast delivery ----------
 

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceEventStreamTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/DeviceEventStreamTests.cs
@@ -23,8 +23,14 @@ namespace Yubico.YubiKit.Core.UnitTests.Devices;
 /// </summary>
 public class DeviceEventStreamTests
 {
+    /// <summary>
+    /// Subscription bookkeeping happens on a background task; give it a generous bound because a
+    /// miss here is a hang, not a slow assert.
+    /// </summary>
+    private static readonly TimeSpan SubscriptionTimeout = TimeSpan.FromSeconds(10);
+
     private static DeviceEvent Added(string deviceId) =>
-        new(DeviceAction.Added, new StubYubiKey(deviceId));
+        new(DeviceAction.Added, new FakeYubiKey(deviceId));
 
     [Fact]
     public async Task WatchAsync_YieldsPublishedEventsInOrder()
@@ -134,10 +140,11 @@ public class DeviceEventStreamTests
         await consumer;
 
         // Breaking out disposes the enumerator, which must release the underlying subscription.
-        await WaitForConditionAsync(
+        await AsyncWait.WaitUntilAsync(
             () => CountSubscribers(broadcaster) == 0,
-            cts.Token,
-            "watcher did not unsubscribe after enumeration stopped");
+            "watcher did not unsubscribe after enumeration stopped",
+            SubscriptionTimeout,
+            cts.Token);
     }
 
     [Fact]
@@ -164,10 +171,11 @@ public class DeviceEventStreamTests
         var first = Task.Run(ConsumeTwoAsync, cts.Token);
         var second = Task.Run(ConsumeTwoAsync, cts.Token);
 
-        await WaitForConditionAsync(
+        await AsyncWait.WaitUntilAsync(
             () => CountSubscribers(broadcaster) == 2,
-            cts.Token,
-            "both watchers did not subscribe");
+            "both watchers did not subscribe",
+            SubscriptionTimeout,
+            cts.Token);
 
         broadcaster.Publish(Added("a"));
         broadcaster.Publish(Added("b"));
@@ -237,10 +245,11 @@ public class DeviceEventStreamTests
             }
         }, cts.Token);
 
-        await WaitForConditionAsync(
+        await AsyncWait.WaitUntilAsync(
             () => CountSubscribers(broadcaster) == 2,
-            cts.Token,
-            "watcher did not subscribe");
+            "watcher did not subscribe",
+            SubscriptionTimeout,
+            cts.Token);
 
         const int total = DeviceEventStream.BufferCapacity + 50;
         for (var i = 0; i < total; i++)
@@ -260,23 +269,11 @@ public class DeviceEventStreamTests
     /// Subscription happens on a background task, so publishing immediately would race it.
     /// </summary>
     private static Task WaitForSubscriberAsync(DeviceEventBroadcaster broadcaster, CancellationToken token) =>
-        WaitForConditionAsync(() => CountSubscribers(broadcaster) > 0, token, "watcher did not subscribe");
-
-    private static async Task WaitForConditionAsync(Func<bool> condition, CancellationToken token, string message)
-    {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
-        while (DateTime.UtcNow < deadline)
-        {
-            if (condition())
-            {
-                return;
-            }
-
-            await Task.Delay(10, token);
-        }
-
-        Assert.Fail(message);
-    }
+        AsyncWait.WaitUntilAsync(
+            () => CountSubscribers(broadcaster) > 0,
+            "watcher did not subscribe",
+            SubscriptionTimeout,
+            token);
 
     /// <summary>
     /// Probes the live subscriber count by publishing to a counting observer is not possible without

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/FindYubiKeysFaultInjectionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/FindYubiKeysFaultInjectionTests.cs
@@ -19,6 +19,7 @@ using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Transports.Hid;
 using Yubico.YubiKit.Core.Transports.SmartCard;
+using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 using Yubico.YubiKit.Core.UnitTests.Protocols.SmartCard.Apdu.Fakes;
 using Yubico.YubiKit.Core.Utilities;
 
@@ -359,11 +360,11 @@ public class FindYubiKeysFaultInjectionTests
             var scanTask = find.FindAllAsync(ConnectionType.All, TestContext.Current.CancellationToken);
 
             Assert.True(
-                await TryWaitForAsync(() => factory.TotalConnectCalls >= 4, TimeSpan.FromSeconds(5)),
+                await AsyncWait.TryWaitUntilAsync(() => factory.TotalConnectCalls >= 4, TimeSpan.FromSeconds(5)),
                 "The first four identity reads never reached a connect; cannot stage admission saturation.");
             factory.ReleaseAllGatedReads();
 
-            allSixConnected = await TryWaitForAsync(() => factory.TotalConnectCalls >= 6, TimeSpan.FromSeconds(3));
+            allSixConnected = await AsyncWait.TryWaitUntilAsync(() => factory.TotalConnectCalls >= 6, TimeSpan.FromSeconds(3));
             factory.ReleaseAllGatedReads();
 
             result = await scanTask;
@@ -412,7 +413,7 @@ public class FindYubiKeysFaultInjectionTests
         finally
         {
             factory.FailAllBlockedReads();
-            allSixEventuallyConnected = await TryWaitForAsync(
+            allSixEventuallyConnected = await AsyncWait.TryWaitUntilAsync(
                 () => factory.TotalConnectCalls >= 6,
                 TimeSpan.FromSeconds(5));
             await DiscoveryWorkerAdmissionCollection.WaitUntilIdleAsync(TestContext.Current.CancellationToken);
@@ -429,19 +430,6 @@ public class FindYubiKeysFaultInjectionTests
     // ---------------------------------------------------------------------------------------------
     // Rig construction
     // ---------------------------------------------------------------------------------------------
-
-    private static async Task<bool> TryWaitForAsync(Func<bool> condition, TimeSpan timeout)
-    {
-        var clock = System.Diagnostics.Stopwatch.StartNew();
-        while (clock.Elapsed < timeout)
-        {
-            if (condition())
-                return true;
-            await Task.Delay(TimeSpan.FromMilliseconds(10), TestContext.Current.CancellationToken);
-        }
-
-        return condition();
-    }
 
     private static (FindYubiKeys Find, ScriptedIdentityFactory Factory, MutableFindPcscDevices Pcsc, MutableFindHidDevices Hid)
         CreateTwoDualKeyRig()

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/FindYubiKeysTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/FindYubiKeysTests.cs
@@ -17,6 +17,7 @@ using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.Protocols.SmartCard.Apdu;
 using Yubico.YubiKit.Core.Transports.Hid;
 using Yubico.YubiKit.Core.Transports.SmartCard;
+using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -126,15 +127,5 @@ public class FindYubiKeysTests
         public IHidConnection ConnectToFeatureReports() => throw new NotSupportedException();
 
         public IHidConnection ConnectToIOReports() => throw new NotSupportedException();
-    }
-
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException("FakeYubiKey does not support connections.");
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ResolvePreferredConnectionTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ResolvePreferredConnectionTests.cs
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
+using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
@@ -38,7 +38,7 @@ public class ResolvePreferredConnectionTests
     [InlineData(ConnectionType.Unknown, ConnectionType.Unknown)]
     public void ManagementOrder_ResolvesExpected(ConnectionType available, ConnectionType expected)
     {
-        var device = new FakeYubiKey(available);
+        var device = new FakeYubiKey("fake", available);
         Assert.Equal(expected, device.ResolvePreferredConnection(ManagementOrder));
     }
 
@@ -50,7 +50,7 @@ public class ResolvePreferredConnectionTests
     [InlineData(ConnectionType.HidFido, ConnectionType.Unknown)]
     public void YubiOtpOrder_ResolvesExpected(ConnectionType available, ConnectionType expected)
     {
-        var device = new FakeYubiKey(available);
+        var device = new FakeYubiKey("fake", available);
         Assert.Equal(expected, device.ResolvePreferredConnection(YubiOtpOrder));
     }
 
@@ -58,16 +58,6 @@ public class ResolvePreferredConnectionTests
     public void SingleInterfaceDevice_ResolvesToThatInterface()
     {
         Assert.Equal(ConnectionType.HidOtp,
-            new FakeYubiKey(ConnectionType.HidOtp).ResolvePreferredConnection(ManagementOrder));
-    }
-
-    private sealed class FakeYubiKey(ConnectionType available) : IYubiKey
-    {
-        public string DeviceId => "fake";
-        public ConnectionType AvailableConnections { get; } = available;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException();
+            new FakeYubiKey("fake", ConnectionType.HidOtp).ResolvePreferredConnection(ManagementOrder));
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/RxInteropTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/RxInteropTests.cs
@@ -32,7 +32,7 @@ namespace Yubico.YubiKit.Core.UnitTests.Devices;
 public class RxInteropTests
 {
     private static DeviceEvent Event(DeviceAction action, string deviceId) =>
-        new(action, new StubYubiKey(deviceId));
+        new(action, new FakeYubiKey(deviceId));
 
     [Fact]
     public void RxSubscribeActionOverload_WorksAgainstTheSdkObservable()
@@ -43,7 +43,7 @@ public class RxInteropTests
         // ObservableExtensions.Subscribe(Action<T>) comes from System.Reactive, not the BCL.
         using var subscription = repository.DeviceChanges.Subscribe(e => seen.Add(e.Device.DeviceId));
 
-        repository.UpdateCache([new StubYubiKey("device-1")]);
+        repository.UpdateCache([new FakeYubiKey("device-1")]);
 
         Assert.Equal(["device-1"], seen);
     }
@@ -59,8 +59,8 @@ public class RxInteropTests
             .Select(e => e.Device.DeviceId)
             .Subscribe(added.Add);
 
-        repository.UpdateCache([new StubYubiKey("device-1"), new StubYubiKey("device-2")]);
-        repository.UpdateCache([new StubYubiKey("device-1")]);
+        repository.UpdateCache([new FakeYubiKey("device-1"), new FakeYubiKey("device-2")]);
+        repository.UpdateCache([new FakeYubiKey("device-1")]);
 
         // Two arrivals; the removal is filtered out by Where.
         Assert.Equal(2, added.Count);
@@ -78,8 +78,8 @@ public class RxInteropTests
             .Take(1)
             .Subscribe(onNext: _ => received++, onCompleted: () => completed = true);
 
-        repository.UpdateCache([new StubYubiKey("device-1")]);
-        repository.UpdateCache([new StubYubiKey("device-1"), new StubYubiKey("device-2")]);
+        repository.UpdateCache([new FakeYubiKey("device-1")]);
+        repository.UpdateCache([new FakeYubiKey("device-1"), new FakeYubiKey("device-2")]);
 
         Assert.Equal(1, received);
         Assert.True(completed);

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceManagerTests.cs
@@ -110,7 +110,7 @@ public class YubiKeyDeviceManagerTests
         // Start monitoring performs one startup rescan, then FindAllAsync returns cache.
         manager.StartMonitoring(TimeSpan.FromSeconds(10));
 
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Monitoring startup rescan did not run");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Monitoring startup rescan did not run");
         var scanCountAfterStart = findYubiKeys.ScanCount;
 
         // Act - Call FindAllAsync while monitoring
@@ -352,20 +352,6 @@ public class YubiKeyDeviceManagerTests
         return (manager, findYubiKeys, repository);
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition, string failureMessage)
-    {
-        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
-        while (!condition())
-        {
-            if (DateTimeOffset.UtcNow >= deadline)
-            {
-                throw new TimeoutException(failureMessage);
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
-        }
-    }
-
     /// <summary>
     /// Fake IFindYubiKeys for testing with scan counting. Counters use interlocked/volatile
     /// access because scans run on the monitor loop while tests read from the test thread.
@@ -423,19 +409,6 @@ public class YubiKeyDeviceManagerTests
         public void Stop() => Status = DeviceListenerStatus.Stopped;
 
         public void Dispose() => DeviceEvent = null;
-    }
-
-    /// <summary>
-    /// Minimal fake IYubiKey implementation for testing.
-    /// </summary>
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException("FakeYubiKey does not support connections.");
     }
 
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceMonitorServiceTests.cs
@@ -119,7 +119,7 @@ public class YubiKeyDeviceMonitorServiceTests
         service.StartMonitoring(TimeSpan.FromSeconds(10));
 
         // Assert
-        await WaitUntilAsync(() => repository.HasData, "Initial monitoring rescan did not update repository");
+        await AsyncWait.WaitUntilAsync(() => repository.HasData, "Initial monitoring rescan did not update repository");
         Assert.Single(repository.GetAll());
         Assert.Equal(1, findYubiKeys.ScanCount);
 
@@ -135,7 +135,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // Arrange
         var (service, repository, findYubiKeys, hidListener, _) = CreateService();
         service.StartMonitoring(TimeSpan.FromSeconds(10));
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
 
         var events = new RecordingObserver<DeviceEvent>();
         using var subscription = repository.DeviceChanges.Subscribe(events);
@@ -148,7 +148,7 @@ public class YubiKeyDeviceMonitorServiceTests
             DevicePath: "/dev/hidraw999"));
 
         // Assert
-        await WaitUntilAsync(() => findYubiKeys.ScanCount > scanCount, "HID hint did not trigger rescan");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount > scanCount, "HID hint did not trigger rescan");
         Assert.Empty(events);
         Assert.Empty(repository.GetAll());
 
@@ -164,7 +164,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // Arrange
         var (service, repository, findYubiKeys, hidListener, _) = CreateService();
         service.StartMonitoring(TimeSpan.FromSeconds(10));
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Initial monitoring rescan did not run");
 
         findYubiKeys.SetDevices([new FakeYubiKey("device-2", ConnectionType.HidOtp)]);
 
@@ -172,7 +172,7 @@ public class YubiKeyDeviceMonitorServiceTests
         hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Removed));
 
         // Assert
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => repository.GetAll().Any(device => device.DeviceId == "device-2"),
             "Unknown HID removal hint did not trigger repository rescan");
 
@@ -190,7 +190,7 @@ public class YubiKeyDeviceMonitorServiceTests
         findYubiKeys.ScanDelay = TimeSpan.FromMilliseconds(80);
 
         service.StartMonitoring(TimeSpan.FromSeconds(10));
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
             "Initial monitoring rescan did not complete");
 
@@ -217,7 +217,7 @@ public class YubiKeyDeviceMonitorServiceTests
         await Task.WhenAll(tasks);
 
         // Assert
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Listener events did not trigger a rescan");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Listener events did not trigger a rescan");
         Assert.Equal(1, findYubiKeys.MaxConcurrentScans);
 
         service.StopMonitoring();
@@ -233,7 +233,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // Arrange
         var (service, repository, findYubiKeys, hidListener, _) = CreateService();
         service.StartMonitoring(TimeSpan.FromSeconds(30));
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
             "Initial monitoring rescan did not complete");
 
@@ -245,7 +245,7 @@ public class YubiKeyDeviceMonitorServiceTests
             hidListener.Raise(new HidDeviceRescanHint(HidDeviceChangeKind.Added, $"hid-{i}"));
         }
 
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Hint burst did not trigger a rescan");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 1, "Hint burst did not trigger a rescan");
 
         // Allow any (incorrect) trailing per-hint rescans to surface before asserting the bound.
         await Task.Delay(YubiKeyDeviceMonitorService.MaxCoalesceInterval + YubiKeyDeviceMonitorService.ThrottleInterval,
@@ -267,7 +267,7 @@ public class YubiKeyDeviceMonitorServiceTests
         var (service, repository, findYubiKeys, hidListener, smartCardListener) = CreateService();
         findYubiKeys.HangIgnoringCancellation = true;
         service.StartMonitoring(TimeSpan.FromHours(1));
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial blocked scan did not start");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial blocked scan did not start");
 
         for (var i = 0; i < 128; i++)
         {
@@ -278,7 +278,7 @@ public class YubiKeyDeviceMonitorServiceTests
         }
 
         findYubiKeys.ReleaseHungScans();
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => findYubiKeys.ScanCount == 2 && findYubiKeys.ActiveScans == 0,
             "Exactly one follow-up scan did not finish");
         await Task.Delay(
@@ -298,7 +298,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // Arrange
         var (service, repository, findYubiKeys, hidListener, _) = CreateService();
         service.StartMonitoring(TimeSpan.FromSeconds(30));
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
             "Initial monitoring rescan did not complete");
 
@@ -576,7 +576,7 @@ public class YubiKeyDeviceMonitorServiceTests
         Assert.Equal(1, failedSmartCard.StopCount);
         Assert.Equal(1, failedSmartCard.DisposeCount);
 
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => findYubiKeys.ScanCount >= 1 && findYubiKeys.ActiveScans == 0,
             "Initial scan did not finish");
         var scanCountBeforeStaleCallback = findYubiKeys.ScanCount;
@@ -619,7 +619,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // With no listeners to signal, only the 200ms interval fallback can drive
         // rescans. Require at least two scans so we prove the interval loop keeps
         // running on its own, not merely the one-shot startup rescan.
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Interval fallback rescan did not run without listeners");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Interval fallback rescan did not run without listeners");
 
         service.StopMonitoring();
         await service.DisposeAsync();
@@ -697,7 +697,7 @@ public class YubiKeyDeviceMonitorServiceTests
         findYubiKeys.HangIgnoringCancellation = true;
 
         service.StartMonitoring(TimeSpan.FromHours(1));
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial rescan never started");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial rescan never started");
 
         // Act - disposal must abandon the stuck loop and rescan gate instead of hanging
         await service.DisposeAsync().AsTask()
@@ -705,7 +705,7 @@ public class YubiKeyDeviceMonitorServiceTests
 
         // Cleanup - unblock the stuck scan; the abandoned (undisposed) gate accepts its Release
         findYubiKeys.ReleaseHungScans();
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Hung rescan never completed after release");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Hung rescan never completed after release");
 
         repository.Dispose();
     }
@@ -720,7 +720,7 @@ public class YubiKeyDeviceMonitorServiceTests
         findYubiKeys.HangIgnoringCancellation = true;
 
         var staleRescan = service.RescanAsync(TestContext.Current.CancellationToken);
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans >= 1, "Manual rescan never started");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans >= 1, "Manual rescan never started");
 
         // Act - start/stop swaps the monitor generation; the manual rescan's
         // captured generation is now superseded.
@@ -735,7 +735,7 @@ public class YubiKeyDeviceMonitorServiceTests
 
         // The superseded rescan completes silently without publishing.
         await staleRescan;
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Hung scans never unwound");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Hung scans never unwound");
 
         // Assert - the stale snapshot was discarded, not published as device truth.
         Assert.Empty(events);
@@ -754,7 +754,7 @@ public class YubiKeyDeviceMonitorServiceTests
         var (service, repository, findYubiKeys, _, _) = CreateService(shutdownTimeout: TimeSpan.FromMilliseconds(250));
         findYubiKeys.HangIgnoringCancellation = true;
         service.StartMonitoring(TimeSpan.FromHours(1));
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial scan never started");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial scan never started");
 
         service.StopMonitoring();
         Assert.False(service.IsMonitoring);
@@ -766,7 +766,7 @@ public class YubiKeyDeviceMonitorServiceTests
         service.StartMonitoring(TimeSpan.FromHours(1));
         Assert.True(service.IsMonitoring);
 
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => repository.GetAll().Any(d => d.DeviceId == "device-b"),
             "Restarted monitoring did not publish with a new generation");
 
@@ -776,7 +776,7 @@ public class YubiKeyDeviceMonitorServiceTests
         using var subscription = repository.DeviceChanges.Subscribe(events);
         findYubiKeys.SetDevices([new FakeYubiKey("device-c", ConnectionType.SmartCard)]);
         findYubiKeys.ReleaseHungScans();
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Abandoned scan never unwound");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Abandoned scan never unwound");
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         Assert.Empty(events);
@@ -842,7 +842,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // The successor generation scans immediately (its scan is not serialized
         // behind the dead generation) but must not enter UpdateCache while the
         // old publication holds the publication gate.
-        await WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Successor generation never scanned");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ScanCount >= 2, "Successor generation never scanned");
         await Task.Delay(100, TestContext.Current.CancellationToken);
         Assert.Contains(repository.GetAll(), d => d.DeviceId == "device-a");
         Assert.DoesNotContain(repository.GetAll(), d => d.DeviceId == "device-b");
@@ -850,7 +850,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // Release the old publication: it completes first, then the successor's
         // snapshot lands last. Publications never interleave.
         subscriberRelease.Set();
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => repository.GetAll().Any(d => d.DeviceId == "device-b"),
             "Successor snapshot was never published");
 
@@ -910,7 +910,7 @@ public class YubiKeyDeviceMonitorServiceTests
 
         // Assert - admission failed for the parked snapshot; it was discarded and
         // the successor generation published.
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => repository.GetAll().Any(d => d.DeviceId == "device-b"),
             "Successor generation did not publish");
         Assert.DoesNotContain(repository.GetAll(), d => d.DeviceId == "stale-device");
@@ -976,12 +976,12 @@ public class YubiKeyDeviceMonitorServiceTests
         for (var cycle = 0; cycle < 3; cycle++)
         {
             service.StartMonitoring(TimeSpan.FromHours(1));
-            await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, $"Cycle {cycle}: scan never started");
+            await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, $"Cycle {cycle}: scan never started");
 
             service.StopMonitoring();
 
             Assert.False(service.IsMonitoring);
-            await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, $"Cycle {cycle}: cancelled scan never unwound");
+            await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, $"Cycle {cycle}: cancelled scan never unwound");
         }
 
         // One scan per generation - no blocked loops accumulated across cycles.
@@ -999,7 +999,7 @@ public class YubiKeyDeviceMonitorServiceTests
         var (service, repository, findYubiKeys, _, _) = CreateService(shutdownTimeout: TimeSpan.FromMilliseconds(250));
         findYubiKeys.HangIgnoringCancellation = true;
         service.StartMonitoring(TimeSpan.FromHours(1));
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial scan never started");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 1, "Initial scan never started");
 
         service.StopMonitoring();
 
@@ -1010,7 +1010,7 @@ public class YubiKeyDeviceMonitorServiceTests
         // be suppressed, not published.
         findYubiKeys.SetDevices([new FakeYubiKey("stale-device", ConnectionType.SmartCard)]);
         findYubiKeys.ReleaseHungScans();
-        await WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Slow scan never completed");
+        await AsyncWait.WaitUntilAsync(() => findYubiKeys.ActiveScans == 0, "Slow scan never completed");
         await Task.Delay(200, TestContext.Current.CancellationToken);
 
         Assert.Empty(events);
@@ -1020,7 +1020,7 @@ public class YubiKeyDeviceMonitorServiceTests
         findYubiKeys.HangIgnoringCancellation = false;
         findYubiKeys.SetDevices([new FakeYubiKey("device-b", ConnectionType.SmartCard)]);
         service.StartMonitoring(TimeSpan.FromHours(1));
-        await WaitUntilAsync(
+        await AsyncWait.WaitUntilAsync(
             () => repository.GetAll().Any(d => d.DeviceId == "device-b"),
             "Restart after an abandoned stop did not publish");
         Assert.DoesNotContain(events, e => e.Device.DeviceId == "stale-device");
@@ -1335,20 +1335,6 @@ public class YubiKeyDeviceMonitorServiceTests
         return (service, repository, findYubiKeys, hidListener, smartCardListener);
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition, string failureMessage)
-    {
-        var deadline = DateTimeOffset.UtcNow.AddSeconds(5);
-        while (!condition())
-        {
-            if (DateTimeOffset.UtcNow >= deadline)
-            {
-                throw new TimeoutException(failureMessage);
-            }
-
-            await Task.Delay(TimeSpan.FromMilliseconds(20), TestContext.Current.CancellationToken);
-        }
-    }
-
     private sealed class FakeHidDeviceListener : HidDeviceListener
     {
         public int StartCount { get; private set; }
@@ -1556,19 +1542,6 @@ public class YubiKeyDeviceMonitorServiceTests
                 }
             }
         }
-    }
-
-    /// <summary>
-    /// Minimal fake IYubiKey implementation for testing.
-    /// </summary>
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException("FakeYubiKey does not support connections.");
     }
 
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceRepositoryCompositeTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceRepositoryCompositeTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
@@ -230,14 +229,4 @@ public class YubiKeyDeviceRepositoryCompositeTests
                 new FakeYubiKey(hidFidoId, ConnectionType.HidFido)
             ],
             null);
-
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException();
-    }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceRepositoryTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyDeviceRepositoryTests.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using Yubico.YubiKit.Core.Abstractions;
 using Yubico.YubiKit.Core.Devices;
 using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
@@ -504,19 +503,5 @@ public class YubiKeyDeviceRepositoryTests
 
         // Assert
         Assert.Empty(exceptions);
-    }
-
-
-    /// <summary>
-    /// Minimal fake IYubiKey implementation for testing.
-    /// </summary>
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection
-            => throw new NotSupportedException("FakeYubiKey does not support connections.");
     }
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Infrastructure/AsyncWait.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Infrastructure/AsyncWait.cs
@@ -1,0 +1,94 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License").
+// You may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Diagnostics;
+
+namespace Yubico.YubiKit.Core.UnitTests.Infrastructure;
+
+/// <summary>
+/// Polls a condition until it holds, for concurrency tests that observe work happening on another
+/// thread (monitor loops, discovery workers, subscription bookkeeping).
+/// </summary>
+/// <remarks>
+/// <para>
+/// The condition is evaluated once before the first delay and once more before the timeout is
+/// reported, so a condition that becomes true inside the final poll window is never missed.
+/// </para>
+/// <para>
+/// Two shapes, because the callers genuinely differ: <see cref="WaitUntilAsync"/> treats a timeout as
+/// a test failure, while <see cref="TryWaitUntilAsync"/> returns the outcome for tests where "did not
+/// happen within the bound" is the thing being asserted rather than a broken precondition.
+/// </para>
+/// </remarks>
+internal static class AsyncWait
+{
+    /// <summary>
+    /// Default bound for "this should already have happened". Generous on purpose: these waits gate
+    /// on real scheduler progress, and CI machines are slower than laptops.
+    /// </summary>
+    public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
+
+    private static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(20);
+
+    /// <summary>
+    /// Waits for <paramref name="condition"/>, returning whether it held within the bound.
+    /// </summary>
+    /// <param name="condition">Polled predicate. Must be cheap and side-effect free.</param>
+    /// <param name="timeout">Bound to wait for; defaults to <see cref="DefaultTimeout"/>.</param>
+    /// <param name="cancellationToken">
+    /// Defaults to the ambient <see cref="TestContext.Current"/> token. Pass an explicit token only
+    /// when the test drives its own <see cref="CancellationTokenSource"/>.
+    /// </param>
+    public static async Task<bool> TryWaitUntilAsync(
+        Func<bool> condition,
+        TimeSpan? timeout = null,
+        CancellationToken? cancellationToken = null)
+    {
+        var bound = timeout ?? DefaultTimeout;
+        var token = cancellationToken ?? TestContext.Current.CancellationToken;
+        var elapsed = Stopwatch.StartNew();
+
+        while (true)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            if (elapsed.Elapsed >= bound)
+            {
+                return false;
+            }
+
+            await Task.Delay(PollInterval, token);
+        }
+    }
+
+    /// <summary>
+    /// Waits for <paramref name="condition"/>, throwing <see cref="TimeoutException"/> with
+    /// <paramref name="failureMessage"/> if it does not hold within the bound.
+    /// </summary>
+    /// <inheritdoc cref="TryWaitUntilAsync" path="/param"/>
+    public static async Task WaitUntilAsync(
+        Func<bool> condition,
+        string failureMessage,
+        TimeSpan? timeout = null,
+        CancellationToken? cancellationToken = null)
+    {
+        if (!await TryWaitUntilAsync(condition, timeout, cancellationToken))
+        {
+            throw new TimeoutException(failureMessage);
+        }
+    }
+}

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Infrastructure/FakeYubiKey.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Infrastructure/FakeYubiKey.cs
@@ -21,11 +21,11 @@ namespace Yubico.YubiKit.Core.UnitTests.Infrastructure;
 /// Inert <see cref="IYubiKey"/> for tests that only need identity and advertised connections.
 /// </summary>
 /// <remarks>
-/// Connecting throws — this is for tests about discovery, caching, and event plumbing, not about
-/// transports. Several older test files still declare their own private equivalents; prefer this one
-/// for new tests so the copies can be retired opportunistically.
+/// Connecting throws — this is for tests about discovery, caching, merging, and event plumbing, not
+/// about transports. A test that needs <see cref="ConnectAsync{TConnection}"/> to actually hand back a
+/// connection is testing something else and should declare its own double rather than extend this one.
 /// </remarks>
-internal sealed class StubYubiKey(
+internal sealed class FakeYubiKey(
     string deviceId,
     ConnectionType availableConnections = ConnectionType.SmartCard) : IYubiKey
 {
@@ -35,5 +35,5 @@ internal sealed class StubYubiKey(
 
     public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
         where TConnection : class, IConnection =>
-        throw new NotSupportedException();
+        throw new NotSupportedException("FakeYubiKey does not support connections.");
 }

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Sessions/RawSessionYubiKeyExtensionsTests.cs
@@ -30,7 +30,7 @@ public class RawSessionYubiKeyExtensionsTests
     public async Task CreateRawSmartCardSessionAsync_DisposeSession_DisposesHiddenConnection()
     {
         var connection = new MultiTransportConnection(ConnectionType.SmartCard);
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
 
         RawSmartCardSession session = await yubiKey.CreateRawSmartCardSessionAsync(
             cancellationToken: TestContext.Current.CancellationToken);
@@ -44,7 +44,7 @@ public class RawSessionYubiKeyExtensionsTests
     public async Task CreateRawFidoHidSessionAsync_DisposeSession_DisposesHiddenConnection()
     {
         var connection = new MultiTransportConnection(ConnectionType.HidFido);
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
 
         RawFidoHidSession session = await yubiKey.CreateRawFidoHidSessionAsync(TestContext.Current.CancellationToken);
         await session.DisposeAsync();
@@ -57,7 +57,7 @@ public class RawSessionYubiKeyExtensionsTests
     public async Task CreateRawOtpHidSessionAsync_DisposeSession_DisposesHiddenConnection()
     {
         var connection = new MultiTransportConnection(ConnectionType.HidOtp);
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
 
         RawOtpHidSession session = await yubiKey.CreateRawOtpHidSessionAsync(TestContext.Current.CancellationToken);
         await session.DisposeAsync();
@@ -70,7 +70,7 @@ public class RawSessionYubiKeyExtensionsTests
     public async Task CreateRawSmartCardSessionAsync_WhenScpInitializationFails_DisposesHiddenConnection()
     {
         var connection = new MultiTransportConnection(ConnectionType.SmartCard);
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
         using var scp = Scp03KeyParameters.Default;
 
         await Assert.ThrowsAsync<InvalidOperationException>(() =>
@@ -89,7 +89,7 @@ public class RawSessionYubiKeyExtensionsTests
         var connection = new MultiTransportConnection(ConnectionType.SmartCard);
         connection.Enqueue(new byte[] { 0x90, 0x00 });
         connection.HoldNextOperation();
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
         RawSmartCardSession session = await yubiKey.CreateRawSmartCardSessionAsync(
             cancellationToken: cancellationToken);
         Task<ApduResponse> exchange = session.TransmitAndReceiveAsync(
@@ -124,7 +124,7 @@ public class RawSessionYubiKeyExtensionsTests
         var connection = new MultiTransportConnection(ConnectionType.HidFido);
         connection.Enqueue(CreateFidoInitPacket(0x01020304, 0x42, [0xAB]));
         connection.HoldNextOperation();
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
         RawFidoHidSession session = await yubiKey.CreateRawFidoHidSessionAsync(cancellationToken);
         Task<ReadOnlyMemory<byte>> exchange = session.SendAndReceiveAsync(
             0x42,
@@ -162,7 +162,7 @@ public class RawSessionYubiKeyExtensionsTests
             connection.Enqueue(OtpStatus(programmingSequence: 1));
         connection.Enqueue(OtpStatus(programmingSequence: 2));
         connection.HoldNextOperation();
-        var yubiKey = new StubYubiKey(connection);
+        var yubiKey = new ConnectingYubiKey(connection);
         RawOtpHidSession session = await yubiKey.CreateRawOtpHidSessionAsync(cancellationToken);
         Task<ReadOnlyMemory<byte>> exchange = session.SendAndReceiveAsync(
             0x13,
@@ -203,7 +203,7 @@ public class RawSessionYubiKeyExtensionsTests
     private static byte[] OtpStatus(byte versionMajor = 0, byte programmingSequence = 0) =>
         [0x00, versionMajor, 0x04, 0x03, programmingSequence, 0x00, 0x00, 0x00];
 
-    private sealed class StubYubiKey(IConnection connection) : IYubiKey
+    private sealed class ConnectingYubiKey(IConnection connection) : IYubiKey
     {
         public string DeviceId => "raw-session-test";
         public ConnectionType AvailableConnections => connection.Type;

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/SmartCard/FindPcscDevicesTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Transports/SmartCard/FindPcscDevicesTests.cs
@@ -180,15 +180,4 @@ public class FindPcscDevicesTests
         public IYubiKey Create(IDevice device) =>
             throw new InvalidOperationException("No device should be created when PC/SC admission is saturated.");
     }
-
-    private sealed class FakeYubiKey(string deviceId, ConnectionType connectionType) : IYubiKey
-    {
-        public string DeviceId { get; } = deviceId;
-
-        public ConnectionType AvailableConnections { get; } = connectionType;
-
-        public Task<TConnection> ConnectAsync<TConnection>(CancellationToken cancellationToken = default)
-            where TConnection : class, IConnection =>
-            throw new NotSupportedException();
-    }
 }


### PR DESCRIPTION
Stacked on #609. This test-only pull request consolidates repeated Core unit-test doubles and polling helpers without changing production behavior.

## Changes

- Renames the shared inert `StubYubiKey` to `FakeYubiKey` and replaces equivalent nested test doubles while preserving each call site's device identifier and advertised connections.
- Keeps connection-serving doubles local where tests require real connection dispatch or request recording.
- Adds `AsyncWait.WaitUntilAsync` for waits where timeout is a failed precondition and `AsyncWait.TryWaitUntilAsync` where timeout is itself an asserted outcome.
- Preserves existing deadlines and cancellation behavior. The shared polling interval is 20 ms; this increases two prior 10 ms polling loops without changing their multi-second deadlines or monotonic predicates.
- Leaves stateful stabilization and admission-barrier helpers unconsolidated because their predicates are not side-effect-free polling conditions.

The rebase onto corrected #609 does not modify its operator-driven integration test or reintroduce identity-pairing or settling-delay claims.

## Verification

- Complete Core unit suite: 996 total, 993 passed, 3 hardware/platform skips
- Fast runtime resilience: 74 passed
- Fresh GitHub build, coverage, and dependency-submission checks: passed
- Separate cross-vendor review of the final current-parent diff: passed with no findings

Abbreviations: SDK means software development kit.