### PR TITLE
docs: consolidate dotnet format guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,7 +30,7 @@ This codebase uses a mix of xUnit v2 and xUnit v3 test projects that require dif
 - Modern C# 14 patterns (see `CLAUDE.md`)
 - Memory management with `Span<T>`, `Memory<T>`, `ArrayPool<T>`
 - Security: zero sensitive data, use `CryptographicOperations.ZeroMemory()`
-- EditorConfig compliance: scope `dotnet format` to staged files via `--include` before commit (never the whole solution) — see `CLAUDE.md` Pre-Commit Checklist
+- EditorConfig compliance: follow the root `CLAUDE.md` Pre-Commit Checklist formatting step.
 
 ### Git Discipline
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,90 +1,15 @@
 # GitHub Copilot Instructions
 
-This file provides guidance to GitHub Copilot CLI and other LLM-based tools when working with this repository.
-
 ## Source of Truth
 
-**CRITICAL:** [`CLAUDE.md`](../CLAUDE.md) at the repository root is the canonical source of truth for all development guidelines. You MUST read and follow it.
+**CRITICAL:** Root [`CLAUDE.md`](../CLAUDE.md) is canonical for all development instructions in this repository.
 
-## Key Documentation
+## Required Context Loading
 
-| Document | Purpose |
-|----------|---------|
-| [`CLAUDE.md`](../CLAUDE.md) | Primary development guidelines (read first) |
-| [`docs/AI-DOCS-GUIDE.md`](../docs/AI-DOCS-GUIDE.md) | How to write AI documentation (skills, agents, CLAUDE.md) |
-| [`docs/TESTING.md`](../docs/TESTING.md) | Testing infrastructure and xUnit v2/v3 differences |
-| [`docs/COMMIT_GUIDELINES.md`](../docs/COMMIT_GUIDELINES.md) | Git commit discipline for agents |
-| [`BUILD.md`](../BUILD.md) | Build script usage and targets |
-| Subproject `CLAUDE.md` files | Module-specific patterns |
+- Read root `CLAUDE.md` before making changes.
+- If working in `src/<Module>/` (or module tests), also read that module's `CLAUDE.md`.
 
-## Critical Rules
+## Scope of This File
 
