### PR TITLE
build: drop Microsoft.SourceLink.GitHub to clear CVE-2026-62900

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -71,10 +71,12 @@
         <None Include="$(MSBuildThisFileDirectory)PACKAGE_README.md" Pack="true" PackagePath="\" Visible="false"/>
     </ItemGroup>
 
-    <!-- Source Link Package (for all projects) -->
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All"/>
-    </ItemGroup>
+    <!-- Source Link ships in the .NET SDK (8+) and is enabled by default for GitHub-hosted
+         repositories, so no PackageReference is needed. Referencing Microsoft.SourceLink.GitHub
+         explicitly would override the SDK's copy and drag in the vulnerable
+         Microsoft.Build.Tasks.Git 8.0.0 (CVE-2026-62900), which has no patched 8.0.x release.
+         The Source Link settings above (PublishRepositoryUrl, EmbedUntrackedSources) are read by
+         the SDK's built-in targets. -->
 
     <!-- Determine if this is a test project -->
     <PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,7 +39,6 @@
     <PackageVersion Include="Spectre.Console.Cli" Version="0.49.1" />
     <!-- Build Tools -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="5.6.0" />
     <PackageVersion Include="Bullseye" Version="5.0.0" />


### PR DESCRIPTION
Every restore in the repository currently fails, so all PRs are red regardless of what they touch:

```
toolchain.cs.csproj : error NU1902: Warning As Error: Package 'Microsoft.Build.Tasks.Git'
8.0.0 has a known moderate severity vulnerability, GHSA-23fw-v26w-5fgq
```

`Directory.Build.props` gives every project `TreatWarningsAsErrors`, so the advisory turns a restore-time warning into a hard failure. It fails in the first CI step that runs, `Validate active documentation`, which is why the error text mentions `toolchain.cs.csproj` and looks unrelated to whatever the PR changed. `yubikit` was green on 2026-09-07; the advisory published after that.

## Cause

One package pulls it in:

```
$ dotnet nuget why Yubico.YubiKit.sln Microsoft.Build.Tasks.Git
Microsoft.SourceLink.GitHub (v8.0.0)
  └─ Microsoft.Build.Tasks.Git (v8.0.0)
```

## Why removal rather than a bump or a suppression

[CVE-2026-62900](https://github.com/dotnet/announcements/issues/435) (information disclosure, CVSS 5.9) lists **no patched 8.0.x release** — the advisory says "No patched NuGet version; update to a fixed .NET 8 SDK". A bump inside the 8.0 line does not exist. Moving to the patched 10.0.111 would work, but it would still be pinning a package we do not need:

> Starting with .NET 8, Source Link for the following source control providers is included in the .NET SDK and enabled by default... If your project uses .NET SDK 8+ and is hosted by the above providers it does not need to reference any Source Link packages.
> — [dotnet/sourcelink README](https://github.com/dotnet/sourcelink/blob/main/README.md)

This repository is `net10.0` and hosted on GitHub, so the SDK already provides Source Link. The explicit reference only *overrides* the SDK's own patched copy with an older vulnerable one. Removing the `PackageReference` and its central version entry drops the vulnerable package from every project graph, so the audit passes on its merits.

`NuGetAudit` stays enabled and NU1902 stays an error. No `NoWarn`, no `NuGetAuditSuppress`, no audit-level change — a suppression would have left the vulnerable package in the graph and hidden the next advisory too.

## Source Link output is unchanged

Worth stating explicitly, since removing a package named "SourceLink" invites the assumption that Source Link was dropped. It was not — checked both before and after the change:

- `src/Core/src/obj/Release/net10.0/Yubico.YubiKit.Core.sourcelink.json` is generated in both cases, mapping the repository root to `https://raw.githubusercontent.com/Yubico/Yubico.NET.SDK/<commit>/*`.
- The packed nuspec still carries `<repository type="git" url="..." branch="..." commit="..." />`.

(There is a known issue, [dotnet/sourcelink#1652](https://github.com/dotnet/SourceLink/issues/1652), where an explicit reference *silently disables* Source Link on .NET 8+ SDKs. That did not happen here — this repository's Source Link worked before and works now. Calling this a fix for that bug would overstate it.)

## Verification

Local, .NET SDK 10.0.100 on macOS. Reproduced the failure first (`git stash` → restore → NU1902 with the dependency graph above), then confirmed each gate:

| Command | Result |
| --- | --- |
| `dotnet nuget why Yubico.YubiKit.sln Microsoft.Build.Tasks.Git` | no project depends on it |
| `dotnet toolchain.cs -- docs-qa` | 66 files validated |
| `dotnet toolchain.cs build` | succeeded, 0 warnings |
| `dotnet toolchain.cs test` | 13/13 projects passed |
| `dotnet toolchain.cs -- resilience --fast` | passed |
| `dotnet toolchain.cs pack --package-version 2.0.0-alpha.2` | succeeded |
| `dotnet publish verification/NativeAotVerification -r osx-arm64 --self-contained -p:PublishAot=true` | 10 linked module entry types, host ran clean |

CI on this PR is the real check: `build-and-test` and `native-aot-publish` should go green, and that will be the first passing run since the advisory landed.

## Note on `submit-nuget`

`submit-nuget` also fails on #648, an unrelated Dependabot PR, and may have a separate cause. This PR is scoped to the NU1902 restore failure; if `submit-nuget` is still red afterwards it needs its own look.