### PR TITLE
fix(fido2): preserve forward compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@
 - `Tlv` and `DisposableTlvList` must be disposed. `TlvHelper.EncodeList` does not dispose its inputs; `EncodeAndDisposeList` does.
 - Listener/native retry loops must block, back off, exit, or throttle on every failure path; add no-hardware fault-injection tests for persistent native errors.
 
+## Forward compatibility doctrine
+- Valid device response data that the SDK does not yet model must not block users. Use open value carriers where practical and preserve complete raw response bytes as an escape hatch.
+- Keep malformed, missing required, and security-critical protocol data strict.
+- Prefer response-side raw escape hatches. Do not blindly re-emit unknown response fields in requests; request encoding remains explicitly modeled and validated.
+
 ## Hardware And Integration Tests
 - Integration tests require authorized YubiKey hardware. The shared test infrastructure reads `YubiKeyTests:AllowedSerialNumbers` from `appsettings.json`; an empty/missing allow list can hard-fail with `Environment.Exit(-1)`, and unauthorized devices are filtered out.
 - Linux hardware tests need PC/SC pieces like `pcscd`, `libpcsclite-dev`, and `libudev-dev`; CI starts `pcscd` manually before build/test.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,10 @@ dotnet toolchain.cs -- pack --include-docs
 
 **House style:** `docs/SDK-HOUSE-STYLE.md` is the v2 architectural style guide. Load it before module consolidation, refactoring, or protocol-flow work. It defines flat protocol flow, minimal helper depth, plain `ApduCommand`/DTO usage, and the rule against operation-specific command classes like `AuthenticateCommand`, `PutKeyCommand`, and `GetDataCommand`.
 
+### Forward compatibility doctrine
+
+Valid device response data that the SDK does not yet model must not block users. Represent extensible protocol identifiers with open value carriers where practical, and preserve complete raw response bytes so callers can inspect new fields. Malformed encodings, missing required fields, and security-critical protocol data remain strict. Prefer response-side raw escape hatches; request encoders must not blindly re-emit unknown response fields and must continue to model and validate what they send.
+
 `codemapper .` generates the full surface map. The non-obvious patterns:
 
 - **Device discovery** — `IDeviceRepository` + `DeviceMonitorService` (hosted) + `DeviceListenerService` (background). Events flow through `DeviceEventBroadcaster` (multicast) and `DeviceEventStream` (buffering), surfaced as `YubiKeyManager.WatchAsync` (`IAsyncEnumerable`) and `DeviceChanges` (`IObservable`). No reactive dependency - see `docs/usage/device-discovery.md`.

--- a/src/Fido2/CLAUDE.md
+++ b/src/Fido2/CLAUDE.md
@@ -255,6 +255,17 @@ Key rules:
 - Use `.WithValue(key, writer => ...)` for complex values or sensitive byte spans that should be written directly instead of copied through `.WithBytes(...)`
 - Keep operation-level request builders as pure encoding helpers; do not introduce operation-specific CTAP command classes
 
+## Forward compatibility and escape hatches
+
+Valid authenticator response data that is not yet modeled must remain usable without relaxing malformed or security-critical data checks. The FIDO2 and WebAuthn response escape hatches are:
+
+- `AuthenticatorInfo.RawCbor` for the complete authenticatorGetInfo response.
+- `AttestedCredentialData.CredentialPublicKey`, with `CoseOtherKey.RawCbor` when an unmodeled key type is not claimed by a modeled algorithm. COSE keys must still report an algorithm.
+- `ExtensionOutput.TryGetRawExtension` and `WebAuthnAuthenticatorData.ParsedExtensions` for extension outputs.
+- `IFidoSession.SendCborRequestAsync` for explicitly constructed raw CTAP CBOR requests and responses.
+
+PIN/UV key agreement is a separate security-critical boundary: forward-compatible response handling must not relax its required P-256 key type, curve, coordinates, or protocol structure. Raw response access is not a bypass, and unknown response fields must not be blindly copied into requests.
+
 ## Security Requirements
 
 ### Memory Handling

--- a/src/Fido2/CLAUDE.md
+++ b/src/Fido2/CLAUDE.md
@@ -259,12 +259,15 @@ Key rules:
 
 Valid authenticator response data that is not yet modeled must remain usable without relaxing malformed or security-critical data checks. The FIDO2 and WebAuthn response escape hatches are:
 
-- `AuthenticatorInfo.RawCbor` for the complete authenticatorGetInfo response.
+- `RawData` on non-secret response owners such as `AuthenticatorInfo`, credential metadata, relying-party information, `FingerprintSensorInfo`, and `EnrollmentSampleResult` preserves the complete response envelope.
 - `AttestedCredentialData.CredentialPublicKey`, with `CoseOtherKey.RawCbor` when an unmodeled key type is not claimed by a modeled algorithm. COSE keys must still report an algorithm.
 - `ExtensionOutput.TryGetRawExtension` and `WebAuthnAuthenticatorData.ParsedExtensions` for extension outputs.
 - `IFidoSession.SendCborRequestAsync` for explicitly constructed raw CTAP CBOR requests and responses.
 
 PIN/UV key agreement is a separate security-critical boundary: forward-compatible response handling must not relax its required P-256 key type, curve, coordinates, or protocol structure. Raw response access is not a bypass, and unknown response fields must not be blindly copied into requests.
+
+Add `RawData` to models that own a complete, non-secret authenticator response. Do not duplicate the same buffer on nested entities or add another retained copy of envelopes containing material the SDK should zero.
+Use `RawCbor` only for an encoded nested CBOR structure, such as an attestation statement or unsupported COSE key; it may be a slice of its parent buffer rather than a separately owned copy.
 
 ## Security Requirements
 

--- a/src/Fido2/src/AuthenticatorInfo.cs
+++ b/src/Fido2/src/AuthenticatorInfo.cs
@@ -63,6 +63,15 @@ public sealed class AuthenticatorInfo
     private const int KeyAuthenticatorConfigCommands = 0x1F;
 
     /// <summary>
+    /// Gets the complete original CBOR-encoded authenticatorGetInfo response.
+    /// </summary>
+    /// <remarks>
+    /// This is populated by <see cref="Decode(ReadOnlyMemory{byte})"/> and preserves fields that
+    /// are valid but not modeled by this SDK version. It is empty on caller-constructed instances.
+    /// </remarks>
+    public ReadOnlyMemory<byte> RawCbor { get; init; }
+
+    /// <summary>
     /// Gets the CTAP versions supported by the authenticator.
     /// </summary>
     /// <remarks>
