### PR TITLE
docs: record what the #642 rebase taught about semantic conflicts

### DIFF
--- a/.claude/skills/workflow-stack/SKILL.md
+++ b/.claude/skills/workflow-stack/SKILL.md
@@ -104,6 +104,50 @@ gh stack rebase --continue
 gh stack rebase --abort
 ```
 
+**Rebase on a cadence, not at the end.** The cost of this whole section scales with how far trunk drifted. Rebase weekly, or on every merge to trunk that touches the same area, whichever comes first — while the conflict surface is still one PR wide and you still remember why you wrote the code. A stack that absorbs three overlapping trunk PRs at once is a different and much worse job than three small rebases.
+
+#### Resolving a conflict: read intent, not markers
+
+Before resolving a file, find out what the incoming branch was *trying to do* there:
+
+```bash
+B=$(git merge-base origin/<trunk> origin/<branch>)
+git diff $B origin/<branch> -- <file>     # what the branch actually changed
+```
+
+This matters because the conflict markers are not the whole change. Two traps that a markers-only resolution walks straight into:
+
+- **`git checkout --ours/--theirs` takes the whole file.** If the branch also added something elsewhere in that file which auto-merged, taking a side silently deletes it. Only use `--ours`/`--theirs` after confirming the branch's diff for that file contains *nothing* but the conflicted region.
+- **The markers can cover one signature while a sibling method auto-merges** carrying the old names. Grep the file for the old identifiers after resolving, not just for `<<<<<<<`.
+
+#### Then sweep for semantic conflicts
+
+Git only conflicts when both sides edited the same lines. It says nothing when trunk **renamed or re-meant** something and your branch still uses the old meaning in a file trunk never touched. Those merge clean and are wrong.
+
+```bash
+# 1. what did trunk rename or re-mean since the merge base?
+git log --oneline $B..origin/<trunk>
+git diff $B origin/<trunk> -- '*.cs' | grep -E '^[-+].*(public|internal).*\(' | less
+
+# 2. grep the WHOLE rebased tree for each old identifier - not just .cs
+grep -rn "<oldName>" --include="*.cs" --include="*.md" --include="*.txt" .
+```
+
+Include prose, XML doc comments and samples in the sweep. The compiler is a partial safety net at best:
+
+| Drift | Caught by |
+|---|---|
+| Renamed parameter, positional call | nothing — still compiles |
+| Renamed parameter, named argument | compiler (`CS1739`) |
+| Two branches consolidating different params under the *same* name | compiler (`CS1503`) **only if the types differ** |
+| `<paramref name="old"/>` in a doc comment | **nothing** — `paramref` still resolves, build and tests stay green |
+
+The last row is not hypothetical; it is how doc drift ships. Read the XML docs of every signature you touched.
+
+#### Public API declaration files
+
+If the repo tracks a public API surface (this one does — see `docs/architecture/applet-public-api.md`), those files record **parameter names**, so a rename on trunk invalidates them with zero textual conflict. Follow the reconciliation policy in that document; do not simply regenerate them.
+
 ### 7. Navigate between layers
 
 ```bash
@@ -134,7 +178,10 @@ gh stack sync --prune  # prune local branches for merged PRs
 | Unrelated work → new stack | Keeps reviewer scope narrow |
 | Each layer independently understandable | Reviewer can approve without reading the whole stack |
 | `gh stack rebase` before adding new layers | Keeps history linear |
+| Rebase on a cadence, not once at the end | Conflict cost scales with trunk drift |
+| After resolving, sweep for renames trunk made | Clean merges can still be semantically wrong |
 | Never `git push --force` manually on stack branches | Use `gh stack push` (uses `--force-with-lease` safely) |
+| Changing an owner-decided API shape mid-resolution needs ratification | A code comment is not a decision record; say it in the PR |
 
 ## Common Mistakes
 
@@ -150,12 +197,27 @@ Always use `gh stack push` — it uses `--force-with-lease` per branch and won't
 **❌ Forgetting to `gh stack rebase` after trunk moves**
 GitHub requires fully linear history to merge. If trunk moved, rebase before submitting.
 
