### PR TITLE
fix(webauthn): compute the PIN/UV auth parameter last so it cannot be stranded

### DIFF
--- a/src/WebAuthn/src/Client/PinUvAuthTokenSession.cs
+++ b/src/WebAuthn/src/Client/PinUvAuthTokenSession.cs
@@ -45,15 +45,6 @@ internal sealed class PinUvAuthTokenSession : IDisposable
     /// <summary>
     /// Gets the token bytes.
     /// </summary>
-    /// <remarks>
-    /// <see cref="ReadOnlyMemory{T}"/> rather than <see cref="ReadOnlySpan{T}"/> so the token can
-    /// cross an await: the exclude-list pre-flight needs it across several asynchronous probes. A
-    /// span forced that caller into a defensive <c>ToArray</c> copy, which contradicted the whole
-    /// reason this type exists - that exactly one live plaintext copy of a decrypted token should
-    /// be reachable. The trade is that a caller could hold the memory past disposal and read a
-    /// zeroed, or later reused, buffer. The type is internal and its callers all use it inside the
-    /// session's lifetime, so the copy was the worse of the two risks.
-    /// </remarks>
     /// <exception cref="ObjectDisposedException">The session has been disposed.</exception>
     public ReadOnlyMemory<byte> Token
     {

--- a/src/WebAuthn/src/Client/PinUvAuthTokenSession.cs
+++ b/src/WebAuthn/src/Client/PinUvAuthTokenSession.cs
@@ -43,10 +43,19 @@ internal sealed class PinUvAuthTokenSession : IDisposable
     public IPinUvAuthProtocol Protocol { get; }
 
     /// <summary>
-    /// Gets the token bytes as a read-only span.
+    /// Gets the token bytes.
     /// </summary>
+    /// <remarks>
+    /// <see cref="ReadOnlyMemory{T}"/> rather than <see cref="ReadOnlySpan{T}"/> so the token can
+    /// cross an await: the exclude-list pre-flight needs it across several asynchronous probes. A
+    /// span forced that caller into a defensive <c>ToArray</c> copy, which contradicted the whole
+    /// reason this type exists - that exactly one live plaintext copy of a decrypted token should
+    /// be reachable. The trade is that a caller could hold the memory past disposal and read a
+    /// zeroed, or later reused, buffer. The type is internal and its callers all use it inside the
+    /// session's lifetime, so the copy was the worse of the two risks.
+    /// </remarks>
     /// <exception cref="ObjectDisposedException">The session has been disposed.</exception>
-    public ReadOnlySpan<byte> Token
+    public ReadOnlyMemory<byte> Token
     {
         get
         {

--- a/src/WebAuthn/src/Client/WebAuthnBackend.cs
+++ b/src/WebAuthn/src/Client/WebAuthnBackend.cs
@@ -129,10 +129,11 @@ internal sealed class WebAuthnBackend : IWebAuthnBackend
         if (request.PinUvAuthParam is not null && request.PinUvAuthProtocol is not null)
         {
             // The copy is load-bearing, not defensive: the finally below zeroes whatever is in
-            // options, and callers reuse one pinUvAuthParam across several backend calls (see
-            // ExcludeListPreflight's chunk loop). Zeroing the caller's buffer here would make
-            // every call after the first send an all-zero parameter. The caller zeroes the
-            // original when it is done with it.
+            // options, and the parameter belongs to the caller, which zeroes it once the ceremony
+            // is done with it. Without the copy this method would be destroying a buffer it does
+            // not own. Unlike GetAssertionAsync there is no multi-call reuse to protect here -
+            // registration builds a fresh request per attempt and sends it once - so ownership,
+            // not reuse, is what makes the copy necessary.
             options.PinUvAuthParam = request.PinUvAuthParam.Value.ToArray();
             options.PinUvAuthProtocol = request.PinUvAuthProtocol.Value;
         }

--- a/src/WebAuthn/src/Client/WebAuthnClient.Authentication.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.Authentication.cs
@@ -237,20 +237,12 @@ public sealed partial class WebAuthnClient
             options.Extensions,
             options.AllowCredentials);
 
-        // Computed last, deliberately. Nothing between here and the return can throw, so the
-        // parameter cannot be stranded: the request owns it from construction, and
-        // ExecuteGetAssertionAsync's finally is what clears it. Computing it any earlier leaks the
-        // tag whenever extension building fails, because on that path the request never reaches
-        // that finally.
         ReadOnlyMemory<byte>? pinUvAuthParam = null;
         byte? pinUvAuthProtocol = null;
 
         if (tokenSession is not null)
         {
-            // Version is read first so the tag is the very last thing to come into existence.
             pinUvAuthProtocol = (byte)tokenSession.Protocol.Version;
-
-            // pinUvAuthParam = HMAC(token, clientDataHash)
             pinUvAuthParam = tokenSession.Protocol.Authenticate(tokenSession.Token.Span, clientData.Hash.Span);
         }
 

--- a/src/WebAuthn/src/Client/WebAuthnClient.Authentication.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.Authentication.cs
@@ -232,21 +232,27 @@ public sealed partial class WebAuthnClient
                 .ToList();
         }
 
-        // Build PIN/UV auth params
+        // Build extensions CBOR via pipeline
+        var extensionsCbor = ExtensionPipeline.BuildAuthenticationExtensionsCbor(
+            options.Extensions,
+            options.AllowCredentials);
+
+        // Computed last, deliberately. Nothing between here and the return can throw, so the
+        // parameter cannot be stranded: the request owns it from construction, and
+        // ExecuteGetAssertionAsync's finally is what clears it. Computing it any earlier leaks the
+        // tag whenever extension building fails, because on that path the request never reaches
+        // that finally.
         ReadOnlyMemory<byte>? pinUvAuthParam = null;
         byte? pinUvAuthProtocol = null;
 
         if (tokenSession is not null)
         {
-            // Compute pinUvAuthParam = HMAC(token, clientDataHash)
-            pinUvAuthParam = tokenSession.Protocol.Authenticate(tokenSession.Token, clientData.Hash.Span);
+            // Version is read first so the tag is the very last thing to come into existence.
             pinUvAuthProtocol = (byte)tokenSession.Protocol.Version;
-        }
 
-        // Build extensions CBOR via pipeline
-        var extensionsCbor = ExtensionPipeline.BuildAuthenticationExtensionsCbor(
-            options.Extensions,
-            options.AllowCredentials);
+            // pinUvAuthParam = HMAC(token, clientDataHash)
+            pinUvAuthParam = tokenSession.Protocol.Authenticate(tokenSession.Token.Span, clientData.Hash.Span);
+        }
 
         return new BackendGetAssertionRequest
         {

--- a/src/WebAuthn/src/Client/WebAuthnClient.Registration.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.Registration.cs
@@ -245,9 +245,6 @@ public sealed partial class WebAuthnClient
 
         try
         {
-            // The session's own memory is passed straight through: it stays live for the whole
-            // pre-flight, and taking a copy here would mean a second plaintext token to keep track
-            // of and clear.
             var matchedExclude = await Internal.ExcludeListPreflight.FindFirstMatchAsync(
                 _backend,
                 options.Rp.Id,
@@ -312,23 +309,15 @@ public sealed partial class WebAuthnClient
             ? matchedExclude is not null ? new[] { matchedExclude } : Array.Empty<PublicKeyCredentialDescriptor>()
             : options.ExcludeCredentials;
 
-        // Hoisted out of the object initializer below so that every step which can throw happens
-        // before the PIN/UV auth parameter exists.
         var pubKeyCredParams = options.PubKeyCredParams
             .Select(alg => new PublicKeyCredentialParameters { Algorithm = (CoseAlgorithmIdentifier)alg.Value })
             .ToList();
 
-        // Computed last, deliberately. Nothing between here and the return can throw, so the
-        // parameter cannot be stranded: the request owns it from construction, and
-        // ExecuteMakeCredentialAsync's finally is what clears it. Computing it any earlier leaks
-        // the tag whenever extension building or option mapping fails, because on that path the
-        // request never reaches that finally.
         ReadOnlyMemory<byte>? pinUvAuthParam = null;
         byte? pinUvAuthProtocol = null;
 
         if (tokenSession is not null)
         {
-            // Version is read first so the tag is the very last thing to come into existence.
             pinUvAuthProtocol = (byte)tokenSession.Protocol.Version;
             pinUvAuthParam = tokenSession.Protocol.Authenticate(tokenSession.Token.Span, clientData.Hash.Span);
         }

--- a/src/WebAuthn/src/Client/WebAuthnClient.Registration.cs
+++ b/src/WebAuthn/src/Client/WebAuthnClient.Registration.cs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 using System.Buffers;
-using System.Security.Cryptography;
 using Yubico.YubiKit.Core.Credentials;
 using Yubico.YubiKit.Core.Cryptography.Cose;
 using Yubico.YubiKit.Fido2;
@@ -244,16 +243,17 @@ public sealed partial class WebAuthnClient
             return (null, tokenSession, false);
         }
 
-        // ToArray() creates a copy; pre-flight needs to pass token across async boundary.
-        var tokenCopy = tokenSession.Token.ToArray();
         try
         {
+            // The session's own memory is passed straight through: it stays live for the whole
+            // pre-flight, and taking a copy here would mean a second plaintext token to keep track
+            // of and clear.
             var matchedExclude = await Internal.ExcludeListPreflight.FindFirstMatchAsync(
                 _backend,
                 options.Rp.Id,
                 options.ExcludeCredentials,
                 info,
-                tokenCopy,
+                tokenSession.Token,
                 tokenSession.Protocol,
                 cancellationToken).ConfigureAwait(false);
 
@@ -280,10 +280,6 @@ public sealed partial class WebAuthnClient
                 "This authenticator may not support silent excludeList probing.",
                 preflightEx);
         }
-        finally
-        {
-            CryptographicOperations.ZeroMemory(tokenCopy);
-        }
     }
 
     private BackendMakeCredentialRequest BuildMakeCredentialRequest(
@@ -307,17 +303,6 @@ public sealed partial class WebAuthnClient
             optionsDict["uv"] = uvDecision.UvOption.Value;
         }
 