@@ -279,14 +288,15 @@ public sealed class AuthenticatorInfo
     /// <returns>The decoded AuthenticatorInfo.</returns>
     public static AuthenticatorInfo Decode(ReadOnlyMemory<byte> data)
     {
-        var reader = new CborReader(data, CborConformanceMode.Ctap2Canonical);
-        return Parse(reader);
+        byte[] rawCbor = data.ToArray();
+        var reader = new CborReader(rawCbor, CborConformanceMode.Ctap2Canonical);
+        return Parse(reader, rawCbor);
     }
 
     /// <summary>
     /// Parses an AuthenticatorInfo from a CBOR reader.
     /// </summary>
-    internal static AuthenticatorInfo Parse(CborReader reader)
+    private static AuthenticatorInfo Parse(CborReader reader, ReadOnlyMemory<byte> rawCbor)
     {
         var mapLength = reader.ReadStartMap();
 
@@ -465,6 +475,7 @@ public sealed class AuthenticatorInfo
 
         return new AuthenticatorInfo
         {
+            RawCbor = rawCbor,
             Versions = versions ?? [],
             Extensions = extensions ?? [],
             Aaguid = aaguid ?? [],
@@ -539,8 +550,7 @@ public sealed class AuthenticatorInfo
         for (var i = 0; i < length; i++)
         {
             var key = reader.ReadTextString();
-            var value = reader.ReadBoolean();
-            result[key] = value;
+            result[key] = reader.ReadBoolean();
         }
 
         reader.ReadEndMap();

--- a/src/Fido2/src/AuthenticatorInfo.cs
+++ b/src/Fido2/src/AuthenticatorInfo.cs
@@ -69,7 +69,7 @@ public sealed class AuthenticatorInfo
     /// This is populated by <see cref="Decode(ReadOnlyMemory{byte})"/> and preserves fields that
     /// are valid but not modeled by this SDK version. It is empty on caller-constructed instances.
     /// </remarks>
-    public ReadOnlyMemory<byte> RawCbor { get; init; }
+    public ReadOnlyMemory<byte> RawData { get; private init; }
 
     /// <summary>
     /// Gets the CTAP versions supported by the authenticator.
@@ -475,7 +475,7 @@ public sealed class AuthenticatorInfo
 
         return new AuthenticatorInfo
         {
-            RawCbor = rawCbor,
+            RawData = rawCbor,
             Versions = versions ?? [],
             Extensions = extensions ?? [],
             Aaguid = aaguid ?? [],

--- a/src/Fido2/src/BioEnrollment/BioEnrollmentModels.cs
+++ b/src/Fido2/src/BioEnrollment/BioEnrollmentModels.cs
@@ -112,6 +112,11 @@ public enum FingerprintSampleStatus
 public sealed class FingerprintSensorInfo
 {
     /// <summary>
+    /// Gets the complete original CBOR-encoded authenticator response.
+    /// </summary>
+    public ReadOnlyMemory<byte> RawData { get; private init; }
+
+    /// <summary>
     /// Gets the fingerprint kind (touch or swipe).
     /// </summary>
     public FingerprintKind FingerprintKind { get; private init; }
@@ -137,7 +142,8 @@ public sealed class FingerprintSensorInfo
     /// <returns>The decoded sensor info.</returns>
     public static FingerprintSensorInfo Decode(ReadOnlyMemory<byte> data)
     {
-        var reader = new CborReader(data, CborConformanceMode.Lax);
+        ReadOnlyMemory<byte> rawData = data.ToArray();
+        var reader = new CborReader(rawData, CborConformanceMode.Lax);
 
         var fingerprintKind = FingerprintKind.Touch;
         var maxSamples = 0;
@@ -173,6 +179,7 @@ public sealed class FingerprintSensorInfo
 
         return new FingerprintSensorInfo
         {
+            RawData = rawData,
             FingerprintKind = fingerprintKind,
             MaxCaptureSamplesRequiredForEnroll = maxSamples,
             MaxTemplateCount = maxTemplates
@@ -201,6 +208,11 @@ public enum FingerprintKind
 /// </summary>
 public sealed class EnrollmentSampleResult
 {
+    /// <summary>
+    /// Gets the complete original CBOR-encoded authenticator response.
+    /// </summary>
+    public ReadOnlyMemory<byte> RawData { get; private init; }
+
     /// <summary>
     /// Gets the current template ID for this enrollment.
     /// </summary>
@@ -231,7 +243,8 @@ public sealed class EnrollmentSampleResult
     /// <returns>The decoded enrollment result.</returns>
     public static EnrollmentSampleResult Decode(ReadOnlyMemory<byte> data)
     {
-        var reader = new CborReader(data, CborConformanceMode.Lax);
+        ReadOnlyMemory<byte> rawData = data.ToArray();
+        var reader = new CborReader(rawData, CborConformanceMode.Lax);
 
         ReadOnlyMemory<byte> templateId = default;
         var lastStatus = FingerprintSampleStatus.Good;
@@ -267,6 +280,7 @@ public sealed class EnrollmentSampleResult
 
         return new EnrollmentSampleResult
         {
+            RawData = rawData,
             TemplateId = templateId,
             LastSampleStatus = lastStatus,
             RemainingSamples = remaining

--- a/src/Fido2/src/BioEnrollment/FingerprintBioEnrollment.cs
+++ b/src/Fido2/src/BioEnrollment/FingerprintBioEnrollment.cs
@@ -204,17 +204,14 @@ public sealed class FingerprintBioEnrollment
         for (var i = 0; i < mapCount; i++)
         {
             var key = reader.ReadInt32();
-
             switch (key)
             {
                 case 4: // templateId
                     templateId = reader.ReadByteString();
                     break;
-
                 case 7: // templateFriendlyName
                     friendlyName = reader.ReadTextString();
                     break;
-
                 default:
                     reader.SkipValue();
                     break;

--- a/src/Fido2/src/Cose/CoseArkgP256SeedKey.cs
+++ b/src/Fido2/src/Cose/CoseArkgP256SeedKey.cs
@@ -44,7 +44,7 @@ namespace Yubico.YubiKit.Fido2.Cose;
 /// to simplify downstream ARKG derivation logic.
 /// </para>
 /// <para>
-/// Discriminate this variant from standard EC2 keys by checking alg == -65700 AFTER kty == 2.
+/// Discriminate this variant from standard EC2 keys by checking alg == -65700.
 /// </para>
 /// </remarks>
 /// <param name="Algorithm">COSE algorithm identifier (must be ArkgP256SeedKey = -65700).</param>

--- a/src/Fido2/src/Cose/CoseKey.cs
+++ b/src/Fido2/src/Cose/CoseKey.cs
@@ -42,11 +42,18 @@ public abstract record CoseKey
     /// <returns>A <see cref="CoseKey"/> subclass based on the key type.</returns>
     public static CoseKey Decode(ReadOnlyMemory<byte> coseEncoded)
     {
+        Dictionary<int, object?> parameters = ReadParameters(coseEncoded);
+        int keyType = ReadRequiredInt32(parameters, 1, "Missing required kty parameter");
+        var algorithm = new CoseAlgorithm(
+            ReadRequiredInt32(parameters, 3, "Missing required alg parameter"));
+
+        return CreateKey(keyType, algorithm, parameters, coseEncoded);
+    }
+
+    private static Dictionary<int, object?> ReadParameters(ReadOnlyMemory<byte> coseEncoded)
+    {
         var reader = new CborReader(coseEncoded, CborConformanceMode.Ctap2Canonical);
         reader.ReadStartMap();
-
-        int? keyType = null;
-        int? algorithmValue = null;
         var parameters = new Dictionary<int, object?>();
 
         while (reader.PeekState() != CborReaderState.EndMap)
@@ -55,50 +62,61 @@ public abstract record CoseKey
             if (label is null)
             {
                 reader.SkipValue();
+                continue;
             }
-            else if (label is 1 or 3)
-            {
-                int? value = ReadInt32IfRepresentable(reader);
-                if (value is not null)
-                {
-                    if (label == 1)
-                    {
-                        keyType = value;
-                    }
-                    else
-                    {
-                        algorithmValue = value;
-                    }
-                }
-            }
-            else if (label is -1 or -2 or -3)
-            {
-                parameters[label.Value] = ReadModeledParameterValue(reader);
-            }
-            else
-            {
-                reader.SkipValue();
-            }
+
+            ReadParameter(reader, label.Value, parameters);
         }
+
         reader.ReadEndMap();
+        return parameters;
+    }
 
-        int kty = keyType ??
-            throw new InvalidOperationException("Missing required kty parameter");
-        int alg = algorithmValue ??
-            throw new InvalidOperationException("Missing required alg parameter");
-        CoseAlgorithm algorithm = new(alg);
+    private static void ReadParameter(
+        CborReader reader,
+        int label,
+        Dictionary<int, object?> parameters)
+    {
+        // ReadKnownLabel limits negative labels to the modeled key parameters -1, -2, and -3.
+        if (label < 0)
+        {
+            parameters[label] = ReadModeledParameterValue(reader);
+            return;
+        }
 
-        if (alg == -65700)
+        int? value = ReadInt32IfRepresentable(reader);
+        if (value is not null)
+        {
+            parameters[label] = value;
+        }
+    }
+
+    private static int ReadRequiredInt32(
+        IReadOnlyDictionary<int, object?> parameters,
+        int label,
+        string message) =>
+        parameters.TryGetValue(label, out object? value) && value is int intValue
+            ? intValue
+            : throw new InvalidOperationException(message);
+
+    private static CoseKey CreateKey(
+        int keyType,
+        CoseAlgorithm algorithm,
+        Dictionary<int, object?> parameters,
+        ReadOnlyMemory<byte> coseEncoded)
+    {
+        // ARKG uses an EC2-shaped experimental key selected by its algorithm identifier.
+        if (algorithm == CoseAlgorithm.ArkgP256SeedKey)
         {
             return CoseArkgP256SeedKey.Decode(parameters, algorithm);
         }
 
-        return kty switch
+        return keyType switch
         {
             2 => DecodeEc2(parameters, algorithm),
             1 => DecodeOkp(parameters, algorithm),
             3 => DecodeRsa(parameters, algorithm),
-            _ => new CoseOtherKey(kty, algorithm, coseEncoded.ToArray())
+            _ => new CoseOtherKey(keyType, algorithm, coseEncoded.ToArray())
         };
     }
 

--- a/src/Fido2/src/Cose/CoseKey.cs
+++ b/src/Fido2/src/Cose/CoseKey.cs
@@ -43,37 +43,51 @@ public abstract record CoseKey
     public static CoseKey Decode(ReadOnlyMemory<byte> coseEncoded)
     {
         var reader = new CborReader(coseEncoded, CborConformanceMode.Ctap2Canonical);
+        reader.ReadStartMap();
 
-        // Read map header
-        int? mapSize = reader.ReadStartMap();
+        int? keyType = null;
+        int? algorithmValue = null;
         var parameters = new Dictionary<int, object?>();
 
-        int entriesRead = 0;
         while (reader.PeekState() != CborReaderState.EndMap)
         {
-            int key = reader.ReadInt32();
-            object? value = reader.PeekState() switch
+            int? label = ReadKnownLabel(reader);
+            if (label is null)
             {
-                CborReaderState.ByteString => reader.ReadByteString(),
-                CborReaderState.UnsignedInteger or CborReaderState.NegativeInteger => reader.ReadInt32(),
-                CborReaderState.StartMap => reader.ReadEncodedValue().ToArray(), // nested COSE_Key as raw CBOR
-                _ => throw new InvalidOperationException($"Unsupported CBOR type for COSE key parameter {key}")
-            };
-            parameters[key] = value;
-            entriesRead++;
+                reader.SkipValue();
+            }
+            else if (label is 1 or 3)
+            {
+                int? value = ReadInt32IfRepresentable(reader);
+                if (value is not null)
+                {
+                    if (label == 1)
+                    {
+                        keyType = value;
+                    }
+                    else
+                    {
+                        algorithmValue = value;
+                    }
+                }
+            }
+            else if (label is -1 or -2 or -3)
+            {
+                parameters[label.Value] = ReadModeledParameterValue(reader);
+            }
+            else
+            {
+                reader.SkipValue();
+            }
         }
         reader.ReadEndMap();
 
-        // Extract common parameters
-        int kty = parameters.TryGetValue(1, out var ktyValue) && ktyValue is int k ? k :
+        int kty = keyType ??
             throw new InvalidOperationException("Missing required kty parameter");
-        int alg = parameters.TryGetValue(3, out var algValue) && algValue is int a ? a :
+        int alg = algorithmValue ??
             throw new InvalidOperationException("Missing required alg parameter");
-
         CoseAlgorithm algorithm = new(alg);
 
-        // Dispatch on alg first for ARKG seed keys. They use a sentinel kty that is not in
-        // the standard COSE kty registry, so the regular kty switch cannot route them.
         if (alg == -65700)
         {
             return CoseArkgP256SeedKey.Decode(parameters, algorithm);
@@ -86,6 +100,70 @@ public abstract record CoseKey
             3 => DecodeRsa(parameters, algorithm),
             _ => new CoseOtherKey(kty, algorithm, coseEncoded.ToArray())
         };
+    }
+
+    private static int? ReadKnownLabel(CborReader reader) => reader.PeekState() switch
+    {
+        CborReaderState.UnsignedInteger => ReadKnownUnsignedLabel(reader),
+        CborReaderState.NegativeInteger => ReadKnownNegativeLabel(reader),
+        _ => SkipLabel(reader)
+    };
+
+    private static int? ReadKnownUnsignedLabel(CborReader reader)
+    {
+        ulong label = reader.ReadUInt64();
+        return label is 1 or 3 ? (int)label : null;
+    }
+
+    private static int? ReadKnownNegativeLabel(CborReader reader)
+    {
+        ulong representation = reader.ReadCborNegativeIntegerRepresentation();
+        return representation <= 2 ? -1 - (int)representation : null;
+    }
+
+    private static int? SkipLabel(CborReader reader)
+    {
+        reader.SkipValue();
+        return null;
+    }
+
+    private static int? ReadInt32IfRepresentable(CborReader reader) => reader.PeekState() switch
+    {
+        CborReaderState.UnsignedInteger => ReadUnsignedInt32IfRepresentable(reader),
+        CborReaderState.NegativeInteger => ReadNegativeInt32IfRepresentable(reader),
+        _ => SkipInt32Value(reader)
+    };
+
+    private static int? ReadUnsignedInt32IfRepresentable(CborReader reader)
+    {
+        ulong value = reader.ReadUInt64();
+        return value <= int.MaxValue ? (int)value : null;
+    }
+
+    private static int? ReadNegativeInt32IfRepresentable(CborReader reader)
+    {
+        ulong representation = reader.ReadCborNegativeIntegerRepresentation();
+        return representation <= int.MaxValue ? -1 - (int)representation : null;
+    }
+
+    private static int? SkipInt32Value(CborReader reader)
+    {
+        reader.SkipValue();
+        return null;
+    }
+
+    private static object? ReadModeledParameterValue(CborReader reader) => reader.PeekState() switch
+    {
+        CborReaderState.ByteString => reader.ReadByteString(),
+        CborReaderState.UnsignedInteger or CborReaderState.NegativeInteger => ReadInt32IfRepresentable(reader),
+        CborReaderState.StartMap => reader.ReadEncodedValue().ToArray(),
+        _ => SkipParameterValue(reader)
+    };
+
+    private static object? SkipParameterValue(CborReader reader)
+    {
+        reader.SkipValue();
+        return null;
     }
 
     private static CoseEc2Key DecodeEc2(Dictionary<int, object?> parameters, CoseAlgorithm algorithm)

--- a/src/Fido2/src/CredentialManagement/CredentialManagementModels.cs
+++ b/src/Fido2/src/CredentialManagement/CredentialManagementModels.cs
@@ -23,6 +23,11 @@ namespace Yubico.YubiKit.Fido2.CredentialManagement;
 public sealed class CredentialMetadata
 {
     /// <summary>
+    /// Gets the complete original CBOR-encoded authenticator response.
+    /// </summary>
+    public ReadOnlyMemory<byte> RawData { get; }
+
+    /// <summary>
     /// Gets the number of existing discoverable credentials on the authenticator.
     /// </summary>
     public int ExistingResidentCredentialsCount { get; }
@@ -32,8 +37,9 @@ public sealed class CredentialMetadata
     /// </summary>
     public int MaxPossibleRemainingResidentCredentialsCount { get; }
 
-    private CredentialMetadata(int existingCount, int maxRemaining)
+    private CredentialMetadata(ReadOnlyMemory<byte> rawData, int existingCount, int maxRemaining)
     {
+        RawData = rawData;
         ExistingResidentCredentialsCount = existingCount;
         MaxPossibleRemainingResidentCredentialsCount = maxRemaining;
     }
@@ -45,7 +51,8 @@ public sealed class CredentialMetadata
     /// <returns>The decoded credential metadata.</returns>
     public static CredentialMetadata Decode(ReadOnlyMemory<byte> data)
     {
-        var reader = new CborReader(data, CborConformanceMode.Ctap2Canonical);
+        ReadOnlyMemory<byte> rawData = data.ToArray();
+        var reader = new CborReader(rawData, CborConformanceMode.Ctap2Canonical);
 
         var existingCount = 0;
         var maxRemaining = 0;
@@ -69,7 +76,7 @@ public sealed class CredentialMetadata
         }
         reader.ReadEndMap();
 
-        return new CredentialMetadata(existingCount, maxRemaining);
+        return new CredentialMetadata(rawData, existingCount, maxRemaining);
     }
 }
 
@@ -78,6 +85,11 @@ public sealed class CredentialMetadata
 /// </summary>
 public sealed class RelyingPartyInfo
 {
+    /// <summary>
+    /// Gets the complete original CBOR-encoded authenticator response.
+    /// </summary>
+    public ReadOnlyMemory<byte> RawData { get; }
+
     /// <summary>
     /// Gets the relying party entity information.
     /// </summary>
@@ -93,8 +105,13 @@ public sealed class RelyingPartyInfo
     /// </summary>
     public int? TotalRpCount { get; }
 
-    private RelyingPartyInfo(PublicKeyCredentialRpEntity rp, ReadOnlyMemory<byte> rpIdHash, int? totalRpCount)
+    private RelyingPartyInfo(
+        ReadOnlyMemory<byte> rawData,
+        PublicKeyCredentialRpEntity rp,
+        ReadOnlyMemory<byte> rpIdHash,
+        int? totalRpCount)
     {
+        RawData = rawData;
         RelyingParty = rp;
         RpIdHash = rpIdHash;
         TotalRpCount = totalRpCount;
@@ -107,7 +124,8 @@ public sealed class RelyingPartyInfo
     /// <returns>The decoded relying party info.</returns>
     public static RelyingPartyInfo Decode(ReadOnlyMemory<byte> data)
     {
-        var reader = new CborReader(data, CborConformanceMode.Ctap2Canonical);
+        ReadOnlyMemory<byte> rawData = data.ToArray();
+        var reader = new CborReader(rawData, CborConformanceMode.Ctap2Canonical);
 
         PublicKeyCredentialRpEntity? rp = null;
         byte[]? rpIdHash = null;
@@ -140,7 +158,7 @@ public sealed class RelyingPartyInfo
             throw new InvalidOperationException("Invalid RP info response: missing required fields.");
         }
 
-        return new RelyingPartyInfo(rp, rpIdHash, totalRpCount);
+        return new RelyingPartyInfo(rawData, rp, rpIdHash, totalRpCount);
     }
 
     private static PublicKeyCredentialRpEntity DecodeRpEntity(CborReader reader)

--- a/src/Fido2/src/Credentials/MakeCredentialResponse.cs
+++ b/src/Fido2/src/Credentials/MakeCredentialResponse.cs
@@ -122,15 +122,19 @@ public sealed class MakeCredentialResponse
     /// </summary>
     /// <param name="reader">The CBOR reader.</param>
     /// <returns>The parsed response.</returns>
-    public static MakeCredentialResponse Decode(CborReader reader) =>
-        DecodeInternal(reader, fullCbor: null);
+    /// <remarks>The returned response may reference the reader's underlying buffer.</remarks>
+    public static MakeCredentialResponse Decode(CborReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+        return Decode(reader.ReadEncodedValue(disableConformanceModeChecks: true));
+    }
 
     /// <summary>
-    /// Internal decoder that optionally captures raw CBOR for attestation statement.
+    /// Core decoder for the owned response bytes.
     /// </summary>
     private static MakeCredentialResponse DecodeInternal(
         CborReader reader,
-        ReadOnlyMemory<byte>? fullCbor)
+        ReadOnlyMemory<byte> fullCbor)
     {
         var mapLength = reader.ReadStartMap();
 
@@ -173,9 +177,7 @@ public sealed class MakeCredentialResponse
                     // Calculate how many bytes were consumed
                     var attStmtBytesConsumed = attStmtBytesBefore - reader.BytesRemaining;
                     attStmtLength = attStmtBytesConsumed;
-                    attStmtOffset = fullCbor.HasValue
-                        ? fullCbor.Value.Length - attStmtBytesBefore
-                        : -1;
+                    attStmtOffset = fullCbor.Length - attStmtBytesBefore;
                     break;
                 case 4: // epAtt
                     epAtt = reader.ReadBoolean();
@@ -195,12 +197,8 @@ public sealed class MakeCredentialResponse
                         reader.SkipValue();
                         int bytesConsumed = bytesRemainingBefore - reader.BytesRemaining;
 
-                        // Extract the value from fullCbor if available
-                        if (fullCbor.HasValue)
-                        {
-                            int valueOffset = fullCbor.Value.Length - bytesRemainingBefore;
-                            unsignedExtensionOutputs[extId] = fullCbor.Value.Slice(valueOffset, bytesConsumed);
-                        }
+                        int valueOffset = fullCbor.Length - bytesRemainingBefore;
+                        unsignedExtensionOutputs[extId] = fullCbor.Slice(valueOffset, bytesConsumed);
                     }
                     reader.ReadEndMap();
                     break;
@@ -218,15 +216,15 @@ public sealed class MakeCredentialResponse
         }
 
         // Decode attestation statement using the format-aware typed decoder
-        if (fullCbor.HasValue && attStmtOffset >= 0 && attStmtLength > 0)
+        if (attStmtOffset >= 0 && attStmtLength > 0)
         {
-            var rawAttStmt = fullCbor.Value.Slice(attStmtOffset, attStmtLength);
+            var rawAttStmt = fullCbor.Slice(attStmtOffset, attStmtLength);
             var attestationFormat = ParseAttestationFormat(format);
             attStmt = AttestationStatement.Decode(attestationFormat, rawAttStmt);
         }
         else
         {
-            throw new InvalidOperationException("AttestationStatement decoding requires fullCbor parameter.");
+            throw new InvalidOperationException("MakeCredential response missing attestation statement.");
         }
 
         return new MakeCredentialResponse(

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/AuthenticatorInfoTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/AuthenticatorInfoTests.cs
@@ -87,7 +87,7 @@ public class AuthenticatorInfoTests
     }
 
     [Fact]
-    public void Decode_WithUnknownBooleanOptionAndUnknownTopLevelKey_ParsesKnownFieldsAndPreservesRawCbor()
+    public void Decode_WithUnknownBooleanOptionAndUnknownTopLevelKey_ParsesKnownFieldsAndPreservesRawData()
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
         writer.WriteStartMap(3);
@@ -109,7 +109,7 @@ public class AuthenticatorInfoTests
         writer.WriteEndMap();
         writer.WriteEndMap();
         byte[] data = writer.Encode();
-        byte[] expectedRawCbor = data.ToArray();
+        byte[] expectedRawData = data.ToArray();
 
         var info = AuthenticatorInfo.Decode(data);
         data[0] = 0;
@@ -118,7 +118,7 @@ public class AuthenticatorInfoTests
         info.Options.Should().HaveCount(2);
         info.Options["rk"].Should().BeTrue();
         info.Options["vendor"].Should().BeFalse();
-        info.RawCbor.ToArray().Should().Equal(expectedRawCbor);
+        info.RawData.ToArray().Should().Equal(expectedRawData);
     }
 
     [Fact]

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/AuthenticatorInfoTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/AuthenticatorInfoTests.cs
@@ -87,6 +87,56 @@ public class AuthenticatorInfoTests
     }
 
     [Fact]
+    public void Decode_WithUnknownBooleanOptionAndUnknownTopLevelKey_ParsesKnownFieldsAndPreservesRawCbor()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(3);
+        writer.WriteInt32(0x01);
+        writer.WriteStartArray(1);
+        writer.WriteTextString("FIDO_2_1");
+        writer.WriteEndArray();
+        writer.WriteInt32(0x04);
+        writer.WriteStartMap(2);
+        writer.WriteTextString("rk");
+        writer.WriteBoolean(true);
+        writer.WriteTextString("vendor");
+        writer.WriteBoolean(false);
+        writer.WriteEndMap();
+        writer.WriteInt32(0x7F);
+        writer.WriteStartMap(1);
+        writer.WriteTextString("future");
+        writer.WriteBoolean(true);
+        writer.WriteEndMap();
+        writer.WriteEndMap();
+        byte[] data = writer.Encode();
+        byte[] expectedRawCbor = data.ToArray();
+
+        var info = AuthenticatorInfo.Decode(data);
+        data[0] = 0;
+
+        info.Versions.Should().ContainSingle().Which.Should().Be("FIDO_2_1");
+        info.Options.Should().HaveCount(2);
+        info.Options["rk"].Should().BeTrue();
+        info.Options["vendor"].Should().BeFalse();
+        info.RawCbor.ToArray().Should().Equal(expectedRawCbor);
+    }
+
+    [Fact]
+    public void Decode_WithNonBooleanOption_Throws()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(1);
+        writer.WriteInt32(0x04);
+        writer.WriteStartMap(1);
+        writer.WriteTextString("rk");
+        writer.WriteInt32(1);
+        writer.WriteEndMap();
+        writer.WriteEndMap();
+
+        Assert.Throws<InvalidOperationException>(() => AuthenticatorInfo.Decode(writer.Encode()));
+    }
+
+    [Fact]
     public void Decode_WithMaxMsgSize_ParsesInteger()
     {
         // Arrange

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/BioEnrollment/BioEnrollmentModelsTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/BioEnrollment/BioEnrollmentModelsTests.cs
@@ -104,40 +104,50 @@ public class BioEnrollmentModelsTests
         writer.WriteInt32(100); // Another unknown key
         writer.WriteInt32(42);
         writer.WriteEndMap();
-        var cbor = writer.Encode();
+        byte[] cbor = writer.Encode();
+        byte[] expectedRawData = cbor.ToArray();
 
         // Act
         var info = FingerprintSensorInfo.Decode(cbor);
+        cbor.AsSpan().Clear();
 
         // Assert
         Assert.Equal(FingerprintKind.Touch, info.FingerprintKind);
         Assert.Equal(5, info.MaxCaptureSamplesRequiredForEnroll);
+        Assert.Equal(expectedRawData, info.RawData.ToArray());
     }
 
     [Fact]
-    public void EnrollmentSampleResult_Decode_ParsesFirstSample()
+    public void EnrollmentSampleResult_Decode_WithUnknownField_PreservesOwnedRawData()
     {
         // Arrange - CBOR response from enrollBegin
         var templateId = new byte[] { 0x01, 0x02, 0x03, 0x04 };
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
-        writer.WriteStartMap(3);
+        writer.WriteStartMap(4);
         writer.WriteInt32(4); // templateId key
         writer.WriteByteString(templateId);
         writer.WriteInt32(5); // lastEnrollSampleStatus key
         writer.WriteInt32(0); // Good
         writer.WriteInt32(6); // remainingSamples key
         writer.WriteInt32(4);
+        writer.WriteInt32(99);
+        writer.WriteStartArray(1);
+        writer.WriteBoolean(true);
+        writer.WriteEndArray();
         writer.WriteEndMap();
-        var cbor = writer.Encode();
+        byte[] cbor = writer.Encode();
+        byte[] expectedRawData = cbor.ToArray();
 
         // Act
         var result = EnrollmentSampleResult.Decode(cbor);
+        cbor.AsSpan().Clear();
 
         // Assert
         Assert.Equal(templateId, result.TemplateId.ToArray());
         Assert.Equal(FingerprintSampleStatus.Good, result.LastSampleStatus);
         Assert.Equal(4, result.RemainingSamples);
         Assert.False(result.IsComplete);
+        Assert.Equal(expectedRawData, result.RawData.ToArray());
     }
 
     [Fact]

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseArkgP256SeedKeyTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseArkgP256SeedKeyTests.cs
@@ -226,4 +226,24 @@ public class CoseArkgP256SeedKeyTests
         // Assert - should dispatch to CoseEc2Key, not CoseArkgP256SeedKey
         Assert.IsType<CoseEc2Key>(decoded);
     }
+
+    [Fact]
+    public void Decode_WithArkgAlgorithmAndNonEc2KeyType_UsesArkgVariant()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(5);
+        writer.WriteInt32(-3);
+        writer.WriteInt32(-9);
+        writer.WriteInt32(-2);
+        writer.WriteByteString(BuildNestedEc2Key(TestKemX, TestKemY));
+        writer.WriteInt32(-1);
+        writer.WriteByteString(BuildNestedEc2Key(TestBlX, TestBlY));
+        writer.WriteInt32(1);
+        writer.WriteInt32(99);
+        writer.WriteInt32(3);
+        writer.WriteInt32(-65700);
+        writer.WriteEndMap();
+
+        Assert.IsType<CoseArkgP256SeedKey>(CoseKey.Decode(writer.Encode()));
+    }
 }

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseKeyForwardCompatibilityTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseKeyForwardCompatibilityTests.cs
@@ -1,0 +1,184 @@
+// Copyright 2026 Yubico AB
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Formats.Cbor;
+using Yubico.YubiKit.Fido2.Cose;
+
+namespace Yubico.YubiKit.Fido2.UnitTests.Cose;
+
+public class CoseKeyForwardCompatibilityTests
+{
+    [Fact]
+    public void Decode_UnknownKeyTypeWithArrayParameter_ReturnsOtherKeyWithRawCbor()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(3);
+        writer.WriteInt32(-1);
+        writer.WriteStartArray(2);
+        writer.WriteInt32(1);
+        writer.WriteTextString("vendor");
+        writer.WriteEndArray();
+        writer.WriteInt32(1);
+        writer.WriteInt32(99);
+        writer.WriteInt32(3);
+        writer.WriteInt32(-70000);
+        writer.WriteEndMap();
+        byte[] encoded = writer.Encode();
+
+        var key = Assert.IsType<CoseOtherKey>(CoseKey.Decode(encoded));
+
+        Assert.Equal(99, key.KeyType);
+        Assert.Equal(-70000, key.Algorithm.Value);
+        Assert.Equal(encoded, key.RawCbor.ToArray());
+    }
+
+    [Fact]
+    public void Decode_UnknownAlgorithmOnEc2Key_ReturnsEc2Key()
+    {
+        byte[] encoded = EncodeEc2Key(algorithm: -70000, curve: 1);
+
+        var key = Assert.IsType<CoseEc2Key>(CoseKey.Decode(encoded));
+
+        Assert.Equal(-70000, key.Algorithm.Value);
+    }
+
+    [Fact]
+    public void Decode_UnknownCurveOnEc2Key_ReturnsEc2Key()
+    {
+        byte[] encoded = EncodeEc2Key(algorithm: -7, curve: 99);
+
+        var key = Assert.IsType<CoseEc2Key>(CoseKey.Decode(encoded));
+
+        Assert.Equal(99, key.Curve);
+    }
+
+    [Fact]
+    public void Decode_Ec2KeyWithExtraArrayParameter_ReturnsEc2Key()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(6);
+        writer.WriteInt32(-4);
+        writer.WriteStartArray(2);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteEndArray();
+        WriteEc2Parameters(writer, algorithm: -7, curve: 1);
+        writer.WriteEndMap();
+
+        Assert.IsType<CoseEc2Key>(CoseKey.Decode(writer.Encode()));
+    }
+
+    [Fact]
+    public void Decode_Ec2KeyWithTextStringLabel_ReturnsEc2Key()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(6);
+        WriteEc2Parameters(writer, algorithm: -7, curve: 1);
+        writer.WriteTextString("vendor");
+        writer.WriteStartMap(1);
+        writer.WriteTextString("version");
+        writer.WriteInt32(1);
+        writer.WriteEndMap();
+        writer.WriteEndMap();
+
+        Assert.IsType<CoseEc2Key>(CoseKey.Decode(writer.Encode()));
+    }
+
+    [Fact]
+    public void Decode_Ec2KeyWithWideIntegerLabels_ReturnsEc2Key()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(8);
+        writer.WriteCborNegativeIntegerRepresentation(ulong.MaxValue);
+        writer.WriteBoolean(true);
+        writer.WriteInt64(long.MinValue);
+        writer.WriteTextString("future-negative");
+        WriteEc2Parameters(writer, algorithm: -7, curve: 1);
+        writer.WriteUInt64(ulong.MaxValue);
+        writer.WriteStartArray(1);
+        writer.WriteTextString("future");
+        writer.WriteEndArray();
+        writer.WriteEndMap();
+
+        Assert.IsType<CoseEc2Key>(CoseKey.Decode(writer.Encode()));
+    }
+
+    [Fact]
+    public void Decode_MalformedCbor_Throws()
+    {
+        byte[] malformed = [0xA2, 0x01, 0x02, 0x03];
+
+        Assert.Throws<CborContentException>(() => CoseKey.Decode(malformed));
+    }
+
+    [Fact]
+    public void Decode_MissingKeyTypeOrAlgorithm_Throws()
+    {
+        var missingKeyType = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        missingKeyType.WriteStartMap(1);
+        missingKeyType.WriteInt32(3);
+        missingKeyType.WriteInt32(-7);
+        missingKeyType.WriteEndMap();
+
+        var missingAlgorithm = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        missingAlgorithm.WriteStartMap(1);
+        missingAlgorithm.WriteInt32(1);
+        missingAlgorithm.WriteInt32(2);
+        missingAlgorithm.WriteEndMap();
+
+        Assert.Throws<InvalidOperationException>(() => CoseKey.Decode(missingKeyType.Encode()));
+        Assert.Throws<InvalidOperationException>(() => CoseKey.Decode(missingAlgorithm.Encode()));
+    }
+
+    [Fact]
+    public void Decode_Ec2KeyMissingRequiredCoordinate_Throws()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(4);
+        writer.WriteInt32(-2);
+        writer.WriteByteString(new byte[32]);
+        writer.WriteInt32(-1);
+        writer.WriteInt32(1);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteInt32(3);
+        writer.WriteInt32(-7);
+        writer.WriteEndMap();
+
+        Assert.Throws<InvalidOperationException>(() => CoseKey.Decode(writer.Encode()));
+    }
+
+    private static byte[] EncodeEc2Key(int algorithm, int curve)
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(5);
+        WriteEc2Parameters(writer, algorithm, curve);
+        writer.WriteEndMap();
+        return writer.Encode();
+    }
+
+    private static void WriteEc2Parameters(CborWriter writer, int algorithm, int curve)
+    {
+        writer.WriteInt32(-3);
+        writer.WriteByteString(new byte[32]);
+        writer.WriteInt32(-2);
+        writer.WriteByteString(new byte[32]);
+        writer.WriteInt32(-1);
+        writer.WriteInt32(curve);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteInt32(3);
+        writer.WriteInt32(algorithm);
+    }
+}

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseKeyForwardCompatibilityTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Cose/CoseKeyForwardCompatibilityTests.cs
@@ -142,6 +142,34 @@ public class CoseKeyForwardCompatibilityTests
     }
 
     [Fact]
