### PR TITLE
test(core): make YubiKeyManagerStaticTests hermetic by deleting what it duplicated

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -604,6 +604,8 @@ Full rules: `docs/COMMIT_GUIDELINES.md`. Skill: `.claude/skills/git-commit/SKILL
    The `whitespace` subcommand (`dotnet format whitespace ... --include <files>`) is fine and often faster, **as long as it is scoped with `--include` to your own files**. The rule being enforced is "never reformat files you did not change", not "never use a particular subcommand". Unscoped formatting of the whole solution is what is forbidden.
 
    Caveat: `dotnet format` only visits documents that belong to a project in the solution. Scoping it to a file-based app script such as `toolchain.cs`, or to a Markdown/props file, matches zero documents and exits `0` — that is "skipped", not "verified clean". Do not report it as a passing gate.
+
+   Caveat: `--include` takes a **space-separated** list, which is why the command above leaves `$(...)` unquoted and lets the shell word-split it. Passing several paths as one quoted string joined by `;` or `,` matches **zero** documents and exits `0`, indistinguishable from a clean run. If you build the file list yourself, prove the check is live before trusting it: introduce a trailing space in one of your own files, confirm the command reports `error WHITESPACE`, then revert. A gate that cannot fail has not passed.
 5. ✅ No nullable warnings
 6. ✅ Sensitive data zeroed (`ZeroMemory` / `Dispose`)
 7. ✅ No unnecessary allocations in hot paths

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/ConnectionOwnershipContractTests.cs
@@ -39,7 +39,6 @@ namespace Yubico.YubiKit.Core.UnitTests.Devices;
 ///         connection possible, which is the ergonomic price of the two refusal rules.
 ///     </para>
 /// </remarks>
-[Collection(DiscoveryWorkerAdmissionCollection.Name)]
 public class ConnectionOwnershipContractTests
 {
     private static CancellationToken Ct => TestContext.Current.CancellationToken;

--- a/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyManagerStaticTests.cs
+++ b/src/Core/tests/Yubico.YubiKit.Core.UnitTests/Devices/YubiKeyManagerStaticTests.cs
@@ -13,277 +13,43 @@
 // limitations under the License.
 
 using Yubico.YubiKit.Core.Devices;
-using Yubico.YubiKit.Core.UnitTests.Infrastructure;
 
 namespace Yubico.YubiKit.Core.UnitTests.Devices;
 
 /// <summary>
-/// Static-lifecycle assertions for the <see cref="YubiKeyManager"/> facade: which members exist,
-/// what shape they have, and how <c>StartMonitoring</c> / <c>StopMonitoring</c> / <c>ShutdownAsync</c>
-/// compose. Behaviour that belongs to the pieces behind the facade is asserted on those pieces,
-/// where fakes can stand in for hardware: watcher delivery on <c>DeviceEventHubTests</c> and
-/// <c>YubiKeyDeviceRepositoryTests</c>, and monitoring on <c>YubiKeyDeviceManagerTests</c>.
+/// The two things about <see cref="YubiKeyManager"/> that are only true of the facade: what its
+/// public surface does <em>not</em> expose, and the lazy create/recreate policy around its static
+/// manager.
 /// </summary>
 /// <remarks>
-/// The facade has no injection seam by design — being usable without DI is the point of it — so the
-/// lifecycle assertions that remain here do reach the real listeners and the real device scan.
-/// That makes them consumers of the process-wide four-slot discovery-worker pool, which is what
-/// <see cref="DiscoveryWorkerAdmissionCollection"/> serializes. Without that membership they ran
-/// concurrently with the tests that deliberately saturate the pool, and either side could then fail
-/// with "PC/SC device enumeration could not start because discovery worker capacity is saturated".
-/// Anything here that does not genuinely need the facade's own lifecycle belongs on a seam instead.
+/// <para>
+/// Everything the facade merely forwards is asserted where fakes can stand in for hardware, and is
+/// deliberately not repeated here: discovery and monitoring lifecycle on
+/// <c>YubiKeyDeviceManagerTests</c> and <c>YubiKeyDeviceMonitorServiceTests</c>, watcher delivery
+/// and cancellation on <c>DeviceEventHubTests</c> and <c>YubiKeyDeviceRepositoryTests</c>, and the
+/// real zero-configuration scan on the integration suite's <c>YubiKeyManagerTests</c>. Duplicating
+/// those here bought no coverage and cost a real device scan per test.
+/// </para>
+/// <para>
+/// What remains is hermetic. Enumerating <see cref="YubiKeyManager.WatchAsync"/> constructs the
+/// manager but starts no listener and runs no scan, so nothing here consumes the process-wide
+/// discovery-worker pool that <see cref="DiscoveryWorkerAdmissionCollection"/> serializes — which
+/// is why this class no longer joins it.
+/// </para>
+/// <para>
+/// The negative assertions below are the ones compilation cannot make for us: a member that should
+/// be absent stays absent only if something checks.
+/// </para>
 /// </remarks>
-[Collection(DiscoveryWorkerAdmissionCollection.Name)]
 public class YubiKeyManagerStaticTests : IAsyncLifetime
 {
     public ValueTask InitializeAsync() => ValueTask.CompletedTask;
 
     public async ValueTask DisposeAsync()
     {
-        // Always clean up static state after each test
+        // Enumerating a watcher creates the static manager, so every test here leaves one behind.
         await YubiKeyManager.ShutdownAsync();
     }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_IsStaticMethod()
-    {
-        // FindAllAsync should be callable as static method
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.NotNull(result);
-        Assert.IsAssignableFrom<IReadOnlyList<Yubico.YubiKit.Core.Abstractions.IYubiKey>>(result);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_WithConnectionType_IsStaticMethod()
-    {
-        // FindAllAsync with ConnectionType should be callable as static method
-        var result = await YubiKeyManager.FindAllAsync(ConnectionType.SmartCard, cancellationToken: CancellationToken.None);
-
-        Assert.NotNull(result);
-        Assert.IsAssignableFrom<IReadOnlyList<Yubico.YubiKit.Core.Abstractions.IYubiKey>>(result);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_WorksWithoutDISetup()
-    {
-        // Verify method works without calling any initialization or DI setup
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.NotNull(result);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_ReturnsIReadOnlyList()
-    {
-        // Verify returns IReadOnlyList<IYubiKey>
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.IsAssignableFrom<IReadOnlyList<Yubico.YubiKit.Core.Abstractions.IYubiKey>>(result);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_NoDevices_ReturnsEmptyList()
-    {
-        // Handle no devices connected -> Return empty list (not null)
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        Assert.NotNull(result);
-        // In unit test environment, expect empty (no real devices)
-        // But importantly: not null
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_Cancellation_PropagatesToken()
-    {
-        // Cancellation is propagated to underlying operations
-        using var cts = new CancellationTokenSource();
-
-        // A non-cancelled token should work
-        var result = await YubiKeyManager.FindAllAsync(cts.Token);
-        Assert.NotNull(result);
-
-        // Verify the method signature accepts CancellationToken
-        var method = typeof(YubiKeyManager).GetMethod(
-            nameof(YubiKeyManager.FindAllAsync),
-            [typeof(CancellationToken)]);
-
-        Assert.NotNull(method);
-        var parameters = method.GetParameters();
-        Assert.Contains(parameters, p => p.ParameterType == typeof(CancellationToken));
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_FindAllAsync_ConcurrentCalls_ThreadSafe()
-    {
-        // Handle concurrent FindAllAsync() calls -> Thread-safe
-        const int concurrentCalls = 10;
-        var tasks = Enumerable.Range(0, concurrentCalls)
-            .Select(_ => YubiKeyManager.FindAllAsync())
-            .ToArray();
-
-        var results = await Task.WhenAll(tasks);
-
-        Assert.All(results, r => Assert.NotNull(r));
-    }
-
-    [Fact]
-    public void PlatformInteropException_Exists_AndIsProperException()
-    {
-        // PlatformInteropException should be available for platform API errors
-        var exceptionType = typeof(PlatformInteropException);
-
-        // Verify it inherits from Exception
-        Assert.True(typeof(Exception).IsAssignableFrom(exceptionType));
-
-        // Verify it has a message constructor
-        var ex1 = new PlatformInteropException("Test error");
-        Assert.Equal("Test error", ex1.Message);
-
-        // Verify it has a message + inner exception constructor
-        var innerEx = new InvalidOperationException("Inner error");
-        var ex2 = new PlatformInteropException("Outer error", innerEx);
-        Assert.Equal("Outer error", ex2.Message);
-        Assert.Same(innerEx, ex2.InnerException);
-    }
-
-    [Fact]
-    public void PlatformInteropException_CanContain_ContextInformation()
-    {
-        // Exception should carry context about what operation failed
-        var ex = new PlatformInteropException("PC/SC service unavailable: 0x8010001D",
-            new InvalidOperationException("SCardEstablishContext failed"));
-
-        Assert.Contains("PC/SC", ex.Message);
-        Assert.NotNull(ex.InnerException);
-    }
-
-    // Phase 3: Monitoring Lifecycle Tests
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_MethodExists()
-    {
-        // YubiKeyManager should have static StartMonitoring() method
-        var method = typeof(YubiKeyManager).GetMethod(
-            "StartMonitoring",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
-            Type.EmptyTypes);
-
-        Assert.NotNull(method);
-        Assert.True(method.IsStatic);
-        Assert.Equal(typeof(void), method.ReturnType);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_WithInterval_MethodExists()
-    {
-        // YubiKeyManager should have static StartMonitoring(TimeSpan) method
-        var method = typeof(YubiKeyManager).GetMethod(
-            "StartMonitoring",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
-            [typeof(TimeSpan)]);
-
-        Assert.NotNull(method);
-        Assert.True(method.IsStatic);
-        Assert.Equal(typeof(void), method.ReturnType);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StopMonitoring_MethodExists()
-    {
-        // YubiKeyManager should have static StopMonitoring() method
-        var method = typeof(YubiKeyManager).GetMethod(
-            "StopMonitoring",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
-            Type.EmptyTypes);
-
-        Assert.NotNull(method);
-        Assert.True(method.IsStatic);
-        Assert.Equal(typeof(void), method.ReturnType);
-    }
-
-    [Fact]
-    public void YubiKeyManager_IsMonitoring_PropertyExists()
-    {
-        // YubiKeyManager should have static IsMonitoring property
-        var property = typeof(YubiKeyManager).GetProperty(
-            "IsMonitoring",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
-
-        Assert.NotNull(property);
-        Assert.Equal(typeof(bool), property.PropertyType);
-        Assert.True(property.CanRead);
-        Assert.False(property.CanWrite);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_ZeroInterval_ThrowsArgumentOutOfRangeException()
-    {
-        // Handle interval = 0ms -> Throw ArgumentOutOfRangeException
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
-            YubiKeyManager.StartMonitoring(TimeSpan.Zero));
-
-        Assert.Equal("interval", exception.ParamName);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_NegativeInterval_ThrowsArgumentOutOfRangeException()
-    {
-        // Handle negative interval -> Throw ArgumentOutOfRangeException
-        var exception = Assert.Throws<ArgumentOutOfRangeException>(() =>
-            YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(-1)));
-
-        Assert.Equal("interval", exception.ParamName);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_SetsIsMonitoring()
-    {
-        // Starting monitoring sets IsMonitoring to true
-        Assert.False(YubiKeyManager.IsMonitoring);
-
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(1));
-
-        Assert.True(YubiKeyManager.IsMonitoring);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StopMonitoring_SetsIsMonitoringFalse()
-    {
-        // Stopping monitoring sets IsMonitoring to false
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(1));
-        Assert.True(YubiKeyManager.IsMonitoring);
-
-        YubiKeyManager.StopMonitoring();
-
-        Assert.False(YubiKeyManager.IsMonitoring);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StartMonitoring_WhenAlreadyMonitoring_IsIdempotent()
-    {
-        // StartMonitoring when already monitoring -> No-op (idempotent)
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(1));
-        Assert.True(YubiKeyManager.IsMonitoring);
-
-        // Call again - should not throw or change behavior
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(2));
-        Assert.True(YubiKeyManager.IsMonitoring);
-    }
-
-    [Fact]
-    public void YubiKeyManager_StopMonitoring_WhenNotMonitoring_IsIdempotent()
-    {
-        // StopMonitoring when not monitoring -> No-op (idempotent)
-        Assert.False(YubiKeyManager.IsMonitoring);
-
-        // Call again - should not throw
-        YubiKeyManager.StopMonitoring();
-
-        Assert.False(YubiKeyManager.IsMonitoring);
-    }
-
-    // Phase 4: Device Events Tests
 
     [Fact]
     public void YubiKeyManager_WatchAsync_IsTheOnlyDeviceChangeStream()
@@ -309,28 +75,6 @@ public class YubiKeyManagerStaticTests : IAsyncLifetime
     }
 
     [Fact]
-    public void DeviceEvent_ContainsExpectedMembers()
-    {
-        // Verify DeviceEvent contains IYubiKey and DeviceAction enum
-        var deviceEventType = typeof(DeviceEvent);
-
-        // Should have a Device property of type IYubiKey
-        var deviceProperty = deviceEventType.GetProperty("Device");
-        Assert.NotNull(deviceProperty);
-        Assert.True(typeof(Yubico.YubiKit.Core.Abstractions.IYubiKey).IsAssignableFrom(deviceProperty.PropertyType));
-
-        // Should have an Action property of type DeviceAction
-        var actionProperty = deviceEventType.GetProperty("Action");
-        Assert.NotNull(actionProperty);
-        Assert.Equal(typeof(DeviceAction), actionProperty.PropertyType);
-
-        // DeviceAction should be an enum with Added and Removed
-        Assert.True(typeof(DeviceAction).IsEnum);
-        Assert.True(Enum.IsDefined(typeof(DeviceAction), "Added"));
-        Assert.True(Enum.IsDefined(typeof(DeviceAction), "Removed"));
-    }
-
-    [Fact]
     public void DeviceAction_DoesNotContainUpdated()
     {
         // DeviceAction.Updated was removed per PRD
@@ -352,137 +96,38 @@ public class YubiKeyManagerStaticTests : IAsyncLifetime
         await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await pending);
     }
 
-    [Fact]
-    public async Task YubiKeyManager_WatchAsync_MultipleConcurrentWatchersAllowed()
-    {
-        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-
-        var enumerators = new List<IAsyncEnumerator<DeviceEvent>>();
-        var pending = new List<ValueTask<bool>>();
-        for (var i = 0; i < 3; i++)
-        {
-            var enumerator = YubiKeyManager.WatchAsync(cts.Token).GetAsyncEnumerator(cts.Token);
-            enumerators.Add(enumerator);
-            pending.Add(enumerator.MoveNextAsync());
-        }
-
-        // Each enumeration is independent; none of them rejected or displaced the others.
-        await cts.CancelAsync();
-        foreach (var move in pending)
-        {
-            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await move);
-        }
-
-        foreach (var enumerator in enumerators)
-        {
-            await enumerator.DisposeAsync();
-        }
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_WatchAsync_WhenCancelled_ThrowsOperationCanceled()
-    {
-        using var cts = new CancellationTokenSource();
-        await using var enumerator = YubiKeyManager.WatchAsync(cts.Token).GetAsyncEnumerator(cts.Token);
-
-        var moveNext = enumerator.MoveNextAsync().AsTask();
-        await cts.CancelAsync();
-
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => moveNext);
-    }
-
-    // Watcher independence while monitoring runs is asserted on the manager seam, in
-    // YubiKeyDeviceManagerTests.WatchAsync_EndingOneWatcher_LeavesMonitoringAndTheOtherWatcherRunning.
-    // Asserting it here meant starting real HID and PC/SC listeners from a unit test, which
-    // contends for the process-wide discovery-worker pool and made unrelated tests fail with
-    // "discovery worker capacity is saturated".
-
-    // Phase 5: Shutdown Tests
-
-    [Fact]
-    public void YubiKeyManager_ShutdownAsync_MethodExists()
-    {
-        // YubiKeyManager should have static ShutdownAsync method
-        var method = typeof(YubiKeyManager).GetMethod(
-            "ShutdownAsync",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
-            [typeof(CancellationToken)]);
-
-        Assert.NotNull(method);
-        Assert.True(method.IsStatic);
-        Assert.Equal(typeof(Task), method.ReturnType);
-    }
-
-    [Fact]
-    public void YubiKeyManager_Shutdown_MethodExists()
-    {
-        // YubiKeyManager should have static Shutdown sync wrapper
-        var method = typeof(YubiKeyManager).GetMethod(
-            "Shutdown",
-            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static,
-            Type.EmptyTypes);
-
-        Assert.NotNull(method);
-        Assert.True(method.IsStatic);
-        Assert.Equal(typeof(void), method.ReturnType);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_ShutdownAsync_StopsMonitoring()
-    {
-        // Verify ShutdownAsync stops monitoring if active
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(1));
-        Assert.True(YubiKeyManager.IsMonitoring);
-
-        await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
-
-        Assert.False(YubiKeyManager.IsMonitoring);
-    }
-
+    /// <summary>
+    /// Shutting down when nothing was ever created must be a no-op rather than a null dereference.
+    /// </summary>
     [Fact]
     public async Task YubiKeyManager_ShutdownAsync_IsIdempotent()
     {
-        // Handle multiple Shutdown() calls -> Idempotent
-        // Multiple shutdown calls should not throw
         await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
         await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
 
         Assert.False(YubiKeyManager.IsMonitoring);
     }
 
+    /// <summary>
+    /// The facade tolerates being asked to stop, and being asked whether it is monitoring, before
+    /// anything has ever been created.
+    /// </summary>
+    /// <remarks>
+    /// This is the one piece of monitoring behaviour that is the facade's own rather than the
+    /// manager's: <c>StopMonitoring</c> and <c>IsMonitoring</c> both read the static field and
+    /// null-guard it, so with no manager they must be a no-op and <see langword="false"/> instead
+    /// of a null dereference. Everything past that guard forwards to
+    /// <c>YubiKeyDeviceManager</c>/<c>YubiKeyDeviceMonitorService</c> and is asserted there,
+    /// against fakes, without starting real listeners.
+    /// </remarks>
     [Fact]
-    public async Task YubiKeyManager_AfterShutdown_FindAllAsync_Works()
+    public void YubiKeyManager_StopMonitoring_WithNoManager_IsNoOp()
     {
-        // Verify after shutdown, FindAllAsync performs fresh scan
-        await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
+        Assert.False(YubiKeyManager.IsMonitoring);
 
-        // FindAllAsync should work after shutdown
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotNull(result);
-    }
+        YubiKeyManager.StopMonitoring();
 
-    [Fact]
-    public async Task YubiKeyManager_AfterShutdown_StartMonitoring_Works()
-    {
-        // Verify after shutdown, StartMonitoring works correctly
-        await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
-
-        // StartMonitoring should work after shutdown
-        YubiKeyManager.StartMonitoring(TimeSpan.FromSeconds(1));
-        Assert.True(YubiKeyManager.IsMonitoring);
-    }
-
-    [Fact]
-    public async Task YubiKeyManager_ShutdownAsync_ResetsContext()
-    {
-        // After shutdown, a new context is created on next use
-        _ = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-
-        await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
-
-        // Next call should create new context and work
-        var result = await YubiKeyManager.FindAllAsync(cancellationToken: TestContext.Current.CancellationToken);
-        Assert.NotNull(result);
+        Assert.False(YubiKeyManager.IsMonitoring);
     }
 
     /// <summary>
@@ -490,26 +135,46 @@ public class YubiKeyManagerStaticTests : IAsyncLifetime
     /// one, whose repository would end every enumeration immediately.
     /// </summary>
     /// <remarks>
-    /// The liveness assertion is "cancelling it raises <see cref="OperationCanceledException"/>",
-    /// not "it had not completed yet". A dead sequence ends normally with no elements, so it never
-    /// reaches the cancellation; the previous form asserted <c>pending.IsCompleted == false</c>
-    /// immediately after starting it, which is a statement about how fast the machine happened to
-    /// be rather than about the facade. Nothing here starts monitoring, so the fresh repository has
-    /// no publisher and cannot deliver an element that would make the wait complete for real
-    /// reasons. The same recreation is asserted for the other entry points by
-    /// <see cref="YubiKeyManager_AfterShutdown_FindAllAsync_Works"/> and
-    /// <see cref="YubiKeyManager_AfterShutdown_StartMonitoring_Works"/>.
+    /// <para>
+    /// The test creates a manager <em>before</em> shutting down, which is what makes it about
+    /// recreation at all. Shutting down first would only prove ordinary first-time lazy creation,
+    /// since cleanup already leaves the static field null - the assertion would hold just as well
+    /// with the recreation logic removed.
+    /// </para>
+    /// <para>
+    /// Two things are asserted, and both are needed. The pre-shutdown enumeration must end
+    /// normally, proving the old manager really was disposed rather than left running. The
+    /// post-shutdown enumeration must then be cancellable, which is the liveness claim: a dead
+    /// sequence ends with no elements and so never reaches the cancellation, whereas a live one
+    /// waits. Nothing here starts monitoring, so the fresh repository has no publisher and cannot
+    /// deliver an element that would end the wait for real reasons.
+    /// </para>
     /// </remarks>
     [Fact]
-    public async Task YubiKeyManager_WatchAsync_AfterShutdown_AutoRecreatesContext()
+    public async Task YubiKeyManager_WatchAsync_AfterShutdown_RecreatesTheContext()
     {
-        await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
-
         using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
-        await using var enumerator = YubiKeyManager.WatchAsync(cts.Token).GetAsyncEnumerator(cts.Token);
-        var pending = enumerator.MoveNextAsync();
 
-        await cts.CancelAsync();
-        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await pending);
+        // Enumerating is what subscribes, so this is what actually creates the manager.
+        var firstEnumerator = YubiKeyManager.WatchAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        await using (firstEnumerator.ConfigureAwait(false))
+        {
+            var pendingOnFirst = firstEnumerator.MoveNextAsync();
+
+            await YubiKeyManager.ShutdownAsync(TestContext.Current.CancellationToken);
+
+            // The disposed manager completes its stream rather than leaving the watcher hanging.
+            Assert.False(await pendingOnFirst);
+        }
+
+        // A second watcher must be served by a newly built manager, not the disposed one.
+        var secondEnumerator = YubiKeyManager.WatchAsync(cts.Token).GetAsyncEnumerator(cts.Token);
+        await using (secondEnumerator.ConfigureAwait(false))
+        {
+            var pendingOnSecond = secondEnumerator.MoveNextAsync();
+
+            await cts.CancelAsync();
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await pendingOnSecond);
+        }
     }
 }


### PR DESCRIPTION
Third and last of the #643 follow-ups. No production code changes.

## The problem

`YubiKeyManagerStaticTests` lived in the **unit** test project but reached real hardware: `FindAllAsync` ran a device scan and `StartMonitoring` started real PC/SC and HID listeners. Two consequences — unit results depended on what was plugged into the machine, and the class became a consumer of the process-wide four-slot discovery-worker pool, colliding with the tests that deliberately saturate it. The mitigation had been to serialise **nine** test classes through `DiscoveryWorkerAdmissionCollection` with `DisableParallelization = true`.

## What I expected to do, and why I didn't

The plan was to add an `internal static` manager-factory seam and convert the hardware-touching tests to fakes. A fit audit talked me out of it, and I verified its claims before acting:

- the "works without DI setup" assertion — the main reason to keep a real-platform test here — **already exists in the integration suite** as `YubiKeyManagerTests.FindAllAsync_HasAtLeastOneDevice`, using the static API with no configuration. The unit copy was duplicating an integration test while dragging real PC/SC into the unit suite.
- almost every other test had stronger coverage on a seam where fakes are natural.
- the fakes the conversion would have reused (`FakeFindYubiKeys`, `FakeHidDeviceListener`, `FakeSmartCardDeviceListener`) are `private sealed` nested inside `YubiKeyDeviceManagerTests`, so conversion would also have meant moving test infrastructure — a cost that was not in the original plan.

So: delete rather than convert, and add nothing to production.

## What was deleted (28 of 33)

**Ceremony.** The `GetMethod`/`GetProperty` "this member exists" checks — a compile error already catches that, and the same file called those members directly. Plus the two `PlatformInteropException` tests, which only proved that the base `Exception` constructors work.

**Duplicates**, each covered by a named test I checked exists:

| Deleted | Covered by |
|---|---|
| discovery, type filter, concurrency | `YubiKeyDeviceManagerTests` |
| empty results | `YubiKeyDeviceRepositoryTests.GetAll_EmptyCache_ReturnsEmptyList` |
| interval validation, start/stop idempotence | `YubiKeyDeviceMonitorServiceTests` |
| `IsMonitoring` transitions, `DisposeAsync` | manager + monitor service |
| watcher delivery and cancellation | `DeviceEventHubTests`, `YubiKeyDeviceRepositoryTests` |
| real zero-config scan | integration `YubiKeyManagerTests` |

## What was kept (5)

All hermetic, all genuinely facade-specific:

- the **negative** surface assertions — `DeviceChanges`, any `IObservable<DeviceEvent>` property, and `DeviceAction.Updated` stay absent. Compilation cannot check that a member you want gone is still gone.
- the null-manager guards on `StopMonitoring` and `IsMonitoring` (`mgr?.…`), which is the one bit of monitoring behaviour the facade owns rather than forwards
- enumerating a watcher does not auto-start monitoring
- the static manager is rebuilt after shutdown

## The recreation test was rewritten

Worth calling out because the cross-vendor review caught it and it was a real gap. The old version shut down *before* creating anything — and since cleanup already leaves the static field null, it only proved ordinary first-time lazy creation. It would have passed with the recreation logic deleted.

It now creates a manager, asserts the pre-shutdown enumeration **ends normally** (so the old manager is known to be disposed, not merely abandoned), then asserts a fresh enumeration is **cancellable**, which a disposed manager's completed stream could not be.

Confirmed load-bearing by mutation: making `ShutdownAsync` keep the disposed manager turns it red.

## Collection membership: 9 → 7

Removed from this class (it no longer scans) and from `ConnectionOwnershipContractTests`, which never referenced worker admission at all — it runs entirely on fake connections.

Deliberately **kept** on `DeviceConnectionRegistryTests`, though the audit said it could go. It calls `DiscoveryIdentityReader.TryReadAsync` and `CompositeMetadataReader.TryReadAsync`, and proving those never reach admission means proving a negative about production code. Getting that wrong reintroduces exactly the flake this serialisation was added to fix, and the upside is the parallelism of one class.

## One doc fix

`CLAUDE.md` gains a caveat about `dotnet format --include`. It takes a **space-separated** list, which is why the documented command leaves `$(...)` unquoted. Passing several paths as one quoted string joined by `;` or `,` matches zero documents and exits `0` — indistinguishable from a clean run, the same false-pass shape as the existing non-project-file caveat.

Found the hard way here: my first formatting check on this branch was a silent no-op. The doc was right; I had deviated from it.

## Verification

- `dotnet toolchain.cs build` — 0 errors
- `dotnet toolchain.cs test` — 12 projects, **2730** tests, 0 failed (Core 1234, was 1261)
- `dotnet toolchain.cs -- resilience --fast` — 75 passed
- Core suite run **5×** after the de-serialisation — no flake
- formatting verified with a positive control proving the check could actually fail