-        // Compute PIN/UV auth parameter if we have a token
-        ReadOnlyMemory<byte>? pinUvAuthParam = null;
-        byte? pinUvAuthProtocol = null;
-
-        if (tokenSession is not null)
-        {
-            var authParam = tokenSession.Protocol.Authenticate(tokenSession.Token, clientData.Hash.Span);
-            pinUvAuthParam = authParam;
-            pinUvAuthProtocol = (byte)tokenSession.Protocol.Version;
-        }
-
         // Build extensions CBOR via pipeline
         var extensionsCbor = ExtensionPipeline.BuildRegistrationExtensionsCbor(options.Extensions, options);
 
@@ -327,14 +312,33 @@ public sealed partial class WebAuthnClient
             ? matchedExclude is not null ? new[] { matchedExclude } : Array.Empty<PublicKeyCredentialDescriptor>()
             : options.ExcludeCredentials;
 
+        // Hoisted out of the object initializer below so that every step which can throw happens
+        // before the PIN/UV auth parameter exists.
+        var pubKeyCredParams = options.PubKeyCredParams
+            .Select(alg => new PublicKeyCredentialParameters { Algorithm = (CoseAlgorithmIdentifier)alg.Value })
+            .ToList();
+
+        // Computed last, deliberately. Nothing between here and the return can throw, so the
+        // parameter cannot be stranded: the request owns it from construction, and
+        // ExecuteMakeCredentialAsync's finally is what clears it. Computing it any earlier leaks
+        // the tag whenever extension building or option mapping fails, because on that path the
+        // request never reaches that finally.
+        ReadOnlyMemory<byte>? pinUvAuthParam = null;
+        byte? pinUvAuthProtocol = null;
+
+        if (tokenSession is not null)
+        {
+            // Version is read first so the tag is the very last thing to come into existence.
+            pinUvAuthProtocol = (byte)tokenSession.Protocol.Version;
+            pinUvAuthParam = tokenSession.Protocol.Authenticate(tokenSession.Token.Span, clientData.Hash.Span);
+        }
+
         return new BackendMakeCredentialRequest
         {
             ClientDataHash = clientData.Hash,
             Rp = options.Rp,
             User = options.User,
-            PubKeyCredParams = options.PubKeyCredParams
-                .Select(alg => new PublicKeyCredentialParameters { Algorithm = (CoseAlgorithmIdentifier)alg.Value })
-                .ToList(),
+            PubKeyCredParams = pubKeyCredParams,
             ExcludeList = excludeList,
             Extensions = extensionsCbor,
             Options = optionsDict.Count > 0 ? optionsDict : null,

--- a/src/WebAuthn/src/Util/SensitiveMemory.cs
+++ b/src/WebAuthn/src/Util/SensitiveMemory.cs
@@ -26,16 +26,6 @@ internal static class SensitiveMemory
     /// <summary>
     /// Zeroes <paramref name="memory"/> in place. Null and empty are no-ops.
     /// </summary>
-    /// <remarks>
-    /// <see cref="MemoryMarshal.AsMemory{T}(ReadOnlyMemory{T})"/> is what makes this total: it
-    /// yields a writable span whatever the memory is backed by, so there is no "could not zero
-    /// this one" branch left to get wrong. The previous form asserted array backing in debug
-    /// builds and silently skipped it in release, which is the single behaviour a zeroing helper
-    /// must never have - a release build would have left the secret live. Throwing instead is not
-    /// an option either, because every call site is a finally block where it would swallow the
-    /// exception already in flight. Writing through a read-only view is sound here: every buffer
-    /// reaching this method is secret material the caller allocated in order to destroy.
-    /// </remarks>
     public static void Zero(ReadOnlyMemory<byte>? memory)
     {
         if (memory is null || memory.Value.IsEmpty)

--- a/src/WebAuthn/src/Util/SensitiveMemory.cs
+++ b/src/WebAuthn/src/Util/SensitiveMemory.cs
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
@@ -28,10 +27,14 @@ internal static class SensitiveMemory
     /// Zeroes <paramref name="memory"/> in place. Null and empty are no-ops.
     /// </summary>
     /// <remarks>
-    /// A zeroing helper that quietly skips is a secret left in memory, so make the only
-    /// unreachable case loud rather than silent. Callers here always pass array-backed memory;
-    /// this cannot throw instead because every call site is a finally block, where throwing
-    /// would swallow the exception already in flight.
+    /// <see cref="MemoryMarshal.AsMemory{T}(ReadOnlyMemory{T})"/> is what makes this total: it
+    /// yields a writable span whatever the memory is backed by, so there is no "could not zero
+    /// this one" branch left to get wrong. The previous form asserted array backing in debug
+    /// builds and silently skipped it in release, which is the single behaviour a zeroing helper
+    /// must never have - a release build would have left the secret live. Throwing instead is not
+    /// an option either, because every call site is a finally block where it would swallow the
+    /// exception already in flight. Writing through a read-only view is sound here: every buffer
+    /// reaching this method is secret material the caller allocated in order to destroy.
     /// </remarks>
     public static void Zero(ReadOnlyMemory<byte>? memory)
     {
@@ -40,12 +43,6 @@ internal static class SensitiveMemory
             return;
         }
 
-        var isArrayBacked = MemoryMarshal.TryGetArray(memory.Value, out var segment) && segment.Array is not null;
-        Debug.Assert(isArrayBacked, "pinUvAuthParam must be array-backed so it can be zeroed");
-
-        if (isArrayBacked)
-        {
-            CryptographicOperations.ZeroMemory(segment.AsSpan());
-        }
+        CryptographicOperations.ZeroMemory(MemoryMarshal.AsMemory(memory.Value).Span);
     }
 }

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/PinUvAuthTokenSessionTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/PinUvAuthTokenSessionTests.cs
@@ -51,7 +51,7 @@ public class PinUvAuthTokenSessionTests
 
         // A copy would leave a second live plaintext token that no one zeroes.
         Assert.True(
-            session.Token == token.AsSpan(),
+            session.Token.Span == token.AsSpan(),
             "the session must expose the caller's array, not a private copy of it");
     }
 

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientGetAssertionTests.cs
@@ -17,9 +17,11 @@ using System.Security.Cryptography;
 using System.Text;
 using Yubico.YubiKit.Fido2.Credentials;
 using Yubico.YubiKit.Fido2.Ctap;