+    public void Decode_NonIntegerAlgorithm_Throws()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(2);
+        writer.WriteInt32(1);
+        writer.WriteInt32(2);
+        writer.WriteInt32(3);
+        writer.WriteTextString("ES256");
+        writer.WriteEndMap();
+
+        Assert.Throws<InvalidOperationException>(() => CoseKey.Decode(writer.Encode()));
+    }
+
+    [Fact]
+    public void Decode_KeyTypeOutsideInt32_Throws()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(2);
+        writer.WriteInt32(1);
+        writer.WriteUInt64((ulong)int.MaxValue + 1);
+        writer.WriteInt32(3);
+        writer.WriteInt32(-7);
+        writer.WriteEndMap();
+
+        Assert.Throws<InvalidOperationException>(() => CoseKey.Decode(writer.Encode()));
+    }
+
+    [Fact]
     public void Decode_Ec2KeyMissingRequiredCoordinate_Throws()
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/CredentialManagement/CredentialManagementModelsTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/CredentialManagement/CredentialManagementModelsTests.cs
@@ -46,6 +46,29 @@ public class CredentialManagementModelsTests
     }
 
     [Fact]
+    public void CredentialMetadata_Decode_PreservesRawData()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(3);
+        writer.WriteInt32(1);
+        writer.WriteInt32(5);
+        writer.WriteInt32(2);
+        writer.WriteInt32(20);
+        writer.WriteInt32(99);
+        writer.WriteTextString("future");
+        writer.WriteEndMap();
+        byte[] data = writer.Encode();
+        byte[] expected = data.ToArray();
+
+        var metadata = CredentialMetadata.Decode(data);
+        data[0] = 0;
+
+        Assert.Equal(5, metadata.ExistingResidentCredentialsCount);
+        Assert.Equal(20, metadata.MaxPossibleRemainingResidentCredentialsCount);
+        Assert.Equal(expected, metadata.RawData.ToArray());
+    }
+
+    [Fact]
     public void CredentialMetadata_Decode_HandlesZeroCounts()
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
@@ -125,6 +148,32 @@ public class CredentialManagementModelsTests
         Assert.Equal("test.org", rpInfo.RelyingParty.Id);
         Assert.Null(rpInfo.RelyingParty.Name);
         Assert.Null(rpInfo.TotalRpCount);