+**❌ Leaving a stack branch checked out in a second worktree**
+`gh stack rebase` cascades by checking out each branch in turn, so it aborts with `fatal: '<branch>' is already used by worktree at ...` and restores every branch. One worktree per stack, not one per layer — remove the others first (`git worktree remove <path>`) and re-add them afterwards if you want them.
+
+**❌ Trusting `rerere` across a semantically fixed-up rebase**
+`gh stack init` enables `git rerere`, which records the resolution you staged — *not* the follow-up fixes you made afterwards when the build failed. Re-running a similar rebase replays the incomplete resolution with no conflict prompt. Clear it once you have fixed things up beyond what you staged:
+```bash
+rm -rf "$(git rev-parse --git-common-dir)/rr-cache"
+```
+Use `--git-common-dir`, not `--git-dir`. In a worktree `.git` is a *file* and `--git-dir` points at the worktree's private directory, so `rm -rf .git/rr-cache` silently does nothing and a check against `--git-dir` reports zero entries whether or not the real cache is still there.
+
+**❌ Reporting a scoped `dotnet format` run as verified without a control**
+`--include` takes a **space-separated** list. Passing several paths as one quoted string joined by `;` or `,` matches zero documents and exits `0`, which is indistinguishable from clean. Prove the check can fail: add a trailing space to one of your own files, confirm it reports `error WHITESPACE`, revert. See `CLAUDE.md` for the full caveat.
+
 ## Verification
 
 - [ ] `gh stack view` shows all expected layers in order
 - [ ] Each PR targets the branch of the layer below it (not `develop` directly for mid-stack PRs)
 - [ ] `gh stack view --json` shows `needsRebase: false` for all layers
 - [ ] Each PR is independently reviewable (standalone diff, clear title, no unrelated changes)
+- [ ] After a conflicted rebase: swept for trunk's renames across `.cs`, `.md` and XML doc comments
+- [ ] After a conflicted rebase: every public API declaration delta is explained by a known trunk change
 
 ## Related Skills
 

--- a/.claude/skills/workflow-stack/SKILL.md
+++ b/.claude/skills/workflow-stack/SKILL.md
@@ -104,50 +104,6 @@ gh stack rebase --continue
 gh stack rebase --abort
 ```
 
-**Rebase on a cadence, not at the end.** The cost of this whole section scales with how far trunk drifted. Rebase weekly, or on every merge to trunk that touches the same area, whichever comes first — while the conflict surface is still one PR wide and you still remember why you wrote the code. A stack that absorbs three overlapping trunk PRs at once is a different and much worse job than three small rebases.
-
-#### Resolving a conflict: read intent, not markers
-
-Before resolving a file, find out what the incoming branch was *trying to do* there:
-
-```bash
-B=$(git merge-base origin/<trunk> origin/<branch>)
-git diff $B origin/<branch> -- <file>     # what the branch actually changed
-```
-
-This matters because the conflict markers are not the whole change. Two traps that a markers-only resolution walks straight into:
-
-- **`git checkout --ours/--theirs` takes the whole file.** If the branch also added something elsewhere in that file which auto-merged, taking a side silently deletes it. Only use `--ours`/`--theirs` after confirming the branch's diff for that file contains *nothing* but the conflicted region.
-- **The markers can cover one signature while a sibling method auto-merges** carrying the old names. Grep the file for the old identifiers after resolving, not just for `<<<<<<<`.
-
-#### Then sweep for semantic conflicts
-
-Git only conflicts when both sides edited the same lines. It says nothing when trunk **renamed or re-meant** something and your branch still uses the old meaning in a file trunk never touched. Those merge clean and are wrong.
-
-```bash
-# 1. what did trunk rename or re-mean since the merge base?
-git log --oneline $B..origin/<trunk>
-git diff $B origin/<trunk> -- '*.cs' | grep -E '^[-+].*(public|internal).*\(' | less
-
-# 2. grep the WHOLE rebased tree for each old identifier - not just .cs
-grep -rn "<oldName>" --include="*.cs" --include="*.md" --include="*.txt" .
-```
-
-Include prose, XML doc comments and samples in the sweep. The compiler is a partial safety net at best:
-
-| Drift | Caught by |
-|---|---|
-| Renamed parameter, positional call | nothing — still compiles |
-| Renamed parameter, named argument | compiler (`CS1739`) |
-| Two branches consolidating different params under the *same* name | compiler (`CS1503`) **only if the types differ** |
-| `<paramref name="old"/>` in a doc comment | **nothing** — `paramref` still resolves, build and tests stay green |
-
-The last row is not hypothetical; it is how doc drift ships. Read the XML docs of every signature you touched.
-
-#### Public API declaration files
-
-If the repo tracks a public API surface (this one does — see `docs/architecture/applet-public-api.md`), those files record **parameter names**, so a rename on trunk invalidates them with zero textual conflict. Follow the reconciliation policy in that document; do not simply regenerate them.
-
 ### 7. Navigate between layers
 
 ```bash