-### Testing
-
-**ALWAYS use `dotnet toolchain.cs test` - NEVER use `dotnet test` directly.**
-
-This codebase uses a mix of xUnit v2 and xUnit v3 test projects that require different CLI invocations. The build script handles this automatically.
-
-### Code Quality
-
-- Modern C# 14 patterns (see `CLAUDE.md`)
-- Memory management with `Span<T>`, `Memory<T>`, `ArrayPool<T>`
-- Security: zero sensitive data, use `CryptographicOperations.ZeroMemory()`
-- EditorConfig compliance: follow the root `CLAUDE.md` Pre-Commit Checklist formatting step.
-
-### Git Discipline
-
-- Main branch: `develop` (not `main`)
-- **Only commit files YOU modified** - never use `git add .`
-- Follow conventional commits: `feat:`, `fix:`, `refactor:`, etc.
-
-## Skills
-
-Project skills in `.claude/skills/`:
-
-| Skill | Purpose |
-|-------|---------|
-| `build-project` | **REQUIRED** for building/compiling .NET code |
-| `test-project` | **REQUIRED** for running tests |
-| `debug` | Structured debugging process |
-| `tdd` | TDD workflow |
-| `write-plan` | Create implementation plans |
-| `verify` | Verify work before claiming done |
-| `yubikit-compare` | Compare Java and C# implementations |
-| `experiment` | Create experiment scripts |
-| `write-skill` | **REQUIRED** before creating skill files |
-| `write-agent` | **REQUIRED** before creating agent files |
-
-### Mandatory Skills
-
-**NEVER perform these actions without invoking the corresponding skill:**
-
-| Action | Required Skill | Violation |
-|--------|----------------|-----------|
-| Building or compiling | `build-project` | NEVER use `dotnet build` directly |
-| Running tests | `test-project` | NEVER use `dotnet test` directly |
-| Creating files in `.claude/skills/` | `write-skill` | NEVER create skill files manually |
-| Creating files in `.github/agents/` | `write-agent` or `write-agent-copilot` | NEVER create agent files manually |
-| Creating files in `.claude/agents/` | `write-agent` or `write-agent-claudecode` | NEVER create agent files manually |
-
-**If you violate these rules:** Delete the files/output and start over using the correct skill.
-
-## Agents
-
-Custom agents in `.github/agents/`:
-
-| Agent | Purpose |
-|-------|---------|
-| `code-reviewer` | Review completed work against plans and standards |
-| `yubikit-porter` | Port functionality from Java YubiKit |
-
-## Subproject Context
-
-When working in a subproject directory, check for module-specific `CLAUDE.md`:
-- `Yubico.YubiKit.Core/CLAUDE.md`
-- `Yubico.YubiKit.Piv/CLAUDE.md`
-- `Yubico.YubiKit.Fido2/CLAUDE.md`
-- `Yubico.YubiKit.SecurityDomain/CLAUDE.md`
-- `Yubico.YubiKit.Management/CLAUDE.md`
-
-These contain patterns, test infrastructure, and module-specific context.
+- This entry point is intentionally minimal and routes to canonical `CLAUDE.md`.
+- Do not duplicate policy here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
 - Never run a whole `Category=RequiresUserPresence` lane as one blocking command: it blocks for minutes, and aborting mid-ceremony leaves the authenticator holding a user-presence request that wedges the key until it is re-plugged. One narrowly filtered test per invocation, with the human ready.
 - Use `dotnet toolchain.cs -- --help` when arguments act strangely; every script long option, including `--project`, requires the preceding `--` separator.
 - CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.2`.
-- Scope `dotnet format` to your staged files via `--include`, never the whole solution — see `CLAUDE.md` Pre-Commit Checklist for the exact command.
+- Follow root `CLAUDE.md` Pre-Commit Checklist for the scoped `dotnet format` workflow.
 
 ## Project Shape
 - Modules live under `src/` with directory names stripped of the `Yubico.YubiKit.` prefix; assembly, namespace, and package names keep the prefix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,65 +1,11 @@
 # AGENTS.md
 
-## First Reads
-- Root `CLAUDE.md` is the canonical detailed agent guide; this file is only the compact OpenCode ramp-up sheet.
-- If touching `src/<Module>/`, read that module's `CLAUDE.md` first when present. Tests subfolders may also have their own `CLAUDE.md`.
-- Prefer executable truth over prose: `toolchain.cs`, `Directory.Build.props`, `Directory.Packages.props`, `.github/workflows/build.yml`, and test `.csproj` files settle command and runner questions.
+## Source of Truth
 
-## Toolchain Commands
-- Use .NET 10 SDK. The repo defaults to `net10.0`, C# 14, nullable enabled, central package management, and warnings-as-errors for non-test projects.
-- Do not run `dotnet build` directly. Use `dotnet toolchain.cs build` or `dotnet toolchain.cs -- build --project Piv`.
-- Do not run `dotnet test` directly. Unit tests mix xUnit v3/Microsoft Testing Platform and xUnit v2; `dotnet toolchain.cs test` detects and invokes the right runner.
-- Focus tests with both module and filter when possible: `dotnet toolchain.cs -- test --project Fido2 --filter "Method~Sign"`. The toolchain normalises `Method~`/`Name~` to `FullyQualifiedName~` for the xUnit v2 integration projects, which have no `Method` property; use `FullyQualifiedName~` directly if you want to be explicit.
-- A filter matching zero tests fails the target (`No tests matched the specified filter`). Do not judge a run by the closing `Passed: N | ... | Total: N` line — that counts **projects**, not tests. Read the per-project `total:` figure.
-- When touching Core runtime loops, polling paths, recovery logic, or listener lifecycle cleanup, also run `dotnet toolchain.cs -- resilience --fast`.
-- `--integration` requires `--project`: `dotnet toolchain.cs -- test --integration --project Piv --smoke`.
-- `--smoke` skips `Slow` and `RequiresUserPresence`; agents should not run touch/insert/remove tests unless a human explicitly coordinates hardware. It can thin coverage sharply — on WebAuthn it leaves a single SmartCard test — so check `total:` before calling a smoke pass validation.
-- Never run a whole `Category=RequiresUserPresence` lane as one blocking command: it blocks for minutes, and aborting mid-ceremony leaves the authenticator holding a user-presence request that wedges the key until it is re-plugged. One narrowly filtered test per invocation, with the human ready.
-- Use `dotnet toolchain.cs -- --help` when arguments act strangely; every script long option, including `--project`, requires the preceding `--` separator.
-- CI runs `dotnet toolchain.cs build`, `dotnet toolchain.cs test`, then `dotnet toolchain.cs -- pack --package-version 2.0.0-alpha.2`.
-- Follow root `CLAUDE.md` Pre-Commit Checklist for the scoped `dotnet format` workflow.
+- Root [`CLAUDE.md`](./CLAUDE.md) is canonical for all agent behavior, commands, and guardrails.
+- If working in `src/<Module>/` (or module tests), read that module's `CLAUDE.md` after root `CLAUDE.md`.
 
-## Project Shape
-- Modules live under `src/` with directory names stripped of the `Yubico.YubiKit.` prefix; assembly, namespace, and package names keep the prefix.
-- `Core` owns device discovery, connection abstractions, APDU processing, SCP support, platform interop, crypto utilities, and TLV utilities.
-- App modules are `Management`, `Piv`, `Fido2`, `WebAuthn`, `Oath`, `YubiOtp`, `OpenPgp`, `SecurityDomain`, and `YubiHsm`.
-- `WebAuthn` is a higher-level surface over `Fido2`; do not duplicate CTAP/FIDO behavior there.
-- Broad exploration shortcut: run `codemapper .` to generate gitignored API maps in `codebase_ast/`.
-- Core device discovery uses the static `YubiKeyManager`; no Core DI registration is required.
+## Scope of This File
 
-## Architecture Gotchas
-- APDU flow is a decorator pipeline: command chaining, short/extended APDU formatting, `ISmartCardConnection.TransmitAsync()`, then chained response reassembly.
-- `ApplicationSession` centralizes firmware, initialization, authentication, and protocol ownership; prefer `IsSupported(...)` / `EnsureSupports(...)` over duplicating firmware gates.
-- Platform interop belongs under `src/Core/src/PlatformInterop/{Windows,MacOS,Linux,Desktop}` with safe handles and `SdkPlatformInfo` platform selection.
-- FIDO2 over USB primarily uses HID FIDO. SmartCard/CCID FIDO2 is supported over NFC and over USB when the FIDO2 AID is exposed; USB SmartCard FIDO2 requires firmware 5.8.0+.
-- `Tlv` and `DisposableTlvList` must be disposed. `TlvHelper.EncodeList` does not dispose its inputs; `EncodeAndDisposeList` does.
-- Listener/native retry loops must block, back off, exit, or throttle on every failure path; add no-hardware fault-injection tests for persistent native errors.
-
-## Hardware And Integration Tests
-- Integration tests require authorized YubiKey hardware. The shared test infrastructure reads `YubiKeyTests:AllowedSerialNumbers` from `appsettings.json`; an empty/missing allow list can hard-fail with `Environment.Exit(-1)`, and unauthorized devices are filtered out.
-- Linux hardware tests need PC/SC pieces like `pcscd`, `libpcsclite-dev`, and `libudev-dev`; CI starts `pcscd` manually before build/test.
-- `[WithYubiKey]`/`YubiKeyTestState` tests discover devices lazily at execution, not discovery. Devices must already be connected before the test runner starts.
-- Security Domain integration helpers reset the Security Domain by default before each test; pass `resetBeforeUse: false` only when preserving state is intentional.
-- PIV tests commonly need manual application reset to defaults at the start of the test unless a helper documents otherwise.
-
-## Security And Memory Rules
-- Small synchronous byte buffers: `Span<byte>` with `stackalloc` up to 512 bytes. Larger temporary buffers: `ArrayPool<byte>.Shared.Rent()` with `try/finally` return.
-- Async byte data crossing awaits should use `Memory<byte>`, `ReadOnlyMemory<byte>`, or `IMemoryOwner<byte>`, not `Span<byte>`.
-- Avoid `.ToArray()` and LINQ on byte data unless data must escape the current scope.
-- Always zero PINs, PUKs, keys, SCP material, and secret-derived buffers with `CryptographicOperations.ZeroMemory()`.
-- Classify YubiKey-returned data by semantics: device metadata/status does not need special zeroing; authentication material, token material, decrypted plaintext, and secret-derived output does.
-- Use `CryptographicOperations.FixedTimeEquals` for secret-derived comparisons; do not use `SequenceEqual` on secrets.
-- Never store a privately cloned sensitive `byte[]` in a struct; struct copies keep references you cannot reliably zero. Use a sealed disposable class for owned sensitive buffers.
-- Logging is static via `YubiKitLogging.CreateLogger<T>()`; do not add SDK constructors that require `ILogger`/`ILoggerFactory`.
-- Never log PINs, keys, credentials, challenge/response secrets, or sensitive payloads. Log lengths, algorithm IDs, status, and non-secret metadata only.
-
-## Tests Worth Writing
-- Do not add validation-only tests that just prove `ArgumentNullException.ThrowIfNull` or framework type checks work.
-- Do not add skipped placeholder tests. If behavior cannot be unit-tested, document the limitation and point to an integration path.
-- Use fake connections, queued APDU responses, and byte/vector assertions for protocol behavior; use integration tests only for real hardware behavior.
-- Runtime resilience tests should use fakes/seams and must not self-skip because PC/SC, HID, or YubiKey hardware is unavailable.
-
-## Git And Release Notes
-- The workflow file currently triggers on `yubikit` and `yubikit-applets`; verify the active plan/branch before assuming a PR base.
-- Only stage files you changed explicitly; never use `git add .`, `git add -A`, or `git commit -a`.
-- Package signing is `sign.cs` and is Windows-only because it depends on `signtool.exe`, Windows certificate store, NuGet CLI, GitHub CLI, and a signing smart card.
+- This file is intentionally minimal and only routes to canonical `CLAUDE.md`.
+- Do not duplicate operational policy here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ These are the always-loaded mandates. Each section ends with a JIT pointer to de
 > Deep dive: `docs/CSHARP-PATTERNS.md` (load when designing new types, choosing property accessors, writing switch expressions, or using primary constructors / records).
 
 **Code Quality:**
-- ✅ ALWAYS follow `.editorconfig` (run `dotnet format` scoped to your staged files before commit — see Pre-Commit Checklist, never the whole solution)
+- ✅ ALWAYS follow `.editorconfig` (see Pre-Commit Checklist for the formatting workflow)
 - ✅ ALWAYS handle `CancellationToken` in async methods
 - ✅ ALWAYS use `readonly` on fields that don't change
 - ❌ NEVER use `#region` (split large classes instead)