+    }
+
+    [Fact]
+    public void RelyingPartyInfo_Decode_PreservesRawData()
+    {
+        var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
+        writer.WriteStartMap(3);
+        writer.WriteInt32(3);
+        writer.WriteStartMap(1);
+        writer.WriteTextString("id");
+        writer.WriteTextString("example.com");
+        writer.WriteEndMap();
+        writer.WriteInt32(4);
+        writer.WriteByteString(new byte[32]);
+        writer.WriteInt32(99);
+        writer.WriteBoolean(true);
+        writer.WriteEndMap();
+        byte[] data = writer.Encode();
+        byte[] expected = data.ToArray();
+
+        var info = RelyingPartyInfo.Decode(data);
+        data[0] = 0;
+
+        Assert.Equal("example.com", info.RelyingParty.Id);
+        Assert.Equal(32, info.RpIdHash.Length);
+        Assert.Equal(expected, info.RawData.ToArray());
     }
 
     [Fact]
@@ -404,4 +453,5 @@ public class CredentialManagementModelsTests
         Assert.Null(credInfo.LargeBlobKey);
         Assert.Null(credInfo.ThirdPartyPayment);
     }
+
 }

--- a/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Credentials/CredentialResponseTests.cs
+++ b/src/Fido2/tests/Yubico.YubiKit.Fido2.UnitTests/Credentials/CredentialResponseTests.cs
@@ -26,11 +26,11 @@ public class CredentialResponseTests
     /// <summary>
     /// Creates a minimal MakeCredential CBOR response for testing.
     /// </summary>