@@ -178,10 +134,7 @@ gh stack sync --prune  # prune local branches for merged PRs
 | Unrelated work → new stack | Keeps reviewer scope narrow |
 | Each layer independently understandable | Reviewer can approve without reading the whole stack |
 | `gh stack rebase` before adding new layers | Keeps history linear |
-| Rebase on a cadence, not once at the end | Conflict cost scales with trunk drift |
-| After resolving, sweep for renames trunk made | Clean merges can still be semantically wrong |
 | Never `git push --force` manually on stack branches | Use `gh stack push` (uses `--force-with-lease` safely) |
-| Changing an owner-decided API shape mid-resolution needs ratification | A code comment is not a decision record; say it in the PR |
 
 ## Common Mistakes
 
@@ -197,27 +150,12 @@ Always use `gh stack push` — it uses `--force-with-lease` per branch and won't
 **❌ Forgetting to `gh stack rebase` after trunk moves**
 GitHub requires fully linear history to merge. If trunk moved, rebase before submitting.
 
-**❌ Leaving a stack branch checked out in a second worktree**
-`gh stack rebase` cascades by checking out each branch in turn, so it aborts with `fatal: '<branch>' is already used by worktree at ...` and restores every branch. One worktree per stack, not one per layer — remove the others first (`git worktree remove <path>`) and re-add them afterwards if you want them.
-
-**❌ Trusting `rerere` across a semantically fixed-up rebase**
-`gh stack init` enables `git rerere`, which records the resolution you staged — *not* the follow-up fixes you made afterwards when the build failed. Re-running a similar rebase replays the incomplete resolution with no conflict prompt. Clear it once you have fixed things up beyond what you staged:
-```bash
-rm -rf "$(git rev-parse --git-common-dir)/rr-cache"
-```
-Use `--git-common-dir`, not `--git-dir`. In a worktree `.git` is a *file* and `--git-dir` points at the worktree's private directory, so `rm -rf .git/rr-cache` silently does nothing and a check against `--git-dir` reports zero entries whether or not the real cache is still there.
-
-**❌ Reporting a scoped `dotnet format` run as verified without a control**
-`--include` takes a **space-separated** list. Passing several paths as one quoted string joined by `;` or `,` matches zero documents and exits `0`, which is indistinguishable from clean. Prove the check can fail: add a trailing space to one of your own files, confirm it reports `error WHITESPACE`, revert. See `CLAUDE.md` for the full caveat.
-
 ## Verification
 
 - [ ] `gh stack view` shows all expected layers in order
 - [ ] Each PR targets the branch of the layer below it (not `develop` directly for mid-stack PRs)
 - [ ] `gh stack view --json` shows `needsRebase: false` for all layers
 - [ ] Each PR is independently reviewable (standalone diff, clear title, no unrelated changes)
-- [ ] After a conflicted rebase: swept for trunk's renames across `.cs`, `.md` and XML doc comments
-- [ ] After a conflicted rebase: every public API declaration delta is explained by a known trunk change
 
 ## Related Skills
 

--- a/docs/architecture/applet-public-api.md
+++ b/docs/architecture/applet-public-api.md
@@ -55,6 +55,35 @@ containing `NotSupportedException`; the concrete SDK session supplies the real i
 logic in the interface. A large optional subsystem may instead use a companion type, but capability-interface
 proliferation is not the default.
 