@@ -593,9 +593,9 @@ Full rules: `docs/COMMIT_GUIDELINES.md`. Skill: `.claude/skills/git-commit/SKILL
 3. ✅ Tests pass: `dotnet toolchain.cs test`
 4. ✅ Formatted — scope `dotnet format` to your staged files, never the whole solution:
    ```
-   dotnet format Yubico.YubiKit.sln --include $(git diff --name-only --cached -- '*.cs') --verify-no-changes
+   dotnet format Yubico.YubiKit.sln --include $(git diff --name-only --cached -- '*.cs')
    ```
-   Drop `--verify-no-changes` to actually apply fixes. Note: `--include` silently skips nonexistent/stale paths — re-run `git diff --cached --name-only` if a file seems to be missed.
+   Note: `--include` silently skips nonexistent/stale paths — re-run `git diff --cached --name-only` if a file seems to be missed.
 5. ✅ No nullable warnings
 6. ✅ Sensitive data zeroed (`ZeroMemory` / `Dispose`)
 7. ✅ No unnecessary allocations in hot paths

--- a/TOOLCHAIN.md
+++ b/TOOLCHAIN.md
@@ -140,7 +140,7 @@ clean  (standalone — must be specified explicitly)
 
 ## Analyzers and Formatting
 
-- Scope `dotnet format` to your staged files via `--include` (never the whole solution for routine work) — see `CLAUDE.md` Pre-Commit Checklist for the exact command. In CI, or when a repo-wide `.editorconfig`/analyzer rule changes, run it unscoped with `--verify-no-changes`.
+- For routine development, run scoped `dotnet format` with `--include` so formatting fixes apply directly to staged files. For repository-wide rule changes and CI enforcement workflow, follow `docs/DEV-GUIDE.md`.
 - Analyzer configuration details live in `docs/DEV-GUIDE.md`; review that guide before introducing new rules or suppressions.
 
 ## Documentation QA


### PR DESCRIPTION
## Summary
- Make root CLAUDE.md the canonical agent instruction for staged-file formatting.
- Update the pre-commit command to run scoped dotnet format --include directly (no --verify-no-changes).
- Reduce AGENTS.md and .github/copilot-instructions.md to terse references to root CLAUDE.md.
- Keep TOOLCHAIN.md independent of the root instruction chain while preserving toolchain-owned guidance.

## Why
This removes the agent round-trip caused by --verify-no-changes in routine formatting guidance and allows the formatter to apply fixes directly when scoped with --include.

## Notes
- docs/DEV-GUIDE.md remains unchanged as human-focused documentation.