-    private static byte[] CreateMakeCredentialResponse(string format = "none")
+    private static byte[] CreateMakeCredentialResponse(string format = "none", bool includeUnknown = false)
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
 
-        writer.WriteStartMap(3);
+        writer.WriteStartMap(includeUnknown ? 4 : 3);
 
         // 0x01: fmt
         writer.WriteInt32(1);
@@ -58,6 +58,12 @@ public class CredentialResponseTests
             // "none" format has empty attStmt per CTAP 2.1 §8.7.
             writer.WriteStartMap(0);
             writer.WriteEndMap();
+        }
+
+        if (includeUnknown)
+        {
+            writer.WriteInt32(99);
+            writer.WriteTextString("future");
         }
 
         writer.WriteEndMap();
@@ -125,13 +131,17 @@ public class CredentialResponseTests
     /// <summary>
     /// Creates a minimal GetAssertion CBOR response for testing.
     /// </summary>
-    private static byte[] CreateGetAssertionResponse(bool includeCredential = false, bool includeUser = false)
+    private static byte[] CreateGetAssertionResponse(
+        bool includeCredential = false,
+        bool includeUser = false,
+        bool includeUnknown = false)
     {
         var writer = new CborWriter(CborConformanceMode.Ctap2Canonical);
 
         var mapCount = 2; // authData + signature
         if (includeCredential) mapCount++;
         if (includeUser) mapCount++;
+        if (includeUnknown) mapCount++;
 
         writer.WriteStartMap(mapCount);
 
@@ -170,6 +180,14 @@ public class CredentialResponseTests
             writer.WriteEndMap();
         }
 