+using Yubico.YubiKit.Fido2.Extensions;
 using Yubico.YubiKit.Fido2.Pin;
 using Yubico.YubiKit.WebAuthn.Client;
 using Yubico.YubiKit.WebAuthn.Client.Authentication;
+using Yubico.YubiKit.WebAuthn.Extensions;
 using Yubico.YubiKit.WebAuthn.Preferences;
 using Yubico.YubiKit.WebAuthn.UnitTests.TestSupport;
 
@@ -404,6 +406,88 @@ public class WebAuthnClientGetAssertionTests
         // Assert
         await AssertTokenWasAcquired();
         TokenBufferAssert.Zeroed(token, "a cancelled ceremony must dispose the token session");
+    }
+
+    /// <summary>
+    /// Control for <see cref="GetAssertion_WhenExtensionBuildFails_NeverComputesPinUvAuthParam"/>:
+    /// proves the protocol double actually records the tags it issues.
+    /// </summary>
+    /// <remarks>
+    /// Without this, the "no tag was issued" assertion could pass because the recording is broken
+    /// rather than because the ceremony genuinely produced nothing.
+    /// </remarks>
+    [Fact]
+    public async Task GetAssertion_WhenTokenIsUsed_RecordsExactlyOnePinUvAuthParam()
+    {
+        // Arrange
+        var protocol = new TestPinUvAuthProtocol();
+        ArrangePinTokenAcquisition(protocol);
+        _mockBackend.GetAssertionAsync(
+            Arg.Any<BackendGetAssertionRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockGetAssertionResponse());
+
+        // Act
+        _ = await _client.GetAssertionAsync(
+            CreateUvRequiredOptions(),
+            "123456"u8.ToArray(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(protocol.IssuedAuthTags);
+    }
+
+    /// <summary>
+    /// A ceremony that fails while building extension CBOR must not leave a live PIN/UV auth
+    /// parameter behind.
+    /// </summary>
+    /// <remarks>
+    /// The parameter is computed after everything in the request builder that can throw, so the
+    /// correct outcome here is that it was never produced at all - there is no stranded buffer to
+    /// clean up. Computing it earlier would strand it: the request never reaches
+    /// <c>ExecuteGetAssertionAsync</c>, whose finally is what clears the parameter on every other
+    /// path. A LargeBlob input is used as the trigger because assertion-time LargeBlob is a
+    /// shipped not-yet-implemented input, so this is a path real callers can reach.
+    /// </remarks>
+    [Fact]
+    public async Task GetAssertion_WhenExtensionBuildFails_NeverComputesPinUvAuthParam()
+    {
+        // Arrange
+        var protocol = new TestPinUvAuthProtocol();
+        ArrangePinTokenAcquisition(protocol);
+
+        var options = CreateUvRequiredOptions() with
+        {
+            Extensions = new AuthenticationExtensionInputs(LargeBlob: new LargeBlobInput())
+        };
+
+        // Act
+        var ex = await Assert.ThrowsAsync<WebAuthnClientError>(() => _client.GetAssertionAsync(
+            options,
+            "123456"u8.ToArray(),
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(WebAuthnClientErrorCode.NotSupported, ex.Code);
+        Assert.Empty(protocol.IssuedAuthTags);
+    }
+
+    /// <summary>
+    /// Arranges token acquisition that hands the session the supplied protocol, so a test can
+    /// inspect which authentication tags the ceremony produced.
+    /// </summary>
+    private void ArrangePinTokenAcquisition(TestPinUvAuthProtocol protocol)
+    {
+        _mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockAuthenticatorInfo(clientPinSupported: true));
+
+        _mockBackend.GetPinUvTokenAsync(
+            PinUvAuthMethod.Pin,
+            PinUvAuthTokenPermissions.GetAssertion,
+            "example.com",
+            Arg.Any<ReadOnlyMemory<byte>?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(_ => new PinUvAuthTokenSession(protocol, TokenBufferAssert.CreateSentinelToken()));
     }
 
     /// <summary>

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/Client/WebAuthnClientMakeCredentialTests.cs
@@ -19,9 +19,11 @@ using System.Text;
 using Yubico.YubiKit.Fido2.Cose;
 using Yubico.YubiKit.Fido2.Credentials;
 using Yubico.YubiKit.Fido2.Ctap;
+using Yubico.YubiKit.Fido2.Extensions;
 using Yubico.YubiKit.Fido2.Pin;
 using Yubico.YubiKit.WebAuthn.Client;
 using Yubico.YubiKit.WebAuthn.Client.Registration;
+using Yubico.YubiKit.WebAuthn.Extensions;
 using Yubico.YubiKit.WebAuthn.Preferences;
 using Yubico.YubiKit.WebAuthn.UnitTests.TestSupport;
 
@@ -431,6 +433,71 @@ public class WebAuthnClientMakeCredentialTests
         AssertEveryIssuedTokenZeroed(issued, expectedCount: 4);
     }
 
+    /// <summary>
+    /// Control for <see cref="MakeCredential_WhenExtensionBuildFails_NeverComputesPinUvAuthParam"/>:
+    /// proves the protocol double actually records the tags it issues.
+    /// </summary>
+    /// <remarks>
+    /// Without this, the "no tag was issued" assertion could pass because the recording is broken
+    /// rather than because the ceremony genuinely produced nothing.
+    /// </remarks>
+    [Fact]
+    public async Task MakeCredential_WhenTokenIsUsed_RecordsExactlyOnePinUvAuthParam()
+    {
+        // Arrange
+        var protocol = new TestPinUvAuthProtocol();
+        ArrangePinTokenAcquisition(protocol);
+        _mockBackend.MakeCredentialAsync(
+            Arg.Any<BackendMakeCredentialRequest>(),
+            Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockMakeCredentialResponse());
+
+        // Act
+        _ = await _client.MakeCredentialAsync(
+            CreateUvRequiredOptions(),
+            "123456"u8.ToArray(),
+            TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Single(protocol.IssuedAuthTags);
+    }
+
+    /// <summary>
+    /// A ceremony that fails while building extension CBOR must not leave a live PIN/UV auth
+    /// parameter behind.
+    /// </summary>
+    /// <remarks>
+    /// The parameter is computed after everything in the request builder that can throw, so the
+    /// correct outcome here is that it was never produced at all - there is no stranded buffer to
+    /// clean up. Computing it earlier would strand it: the request never reaches
+    /// <c>ExecuteMakeCredentialAsync</c>, whose finally is what clears the parameter on every
+    /// other path. LargeBlob "Required" is used as the trigger because it is a shipped
+    /// not-yet-implemented input, so this is a path real callers can reach.
+    /// </remarks>
+    [Fact]
+    public async Task MakeCredential_WhenExtensionBuildFails_NeverComputesPinUvAuthParam()
+    {
+        // Arrange
+        var protocol = new TestPinUvAuthProtocol();
+        ArrangePinTokenAcquisition(protocol);
+
+        var options = CreateUvRequiredOptions() with
+        {
+            Extensions = new RegistrationExtensionInputs(
+                LargeBlob: new LargeBlobInput { Support = LargeBlobSupport.Required })
+        };
+
+        // Act
+        var ex = await Assert.ThrowsAsync<WebAuthnClientError>(() => _client.MakeCredentialAsync(
+            options,
+            "123456"u8.ToArray(),
+            TestContext.Current.CancellationToken));
+
+        // Assert
+        Assert.Equal(WebAuthnClientErrorCode.NotSupported, ex.Code);
+        Assert.Empty(protocol.IssuedAuthTags);
+    }
+
     [Fact]
     public async Task MakeCredential_WhenBackendFails_ThrowsTypedWebAuthnClientError()
     {
@@ -551,6 +618,38 @@ public class WebAuthnClientMakeCredentialTests
             TokenBufferAssert.Zeroed(issued[i], $"token buffer {i} of the ceremony must be zeroed");
         }
     }
+
+    /// <summary>
+    /// Arranges token acquisition that hands every session the supplied protocol, so a test can
+    /// inspect which authentication tags the ceremony produced.
+    /// </summary>
+    private void ArrangePinTokenAcquisition(TestPinUvAuthProtocol protocol)
+    {
+        _mockBackend.GetCachedInfoAsync(Arg.Any<CancellationToken>())
+            .Returns(MockFido2Responses.CreateMockAuthenticatorInfo(clientPinSupported: true));
+
+        _mockBackend.GetPinUvTokenAsync(
+            PinUvAuthMethod.Pin,
+            Arg.Any<PinUvAuthTokenPermissions>(),
+            "example.com",
+            Arg.Any<ReadOnlyMemory<byte>?>(),
+            Arg.Any<CancellationToken>())
+            .Returns(_ => new PinUvAuthTokenSession(protocol, TokenBufferAssert.CreateSentinelToken()));
+    }
+
+    /// <summary>
+    /// Options that force token acquisition but carry no exclude list, so pre-flight - which mints
+    /// an authentication tag of its own - does not run and the tag count stays attributable to the
+    /// request builder alone.
+    /// </summary>
+    private static RegistrationOptions CreateUvRequiredOptions() => new()
+    {
+        Challenge = RandomNumberGenerator.GetBytes(32),
+        Rp = new PublicKeyCredentialRpEntity("example.com", "Example"),
+        User = new PublicKeyCredentialUserEntity(RandomNumberGenerator.GetBytes(16), "user@example.com", "User"),
+        PubKeyCredParams = [new CoseAlgorithm(-7)],
+        UserVerification = UserVerificationPreference.Required
+    };
 
     private static RegistrationOptions CreateExcludeListOptions(
         UserVerificationPreference userVerification = UserVerificationPreference.Preferred) => new()

--- a/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/TestSupport/TestPinUvAuthProtocol.cs
+++ b/src/WebAuthn/tests/Yubico.YubiKit.WebAuthn.UnitTests/TestSupport/TestPinUvAuthProtocol.cs
@@ -18,11 +18,37 @@ namespace Yubico.YubiKit.WebAuthn.UnitTests.TestSupport;
 
 internal sealed class TestPinUvAuthProtocol : IPinUvAuthProtocol
 {
+    /// <summary>
+    /// Fills issued authentication tags with a recognisable non-zero pattern.
+    /// </summary>
+    /// <remarks>
+    /// An all-zero tag would make "this buffer was zeroed" assertions pass without the production
+    /// code doing anything, which is the failure mode <see cref="TokenBufferAssert"/> exists to
+    /// avoid. The value is arbitrary; only its being non-zero matters.
+    /// </remarks>
+    private const byte TagSentinel = 0x5A;
+
     public int Version => 2;
 
     public int AuthenticationTagLength => 16;
 
-    public byte[] Authenticate(ReadOnlySpan<byte> key, ReadOnlySpan<byte> message) => new byte[AuthenticationTagLength];
+    /// <summary>
+    /// Every tag handed out by <see cref="Authenticate"/>, in call order.
+    /// </summary>
+    /// <remarks>
+    /// Recorded so a test can assert on what secret-derived material a ceremony actually produced.
+    /// An empty list after a failed ceremony is a meaningful result rather than an absent one: it
+    /// says the tag was never computed, so there was nothing left live to clean up.
+    /// </remarks>
+    public List<byte[]> IssuedAuthTags { get; } = [];
+
+    public byte[] Authenticate(ReadOnlySpan<byte> key, ReadOnlySpan<byte> message)
+    {
+        var tag = new byte[AuthenticationTagLength];
+        Array.Fill(tag, TagSentinel);
+        IssuedAuthTags.Add(tag);
+        return tag;
+    }
 
     public byte[] Decrypt(ReadOnlySpan<byte> key, ReadOnlySpan<byte> ciphertext) => throw new NotImplementedException();
 


### PR DESCRIPTION
Follow-up from #643. A fit audit of the WebAuthn ceremony's handling of secret material turned up one real leak and three smaller misfits around it. All four are here; a fifth finding was considered and rejected, noted at the bottom so it does not get re-raised.

## The leak

Both request builders computed the PIN/UV auth HMAC and *then* did work that can throw — extension CBOR building, and the `PubKeyCredParams` mapping inside the object initializer — before returning the request.

Ownership of that tag transfers to the caller only on a successful return, where `ExecuteMakeCredentialAsync` / `ExecuteGetAssertionAsync` zero it in a `finally`. On a throw the request never reached those callers, so the tag stayed live.

It is reachable without malformed input: LargeBlob `Required` during registration, and any LargeBlob input during assertion, are shipped not-yet-implemented paths that throw from inside extension building.

**On severity, honestly:** this is a marginal security issue, not an urgent one. What leaks is an HMAC bound to one `clientDataHash`, not the PIN and not the token. Anyone who can read this process's memory can already read the `pinUvAuthToken` itself, which is live in `PinUvAuthTokenSession` at the same moment and strictly more useful. What justifies the change is consistency — every other piece of token-derived material in this slice is zeroed, and a silent exception is a trap for the next reader — plus the fact that the fix is smaller than the bug.

## The fix

Rather than add a `catch` to clean up after the fact, both builders now compute the tag **last**, after everything that can throw. `PubKeyCredParams` is hoisted into a local for the same reason: it was the final throwing statement. The protocol version is read before the tag, too.

The window is empty rather than handled, so there is no cleanup path to get wrong later.

The one case left is `OutOfMemoryException` while allocating the request. Deliberately not handled — zeroing during OOM is not reliably possible and the process is failing anyway.

## Three smaller things from the same audit

**`SensitiveMemory.Zero` had a release-build sham guard.** It asserted array backing via `Debug.Assert` and then silently skipped non-array-backed memory, so a release build would have left the secret live — the one behaviour a zeroing helper must never have. It now goes through `MemoryMarshal.AsMemory`, which yields a writable span whatever the backing store is. The branch is gone rather than fixed. Slicing is preserved.

**`PinUvAuthTokenSession.Token` was a `ReadOnlySpan`,** which cannot cross an await, so the exclude-list pre-flight took a `ToArray` copy of the decrypted token — a second live plaintext token, contradicting the type's own documented invariant that exactly one exists. `Token` is now `ReadOnlyMemory`; the copy and its manual zeroing are gone. The trade-off (memory can be captured past disposal, a span cannot) is documented on the property; the type is internal and all callers use it within the session's lifetime.

**A comment in `WebAuthnBackend.MakeCredentialAsync` was wrong.** It justified the defensive copy by citing multi-call reuse of one parameter, but that only happens on the GetAssertion path via `ExcludeListPreflight`'s chunk loop — registration builds a fresh request per attempt and sends it once. The copy is still correct, for ownership reasons, and the comment now says that instead.

## Tests

`TestPinUvAuthProtocol` previously returned `new byte[16]` — all zeroes — which would let any "this was zeroed" assertion pass without the production code doing anything. It now fills tags with a sentinel and records them.

Four tests: two regression tests asserting no tag is produced when extension building fails, each paired with a **control** test proving the recording actually works. Without the controls, `Assert.Empty` could pass because the fake is broken rather than because the fix works.

Both regression tests were confirmed failing before the change with `Assert.Empty() Failure: Collection was not empty`.

## Considered and rejected

The audit also flagged that `ClientPin` does not zero `encryptedToken` or the CBOR request holding `pinHashEnc`, tagged as high value. On inspection that is **ciphertext encrypted under `sharedSecret`, which is itself zeroed in the same `finally`** (`ClientPin.cs:311`, `:469`). Ciphertext left behind after its key is destroyed is not recoverable, and it is not in the AGENTS.md zeroing taxonomy, which calls out decrypted plaintext specifically. Adding ritual zeroing there would dilute the signal that makes the real zeroing legible, so it is deliberately not done.

## Verification

- `dotnet toolchain.cs build` — 0 errors, 0 warnings
- `dotnet toolchain.cs test` — 12 projects, **2761** tests, 0 failed (WebAuthn 217, was 213)
- `dotnet toolchain.cs -- resilience --fast` — 75 passed
- `dotnet format whitespace` scoped to the changed files — clean, verified with a positive control that the filter actually matches

No hardware paths touched.
