### PR TITLE
docs(migration): correct the stale Utf8 secret-parameter guidance

### DIFF
--- a/docs/migration/v1-to-v2.md
+++ b/docs/migration/v1-to-v2.md
@@ -106,7 +106,7 @@ below before diagnosing behavior changes.
 | A direct applet factory with a mismatched `SessionCreationOptions.PreferredConnectionType` | All eight direct factories now throw `ArgumentException` before device input/output. |
 | Public `DeviceConfig.GetBytes(reboot, currentLockCode, newLockCode)` | Removed. Pass `SetDeviceConfigOptions` to `SetDeviceConfigAsync`; wire encoding is session implementation detail. |
 | Named PIV arguments `ChangePukAsync(pukUtf8: ...)`, `RecoverPinOnlyModeAsync(pin: ...)`, or `SetPinOnlyModeAsync(pin: ...)` | Rename them to `currentPukUtf8:` or `pinUtf8:` as appropriate. |
-| Named OpenPGP `Kdf.Process(..., pinUtf8Bytes: ...)` argument | Rename it to `pinUtf8:`. |
+| Named OpenPGP `Kdf.Process(..., pinUtf8Bytes: ...)` argument | Rename it to `pin:`. The parameter is `ReadOnlySpan<byte> pin`; it carries UTF-8 bytes but does not use the `Utf8` suffix. |
 
 The following dependency-injection APIs were removed rather than replaced. Call the normalized static factory or
 the corresponding `IYubiKey.CreateXSessionAsync` extension directly:
@@ -585,7 +585,7 @@ Use `Yubico.YubiKit.YubiHsm` for YubiHSM 2 workflows. Review connector/session c
 
 A dedicated `HsmAuthRetryException.RetriesRemaining` and an `HsmAuthSession.OnTouchRequired` callback were restored after an initial v2 gap; see `yubihsm-retry-exception` and `yubihsm-touch-notify` in `v1-to-v2-map.yml`. `HsmAuthCredential.Counter` was hardware-verified and renamed to `RetriesRemaining` to match v1's "retries remaining before deletion" semantics; see `yubihsm-credential-retries-remaining-rename`.
 
-Credential passwords moved from `string` to UTF-8 `ReadOnlyMemory<byte>` across nine `IHsmAuthSession`/`HsmAuthSession` members (parameters renamed with the `...Utf8` suffix), closing a v1 regression rather than introducing one, since v1's equivalent path already used byte-based passwords; see `yubihsm-credential-password-bytes` in `v1-to-v2-map.yml`.
+Credential passwords moved from `string` to UTF-8 `ReadOnlyMemory<byte>` across nine `IHsmAuthSession`/`HsmAuthSession` members, closing a v1 regression rather than introducing one, since v1's equivalent path already used byte-based passwords; see `yubihsm-credential-password-bytes` in `v1-to-v2-map.yml`. The parameters are named plainly — `credentialPassword`, `derivationPassword`, `currentPassword`, `newPassword`, and `password` — with no `Utf8` suffix; `refactor(fido2,openpgp,oath)!: drop Utf8 param suffix from secret parameters` (`5af953f6`) applied the same convention to FIDO2, OpenPGP, and OATH. PIV is the exception and still uses `pinUtf8`, `pukUtf8`, and friends.
 
 ## Manual Low-Level Command Cases
 


### PR DESCRIPTION
Two statements in `docs/migration/v1-to-v2.md` describe a parameter-naming convention that was removed by `5af953f6` (`refactor(fido2,openpgp,oath)!: drop Utf8 param suffix from secret parameters`) and `c5dc3aec`. A migrator who follows either one writes code that does not compile, which is the worst failure mode for a migration guide.

## What is wrong

**Line 109 — OpenPGP.** The row says to rename the named argument to `pinUtf8:`. The parameter is `pin`:

```csharp
// src/OpenPgp/src/Kdf.cs:52
public abstract byte[] Process(Pw pw, ReadOnlySpan<byte> pin);
```

**Line 588 — YubiHSM Auth.** The paragraph says the nine members' parameters were "renamed with the `...Utf8` suffix". They are plain — `credentialPassword`, `derivationPassword`, `currentPassword`, `newPassword`, `password` (`src/YubiHsm/src/IHsmAuthSession.cs:58-263`).

## What this changes

Both corrected against current source. The YubiHSM paragraph now states the convention once for the applets that adopted it and names PIV as the exception, since PIV genuinely still uses `pinUtf8`, `pukUtf8`, and friends (`src/Piv/src/IPivSession.cs:113,145,154`) — that asymmetry is exactly the kind of thing a migrator gets wrong. The neighbouring PIV row at line 108 was already correct and is untouched.

Scoped deliberately to the two wrong statements. No watermark change, no map edits, nothing else in the lane.

## Provenance

Found while refreshing `docs/v1-to-v2-comparison.md` in #652. That page cites this guide as the canonical v1→v2 API mapping, so it could not describe the rename accurately without contradicting the thing it points readers to. #652 noted the discrepancy as out of scope; this closes it.

Worth flagging for whoever owns the automation lane: `docs/architecture/applet-public-api.md:27` still documents the `Utf8` suffix as *the* convention, which is now only true for PIV. That is a decision record rather than generated output, so I have left it alone, but it is the likely upstream source of this drift.

## Verification

```
dotnet toolchain.cs -- docs-qa   # 66 active docs validated
git diff --check                 # clean
```

Documentation only — no source changes, so no build or test run. Does not conflict with #654, which touches a different part of this file.