+        if (includeUnknown)
+        {
+            writer.WriteInt32(99);
+            writer.WriteStartArray(1);
+            writer.WriteTextString("future");
+            writer.WriteEndArray();
+        }
+
         writer.WriteEndMap();
 
         return writer.Encode();
@@ -195,6 +213,37 @@ public class CredentialResponseTests
         var response = MakeCredentialResponse.Decode(cbor);
 
         Assert.Equal("packed", response.Format);
+    }
+
+    [Fact]
+    public void MakeCredentialResponse_Decode_IgnoresUnknownField()
+    {
+        byte[] cbor = CreateMakeCredentialResponse(includeUnknown: true);
+        var response = MakeCredentialResponse.Decode(cbor);
+
+        Assert.Equal("none", response.Format);
+        Assert.True(response.AuthenticatorData.UserPresent);
+    }
+
+    [Fact]
+    public void MakeCredentialResponse_DecodeFromReader_ParsesOneValue()
+    {
+        byte[] cbor = CreateMakeCredentialResponse("packed", includeUnknown: true);
+        var writer = new CborWriter(CborConformanceMode.Lax, convertIndefiniteLengthEncodings: false, allowMultipleRootLevelValues: true);
+        writer.WriteBoolean(true);
+        writer.WriteEncodedValue(cbor);
+        var reader = new CborReader(
+            writer.Encode(),
+            CborConformanceMode.Ctap2Canonical,
+            allowMultipleRootLevelValues: true);
+        Assert.True(reader.ReadBoolean());
+
+        var response = MakeCredentialResponse.Decode(reader);
+
+        Assert.Equal("packed", response.Format);
+        Assert.Equal([0xA2, 0x63, 0x61, 0x6C, 0x67, 0x26, 0x63, 0x73, 0x69, 0x67, 0x42, 0x30, 0x44],
+            response.AttestationStatement.RawCbor.ToArray());
+        Assert.Equal(CborReaderState.Finished, reader.PeekState());
     }
 
     [Fact]