+### Reconciling the declaration files after a rebase
+
+The declaration files record full signatures **including parameter names**. A rename on the trunk therefore
+invalidates every entry it touches while producing no textual conflict at all, so a rebase can leave the files
+stale in ways nothing flags until the analyzer runs. Expect one `RS0017` (declared but not found) and one
+`RS0016` (found but not declared) per renamed signature.
+
+The analyzer names the exact string to remove and to add, so reconciliation is mechanical and should be driven
+from its output rather than by hand. What must not be mechanical is accepting the result:
+
+> **Classify every changed entry against a known trunk change.** An entry explained by a rename, a deliberate
+> removal, or a type becoming internal is fine. An entry you cannot explain is a suspected merge error, not a
+> record to accept.
+
+That step is the whole point. Regenerating the files from analyzer output means regenerating them *from the
+code* — so at the one moment they are supposed to be an independent check on the merge, they stop being one. If
+the merge silently dropped a default, changed nullability, or widened an accessibility, a blind regeneration
+records the mistake as the new truth and the review diff looks intentional.
+
+A practical audit: diff the declaration files against their pre-rebase state and confirm each removal pairs with
+an addition that differs only in the way the known trunk change predicts.
+
+```bash
+git diff <pre-rebase-ref> HEAD -- '*PublicAPI.Unshipped.txt'
+```
+
+Unpaired removals should map to something the trunk deleted or made internal; unpaired additions should map to
+something the trunk added. Anything left over needs explaining before the PR is pushed.
+
 ## Taxonomy
 
 | ID | Category | Decision |


### PR DESCRIPTION
Follow-up to the #642/#644 stack rebase. Docs only, no code.

Rebasing that stack onto a trunk which had moved by three overlapping PRs turned up four hazards — and **only one of them was a conflict**. The other three merged cleanly and were still wrong. This writes down how to find that class deliberately rather than by luck.

## What actually went wrong, and what caught it

| Hazard | Caught by |
|---|---|
| `options` / `options` — both PRs consolidated different params under the same name | compiler (`CS1503`) — but **only because the types differed** |
| `firmwareVersion:` named argument against a changed signature | compiler (`CS1739`) |
| 41 stale `PublicAPI.*.txt` entries (those files record *parameter names*) | the analyzer, after the fact |
| `<paramref name="options"/>` left pointing at the wrong parameter | **nothing** — it still resolves; build and 2747 tests were green |

That last row shipped. It was found by reading the file during the retrospective, not by any gate.

## `.claude/skills/workflow-stack/SKILL.md`

- **Rebase on a cadence.** The whole cost scales with drift; absorbing three trunk PRs at once is a different job from three small rebases.
- **Read intent before markers** — `git diff $(git merge-base ...) <branch> -- <file>` shows what the branch was *trying* to do. This is what catches the two cases a markers-only resolution destroys silently: `checkout --ours` discarding an addition that auto-merged elsewhere in the same file, and markers covering one signature while a sibling method auto-merges carrying the old names. Both happened here.
- **Then sweep for trunk's renames** across `.cs`, `.md` and XML doc comments, with the table above.
- Three mechanical traps, all hit during the rebase: `gh stack rebase` aborts if a stack branch is checked out in a second worktree; `rerere` replays the resolution you *staged*, not the fixes you made afterwards when the build failed; and clearing it needs `--git-common-dir` — in a worktree `.git` is a file, so `rm -rf .git/rr-cache` silently does nothing and a check against `--git-dir` reports zero either way. That one is not theoretical: my cleanup during the rebase was a no-op and reported success. The cache still had 7 stale entries.

## `docs/architecture/applet-public-api.md`

Adds the reconciliation policy under *Compatibility process*. The declaration files record parameter names, so a trunk rename invalidates them with **no textual conflict**; the analyzer's `RS0016`/`RS0017` output is the right way to drive the fix.

What must not be mechanical is *accepting* it:

> Regenerating the declarations from analyzer output means regenerating them **from the code** — so at the one moment they are meant to be an independent check on the merge, they stop being one.

A silently dropped default or widened accessibility would be recorded as the new truth and read as intentional in review. So: classify every delta against a known trunk change; anything unexplained is a suspected merge error, not a record to accept.

## Verification

Docs only. Build re-run at this commit: 0 errors, 0 warnings. Every rule ID and error string quoted here was checked against the actual build logs from the rebase rather than from memory.