@@ -259,6 +308,16 @@ public class CredentialResponseTests
         var response = GetAssertionResponse.Decode(cbor);
 
         Assert.False(response.Signature.IsEmpty);
+    }
+
+    [Fact]
+    public void GetAssertionResponse_Decode_IgnoresUnknownField()
+    {
+        byte[] cbor = CreateGetAssertionResponse(includeUnknown: true);
+        var response = GetAssertionResponse.Decode(cbor);
+
+        Assert.True(response.AuthenticatorData.UserPresent);
+        Assert.Equal([0x30, 0x44], response.Signature.ToArray());
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- tolerate valid but unmodeled COSE key labels, parameter shapes, algorithms, curves, and key types while preserving raw bytes for unsupported key types
- expose complete owned `RawData` on non-secret response owners: `AuthenticatorInfo`, `CredentialMetadata`, `RelyingPartyInfo`, `FingerprintSensorInfo`, and `EnrollmentSampleResult`
- fix `MakeCredentialResponse.Decode(CborReader)` so it captures exactly one CBOR value and no longer always throws
- document an SDK-wide forward-compatibility doctrine and the FIDO2/WebAuthn escape hatches

## Design boundary

Valid device response data that the SDK does not yet model must not block callers. Malformed CBOR, missing required fields, structurally incomplete modeled keys, and security-critical PIN/UV key agreement remain strict. Unknown response fields are not blindly re-emitted in requests.

`RawData` means an owned copy of a complete non-secret response envelope. `RawCbor` remains the name for encoded nested CBOR structures such as attestation statements and unsupported COSE keys, which may be slices of a parent buffer. We do not add another retained whole-envelope copy to responses containing key material such as `largeBlobKey`; callers needing those raw ceremony responses can use `IFidoSession.SendCborRequestAsync`.

GetInfo option values remain strict Booleans because CTAP defines that shape; unknown Boolean option names remain accepted.

## Audit scope

The FIDO2 applet response surface was audited in parallel across session/PIN/config, credentials/credential management/COSE, and extensions/bio/large blobs. Canonical Rust yubikit, python-fido2, and libfido2 were consulted for biometric wire behavior. That comparison found a pre-existing bio-enrollment mismatch (enumeration should decode top-level key 7 as an array of nested template maps with keys 1/2); it is deliberately deferred rather than folded into this forward-compatibility PR.

## Verification

- `dotnet toolchain.cs -- test --project Fido2` (447 passed)
- `dotnet toolchain.cs -- test --project WebAuthn` (182 passed)
- scoped `dotnet format ... --include ... --verify-no-changes`
- `git diff --check`

No integration or user-presence tests were run; these changes are covered by unit tests and did not contend for shared YubiKeys.

## Review

Completed multiple cross-vendor Engineer/Reviewer loops. Review feedback restored strict non-Boolean GetInfo handling, reduced COSE decoding CRAP from 16.01 to 1, narrowed raw response ownership to avoid duplicate retained key material, and strengthened the CBOR-reader overload test with a packed attestation at a non-zero root offset.